### PR TITLE
Proxy server using create react app

### DIFF
--- a/packages/amplication-client/.env
+++ b/packages/amplication-client/.env
@@ -1,2 +1,1 @@
-REACT_APP_APOLLO_URI="http://localhost:3000/graphql"
 PORT=3001 

--- a/packages/amplication-client/package.json
+++ b/packages/amplication-client/package.json
@@ -57,6 +57,7 @@
     "check-format": "prettier --check \"**/*.{js,ts,json,gql,md,yaml}\"",
     "format": "prettier --write \"**/*.{js,ts,json,gql,md,yaml}\""
   },
+  "proxy": "http://localhost:3000",
   "eslintConfig": {
     "extends": "react-app",
     "rules": {

--- a/packages/amplication-client/src/index.tsx
+++ b/packages/amplication-client/src/index.tsx
@@ -10,7 +10,6 @@ import { getToken } from "./authentication/authentication";
 import { RMWCProvider } from "@rmwc/provider";
 
 const apolloClient = new ApolloClient({
-  uri: process.env.REACT_APP_APOLLO_URI,
   request: (operation) => {
     const token = getToken();
     operation.setContext({


### PR DESCRIPTION
This change simplifies the connection to the server by not introducing a new environment variable and allows the built app to access the server at the same host.