### PR TITLE
Data Service Generator: Fix DTO Optional Fields

### DIFF
--- a/packages/amplication-data-service-generator/src/resource/dto/create-dto.spec.ts
+++ b/packages/amplication-data-service-generator/src/resource/dto/create-dto.spec.ts
@@ -29,6 +29,7 @@ import {
   VALIDATE_NESTED_ID,
   TYPE_ID,
   createFieldValueTypeFromPrismaField,
+  IS_OPTIONAL_ID,
 } from "./create-dto";
 import {
   ObjectField,
@@ -383,6 +384,29 @@ describe("createFieldClassProperty", () => {
       ),
     ],
     [
+      "optional id field (not input)",
+      EXAMPLE_OPTIONAL_ENTITY_FIELD,
+      !EXAMPLE_OPTIONAL_ENTITY_FIELD.required,
+      false,
+      EXAMPLE_ENTITY_ID_TO_NAME,
+      classProperty(
+        builders.identifier(EXAMPLE_OPTIONAL_ENTITY_FIELD.name),
+        builders.tsTypeAnnotation(
+          builders.tsUnionType([
+            builders.tsStringKeyword(),
+            builders.tsNullKeyword(),
+          ])
+        ),
+        true,
+        false,
+        null,
+        [
+          builders.decorator(builders.callExpression(IS_STRING_ID, [])),
+          builders.decorator(builders.callExpression(IS_OPTIONAL_ID, [])),
+        ]
+      ),
+    ],
+    [
       "lookup field (not input)",
       EXAMPLE_ENTITY_LOOKUP_FIELD,
       !EXAMPLE_ENTITY_LOOKUP_FIELD.required,
@@ -416,8 +440,10 @@ describe("createFieldClassProperty", () => {
     "%s",
     (name, field, optional, entityIdToName, isInput, expected) => {
       expect(
-        createFieldClassProperty(field, optional, entityIdToName, isInput)
-      ).toEqual(expected);
+        print(
+          createFieldClassProperty(field, optional, entityIdToName, isInput)
+        ).code
+      ).toEqual(print(expected).code);
     }
   );
 });

--- a/packages/amplication-data-service-generator/src/resource/dto/create-dto.ts
+++ b/packages/amplication-data-service-generator/src/resource/dto/create-dto.ts
@@ -322,13 +322,13 @@ export function createFieldClassProperty(
     isEnum
   );
   const typeAnnotation = builders.tsTypeAnnotation(type);
-  let definitive = !optional;
   const decorators: namedTypes.Decorator[] = [];
 
   if (prismaField.isList && prismaField.kind === FieldKind.Object) {
-    definitive = false;
     optional = true;
   }
+  const optionalProperty = optional && isInput;
+  const definitive = !optionalProperty;
 
   if (prismaField.kind === FieldKind.Scalar) {
     const id = PRISMA_SCALAR_TO_DECORATOR_ID[prismaField.type];
@@ -376,7 +376,7 @@ export function createFieldClassProperty(
     id,
     typeAnnotation,
     definitive,
-    optional,
+    optionalProperty,
     null,
     decorators
   );

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -242,10 +242,10 @@ export class Customer {
   email!: string;
   @IsString()
   @IsOptional()
-  firstName?: string | null;
+  firstName!: string | null;
   @IsString()
   @IsOptional()
-  lastName?: string | null;
+  lastName!: string | null;
 }
 ",
   "customer/CustomerCreateInput.ts": "import { IsString, IsOptional, ValidateNested } from \\"class-validator\\";


### PR DESCRIPTION
Make DTO fields always definitive to comply with the type returned by the controller.

```diff
class Example {
  @IsString()
  @IsOptional()
-  field?: string | null;
+  field!: string | null;
}
```