### PR TITLE
Show saved properties on selected field change

### DIFF
--- a/packages/amplication-client/src/Entity/DataTypeSelectField.tsx
+++ b/packages/amplication-client/src/Entity/DataTypeSelectField.tsx
@@ -21,18 +21,23 @@ type Props = Omit<SelectFieldProps, "options" | "name">;
 const DataTypeSelectField = (props: Props) => {
   const formik = useFormikContext<{
     dataType: models.EnumDataType;
+    id: models.EnumDataType;
   }>();
   const previousDataTypeValue = useRef<models.EnumDataType>();
+  const previousFieldId = useRef<string>();
 
   //Reset the properties list and the properties default values when data type is changed
   /**@todo: keep values of previous data type when properties are equal */
   /**@todo: keep values of previous data type to be restored if the previous data type is re-selected */
   useEffect(() => {
     const nextDataTypeValue = formik.values.dataType;
-    //do not reset to default on the initial selection of data type
+    const nextFieldId = formik.values.id;
+
+    //only reset to default if the field ID did not change, and the Data Type was changed
     if (
       previousDataTypeValue.current &&
-      previousDataTypeValue.current !== nextDataTypeValue
+      previousDataTypeValue.current !== nextDataTypeValue &&
+      previousFieldId.current === nextFieldId
     ) {
       const schema = getSchemaForDataType(formik.values.dataType);
       const defaultValues = Object.fromEntries(
@@ -44,6 +49,7 @@ const DataTypeSelectField = (props: Props) => {
 
       formik.setFieldValue("properties", defaultValues);
     }
+    previousFieldId.current = nextFieldId;
     previousDataTypeValue.current = nextDataTypeValue;
   }, [formik]);
 

--- a/packages/amplication-client/src/Entity/EntityField.tsx
+++ b/packages/amplication-client/src/Entity/EntityField.tsx
@@ -45,12 +45,13 @@ const EntityField = () => {
 
   const handleSubmit = useCallback(
     (data) => {
+      const { id, ...rest } = data;
       updateEntityField({
         variables: {
           where: {
             id: field,
           },
-          data,
+          data: rest,
         },
       }).catch(console.error);
     },

--- a/packages/amplication-client/src/Entity/EntityFieldForm.tsx
+++ b/packages/amplication-client/src/Entity/EntityFieldForm.tsx
@@ -15,12 +15,13 @@ import FormikAutoSave from "../util/formikAutoSave";
 import { Form } from "../Components/Form";
 
 type Values = {
+  id: string; //the id field is required in the form context to be used in "DataTypeSelectField"
   name: string;
   displayName: string;
   dataType: models.EnumDataType;
   required: boolean;
   searchable: boolean;
-  description: string;
+  description: string | null;
   properties: Object;
 };
 
@@ -47,14 +48,10 @@ const FORM_SCHEMA = {
   },
 };
 
-const NON_INPUT_GRAPHQL_PROPERTIES = [
-  "id",
-  "createdAt",
-  "updatedAt",
-  "__typename",
-];
+const NON_INPUT_GRAPHQL_PROPERTIES = ["createdAt", "updatedAt", "__typename"];
 
 export const INITIAL_VALUES: Values = {
+  id: "",
   name: "",
   displayName: "",
   dataType: models.EnumDataType.SingleLineText,


### PR DESCRIPTION
When a user select another field - do not reset the properties to default in order to show the saved properties values