### PR TITLE
Error handling

### DIFF
--- a/packages/amplication-client/src/util/error.ts
+++ b/packages/amplication-client/src/util/error.ts
@@ -6,6 +6,7 @@ export function formatError(error: Error | undefined): string | undefined {
   }
   if ((error as ApolloError).graphQLErrors) {
     // show the first error
+    /**@todo: return multiple errors */
     const [gqlError] = (error as ApolloError).graphQLErrors;
     if (gqlError && gqlError.message) {
       return gqlError.message;

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -3,7 +3,7 @@ import {
   NotFoundException,
   ConflictException
 } from '@nestjs/common';
-import { AmplicationDataConflictError } from 'src/errors/AmplicationDataConflictError';
+import { DataConflictError } from 'src/errors/DataConflictError';
 import {
   SortOrder,
   EntityFieldDeleteArgs,
@@ -1114,7 +1114,7 @@ export class EntityService {
     const { entity, ...data } = args.data;
 
     if (args.data.dataType === EnumDataType.Id) {
-      throw new AmplicationDataConflictError(
+      throw new DataConflictError(
         `The ID data type cannot be used to created new fields`
       );
     }

--- a/packages/amplication-server/src/errors/AmplicationError.ts
+++ b/packages/amplication-server/src/errors/AmplicationError.ts
@@ -1,5 +1,6 @@
-export class AmplicationError extends Error {
-  constructor(message: string) {
-    super(message);
-  }
-}
+/**
+ * A default Error type for custom exceptions.
+ * Only AmplicationError or other custom error types that extends AmplicationError are passed to the client
+ *
+ */
+export class AmplicationError extends Error {}

--- a/packages/amplication-server/src/errors/DataConflictError.ts
+++ b/packages/amplication-server/src/errors/DataConflictError.ts
@@ -1,6 +1,6 @@
 import { AmplicationError } from './AmplicationError';
 
-export class AmplicationDataConflictError extends AmplicationError {
+export class DataConflictError extends AmplicationError {
   constructor(message: string) {
     super(message);
   }

--- a/packages/amplication-server/src/filters/GqlResolverExceptions.filter.ts
+++ b/packages/amplication-server/src/filters/GqlResolverExceptions.filter.ts
@@ -13,6 +13,8 @@ import { PrismaClientKnownRequestError } from '@prisma/client';
 import { ApolloError } from 'apollo-server-express';
 import { AmplicationError } from '../errors/AmplicationError';
 
+const PRISMA_CODE_UNIQUE_KEY_VIOLATION = 'P2002';
+
 @Catch()
 export class GqlResolverExceptionsFilter implements GqlExceptionFilter {
   constructor(
@@ -25,12 +27,12 @@ export class GqlResolverExceptionsFilter implements GqlExceptionFilter {
     );
     let clientError;
     if (exception instanceof PrismaClientKnownRequestError) {
-      /**Convert PrismaError to ApolloError and pass the error to the client */
+      //Convert PrismaError to ApolloError and pass the error to the client
       let message;
       switch (exception.code) {
-        /**This is an example of a specific prisma error code */
+        //This is an example of a specific prisma error code
         /**@todo: Complete the list or expected error codes */
-        case 'P2002':
+        case PRISMA_CODE_UNIQUE_KEY_VIOLATION:
           const fields = ((exception.meta as any).target as Array<string>).join(
             ', '
           );
@@ -45,7 +47,7 @@ export class GqlResolverExceptionsFilter implements GqlExceptionFilter {
       clientError = new ApolloError(message);
       this.logger.error(clientError.message, { requestData });
     } else if (exception instanceof AmplicationError) {
-      /**Convert AmplicationError to ApolloError and pass the error to the client */
+      //Convert AmplicationError to ApolloError and pass the error to the client
       clientError = new ApolloError(exception.message);
       this.logger.error(clientError.message, { requestData });
     } else {


### PR DESCRIPTION
@iddan, this is a suggested infrastructure for error handling on the server-side.
The exception filter only passes known types to the client.
We should use custom Error types that extend AmplcationError in order to pass the message to the client.

let me know what you think