### PR TITLE
Terraform: Use google_project_service_identity to get cloud build service account

### DIFF
--- a/terraform/modules/apps_env_baseline/main.tf
+++ b/terraform/modules/apps_env_baseline/main.tf
@@ -98,20 +98,21 @@ resource "google_dns_record_set" "cname" {
 
 # IAM
 
-module "default_cloud_build_service_account" {
-  source  = "../../modules/cloud_build_default_service_account"
-  project = var.project
+resource "google_project_service_identity" "cloud_build" {
+  provider = google-beta
+  project  = var.project
+  service  = "cloudbuild.googleapis.com"
 }
 
 resource "google_project_iam_member" "cloud_build_editor" {
   role       = "roles/editor"
-  member     = "serviceAccount:${module.default_cloud_build_service_account.email}"
+  member     = "serviceAccount:${google_project_service_identity.cloud_build.email}"
   depends_on = [google_project_service.cloud_build_api]
 }
 
 resource "google_project_iam_member" "cloud_build_run_admin" {
   role       = "roles/run.admin"
-  member     = "serviceAccount:${module.default_cloud_build_service_account.email}"
+  member     = "serviceAccount:${google_project_service_identity.cloud_build.email}"
   depends_on = [google_project_service.cloud_build_api]
 }
 
@@ -127,14 +128,15 @@ resource "google_project_iam_member" "cloud_run" {
   depends_on = [google_project_service.cloud_run_admin_api]
 }
 
-module "platform_cloud_build_service_account" {
-  source  = "../../modules/cloud_build_default_service_account"
-  project = var.platform_project
+resource "google_project_service_identity" "platform_cloud_build" {
+  provider = google-beta
+  project  = var.platform_project
+  service  = "cloudbuild.googleapis.com"
 }
 
 resource "google_project_iam_member" "platform_cloud_build" {
   role   = "roles/editor"
-  member = "serviceAccount:${module.platform_cloud_build_service_account.email}"
+  member = "serviceAccount:${google_project_service_identity.platform_cloud_build.email}"
 }
 
 # Output

--- a/terraform/modules/cd/main.tf
+++ b/terraform/modules/cd/main.tf
@@ -31,14 +31,15 @@ resource "google_project_service" "iam_api" {
 
 # IAM
 
-module "cloud_build_service_account" {
-  source  = "../../modules/cloud_build_default_service_account"
-  project = var.project
+resource "google_project_service_identity" "cloud_build" {
+  provider = google-beta
+  project  = var.project
+  service  = "cloudbuild.googleapis.com"
 }
 
 resource "google_project_iam_binding" "cloud_build_editor" {
   role    = "roles/editor"
-  members = ["serviceAccount:${module.cloud_build_service_account.email}"]
+  members = ["serviceAccount:${google_project_service_identity.cloud_build.email}"]
 }
 
 # Cloud SQL

--- a/terraform/modules/cloud_build_default_service_account/main.tf
+++ b/terraform/modules/cloud_build_default_service_account/main.tf
@@ -1,7 +1,0 @@
-data "google_project" "project" {
-  project_id = var.project
-}
-
-output "email" {
-  value = "${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
-}

--- a/terraform/modules/cloud_build_default_service_account/variables.tf
+++ b/terraform/modules/cloud_build_default_service_account/variables.tf
@@ -1,3 +1,0 @@
-variable "project" {
-  type = string
-}

--- a/terraform/modules/env_baseline/main.tf
+++ b/terraform/modules/env_baseline/main.tf
@@ -131,15 +131,16 @@ resource "google_storage_bucket" "artifacts" {
   force_destroy = true
 }
 
-module "apps_cloud_build_service_account" {
-  source  = "../../modules/cloud_build_default_service_account"
-  project = var.apps_project
+resource "google_project_service_identity" "apps_cloud_build" {
+  provider = google-beta
+  project  = var.apps_project
+  service  = "cloudbuild.googleapis.com"
 }
 
 resource "google_storage_bucket_iam_member" "apps" {
   bucket = google_storage_bucket.artifacts.name
   role   = "roles/storage.admin"
-  member = "serviceAccount:${module.apps_cloud_build_service_account.email}"
+  member = "serviceAccount:${google_project_service_identity.apps_cloud_build.email}"
 }
 
 # Cloud Run

--- a/terraform/modules/manual_deploy/main.tf
+++ b/terraform/modules/manual_deploy/main.tf
@@ -31,15 +31,16 @@ resource "google_project_service" "secret_manager_api" {
 
 # IAM
 
-module "cloud_build_service_account" {
-  source  = "../../modules/cloud_build_default_service_account"
-  project = var.project
+resource "google_project_service_identity" "cloud_build" {
+  provider = google-beta
+  project  = var.project
+  service  = "cloudbuild.googleapis.com"
 }
 
-// resource "google_project_iam_binding" "cloud_build_editor" {
-//   role    = "roles/editor"
-//   members = ["serviceAccount:${module.cloud_build_service_account.email}"]
-// }
+resource "google_project_iam_binding" "cloud_build_editor" {
+  role    = "roles/editor"
+  members = ["serviceAccount:${google_project_service_identity.cloud_build.email}"]
+}
 
 # Cloud SQL
 
@@ -60,7 +61,7 @@ resource "google_sql_user" "database_user" {
 resource "google_secret_manager_secret_iam_member" "secret_iam_member" {
   secret_id = var.github_client_secret_id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${module.cloud_build_service_account.email}"
+  member    = "serviceAccount:${google_project_service_identity.cloud_build.email}"
 }
 
 # Cloud Build


### PR DESCRIPTION
Replace our `cloud_build_default_service_account` Terraform module with Terraform's recommended `google_project_service_identity` to obtain Cloud Build service account.
See: https://github.com/hashicorp/terraform-provider-google/issues/7522