### PR TITLE
Refactor - entity version clone data

### DIFF
--- a/packages/amplication-server/src/core/entity/entity.service.spec.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.spec.ts
@@ -1,20 +1,30 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { FindOneEntityFieldArgs, SortOrder } from '@prisma/client';
+import {
+  FindOneEntityFieldArgs,
+  SortOrder,
+  FindOneEntityVersionArgs,
+  EntityVersionCreateArgs
+} from '@prisma/client';
 import { EntityService, NAME_VALIDATION_ERROR_MESSAGE } from './entity.service';
 import { PrismaService } from 'nestjs-prisma';
 import { Entity, EntityVersion, EntityField, User, Commit } from 'src/models';
 import { EnumDataType } from 'src/enums/EnumDataType';
 import { FindManyEntityArgs } from './dto';
-import omit from 'lodash.omit';
 import { CURRENT_VERSION_NUMBER } from './constants';
 import { JsonSchemaValidationModule } from 'src/services/jsonSchemaValidation.module';
 import { prepareDeletedItemName } from 'src/util/softDelete';
 
 const EXAMPLE_ENTITY_ID = 'exampleEntityId';
+const EXAMPLE_CURRENT_ENTITY_VERSION_ID = 'currentEntityVersionId';
+const EXAMPLE_LAST_ENTITY_VERSION_ID = 'lastEntityVersionId';
+const EXAMPLE_LAST_ENTITY_VERSION_NUMBER = 4;
 
 const EXAMPLE_COMMIT_ID = 'exampleCommitId';
 const EXAMPLE_USER_ID = 'exampleUserId';
 const EXAMPLE_MESSAGE = 'exampleMessage';
+
+const EXAMPLE_ENTITY_FIELD_NAME = 'exampleFieldName';
+const EXAMPLE_NON_EXISTING_ENTITY_FIELD_NAME = 'nonExistingFieldName';
 
 const EXAMPLE_COMMIT: Commit = {
   id: EXAMPLE_COMMIT_ID,
@@ -36,35 +46,6 @@ const EXAMPLE_ENTITY: Entity = {
   lockedAt: null
 };
 
-const EXAMPLE_ENTITY_VERSION: EntityVersion = {
-  id: 'exampleEntityVersion',
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  entityId: 'exampleEntity',
-  versionNumber: CURRENT_VERSION_NUMBER,
-  commitId: EXAMPLE_COMMIT_ID,
-  name: 'exampleEntity',
-  displayName: 'example entity',
-  pluralDisplayName: 'exampleEntities',
-  description: 'example entity'
-};
-
-const EXAMPLE_ENTITY_FIELD_NAME = 'exampleFieldName';
-const EXAMPLE_NON_EXISTING_ENTITY_FIELD_NAME = 'nonExistingFieldName';
-
-const EXAMPLE_ENTITY_FIELD_DATA = {
-  name: 'exampleEntityFieldName',
-  displayName: 'Example Entity Field Display Name',
-  required: false,
-  searchable: false,
-  description: '',
-  dataType: EnumDataType.SingleLineText,
-  properties: {
-    maxLength: 42
-  },
-  entityVersion: { connect: { id: EXAMPLE_ENTITY_VERSION.id } }
-};
-
 const EXAMPLE_ENTITY_FIELD: EntityField = {
   id: 'exampleEntityField',
   permanentId: 'exampleEntityFieldPermanentId',
@@ -78,6 +59,51 @@ const EXAMPLE_ENTITY_FIELD: EntityField = {
   required: true,
   searchable: true,
   description: 'example field'
+};
+
+const EXAMPLE_CURRENT_ENTITY_VERSION: EntityVersion = {
+  id: EXAMPLE_CURRENT_ENTITY_VERSION_ID,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  entityId: 'exampleEntity',
+  versionNumber: CURRENT_VERSION_NUMBER,
+  commitId: null,
+  name: 'exampleEntity',
+  displayName: 'example entity',
+  pluralDisplayName: 'exampleEntities',
+  description: 'example entity'
+};
+
+const EXAMPLE_LAST_ENTITY_VERSION: EntityVersion = {
+  id: EXAMPLE_LAST_ENTITY_VERSION_ID,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  entityId: 'exampleEntity',
+  versionNumber: EXAMPLE_LAST_ENTITY_VERSION_NUMBER,
+  commitId: EXAMPLE_COMMIT_ID,
+  name: 'exampleEntity',
+  displayName: 'example entity',
+  pluralDisplayName: 'exampleEntities',
+  description: 'example entity',
+  fields: [
+    {
+      ...EXAMPLE_ENTITY_FIELD,
+      entityVersionId: EXAMPLE_LAST_ENTITY_VERSION_ID
+    }
+  ]
+};
+
+const EXAMPLE_ENTITY_FIELD_DATA = {
+  name: 'exampleEntityFieldName',
+  displayName: 'Example Entity Field Display Name',
+  required: false,
+  searchable: false,
+  description: '',
+  dataType: EnumDataType.SingleLineText,
+  properties: {
+    maxLength: 42
+  },
+  entityVersion: { connect: { id: EXAMPLE_CURRENT_ENTITY_VERSION.id } }
 };
 
 const prismaEntityFindOneMock = jest.fn(() => {
@@ -100,20 +126,49 @@ const prismaEntityUpdateMock = jest.fn(() => {
   return EXAMPLE_ENTITY;
 });
 
-const prismaEntityVersionFindOneMock = jest.fn(() => ({
-  then: resolve => resolve(EXAMPLE_ENTITY_VERSION),
-  commit: () => EXAMPLE_COMMIT
-}));
+const prismaEntityVersionFindOneMock = jest.fn(
+  (args: FindOneEntityVersionArgs) => {
+    const entityVersionList = [
+      EXAMPLE_CURRENT_ENTITY_VERSION,
+      EXAMPLE_LAST_ENTITY_VERSION
+    ];
+
+    const version = entityVersionList.find(item => item.id == args.where.id);
+
+    if (args.include?.fields) {
+      version.fields = [
+        {
+          ...EXAMPLE_ENTITY_FIELD,
+          entityVersionId: version.id
+        }
+      ];
+    }
+
+    if (args.include?.permissions) {
+      version.permissions = [];
+    }
+
+    return {
+      then: resolve => resolve(version),
+      commit: () => EXAMPLE_COMMIT
+    };
+  }
+);
 
 const prismaEntityVersionFindManyMock = jest.fn(() => {
-  return [EXAMPLE_ENTITY_VERSION];
+  return [EXAMPLE_CURRENT_ENTITY_VERSION, EXAMPLE_LAST_ENTITY_VERSION];
 });
 
-const prismaEntityVersionCreateMock = jest.fn(() => {
-  return EXAMPLE_ENTITY_VERSION;
-});
+const prismaEntityVersionCreateMock = jest.fn(
+  (args: EntityVersionCreateArgs) => {
+    return {
+      ...EXAMPLE_LAST_ENTITY_VERSION,
+      versionNumber: args.data.versionNumber
+    };
+  }
+);
 const prismaEntityVersionUpdateMock = jest.fn(() => {
-  return EXAMPLE_ENTITY_VERSION;
+  return EXAMPLE_CURRENT_ENTITY_VERSION;
 });
 
 const prismaEntityFieldFindManyMock = jest.fn(() => {
@@ -122,7 +177,10 @@ const prismaEntityFieldFindManyMock = jest.fn(() => {
 
 const prismaEntityFieldFindOneMock = jest.fn((args: FindOneEntityFieldArgs) => {
   if (args?.include?.entityVersion) {
-    return { ...EXAMPLE_ENTITY_FIELD, entityVersion: EXAMPLE_ENTITY_VERSION };
+    return {
+      ...EXAMPLE_ENTITY_FIELD,
+      entityVersion: EXAMPLE_CURRENT_ENTITY_VERSION
+    };
   }
   return EXAMPLE_ENTITY_FIELD;
 });
@@ -203,7 +261,7 @@ describe('EntityService', () => {
       where: {
         id: EXAMPLE_ENTITY_ID
       },
-      version: EXAMPLE_ENTITY_VERSION.versionNumber
+      version: EXAMPLE_CURRENT_ENTITY_VERSION.versionNumber
     };
     const returnArgs = {
       where: {
@@ -363,7 +421,7 @@ describe('EntityService', () => {
   it('should get entity fields', async () => {
     const entity = {
       entityId: EXAMPLE_ENTITY_ID,
-      versionNumber: EXAMPLE_ENTITY_VERSION.versionNumber,
+      versionNumber: EXAMPLE_CURRENT_ENTITY_VERSION.versionNumber,
       args: { where: {} }
     };
     const returnArgs = {
@@ -390,7 +448,7 @@ describe('EntityService', () => {
   it('should create a new version', async () => {
     const args = {
       data: {
-        commit: { connect: { id: EXAMPLE_ENTITY_VERSION.commitId } },
+        commit: { connect: { id: EXAMPLE_LAST_ENTITY_VERSION.commitId } },
         entity: { connect: { id: EXAMPLE_ENTITY_ID } }
       }
     };
@@ -402,12 +460,8 @@ describe('EntityService', () => {
         versionNumber: SortOrder.asc
       }
     };
-    const entityFieldFindManyArgs = {
-      where: {
-        entityVersion: { id: EXAMPLE_ENTITY_VERSION.id }
-      }
-    };
-    const nextVersionNumber = EXAMPLE_ENTITY_VERSION.versionNumber + 1;
+
+    const nextVersionNumber = EXAMPLE_LAST_ENTITY_VERSION.versionNumber + 1;
     const entityVersionCreateArgs = {
       data: {
         name: EXAMPLE_ENTITY.name,
@@ -424,21 +478,17 @@ describe('EntityService', () => {
           connect: {
             id: args.data.entity.connect.id
           }
-        },
-        fields: {
-          create: [omit(EXAMPLE_ENTITY_FIELD, ['entityVersionId', 'id'])]
         }
       }
     };
-    expect(await service.createVersion(args)).toEqual(EXAMPLE_ENTITY_VERSION);
+    expect(await service.createVersion(args)).toEqual(
+      EXAMPLE_CURRENT_ENTITY_VERSION
+    );
     expect(prismaEntityVersionFindManyMock).toBeCalledTimes(1);
     expect(prismaEntityVersionFindManyMock).toBeCalledWith(
       entityVersionFindManyArgs
     );
-    expect(prismaEntityFieldFindManyMock).toBeCalledTimes(1);
-    expect(prismaEntityFieldFindManyMock).toBeCalledWith(
-      entityFieldFindManyArgs
-    );
+
     expect(prismaEntityVersionCreateMock).toBeCalledTimes(1);
     expect(prismaEntityVersionCreateMock).toBeCalledWith(
       entityVersionCreateArgs
@@ -447,7 +497,10 @@ describe('EntityService', () => {
 
   it('should get many versions', async () => {
     const args = {};
-    expect(await service.getVersions(args)).toEqual([EXAMPLE_ENTITY_VERSION]);
+    expect(await service.getVersions(args)).toEqual([
+      EXAMPLE_CURRENT_ENTITY_VERSION,
+      EXAMPLE_LAST_ENTITY_VERSION
+    ]);
     expect(prismaEntityVersionFindManyMock).toBeCalledTimes(1);
     expect(prismaEntityVersionFindManyMock).toBeCalledWith(args);
   });
@@ -484,7 +537,7 @@ describe('EntityService', () => {
         },
         entityVersion: {
           entityId: args.entityId,
-          versionNumber: EXAMPLE_ENTITY_VERSION.versionNumber
+          versionNumber: EXAMPLE_CURRENT_ENTITY_VERSION.versionNumber
         }
       },
       select: { name: true }
@@ -497,7 +550,7 @@ describe('EntityService', () => {
   });
 
   it('should get a version commit', async () => {
-    const entityVersionId = EXAMPLE_ENTITY_VERSION.id;
+    const entityVersionId = EXAMPLE_LAST_ENTITY_VERSION.id;
     const returnArgs = { where: { id: entityVersionId } };
     expect(await service.getVersionCommit(entityVersionId)).toEqual(
       EXAMPLE_COMMIT

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -16,7 +16,7 @@ import head from 'lodash.head';
 import last from 'lodash.last';
 import omit from 'lodash.omit';
 import difference from '@extra-set/difference';
-import { isEmpty } from 'lodash';
+import { isEmpty, pick } from 'lodash';
 import {
   Entity,
   EntityField,
@@ -640,6 +640,13 @@ export class EntityService {
       omit(field, ['entityVersionId', 'id'])
     );
 
+    const names = pick(sourceVersion, [
+      'name',
+      'displayName',
+      'pluralDisplayName',
+      'description'
+    ]);
+
     //update the target version with its fields, and the its parent entity
     targetVersion = await this.prisma.entityVersion.update({
       where: {
@@ -648,16 +655,10 @@ export class EntityService {
       data: {
         entity: {
           update: {
-            name: sourceVersion.name,
-            displayName: sourceVersion.displayName,
-            pluralDisplayName: sourceVersion.pluralDisplayName,
-            description: sourceVersion.description
+            ...names
           }
         },
-        name: sourceVersion.name,
-        displayName: sourceVersion.displayName,
-        pluralDisplayName: sourceVersion.pluralDisplayName,
-        description: sourceVersion.description,
+        ...names,
         fields: {
           create: duplicatedFields
         }

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -557,41 +557,10 @@ export class EntityService {
     }
     const lastVersionNumber = lastEntityVersion.versionNumber;
 
-    // Get entity fields from it's current version
-    const firstEntityVersionFields = await this.prisma.entityField.findMany({
-      where: {
-        entityVersion: { id: firstEntityVersion.id }
-      }
-    });
-
-    // Duplicate the fields of the current version, omitting entityVersionId and
-    // id properties.
-    const duplicatedFields = firstEntityVersionFields.map(field =>
-      omit(field, ['entityVersionId', 'id'])
-    );
-
-    // Get entity permissions from the current version
-    const firstEntityVersionPermissions = await this.prisma.entityPermission.findMany(
-      {
-        where: {
-          entityVersion: { id: firstEntityVersion.id }
-        },
-        include: {
-          permissionRoles: true,
-          permissionFields: {
-            include: {
-              permissionRoles: true,
-              field: true
-            }
-          }
-        }
-      }
-    );
-
     const nextVersionNumber = lastVersionNumber + 1;
 
-    //create the new version with its fields
-    let newEntityVersion = await this.prisma.entityVersion.create({
+    //create the new version
+    const newEntityVersion = await this.prisma.entityVersion.create({
       data: {
         name: firstEntityVersion.name,
         displayName: firstEntityVersion.displayName,
@@ -607,7 +576,88 @@ export class EntityService {
           connect: {
             id: args.data.entity.connect.id
           }
+        }
+      }
+    });
+
+    return this.cloneVersionData(firstEntityVersion.id, newEntityVersion.id);
+  }
+
+  private async cloneVersionData(
+    sourceVersionId: string,
+    targetVersionId: string
+  ): Promise<EntityVersion> {
+    const sourceVersion = await this.prisma.entityVersion.findOne({
+      where: {
+        id: sourceVersionId
+      },
+      include: {
+        fields: true,
+        permissions: {
+          include: {
+            permissionRoles: true,
+            permissionFields: {
+              include: {
+                permissionRoles: true,
+                field: true
+              }
+            }
+          }
+        }
+      }
+    });
+
+    if (!sourceVersion) {
+      throw new Error(`Can't find source (Entity Version ${sourceVersionId})`);
+    }
+
+    //Find the target version and clear any existing fields and permissions (used when discarding changes and rolling back to previous version)
+    let targetVersion = await this.prisma.entityVersion.update({
+      where: {
+        id: targetVersionId
+      },
+      data: {
+        fields: {
+          deleteMany: {
+            entityVersionId: targetVersionId
+          }
         },
+        permissions: {
+          deleteMany: {
+            entityVersionId: targetVersionId
+          }
+        }
+      }
+    });
+
+    if (!targetVersion) {
+      throw new Error(`Can't find target (Entity Version ${sourceVersionId})`);
+    }
+
+    // Duplicate the fields of the source version, omitting entityVersionId and
+    // id properties.
+    const duplicatedFields = sourceVersion.fields.map(field =>
+      omit(field, ['entityVersionId', 'id'])
+    );
+
+    //update the target version with its fields, and the its parent entity
+    targetVersion = await this.prisma.entityVersion.update({
+      where: {
+        id: targetVersionId
+      },
+      data: {
+        entity: {
+          update: {
+            name: sourceVersion.name,
+            displayName: sourceVersion.displayName,
+            pluralDisplayName: sourceVersion.pluralDisplayName,
+            description: sourceVersion.description
+          }
+        },
+        name: sourceVersion.name,
+        displayName: sourceVersion.displayName,
+        pluralDisplayName: sourceVersion.pluralDisplayName,
+        description: sourceVersion.description,
         fields: {
           create: duplicatedFields
         }
@@ -616,7 +666,7 @@ export class EntityService {
 
     //prepare the permissions object
     const createPermissionsData: EntityPermissionCreateManyWithoutEntityVersionInput = {
-      create: firstEntityVersionPermissions.map(permission => {
+      create: sourceVersion.permissions.map(permission => {
         return {
           action: permission.action,
           type: permission.type,
@@ -638,7 +688,7 @@ export class EntityService {
                   connect: {
                     // eslint-disable-next-line @typescript-eslint/camelcase, @typescript-eslint/naming-convention
                     entityVersionId_permanentId: {
-                      entityVersionId: newEntityVersion.id,
+                      entityVersionId: targetVersionId,
                       permanentId: permissionField.fieldPermanentId
                     }
                   }
@@ -649,7 +699,7 @@ export class EntityService {
                       // eslint-disable-next-line @typescript-eslint/camelcase, @typescript-eslint/naming-convention
                       entityVersionId_action_appRoleId: {
                         action: fieldRole.action,
-                        entityVersionId: newEntityVersion.id,
+                        entityVersionId: targetVersionId,
                         appRoleId: fieldRole.appRoleId
                       }
                     };
@@ -662,16 +712,16 @@ export class EntityService {
       })
     };
 
-    newEntityVersion = await this.prisma.entityVersion.update({
+    targetVersion = await this.prisma.entityVersion.update({
       where: {
-        id: newEntityVersion.id
+        id: targetVersionId
       },
       data: {
         permissions: createPermissionsData
       }
     });
 
-    return newEntityVersion;
+    return targetVersion;
   }
 
   //The function must only be used from a @FieldResolver on Entity, otherwise it may return versions of a deleted entity


### PR DESCRIPTION
Extract the logic from EntityService.CreateVersion to a new function EntityService.CloneVersionData

The new function will be used in these cases:
- Commit - to copy data from version 0 to the new version
- Discard Changes - to copy data from the last version to version 0
