### PR TITLE
Case insensitive search

### DIFF
--- a/packages/amplication-client/src/Blocks/BlockList.tsx
+++ b/packages/amplication-client/src/Blocks/BlockList.tsx
@@ -114,7 +114,10 @@ export const BlockList = ({ applicationId, blockTypes, title }: Props) => {
         [sortDir.field || NAME_FIELD]:
           sortDir.order === 1 ? models.SortOrder.Desc : models.SortOrder.Asc,
       },
-      whereName: searchPhrase !== "" ? { contains: searchPhrase } : undefined,
+      whereName:
+        searchPhrase !== ""
+          ? { contains: searchPhrase, mode: models.QueryMode.Insensitive }
+          : undefined,
     },
   });
 

--- a/packages/amplication-client/src/Entity/EntityFieldList.tsx
+++ b/packages/amplication-client/src/Entity/EntityFieldList.tsx
@@ -95,7 +95,10 @@ export const EntityFieldList = React.memo(({ entityId }: Props) => {
         [sortDir.field || NAME_FIELD]:
           sortDir.order === 1 ? models.SortOrder.Desc : models.SortOrder.Asc,
       },
-      whereName: searchPhrase !== "" ? { contains: searchPhrase } : undefined,
+      whereName:
+        searchPhrase !== ""
+          ? { contains: searchPhrase, mode: models.QueryMode.Insensitive }
+          : undefined,
     },
   });
 

--- a/packages/amplication-client/src/Entity/EntityList.tsx
+++ b/packages/amplication-client/src/Entity/EntityList.tsx
@@ -89,7 +89,10 @@ export const EntityList = ({ applicationId }: Props) => {
         [sortDir.field || NAME_FIELD]:
           sortDir.order === 1 ? models.SortOrder.Desc : models.SortOrder.Asc,
       },
-      whereName: searchPhrase !== "" ? { contains: searchPhrase } : undefined,
+      whereName:
+        searchPhrase !== ""
+          ? { contains: searchPhrase, mode: models.QueryMode.Insensitive }
+          : undefined,
     },
   });
 

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -1292,6 +1292,11 @@ export type QueryBuildsArgs = {
   skip?: Maybe<Scalars["Int"]>;
 };
 
+export enum QueryMode {
+  Default = "Default",
+  Insensitive = "Insensitive",
+}
+
 export enum Role {
   Admin = "Admin",
   User = "User",
@@ -1326,6 +1331,7 @@ export type StringFilter = {
   contains?: Maybe<Scalars["String"]>;
   startsWith?: Maybe<Scalars["String"]>;
   endsWith?: Maybe<Scalars["String"]>;
+  mode?: Maybe<QueryMode>;
 };
 
 export type UpdateAccountInput = {

--- a/packages/amplication-data-service-generator/src/models.ts
+++ b/packages/amplication-data-service-generator/src/models.ts
@@ -1292,6 +1292,11 @@ export type QueryBuildsArgs = {
   skip?: Maybe<Scalars["Int"]>;
 };
 
+export enum QueryMode {
+  Default = "Default",
+  Insensitive = "Insensitive",
+}
+
 export enum Role {
   Admin = "Admin",
   User = "User",
@@ -1326,6 +1331,7 @@ export type StringFilter = {
   contains?: Maybe<Scalars["String"]>;
   startsWith?: Maybe<Scalars["String"]>;
   endsWith?: Maybe<Scalars["String"]>;
+  mode?: Maybe<QueryMode>;
 };
 
 export type UpdateAccountInput = {

--- a/packages/amplication-server/package-lock.json
+++ b/packages/amplication-server/package-lock.json
@@ -2311,15 +2311,15 @@
       }
     },
     "@prisma/cli": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@prisma/cli/-/cli-2.4.0.tgz",
-      "integrity": "sha512-+ybn21k+nAwoyILP5I0+VzRmMLfLmCfnJsJmBktg1FgKIWr9ppcM28Fu8LAohb7kQlKNRhv2eJmC5pdZC6unMw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@prisma/cli/-/cli-2.5.1.tgz",
+      "integrity": "sha512-cu7YiskmiXZ6FXNf/8gfkzB10AjoHiCIHUgBOPNnS6lXJPU1Krh6TQOEXH6tNTB19XeUXO7KetTcqKGW48IkMQ==",
       "dev": true
     },
     "@prisma/client": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.4.0.tgz",
-      "integrity": "sha512-kFWCVJ8Ux8IsUjaIOlEQ7n3H2rf9MqxkLwM2bOt7LL7P50WraK0dJ7if8KU/Ui9/QYwUIe/5wATi1bfJSrVIAg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.5.1.tgz",
+      "integrity": "sha512-vIyh6kyNNC7daePZRkrsxTF/xa8uA0bFpR4E9agyknzylGYFJqnjZCMTwtkXz64Vnlc55dMTCONNe/AFJ0UusQ==",
       "requires": {
         "pkg-up": "^3.1.0"
       }

--- a/packages/amplication-server/package.json
+++ b/packages/amplication-server/package.json
@@ -45,7 +45,7 @@
     "@nestjs/passport": "^7.1.0",
     "@nestjs/platform-express": "^7.3.2",
     "@nestjs/serve-static": "^2.1.3",
-    "@prisma/client": "^2.4.0",
+    "@prisma/client": "^2.5.1",
     "@slynova/flydrive": "^1.0.2",
     "@types/adm-zip": "^0.4.33",
     "@types/bull": "^3.14.0",
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@nestjs/cli": "^7.4.1",
     "@nestjs/testing": "^7.3.2",
-    "@prisma/cli": "^2.4.0",
+    "@prisma/cli": "^2.5.1",
     "@types/bcrypt": "3.0.0",
     "@types/express": "4.17.2",
     "@types/jest": "25.1.3",

--- a/packages/amplication-server/prisma/schema.prisma
+++ b/packages/amplication-server/prisma/schema.prisma
@@ -5,7 +5,7 @@ datasource db {
 
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["transactionApi"]
+  previewFeatures = ["insensitiveFilters"]
 
 }
 

--- a/packages/amplication-server/src/dto/StringFilter.ts
+++ b/packages/amplication-server/src/dto/StringFilter.ts
@@ -1,73 +1,67 @@
 import { Field, InputType } from '@nestjs/graphql';
+import { QueryMode } from 'src/enums/QueryMode';
 
 @InputType({
-  isAbstract: true,
-  description: undefined
+  isAbstract: true
 })
 export class StringFilter {
   @Field(() => String, {
-    nullable: true,
-    description: undefined
+    nullable: true
   })
   equals?: string | null;
 
   @Field(() => String, {
-    nullable: true,
-    description: undefined
+    nullable: true
   })
   not?: string | null;
 
   @Field(() => [String], {
-    nullable: true,
-    description: undefined
+    nullable: true
   })
   in?: string[] | null;
 
   @Field(() => [String], {
-    nullable: true,
-    description: undefined
+    nullable: true
   })
   notIn?: string[] | null;
 
   @Field(() => String, {
-    nullable: true,
-    description: undefined
+    nullable: true
   })
   lt?: string | null;
 
   @Field(() => String, {
-    nullable: true,
-    description: undefined
+    nullable: true
   })
   lte?: string | null;
 
   @Field(() => String, {
-    nullable: true,
-    description: undefined
+    nullable: true
   })
   gt?: string | null;
 
   @Field(() => String, {
-    nullable: true,
-    description: undefined
+    nullable: true
   })
   gte?: string | null;
 
   @Field(() => String, {
-    nullable: true,
-    description: undefined
+    nullable: true
   })
   contains?: string | null;
 
   @Field(() => String, {
-    nullable: true,
-    description: undefined
+    nullable: true
   })
   startsWith?: string | null;
 
   @Field(() => String, {
-    nullable: true,
-    description: undefined
+    nullable: true
   })
   endsWith?: string | null;
+
+  @Field(() => QueryMode, {
+    nullable: true
+  })
+  mode?: QueryMode;
 }

--- a/packages/amplication-server/src/enums/QueryMode.ts
+++ b/packages/amplication-server/src/enums/QueryMode.ts
@@ -1,0 +1,10 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum QueryMode {
+  Default = 'default',
+  Insensitive = 'insensitive'
+}
+registerEnumType(QueryMode, {
+  name: 'QueryMode',
+  description: undefined
+});

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -946,6 +946,11 @@ type Query {
   builds(where: BuildWhereInput, orderBy: BuildOrderByInput, take: Int, skip: Int): [Build!]!
 }
 
+enum QueryMode {
+  Default
+  Insensitive
+}
+
 enum Role {
   Admin
   User
@@ -980,6 +985,7 @@ input StringFilter {
   contains: String
   startsWith: String
   endsWith: String
+  mode: QueryMode
 }
 
 input UpdateAccountInput {


### PR DESCRIPTION
Support for case insensitive search based on prisma preview feature.
Currently, the control is on the client-side - the developer needs to explicitly send the API a request for insensitive search.
The default behavior is based on the DB default collation which is case sensitive for PostgreSQL. We should consider changing the default on DB creation of per column.

Resolves: #275 