### PR TITLE
Data Service Generator: Enable CORS for generated app

### DIFF
--- a/packages/amplication-data-service-generator/src/static/main.ts
+++ b/packages/amplication-data-service-generator/src/static/main.ts
@@ -8,7 +8,7 @@ import { AppModule } from "./app.module";
 const { PORT = 3000 } = process.env;
 
 async function main() {
-  const app = await NestFactory.create(AppModule, {});
+  const app = await NestFactory.create(AppModule, { cors: true });
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -1164,7 +1164,7 @@ import { AppModule } from \\"./app.module\\";
 const { PORT = 3000 } = process.env;
 
 async function main() {
-  const app = await NestFactory.create(AppModule, {});
+  const app = await NestFactory.create(AppModule, { cors: true });
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,


### PR DESCRIPTION
Enable CORS in generated apps by default, later we should allow users to define their own policy.