### PR TITLE
Server: Stack traces for unknown errors

### DIFF
--- a/packages/amplication-server/src/filters/GqlResolverExceptions.filter.spec.ts
+++ b/packages/amplication-server/src/filters/GqlResolverExceptions.filter.spec.ts
@@ -25,6 +25,7 @@ const EXAMPLE_PRISMA_UNKNOWN_ERROR = new PrismaClientKnownRequestError(
   'Example Prisma unknown error message',
   'UNKNOWN_CODE'
 );
+const EXAMPLE_ERROR = new Error(EXAMPLE_ERROR_MESSAGE);
 const EXAMPLE_QUERY = 'EXAMPLE_QUERY';
 const EXAMPLE_HOSTNAME = 'EXAMPLE_HOSTNAME';
 const EXAMPLE_IP = 'EXAMPLE_IP';
@@ -75,7 +76,7 @@ describe('GqlResolverExceptionsFilter', () => {
     string,
     Error,
     Error,
-    [string, { requestData: RequestData | null }] | null,
+    [string, { requestData: RequestData | null }] | [Error] | null,
     [string, { requestData: RequestData | null }] | null
   ]> = [
     [
@@ -93,7 +94,7 @@ describe('GqlResolverExceptionsFilter', () => {
       'PrismaClientKnownRequestError unknown',
       EXAMPLE_PRISMA_UNKNOWN_ERROR,
       new InternalServerError(),
-      [EXAMPLE_PRISMA_UNKNOWN_ERROR.message, { requestData: null }],
+      [EXAMPLE_PRISMA_UNKNOWN_ERROR],
       null
     ],
     [
@@ -112,9 +113,9 @@ describe('GqlResolverExceptionsFilter', () => {
     ],
     [
       'Error',
-      new Error(EXAMPLE_ERROR_MESSAGE),
+      EXAMPLE_ERROR,
       new InternalServerError(),
-      [EXAMPLE_ERROR_MESSAGE, { requestData: null }],
+      [EXAMPLE_ERROR],
       null
     ]
   ];

--- a/packages/amplication-server/src/filters/GqlResolverExceptions.filter.spec.ts
+++ b/packages/amplication-server/src/filters/GqlResolverExceptions.filter.spec.ts
@@ -111,13 +111,7 @@ describe('GqlResolverExceptionsFilter', () => {
       null,
       [EXAMPLE_ERROR_MESSAGE, { requestData: null }]
     ],
-    [
-      'Error',
-      EXAMPLE_ERROR,
-      new InternalServerError(),
-      [EXAMPLE_ERROR],
-      null
-    ]
+    ['Error', EXAMPLE_ERROR, new InternalServerError(), [EXAMPLE_ERROR], null]
   ];
   test.each(cases)('%s', (name, exception, expected, errorArgs, infoArgs) => {
     const host = {} as ArgumentsHost;

--- a/packages/amplication-server/src/filters/GqlResolverExceptions.filter.ts
+++ b/packages/amplication-server/src/filters/GqlResolverExceptions.filter.ts
@@ -77,7 +77,10 @@ export class GqlResolverExceptionsFilter implements GqlExceptionFilter {
       this.logger.info(clientError.message, { requestData });
     } else {
       // Log the original exception and return a generic server error to client
-      this.logger.error(exception.message, { requestData });
+      // eslint-disable-next-line
+      // @ts-ignore
+      exception.requestData = requestData;
+      this.logger.error(exception);
       clientError =
         this.configService.get('NODE_ENV') === 'production'
           ? new InternalServerError()


### PR DESCRIPTION
Correct gql resolver exceptions filter to include stacktrace for unknown errors