### PR TITLE
Get user from express request object in auth controller

### DIFF
--- a/packages/amplication-server/src/core/auth/auth.controller.ts
+++ b/packages/amplication-server/src/core/auth/auth.controller.ts
@@ -3,13 +3,13 @@ import {
   UseInterceptors,
   UseGuards,
   Get,
-  Res
+  Res,
+  Req
 } from '@nestjs/common';
 import { MorganInterceptor } from 'nest-morgan';
 import { AuthGuard } from '@nestjs/passport';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { AuthService, AuthUser } from './auth.service';
-import { UserEntity } from 'src/decorators/user.decorator';
 
 @Controller('/')
 @UseInterceptors(MorganInterceptor('combined'))
@@ -23,11 +23,8 @@ export class AuthController {
 
   @Get('/github/callback')
   @UseGuards(AuthGuard('github'))
-  async githubCallback(
-    @UserEntity() user: AuthUser,
-    @Res() response: Response
-  ) {
-    const token = this.authService.prepareToken(user);
+  async githubCallback(@Req() request: Request, @Res() response: Response) {
+    const token = this.authService.prepareToken(request.user as AuthUser);
     response.redirect(301, `/?token=${token}`);
   }
 }


### PR DESCRIPTION
I accidentally used the `@UserEntity()` decorator in a controller (the decorator is suited for resolvers only).