### PR TITLE
Rename delete entity

### DIFF
--- a/packages/amplication-server/src/core/entity/entity.service.spec.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.spec.ts
@@ -9,6 +9,7 @@ import omit from 'lodash.omit';
 import { CURRENT_VERSION_NUMBER } from './constants';
 import { SortOrder } from 'src/enums/SortOrder';
 import { JsonSchemaValidationModule } from 'src/services/jsonSchemaValidation.module';
+import { prepareDeletedItemName } from 'src/util/softDelete';
 
 const EXAMPLE_ENTITY_ID = 'exampleEntityId';
 
@@ -270,6 +271,15 @@ describe('EntityService', () => {
     const updateArgs = {
       where: deleteArgs.args.where,
       data: {
+        name: prepareDeletedItemName(EXAMPLE_ENTITY.name, EXAMPLE_ENTITY.id),
+        displayName: prepareDeletedItemName(
+          EXAMPLE_ENTITY.displayName,
+          EXAMPLE_ENTITY.id
+        ),
+        pluralDisplayName: prepareDeletedItemName(
+          EXAMPLE_ENTITY.pluralDisplayName,
+          EXAMPLE_ENTITY.id
+        ),
         deletedAt: expect.any(Date),
         entityVersions: {
           update: {

--- a/packages/amplication-server/src/util/softDelete.ts
+++ b/packages/amplication-server/src/util/softDelete.ts
@@ -1,0 +1,13 @@
+export function prepareDeletedItemName(
+  currentValue: string,
+  id: string
+): string {
+  return `__${id}_${currentValue}`;
+}
+
+export function revertDeletedItemName(
+  currentValue: string,
+  id: string
+): string {
+  return currentValue.replace(`__${id}_`, '');
+}


### PR DESCRIPTION
In order to allow the creation of new entities with the same name of previously deleted entities, rename the deleted entities with a unique name.
Each of the following fields is prefixed with  __[entity.id]_
entity.name
entity.displayName
entity.pluralDisplayName
