### PR TITLE
changed button url to purple

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Please note that Amplication is currently in alpha version. <b>This means that a
 
 You can ask questions, and participate in discussions about Amplication-related topics in the `Amplication` Discord channel.
 
-<a href="https://discord.gg/b8MrjU6"><img src="https://amplication.com/assets/images/discord_banner.png" /></a>
+<a href="https://discord.gg/b8MrjU6"><img src="https://amplication.com/assets/images/discord_banner_purple.svg" /></a>
 
 ### Create a bug report
 


### PR DESCRIPTION
Readme page has white "join Discord" button which doesn't look good on dark mode. URL points to a new asset. 
Approve site repo first