### PR TITLE
DSG: Remove option to not create admin

### DIFF
--- a/packages/amplication-data-service-generator/src/create-data-service.ts
+++ b/packages/amplication-data-service-generator/src/create-data-service.ts
@@ -19,7 +19,6 @@ export async function createDataService(
   entities: Entity[],
   roles: Role[],
   appInfo: AppInfo,
-  createAdmin = true,
   logger: winston.Logger = defaultLogger
 ): Promise<Module[]> {
   logger.info("Creating application...");
@@ -33,35 +32,29 @@ export async function createDataService(
   const dtos = createDTOs(normalizedEntities, entityIdToName);
 
   logger.info("Copying static modules...");
-  const staticModulesPromise = readStaticModules(
-    STATIC_DIRECTORY,
-    BASE_DIRECTORY
-  );
 
-  const serverModulesPromise = createServerModules(
-    normalizedEntities,
-    roles,
-    appInfo,
-    entityIdToName,
-    dtos,
-    userEntity,
-    logger
-  );
-  const modulePromises = createAdmin
-    ? [
-        staticModulesPromise,
-        serverModulesPromise,
-        createAdminModules(
-          normalizedEntities,
-          roles,
-          appInfo,
-          dtos,
-          entityIdToName,
-          logger
-        ),
-      ]
-    : [staticModulesPromise, serverModulesPromise];
-  const modules = (await Promise.all(modulePromises)).flat();
+  const modules = (
+    await Promise.all([
+      readStaticModules(STATIC_DIRECTORY, BASE_DIRECTORY),
+      createServerModules(
+        normalizedEntities,
+        roles,
+        appInfo,
+        entityIdToName,
+        dtos,
+        userEntity,
+        logger
+      ),
+      createAdminModules(
+        normalizedEntities,
+        roles,
+        appInfo,
+        dtos,
+        entityIdToName,
+        logger
+      ),
+    ])
+  ).flat();
 
   timer.done({ message: "Application creation time" });
 

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -362,7 +362,6 @@ export class BuildService {
             description: app.description,
             version: build.version
           },
-          false,
           dataServiceGeneratorLogger
         );
 


### PR DESCRIPTION
For testing purposes the create admin was disabled when called from the server. This PR removes this behaviour.