### PR TITLE
Remove Compiled Files From Generated Apps

### DIFF
--- a/packages/amplication-data-service-generator/src/create-data-service.ts
+++ b/packages/amplication-data-service-generator/src/create-data-service.ts
@@ -84,6 +84,7 @@ async function readStaticModules(logger: winston.Logger): Promise<Module[]> {
   const staticModules = await fg(`${STATIC_DIRECTORY}/**/*`, {
     absolute: false,
     dot: true,
+    ignore: ["**.js", "**.js.map", "**.d.ts"],
   });
 
   return Promise.all(


### PR DESCRIPTION
Ignore TypeScript compilation output files when copying static files to generated apps