### PR TITLE
Disable camelcase ESLint rule

### DIFF
--- a/packages/amplication-server/.eslintrc.js
+++ b/packages/amplication-server/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     'import/no-cycle': 'error',
+    '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/naming-convention': [
       'error',
       {

--- a/packages/amplication-server/src/core/block/block.service.spec.ts
+++ b/packages/amplication-server/src/core/block/block.service.spec.ts
@@ -192,7 +192,7 @@ describe('BlockService', () => {
     expect(prismaBlockVersionFindOneMock).toHaveBeenCalledTimes(1);
     expect(prismaBlockVersionFindOneMock).toHaveBeenCalledWith({
       where: {
-        // eslint-disable-next-line @typescript-eslint/camelcase, @typescript-eslint/naming-convention
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         blockId_versionNumber: {
           blockId: EXAMPLE_BLOCK.id,
           versionNumber: EXAMPLE_BLOCK_VERSION.versionNumber
@@ -279,7 +279,7 @@ describe('BlockService', () => {
         }
       },
       where: {
-        // eslint-disable-next-line @typescript-eslint/camelcase, @typescript-eslint/naming-convention
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         blockId_versionNumber: {
           blockId: EXAMPLE_BLOCK.appId,
           versionNumber: INITIAL_VERSION_NUMBER

--- a/packages/amplication-server/src/core/block/block.service.ts
+++ b/packages/amplication-server/src/core/block/block.service.ts
@@ -215,7 +215,7 @@ export class BlockService {
   ): Promise<T | null> {
     const version = await this.prisma.blockVersion.findOne({
       where: {
-        // eslint-disable-next-line @typescript-eslint/camelcase, @typescript-eslint/naming-convention
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         blockId_versionNumber: {
           blockId: args.where.id,
           versionNumber: args.version
@@ -376,7 +376,7 @@ export class BlockService {
         }
       },
       where: {
-        // eslint-disable-next-line @typescript-eslint/camelcase, @typescript-eslint/naming-convention
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         blockId_versionNumber: {
           blockId: args.where.id,
           versionNumber: INITIAL_VERSION_NUMBER

--- a/packages/amplication-server/src/core/entity/entity.service.spec.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.spec.ts
@@ -284,7 +284,7 @@ describe('EntityService', () => {
         entityVersions: {
           update: {
             where: {
-              // eslint-disable-next-line @typescript-eslint/camelcase, @typescript-eslint/naming-convention
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               entityId_versionNumber: {
                 entityId: deleteArgs.args.where.id,
                 versionNumber: CURRENT_VERSION_NUMBER

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -153,7 +153,7 @@ export class EntityService {
         ...INITIAL_ENTITY_FIELDS[0],
         entityVersion: {
           connect: {
-            // eslint-disable-next-line @typescript-eslint/camelcase, @typescript-eslint/naming-convention
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             entityId_versionNumber: {
               entityId: newEntity.id,
               versionNumber: CURRENT_VERSION_NUMBER
@@ -167,7 +167,7 @@ export class EntityService {
         ...INITIAL_ENTITY_FIELDS[1],
         entityVersion: {
           connect: {
-            // eslint-disable-next-line @typescript-eslint/camelcase, @typescript-eslint/naming-convention
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             entityId_versionNumber: {
               entityId: newEntity.id,
               versionNumber: CURRENT_VERSION_NUMBER
@@ -181,7 +181,7 @@ export class EntityService {
         ...INITIAL_ENTITY_FIELDS[2],
         entityVersion: {
           connect: {
-            // eslint-disable-next-line @typescript-eslint/camelcase, @typescript-eslint/naming-convention
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             entityId_versionNumber: {
               entityId: newEntity.id,
               versionNumber: CURRENT_VERSION_NUMBER
@@ -221,7 +221,7 @@ export class EntityService {
         entityVersions: {
           update: {
             where: {
-              // eslint-disable-next-line @typescript-eslint/camelcase, @typescript-eslint/naming-convention
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               entityId_versionNumber: {
                 entityId: args.where.id,
                 versionNumber: CURRENT_VERSION_NUMBER
@@ -519,7 +519,7 @@ export class EntityService {
 
     const entityVersion = await this.prisma.entityVersion.findOne({
       where: {
-        // eslint-disable-next-line @typescript-eslint/camelcase, @typescript-eslint/naming-convention
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         entityId_versionNumber: {
           entityId: args.where.id,
           versionNumber: CURRENT_VERSION_NUMBER


### PR DESCRIPTION
The camelcase overlaps with the naming convention rule, so no need for both of them.