### PR TITLE
gcp machine type

### DIFF
--- a/packages/amplication-container-builder/src/cloud-build/config.spec.ts
+++ b/packages/amplication-container-builder/src/cloud-build/config.spec.ts
@@ -51,6 +51,9 @@ describe("createConfig", () => {
           object: EXAMPLE_OBJECT,
         },
       },
+      options: {
+        machineType: "N1_HIGHCPU_8",
+      },
       tags: createBuildTags(EXAMPLE_TAGS),
     });
   });
@@ -69,6 +72,9 @@ describe("createConfig", () => {
           bucket: EXAMPLE_BUCKET,
           object: EXAMPLE_OBJECT,
         },
+      },
+      options: {
+        machineType: "N1_HIGHCPU_8",
       },
       tags: createBuildTags(EXAMPLE_TAGS),
     });

--- a/packages/amplication-container-builder/src/cloud-build/config.ts
+++ b/packages/amplication-container-builder/src/cloud-build/config.ts
@@ -25,6 +25,9 @@ export function createConfig(
         object,
       },
     },
+    options: {
+      machineType: "N1_HIGHCPU_8",
+    },
     tags: createBuildTags(request.tags),
   };
 }

--- a/packages/amplication-deployer/src/gcp/config.spec.ts
+++ b/packages/amplication-deployer/src/gcp/config.spec.ts
@@ -35,6 +35,9 @@ describe("createConfig", () => {
           object: EXAMPLE_ARCHIVE_NAME,
         },
       },
+      options: {
+        machineType: "N1_HIGHCPU_8",
+      },
       tags: DEFAULT_TAGS,
     });
   });

--- a/packages/amplication-deployer/src/gcp/config.ts
+++ b/packages/amplication-deployer/src/gcp/config.ts
@@ -39,6 +39,9 @@ export function createConfig(
         object: archiveFileName,
       },
     },
+    options: {
+      machineType: "N1_HIGHCPU_8",
+    },
     // Tags format: ^[\w][\w.-]{0,127}$
     tags: [
       ...DEFAULT_TAGS,


### PR DESCRIPTION
Temp fix to resolve current high load on GCP Build service
This value should be moved to an external param 
We should look for another platform to execute build as each Google Cloud project is granted quota to run ten builds at a time
https://cloud.google.com/cloud-build/quotas
