### PR TITLE
Fix Cloud Build Production

### DIFF
--- a/production.cloudbuild.yaml
+++ b/production.cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
       - -c
       - |
         image_id=$(docker inspect --format='{{index .RepoDigests 0}}' $_IMAGE:$SHORT_SHA);
-        echo "image_id = \"$image_id\"" >> terraform/envs/production/terraform.tfvars;
+        echo "\nimage_id = \"$image_id\"" >> terraform/envs/production/terraform.tfvars;
 
   - id: "terraform-init"
     name: "hashicorp/terraform:0.13.3"

--- a/production.cloudbuild.yaml
+++ b/production.cloudbuild.yaml
@@ -9,7 +9,8 @@ steps:
     args:
       - -c
       - |
-        docker inspect --format='{{index .RepoDigests 0}}' $_IMAGE:$SHORT_SHA >> /workspace/image-id.txt;
+        image_id=$(docker inspect --format='{{index .RepoDigests 0}}' $_IMAGE:$SHORT_SHA);
+        echo "image_id = \"$image_id\"" >> terraform/envs/production/terraform.tfvars;
 
   - id: "terraform-init"
     name: "hashicorp/terraform:0.13.3"
@@ -24,8 +25,6 @@ steps:
       # 20 minutes
       - "-lock-timeout=1200s"
     dir: terraform/envs/production
-    env:
-      - "TF_VAR_image_id=$(cat /workspace/image-id.txt)"
 
   - name: "node:12-stretch"
     entrypoint: bash

--- a/production.cloudbuild.yaml
+++ b/production.cloudbuild.yaml
@@ -1,4 +1,16 @@
 steps:
+  - id: "docker-pull"
+    name: "gcr.io/cloud-builders/docker"
+    args: ["pull", "$_IMAGE:$SHORT_SHA"]
+
+  - id: "docker-inspect"
+    name: "gcr.io/cloud-builders/docker"
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        docker inspect --format='{{index .RepoDigests 0}}' $_IMAGE:$SHORT_SHA >> /workspace/image-id.txt;
+
   - id: "terraform-init"
     name: "hashicorp/terraform:0.13.3"
     args: ["init"]
@@ -13,7 +25,7 @@ steps:
       - "-lock-timeout=1200s"
     dir: terraform/envs/production
     env:
-      - "TF_VAR_image_id=$_IMAGE:$SHORT_SHA"
+      - "TF_VAR_image_id=$(cat /workspace/image-id.txt)"
 
   - name: "node:12-stretch"
     entrypoint: bash


### PR DESCRIPTION
Cloud run doesn't understand non-exact docker image identifiers from another project.
This PR saves the resolves the image identifier and saves it to Terraform's variables file.
