### PR TITLE
DSG: Disable npm install extra features

### DIFF
--- a/packages/amplication-data-service-generator/Dockerfile
+++ b/packages/amplication-data-service-generator/Dockerfile
@@ -4,6 +4,10 @@ FROM node
 
 # Hide Open Collective message from install logs
 ENV OPENCOLLECTIVE_HIDE=1
+# Hiden NPM security message from install logs
+ENV NPM_CONFIG_AUDIT=false
+# Hide NPM funding message from install logs
+ENV NPM_CONFIG_FUND=false
 
 # Set the working direcotry
 WORKDIR /app

--- a/packages/amplication-data-service-generator/src/static/Dockerfile
+++ b/packages/amplication-data-service-generator/src/static/Dockerfile
@@ -5,6 +5,10 @@ FROM $IMAGE
 
 # Hide Open Collective message from install logs
 ENV OPENCOLLECTIVE_HIDE=1
+# Hiden NPM security message from install logs
+ENV NPM_CONFIG_AUDIT=false
+# Hide NPM funding message from install logs
+ENV NPM_CONFIG_FUND=false
 
 # Set the working direcotry
 WORKDIR /app

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -26,6 +26,10 @@ FROM $IMAGE
 
 # Hide Open Collective message from install logs
 ENV OPENCOLLECTIVE_HIDE=1
+# Hiden NPM security message from install logs
+ENV NPM_CONFIG_AUDIT=false
+# Hide NPM funding message from install logs
+ENV NPM_CONFIG_FUND=false
 
 # Set the working direcotry
 WORKDIR /app


### PR DESCRIPTION
Disable npm install audit and funding options to reduce the installation time and logs emitted when building Docker containers