### PR TITLE
Code generation with base classes (RFC #1224)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/amplication-data-service-generator/src/admin/static/",
     "packages/amplication-data-service-generator/src/server/static/"
   ],
-  "version": "0.2.0"
+  "version": "0.4.0"
 }

--- a/packages/amplication-client/package-lock.json
+++ b/packages/amplication-client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@amplication/client",
-	"version": "0.2.0",
+	"version": "0.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/amplication-client/package.json
+++ b/packages/amplication-client/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@amplication/client",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "private": true,
   "dependencies": {
-    "@amplication/data": "^0.2.0",
-    "@amplication/design-system": "^0.2.0",
+    "@amplication/data": "^0.4.0",
+    "@amplication/design-system": "^0.4.0",
     "@apollo/client": "^3.2.5",
     "@extra-set/difference": "^2.2.3",
     "@primer/components": "^19.1.1",

--- a/packages/amplication-client/src/VersionControl/Commit.tsx
+++ b/packages/amplication-client/src/VersionControl/Commit.tsx
@@ -10,6 +10,7 @@ import { GET_LAST_COMMIT } from "./LastCommit";
 import { TextField } from "@amplication/design-system";
 import { CROSS_OS_CTRL_ENTER } from "../util/hotkeys";
 import { Button, EnumButtonStyle } from "../Components/Button";
+import CommitValidation from "./CommitValidation";
 import "./Commit.scss";
 
 type TCommit = {
@@ -76,9 +77,7 @@ const Commit = ({ applicationId, disabled }: Props) => {
 
   return (
     <div className={CLASS_NAME}>
-      {/* {loading ? (
-        <CircularProgress />
-      ) : ( */}
+      <CommitValidation applicationId={applicationId} />
       <Formik
         initialValues={INITIAL_VALUES}
         onSubmit={handleSubmit}
@@ -91,7 +90,9 @@ const Commit = ({ applicationId, disabled }: Props) => {
 
           return (
             <Form>
-              <GlobalHotKeys keyMap={keyMap} handlers={handlers} />
+              {!disabled && (
+                <GlobalHotKeys keyMap={keyMap} handlers={handlers} />
+              )}
               <TextField
                 rows={3}
                 textarea
@@ -117,7 +118,7 @@ const Commit = ({ applicationId, disabled }: Props) => {
           );
         }}
       </Formik>
-      {/* )} */}
+
       <Snackbar open={Boolean(error)} message={errorMessage} />
     </div>
   );

--- a/packages/amplication-client/src/VersionControl/CommitValidation.scss
+++ b/packages/amplication-client/src/VersionControl/CommitValidation.scss
@@ -1,0 +1,20 @@
+@import "../style/index.scss";
+
+.commit-validation {
+  &__item {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+
+    .amp-icon {
+      color: var(--negative-light);
+      margin-right: var(--default-spacing);
+    }
+
+    a {
+      display: block;
+      color: var(--black100);
+    }
+    color: var(--black90);
+  }
+}

--- a/packages/amplication-client/src/VersionControl/CommitValidation.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitValidation.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect } from "react";
+import { gql, useQuery } from "@apollo/client";
+import { Icon } from "@rmwc/icon";
+import { formatError } from "../util/error";
+import * as models from "../models";
+import "./CommitValidation.scss";
+
+type Props = {
+  applicationId: string;
+};
+const CLASS_NAME = "commit-validation";
+
+type TData = {
+  appValidateBeforeCommit: models.AppValidationResult;
+};
+
+const VALIDATION_MESSAGES_TO_TEXT: {
+  [key in models.AppValidationErrorTypes]: {
+    message: string;
+    url: string | null;
+  };
+} = {
+  [models.AppValidationErrorTypes.CannotMergeCodeToGitHubBreakingChanges]: {
+    message:
+      "The code in the linked GitHub repo was generated with a previous version of Amplication. The current version includes breaking changes that may cause conflicts when merged with code generated with previous versions.",
+    url: "https://docs.amplication.com/docs/errors/merge-conflict",
+  },
+  [models.AppValidationErrorTypes.DataServiceGeneratorVersionInvalid]: {
+    message:
+      "Invalid code generation version ID was found in the linked GitHub repo.",
+    url:
+      "https://docs.amplication.com/docs/errors/invalid-code-generation-version",
+  },
+  [models.AppValidationErrorTypes.DataServiceGeneratorVersionMissing]: {
+    message:
+      "Could not find code generation version ID in the linked GitHub repo.",
+    url:
+      "https://docs.amplication.com/docs/errors/missing-code-generation-version",
+  },
+  [models.AppValidationErrorTypes.CannotMergeCodeToGitHubInvalidAppId]: {
+    message:
+      "The code in the linked GitHub repo was generated from a different app. It may cause conflicts when merged with code generated from the current app.",
+    url: "https://docs.amplication.com/docs/errors/github-different-app-id",
+  },
+};
+const POLL_INTERVAL = 30000;
+
+const CommitValidation = ({ applicationId }: Props) => {
+  const { data, error, startPolling, stopPolling } = useQuery<TData>(
+    APP_VALIDATE_BEFORE_COMMIT,
+    {
+      onCompleted: (data) => {
+        //Start polling if status is invalid
+        if (!data.appValidateBeforeCommit.isValid) {
+          startPolling(POLL_INTERVAL);
+        }
+      },
+      variables: {
+        appId: applicationId,
+      },
+    }
+  );
+
+  //stop polling in case the status is value
+  useEffect(() => {
+    if (data?.appValidateBeforeCommit.isValid) {
+      stopPolling();
+    } else {
+      startPolling(POLL_INTERVAL);
+    }
+  }, [data, stopPolling, startPolling]);
+
+  const errorMessage = formatError(error);
+
+  return (
+    <div className={CLASS_NAME}>
+      {data?.appValidateBeforeCommit.messages.map((message) => {
+        const errorData = VALIDATION_MESSAGES_TO_TEXT[message];
+
+        return (
+          <div className={`${CLASS_NAME}__item`}>
+            <Icon icon="info_circle" />
+            <div>
+              {errorData.message}
+              {errorData.url && (
+                <a target="learn-more" href={errorData.url}>
+                  Learn more
+                </a>
+              )}
+            </div>
+          </div>
+        );
+      })}
+      {errorMessage && (
+        <div className={`${CLASS_NAME}__item`}>
+          <Icon icon="info_circle" />
+          <div> {errorMessage}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CommitValidation;
+
+export const APP_VALIDATE_BEFORE_COMMIT = gql`
+  query appValidateBeforeCommit($appId: String!) {
+    appValidateBeforeCommit(where: { id: $appId }) {
+      isValid
+      messages
+    }
+  }
+`;

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -156,6 +156,19 @@ export type AppUpdateInput = {
   color?: Maybe<Scalars["String"]>;
 };
 
+export enum AppValidationErrorTypes {
+  CannotMergeCodeToGitHubBreakingChanges = "CannotMergeCodeToGitHubBreakingChanges",
+  CannotMergeCodeToGitHubInvalidAppId = "CannotMergeCodeToGitHubInvalidAppId",
+  DataServiceGeneratorVersionMissing = "DataServiceGeneratorVersionMissing",
+  DataServiceGeneratorVersionInvalid = "DataServiceGeneratorVersionInvalid",
+}
+
+export type AppValidationResult = {
+  __typename?: "AppValidationResult";
+  isValid: Scalars["Boolean"];
+  messages: Array<AppValidationErrorTypes>;
+};
+
 export type AppWhereInput = {
   id?: Maybe<Scalars["String"]>;
   createdAt?: Maybe<DateTimeFilter>;
@@ -1086,6 +1099,7 @@ export type Mutation = {
   createEntityFieldByDisplayName: EntityField;
   deleteEntityField: EntityField;
   updateEntityField: EntityField;
+  createDefaultRelatedField: EntityField;
   createAppRole: AppRole;
   deleteAppRole?: Maybe<AppRole>;
   updateAppRole?: Maybe<AppRole>;
@@ -1185,6 +1199,12 @@ export type MutationDeleteEntityFieldArgs = {
 
 export type MutationUpdateEntityFieldArgs = {
   data: EntityFieldUpdateInput;
+  where: WhereUniqueInput;
+  relatedFieldName?: Maybe<Scalars["String"]>;
+  relatedFieldDisplayName?: Maybe<Scalars["String"]>;
+};
+
+export type MutationCreateDefaultRelatedFieldArgs = {
   where: WhereUniqueInput;
   relatedFieldName?: Maybe<Scalars["String"]>;
   relatedFieldDisplayName?: Maybe<Scalars["String"]>;
@@ -1379,6 +1399,7 @@ export type Query = {
   apps: Array<App>;
   pendingChanges: Array<PendingChange>;
   appAvailableGithubRepos: Array<GithubRepo>;
+  appValidateBeforeCommit: AppValidationResult;
   commit?: Maybe<Commit>;
   commits?: Maybe<Array<Commit>>;
   me: User;
@@ -1462,6 +1483,10 @@ export type QueryPendingChangesArgs = {
 
 export type QueryAppAvailableGithubReposArgs = {
   where: AvailableGithubReposFindInput;
+};
+
+export type QueryAppValidateBeforeCommitArgs = {
+  where: WhereUniqueInput;
 };
 
 export type QueryCommitArgs = {

--- a/packages/amplication-container-builder/package-lock.json
+++ b/packages/amplication-container-builder/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@amplication/container-builder",
-	"version": "0.2.0",
+	"version": "0.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/amplication-container-builder/package.json
+++ b/packages/amplication-container-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/container-builder",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "Multi-provider library for building Docker containers",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/amplication-data-service-generator/package-lock.json
+++ b/packages/amplication-data-service-generator/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@amplication/data-service-generator",
-	"version": "0.2.0",
+	"version": "0.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/amplication-data-service-generator/package.json
+++ b/packages/amplication-data-service-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/data-service-generator",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "private": true,
   "main": "./dist/index.js",
   "scripts": {
@@ -18,8 +18,8 @@
     "update-test-data-service-snapshot": "jest -u src/tests/create-data-service.spec.ts"
   },
   "dependencies": {
-    "@amplication/data": "^0.2.0",
-    "@amplication/design-system": "^0.2.0",
+    "@amplication/data": "^0.4.0",
+    "@amplication/design-system": "^0.4.0",
     "@babel/parser": "^7.12.11",
     "@extra-set/difference": "^2.2.3",
     "@nestjs/common": "^7.2.0",

--- a/packages/amplication-data-service-generator/package.json
+++ b/packages/amplication-data-service-generator/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "main": "./dist/index.js",
   "scripts": {
-    "build": "run-s build:compile build:copy-files",
+    "build": "run-s build:update-version build:compile build:copy-files",
     "build:compile": "tsc",
     "build:copy-files": "ts-node scripts/copy-files.ts",
+    "build:update-version": "ts-node scripts/update-version.ts",
     "check-format": "prettier --check .",
     "format": "prettier --write .",
     "lint": "eslint --cache .",

--- a/packages/amplication-data-service-generator/scripts/update-version.ts
+++ b/packages/amplication-data-service-generator/scripts/update-version.ts
@@ -1,0 +1,33 @@
+import path from "path";
+import colors from "colors/safe";
+import fs from "fs";
+import { version } from "../package.json";
+
+if (require.main === module) {
+  void updateVersion().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+async function updateVersion(): Promise<void> {
+  console.log(colors.green("\nUpdate package version data"));
+
+  const versionFilePath = path.join(__dirname + "/../src/version.ts");
+
+  const src = `export const version = '${version}';`;
+
+  // ensure version module pulls value from package.json
+  fs.writeFile(versionFilePath, src, { flag: "w" }, function (error) {
+    console.error(error);
+  });
+
+  console.log(
+    colors.green(`Updating application version ${colors.yellow(version)}`)
+  );
+  console.log(
+    `${colors.green("Writing version module to ")}${colors.yellow(
+      versionFilePath
+    )}\n`
+  );
+}

--- a/packages/amplication-data-service-generator/scripts/update-version.ts
+++ b/packages/amplication-data-service-generator/scripts/update-version.ts
@@ -2,6 +2,7 @@ import path from "path";
 import colors from "colors/safe";
 import fs from "fs";
 import { version } from "../package.json";
+import * as prettier from "prettier";
 
 if (require.main === module) {
   void updateVersion().catch((error) => {
@@ -15,9 +16,10 @@ async function updateVersion(): Promise<void> {
 
   const versionFilePath = path.join(__dirname + "/../src/version.ts");
 
-  const src = `export const version = '${version}';`;
+  const src = prettier.format(`export const version = '${version}';`, {
+    parser: "typescript",
+  });
 
-  // ensure version module pulls value from package.json
   fs.writeFile(versionFilePath, src, { flag: "w" }, function (error) {
     console.error(error);
   });

--- a/packages/amplication-data-service-generator/src/admin/static/package-lock.json
+++ b/packages/amplication-data-service-generator/src/admin/static/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "admin-template",
-	"version": "0.2.0",
+	"version": "0.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/amplication-data-service-generator/src/admin/static/package.json
+++ b/packages/amplication-data-service-generator/src/admin/static/package.json
@@ -1,9 +1,9 @@
 {
   "name": "admin-template",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "private": true,
   "dependencies": {
-    "@amplication/design-system": "^0.2.0",
+    "@amplication/design-system": "^0.4.0",
     "@primer/components": "^20.3.0",
     "@rmwc/provider": "^6.1.4",
     "@testing-library/jest-dom": "^5.11.4",

--- a/packages/amplication-data-service-generator/src/create-data-service-impl.ts
+++ b/packages/amplication-data-service-generator/src/create-data-service-impl.ts
@@ -16,6 +16,7 @@ import {
 import { createUserEntityIfNotExist } from "./server/user-entity";
 import { createAdminModules } from "./admin/create-admin";
 import { createServerModules } from "./server/create-server";
+import { createRootModules } from "./create-root-modules";
 import { readStaticModules } from "./read-static-modules";
 import { types } from "@amplication/data";
 
@@ -53,6 +54,7 @@ export async function createDataServiceImpl(
         logger
       ),
       createAdminModules(normalizedEntities, roles, appInfo, dtos, logger),
+      createRootModules(logger),
     ])
   ).flat();
 

--- a/packages/amplication-data-service-generator/src/create-data-service-impl.ts
+++ b/packages/amplication-data-service-generator/src/create-data-service-impl.ts
@@ -54,7 +54,7 @@ export async function createDataServiceImpl(
         logger
       ),
       createAdminModules(normalizedEntities, roles, appInfo, dtos, logger),
-      createRootModules(logger),
+      createRootModules(appInfo, logger),
     ])
   ).flat();
 

--- a/packages/amplication-data-service-generator/src/create-root-modules.ts
+++ b/packages/amplication-data-service-generator/src/create-root-modules.ts
@@ -1,10 +1,9 @@
 import winston from "winston";
-import { Module } from "./types";
+import { Module, AppGenerationConfig } from "./types";
 import { version } from "./version";
 import { formatJson } from "./util/module";
 
 const AMP_CONFIG_FILE_NAME = "ampconfig.json";
-const AMP_CONFIG_DSG_VERSION_PARAM = "data-service-generator-version";
 
 export async function createRootModules(
   logger: winston.Logger
@@ -16,12 +15,15 @@ async function createAmplicationConfigurationFile(
   logger: winston.Logger
 ): Promise<Module[]> {
   logger.info(`Creating Amplication configuration file ${version}...`);
+
+  const config: AppGenerationConfig = {
+    dataServiceGeneratorVersion: version,
+  };
+
   return [
     {
       path: `${AMP_CONFIG_FILE_NAME}`,
-      code: formatJson(`{
-      "${AMP_CONFIG_DSG_VERSION_PARAM}": "${version}"
-    }`),
+      code: formatJson(JSON.stringify(config)),
     },
   ];
 }

--- a/packages/amplication-data-service-generator/src/create-root-modules.ts
+++ b/packages/amplication-data-service-generator/src/create-root-modules.ts
@@ -1,0 +1,27 @@
+import winston from "winston";
+import { Module } from "./types";
+import { version } from "./version";
+import { formatJson } from "./util/module";
+
+const AMP_CONFIG_FILE_NAME = "ampconfig.json";
+const AMP_CONFIG_DSG_VERSION_PARAM = "data-service-generator-version";
+
+export async function createRootModules(
+  logger: winston.Logger
+): Promise<Module[]> {
+  return createAmplicationConfigurationFile(logger);
+}
+
+async function createAmplicationConfigurationFile(
+  logger: winston.Logger
+): Promise<Module[]> {
+  logger.info(`Creating Amplication configuration file ${version}...`);
+  return [
+    {
+      path: `${AMP_CONFIG_FILE_NAME}`,
+      code: formatJson(`{
+      "${AMP_CONFIG_DSG_VERSION_PARAM}": "${version}"
+    }`),
+    },
+  ];
+}

--- a/packages/amplication-data-service-generator/src/create-root-modules.ts
+++ b/packages/amplication-data-service-generator/src/create-root-modules.ts
@@ -1,23 +1,26 @@
 import winston from "winston";
-import { Module, AppGenerationConfig } from "./types";
+import { Module, AppGenerationConfig, AppInfo } from "./types";
 import { version } from "./version";
 import { formatJson } from "./util/module";
 
 const AMP_CONFIG_FILE_NAME = "ampconfig.json";
 
 export async function createRootModules(
+  appInfo: AppInfo,
   logger: winston.Logger
 ): Promise<Module[]> {
-  return createAmplicationConfigurationFile(logger);
+  return createAmplicationConfigurationFile(appInfo, logger);
 }
 
 async function createAmplicationConfigurationFile(
+  appInfo: AppInfo,
   logger: winston.Logger
 ): Promise<Module[]> {
   logger.info(`Creating Amplication configuration file ${version}...`);
 
   const config: AppGenerationConfig = {
     dataServiceGeneratorVersion: version,
+    appInfo,
   };
 
   return [

--- a/packages/amplication-data-service-generator/src/models.ts
+++ b/packages/amplication-data-service-generator/src/models.ts
@@ -156,6 +156,19 @@ export type AppUpdateInput = {
   color?: Maybe<Scalars["String"]>;
 };
 
+export enum AppValidationErrorTypes {
+  CannotMergeCodeToGitHubBreakingChanges = "CannotMergeCodeToGitHubBreakingChanges",
+  CannotMergeCodeToGitHubInvalidAppId = "CannotMergeCodeToGitHubInvalidAppId",
+  DataServiceGeneratorVersionMissing = "DataServiceGeneratorVersionMissing",
+  DataServiceGeneratorVersionInvalid = "DataServiceGeneratorVersionInvalid",
+}
+
+export type AppValidationResult = {
+  __typename?: "AppValidationResult";
+  isValid: Scalars["Boolean"];
+  messages: Array<AppValidationErrorTypes>;
+};
+
 export type AppWhereInput = {
   id?: Maybe<Scalars["String"]>;
   createdAt?: Maybe<DateTimeFilter>;
@@ -1086,6 +1099,7 @@ export type Mutation = {
   createEntityFieldByDisplayName: EntityField;
   deleteEntityField: EntityField;
   updateEntityField: EntityField;
+  createDefaultRelatedField: EntityField;
   createAppRole: AppRole;
   deleteAppRole?: Maybe<AppRole>;
   updateAppRole?: Maybe<AppRole>;
@@ -1185,6 +1199,12 @@ export type MutationDeleteEntityFieldArgs = {
 
 export type MutationUpdateEntityFieldArgs = {
   data: EntityFieldUpdateInput;
+  where: WhereUniqueInput;
+  relatedFieldName?: Maybe<Scalars["String"]>;
+  relatedFieldDisplayName?: Maybe<Scalars["String"]>;
+};
+
+export type MutationCreateDefaultRelatedFieldArgs = {
   where: WhereUniqueInput;
   relatedFieldName?: Maybe<Scalars["String"]>;
   relatedFieldDisplayName?: Maybe<Scalars["String"]>;
@@ -1379,6 +1399,7 @@ export type Query = {
   apps: Array<App>;
   pendingChanges: Array<PendingChange>;
   appAvailableGithubRepos: Array<GithubRepo>;
+  appValidateBeforeCommit: AppValidationResult;
   commit?: Maybe<Commit>;
   commits?: Maybe<Array<Commit>>;
   me: User;
@@ -1462,6 +1483,10 @@ export type QueryPendingChangesArgs = {
 
 export type QueryAppAvailableGithubReposArgs = {
   where: AvailableGithubReposFindInput;
+};
+
+export type QueryAppValidateBeforeCommitArgs = {
+  where: WhereUniqueInput;
 };
 
 export type QueryCommitArgs = {

--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
@@ -195,6 +195,7 @@ export class CONTROLLER_BASE {
       );
     }
     try {
+      // @ts-ignore
       return await this.service.update({
         ...query,
         where: params,

--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
@@ -1,0 +1,244 @@
+import * as common from "@nestjs/common";
+import * as swagger from "@nestjs/swagger";
+import * as nestMorgan from "nest-morgan";
+import * as nestAccessControl from "nest-access-control";
+// @ts-ignore
+import * as basicAuthGuard from "../auth/basicAuth.guard";
+// @ts-ignore
+import * as abacUtil from "../auth/abac.util";
+// @ts-ignore
+import { isRecordNotFoundError } from "../prisma.util";
+// @ts-ignore
+import * as errors from "../errors";
+
+declare interface CREATE_QUERY {}
+declare interface UPDATE_QUERY {}
+declare interface DELETE_QUERY {}
+
+declare interface CREATE_INPUT {}
+declare interface WHERE_INPUT {}
+declare interface WHERE_UNIQUE_INPUT {}
+declare interface UPDATE_INPUT {}
+
+declare const FINE_ONE_PATH: string;
+declare const UPDATE_PATH: string;
+declare const DELETE_PATH: string;
+declare interface FIND_ONE_QUERY {}
+
+declare class ENTITY {}
+declare interface Select {}
+
+declare interface SERVICE {
+  create(args: { data: CREATE_INPUT; select: Select }): Promise<ENTITY>;
+  findMany(args: { where: WHERE_INPUT; select: Select }): Promise<ENTITY[]>;
+  findOne(args: {
+    where: WHERE_UNIQUE_INPUT;
+    select: Select;
+  }): Promise<ENTITY | null>;
+  update(args: {
+    where: WHERE_UNIQUE_INPUT;
+    data: UPDATE_INPUT;
+    select: Select;
+  }): Promise<ENTITY>;
+  delete(args: { where: WHERE_UNIQUE_INPUT; select: Select }): Promise<ENTITY>;
+}
+
+declare const RESOURCE: string;
+declare const ENTITY_NAME: string;
+declare const CREATE_DATA_MAPPING: CREATE_INPUT;
+declare const UPDATE_DATA_MAPPING: UPDATE_INPUT;
+declare const SELECT: Select;
+
+export class CONTROLLER_BASE {
+  constructor(
+    protected readonly service: SERVICE,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {}
+
+  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
+  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.Post()
+  @nestAccessControl.UseRoles({
+    resource: ENTITY_NAME,
+    action: "create",
+    possession: "any",
+  })
+  @swagger.ApiCreatedResponse({ type: ENTITY })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async create(
+    @common.Query() query: CREATE_QUERY,
+    @common.Body() data: CREATE_INPUT,
+    @nestAccessControl.UserRoles() userRoles: string[]
+  ): Promise<ENTITY> {
+    const permission = this.rolesBuilder.permission({
+      role: userRoles,
+      action: "create",
+      possession: "any",
+      resource: ENTITY_NAME,
+    });
+    const invalidAttributes = abacUtil.getInvalidAttributes(permission, data);
+    if (invalidAttributes.length) {
+      const properties = invalidAttributes
+        .map((attribute: string) => JSON.stringify(attribute))
+        .join(", ");
+      const roles = userRoles
+        .map((role: string) => JSON.stringify(role))
+        .join(",");
+      throw new errors.ForbiddenException(
+        `providing the properties: ${properties} on ${ENTITY_NAME} creation is forbidden for roles: ${roles}`
+      );
+    }
+    // @ts-ignore
+    return await this.service.create({
+      ...query,
+      data: CREATE_DATA_MAPPING,
+      select: SELECT,
+    });
+  }
+
+  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
+  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.Get()
+  @nestAccessControl.UseRoles({
+    resource: ENTITY_NAME,
+    action: "read",
+    possession: "any",
+  })
+  @swagger.ApiOkResponse({ type: [ENTITY] })
+  @swagger.ApiForbiddenResponse()
+  async findMany(
+    @common.Query() query: WHERE_INPUT,
+    @nestAccessControl.UserRoles() userRoles: string[]
+  ): Promise<ENTITY[]> {
+    const permission = this.rolesBuilder.permission({
+      role: userRoles,
+      action: "read",
+      possession: "any",
+      resource: ENTITY_NAME,
+    });
+    const results = await this.service.findMany({
+      where: query,
+      select: SELECT,
+    });
+    return results.map((result) => permission.filter(result));
+  }
+
+  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
+  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.Get(FINE_ONE_PATH)
+  @nestAccessControl.UseRoles({
+    resource: ENTITY_NAME,
+    action: "read",
+    possession: "own",
+  })
+  @swagger.ApiOkResponse({ type: ENTITY })
+  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async findOne(
+    @common.Query() query: FIND_ONE_QUERY,
+    @common.Param() params: WHERE_UNIQUE_INPUT,
+    @nestAccessControl.UserRoles() userRoles: string[]
+  ): Promise<ENTITY | null> {
+    const permission = this.rolesBuilder.permission({
+      role: userRoles,
+      action: "read",
+      possession: "own",
+      resource: ENTITY_NAME,
+    });
+    const result = await this.service.findOne({
+      ...query,
+      where: params,
+      select: SELECT,
+    });
+    if (result === null) {
+      throw new errors.NotFoundException(
+        `No resource was found for ${JSON.stringify(params)}`
+      );
+    }
+    return permission.filter(result);
+  }
+
+  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
+  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.Patch(UPDATE_PATH)
+  @nestAccessControl.UseRoles({
+    resource: ENTITY_NAME,
+    action: "update",
+    possession: "any",
+  })
+  @swagger.ApiOkResponse({ type: ENTITY })
+  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async update(
+    @common.Query() query: UPDATE_QUERY,
+    @common.Param() params: WHERE_UNIQUE_INPUT,
+    @common.Body()
+    data: UPDATE_INPUT,
+    @nestAccessControl.UserRoles() userRoles: string[]
+  ): Promise<ENTITY | null> {
+    const permission = this.rolesBuilder.permission({
+      role: userRoles,
+      action: "update",
+      possession: "any",
+      resource: ENTITY_NAME,
+    });
+    const invalidAttributes = abacUtil.getInvalidAttributes(permission, data);
+    if (invalidAttributes.length) {
+      const properties = invalidAttributes
+        .map((attribute: string) => JSON.stringify(attribute))
+        .join(", ");
+      const roles = userRoles
+        .map((role: string) => JSON.stringify(role))
+        .join(",");
+      throw new errors.ForbiddenException(
+        `providing the properties: ${properties} on ${ENTITY_NAME} update is forbidden for roles: ${roles}`
+      );
+    }
+    try {
+      return await this.service.update({
+        ...query,
+        where: params,
+        data: UPDATE_DATA_MAPPING,
+        select: SELECT,
+      });
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new errors.NotFoundException(
+          `No resource was found for ${JSON.stringify(params)}`
+        );
+      }
+      throw error;
+    }
+  }
+
+  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
+  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.Delete(DELETE_PATH)
+  @nestAccessControl.UseRoles({
+    resource: ENTITY_NAME,
+    action: "delete",
+    possession: "any",
+  })
+  @swagger.ApiOkResponse({ type: ENTITY })
+  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async delete(
+    @common.Query() query: DELETE_QUERY,
+    @common.Param() params: WHERE_UNIQUE_INPUT
+  ): Promise<ENTITY | null> {
+    try {
+      return await this.service.delete({
+        ...query,
+        where: params,
+        select: SELECT,
+      });
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new errors.NotFoundException(
+          `No resource was found for ${JSON.stringify(params)}`
+        );
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
@@ -3,13 +3,13 @@ import * as swagger from "@nestjs/swagger";
 import * as nestMorgan from "nest-morgan";
 import * as nestAccessControl from "nest-access-control";
 // @ts-ignore
-import * as basicAuthGuard from "../auth/basicAuth.guard";
+import * as basicAuthGuard from "../../auth/basicAuth.guard";
 // @ts-ignore
-import * as abacUtil from "../auth/abac.util";
+import * as abacUtil from "../../auth/abac.util";
 // @ts-ignore
-import { isRecordNotFoundError } from "../prisma.util";
+import { isRecordNotFoundError } from "../../prisma.util";
 // @ts-ignore
-import * as errors from "../errors";
+import * as errors from "../../errors";
 
 declare interface CREATE_QUERY {}
 declare interface UPDATE_QUERY {}

--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.template.ts
@@ -1,249 +1,26 @@
 import * as common from "@nestjs/common";
 import * as swagger from "@nestjs/swagger";
-import * as nestMorgan from "nest-morgan";
 import * as nestAccessControl from "nest-access-control";
-// @ts-ignore
-import * as basicAuthGuard from "../auth/basicAuth.guard";
-// @ts-ignore
-import * as abacUtil from "../auth/abac.util";
-// @ts-ignore
-import { isRecordNotFoundError } from "../prisma.util";
-// @ts-ignore
-import * as errors from "../errors";
 
-declare interface CREATE_QUERY {}
-declare interface UPDATE_QUERY {}
-declare interface DELETE_QUERY {}
-
-declare interface CREATE_INPUT {}
-declare interface WHERE_INPUT {}
-declare interface WHERE_UNIQUE_INPUT {}
-declare interface UPDATE_INPUT {}
-
-declare const FINE_ONE_PATH: string;
-declare const UPDATE_PATH: string;
-declare const DELETE_PATH: string;
-declare interface FIND_ONE_QUERY {}
-
-declare class ENTITY {}
-declare interface Select {}
-
-declare interface SERVICE {
-  create(args: { data: CREATE_INPUT; select: Select }): Promise<ENTITY>;
-  findMany(args: { where: WHERE_INPUT; select: Select }): Promise<ENTITY[]>;
-  findOne(args: {
-    where: WHERE_UNIQUE_INPUT;
-    select: Select;
-  }): Promise<ENTITY | null>;
-  update(args: {
-    where: WHERE_UNIQUE_INPUT;
-    data: UPDATE_INPUT;
-    select: Select;
-  }): Promise<ENTITY>;
-  delete(args: { where: WHERE_UNIQUE_INPUT; select: Select }): Promise<ENTITY>;
-}
+declare interface SERVICE {}
 
 declare const RESOURCE: string;
-declare const ENTITY_NAME: string;
-declare const CREATE_DATA_MAPPING: CREATE_INPUT;
-declare const UPDATE_DATA_MAPPING: UPDATE_INPUT;
-declare const SELECT: Select;
+
+declare class CONTROLLER_BASE {
+  protected readonly service: SERVICE;
+  protected rolesBuilder: nestAccessControl.RolesBuilder;
+  constructor(service: SERVICE, rolesBuilder: nestAccessControl.RolesBuilder);
+}
 
 @swagger.ApiBasicAuth()
 @swagger.ApiTags(RESOURCE)
 @common.Controller(RESOURCE)
-export class CONTROLLER {
+export class CONTROLLER extends CONTROLLER_BASE {
   constructor(
-    private readonly service: SERVICE,
+    protected readonly service: SERVICE,
     @nestAccessControl.InjectRolesBuilder()
-    private readonly rolesBuilder: nestAccessControl.RolesBuilder
-  ) {}
-
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
-  @common.Post()
-  @nestAccessControl.UseRoles({
-    resource: ENTITY_NAME,
-    action: "create",
-    possession: "any",
-  })
-  @swagger.ApiCreatedResponse({ type: ENTITY })
-  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(
-    @common.Query() query: CREATE_QUERY,
-    @common.Body() data: CREATE_INPUT,
-    @nestAccessControl.UserRoles() userRoles: string[]
-  ): Promise<ENTITY> {
-    const permission = this.rolesBuilder.permission({
-      role: userRoles,
-      action: "create",
-      possession: "any",
-      resource: ENTITY_NAME,
-    });
-    const invalidAttributes = abacUtil.getInvalidAttributes(permission, data);
-    if (invalidAttributes.length) {
-      const properties = invalidAttributes
-        .map((attribute: string) => JSON.stringify(attribute))
-        .join(", ");
-      const roles = userRoles
-        .map((role: string) => JSON.stringify(role))
-        .join(",");
-      throw new errors.ForbiddenException(
-        `providing the properties: ${properties} on ${ENTITY_NAME} creation is forbidden for roles: ${roles}`
-      );
-    }
-    // @ts-ignore
-    return await this.service.create({
-      ...query,
-      data: CREATE_DATA_MAPPING,
-      select: SELECT,
-    });
-  }
-
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
-  @common.Get()
-  @nestAccessControl.UseRoles({
-    resource: ENTITY_NAME,
-    action: "read",
-    possession: "any",
-  })
-  @swagger.ApiOkResponse({ type: [ENTITY] })
-  @swagger.ApiForbiddenResponse()
-  async findMany(
-    @common.Query() query: WHERE_INPUT,
-    @nestAccessControl.UserRoles() userRoles: string[]
-  ): Promise<ENTITY[]> {
-    const permission = this.rolesBuilder.permission({
-      role: userRoles,
-      action: "read",
-      possession: "any",
-      resource: ENTITY_NAME,
-    });
-    const results = await this.service.findMany({
-      where: query,
-      select: SELECT,
-    });
-    return results.map((result) => permission.filter(result));
-  }
-
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
-  @common.Get(FINE_ONE_PATH)
-  @nestAccessControl.UseRoles({
-    resource: ENTITY_NAME,
-    action: "read",
-    possession: "own",
-  })
-  @swagger.ApiOkResponse({ type: ENTITY })
-  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
-  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async findOne(
-    @common.Query() query: FIND_ONE_QUERY,
-    @common.Param() params: WHERE_UNIQUE_INPUT,
-    @nestAccessControl.UserRoles() userRoles: string[]
-  ): Promise<ENTITY | null> {
-    const permission = this.rolesBuilder.permission({
-      role: userRoles,
-      action: "read",
-      possession: "own",
-      resource: ENTITY_NAME,
-    });
-    const result = await this.service.findOne({
-      ...query,
-      where: params,
-      select: SELECT,
-    });
-    if (result === null) {
-      throw new errors.NotFoundException(
-        `No resource was found for ${JSON.stringify(params)}`
-      );
-    }
-    return permission.filter(result);
-  }
-
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
-  @common.Patch(UPDATE_PATH)
-  @nestAccessControl.UseRoles({
-    resource: ENTITY_NAME,
-    action: "update",
-    possession: "any",
-  })
-  @swagger.ApiOkResponse({ type: ENTITY })
-  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
-  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async update(
-    @common.Query() query: UPDATE_QUERY,
-    @common.Param() params: WHERE_UNIQUE_INPUT,
-    @common.Body()
-    data: UPDATE_INPUT,
-    @nestAccessControl.UserRoles() userRoles: string[]
-  ): Promise<ENTITY | null> {
-    const permission = this.rolesBuilder.permission({
-      role: userRoles,
-      action: "update",
-      possession: "any",
-      resource: ENTITY_NAME,
-    });
-    const invalidAttributes = abacUtil.getInvalidAttributes(permission, data);
-    if (invalidAttributes.length) {
-      const properties = invalidAttributes
-        .map((attribute: string) => JSON.stringify(attribute))
-        .join(", ");
-      const roles = userRoles
-        .map((role: string) => JSON.stringify(role))
-        .join(",");
-      throw new errors.ForbiddenException(
-        `providing the properties: ${properties} on ${ENTITY_NAME} update is forbidden for roles: ${roles}`
-      );
-    }
-    try {
-      // @ts-ignore
-      return await this.service.update({
-        ...query,
-        where: params,
-        data: UPDATE_DATA_MAPPING,
-        select: SELECT,
-      });
-    } catch (error) {
-      if (isRecordNotFoundError(error)) {
-        throw new errors.NotFoundException(
-          `No resource was found for ${JSON.stringify(params)}`
-        );
-      }
-      throw error;
-    }
-  }
-
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
-  @common.Delete(DELETE_PATH)
-  @nestAccessControl.UseRoles({
-    resource: ENTITY_NAME,
-    action: "delete",
-    possession: "any",
-  })
-  @swagger.ApiOkResponse({ type: ENTITY })
-  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
-  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async delete(
-    @common.Query() query: DELETE_QUERY,
-    @common.Param() params: WHERE_UNIQUE_INPUT
-  ): Promise<ENTITY | null> {
-    try {
-      return await this.service.delete({
-        ...query,
-        where: params,
-        select: SELECT,
-      });
-    } catch (error) {
-      if (isRecordNotFoundError(error)) {
-        throw new errors.NotFoundException(
-          `No resource was found for ${JSON.stringify(params)}`
-        );
-      }
-      throw error;
-    }
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
   }
 }

--- a/packages/amplication-data-service-generator/src/server/resource/controller/create-controller.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/create-controller.ts
@@ -133,7 +133,10 @@ async function createControllerModule(
 
   const serviceImport = importNames(
     [serviceId],
-    relativeImportPath(modulePath, entityServiceModule)
+    relativeImportPath(
+      isBaseClass ? moduleBasePath : modulePath,
+      entityServiceModule
+    )
   );
 
   if (isBaseClass) {
@@ -158,7 +161,7 @@ async function createControllerModule(
     const dtoNameToPath = getDTONameToPath(dtos);
     const dtoImports = importContainedIdentifiers(
       file,
-      getImportableDTOs(modulePath, dtoNameToPath)
+      getImportableDTOs(moduleBasePath, dtoNameToPath)
     );
     addImports(file, [serviceImport, ...dtoImports]);
   }

--- a/packages/amplication-data-service-generator/src/server/resource/controller/create-controller.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/create-controller.ts
@@ -1,5 +1,5 @@
 import { print } from "recast";
-import { builders, namedTypes } from "ast-types";
+import { ASTNode, builders, namedTypes } from "ast-types";
 import { camelCase } from "camel-case";
 import { Entity, EntityLookupField, Module } from "../../../types";
 import { readFile, relativeImportPath } from "../../../util/module";
@@ -29,27 +29,30 @@ const TO_MANY_MIXIN_ID = builders.identifier("Mixin");
 export const DATA_ID = builders.identifier("data");
 
 const controllerTemplatePath = require.resolve("./controller.template.ts");
+const controllerBaseTemplatePath = require.resolve(
+  "./controller.base.template.ts"
+);
 const toManyTemplatePath = require.resolve("./to-many.template.ts");
 
-export async function createControllerModule(
+export async function createControllerModules(
   resource: string,
   entityName: string,
   entityType: string,
   entityServiceModule: string,
   entity: Entity,
   dtos: DTOs
-): Promise<Module> {
-  const modulePath = `${SRC_DIRECTORY}/${entityName}/${entityName}.controller.ts`;
-  const file = await readFile(controllerTemplatePath);
-
-  const serviceId = createServiceId(entityType);
-  const controllerId = createControllerId(entityType);
+): Promise<Module[]> {
   const entityDTOs = dtos[entity.name];
   const entityDTO = entityDTOs.entity;
 
-  interpolate(file, {
+  const controllerId = createControllerId(entityType);
+  const controllerBaseId = createControllerBaseId(entityType);
+  const serviceId = createServiceId(entityType);
+
+  const mapping = {
     RESOURCE: builders.stringLiteral(resource),
     CONTROLLER: controllerId,
+    CONTROLLER_BASE: controllerBaseId,
     SERVICE: serviceId,
     ENTITY: entityDTO.id,
     ENTITY_NAME: builders.stringLiteral(entityType),
@@ -79,38 +82,97 @@ export async function createControllerModule(
     /** @todo replace */
     FIND_ONE_QUERY: builders.tsTypeLiteral([]),
     WHERE_UNIQUE_INPUT: entityDTOs.whereUniqueInput.id,
-  });
+  };
+  return [
+    await createControllerModule(
+      controllerTemplatePath,
+      entityName,
+      entityType,
+      entityServiceModule,
+      entity,
+      dtos,
+      mapping,
+      controllerBaseId,
+      serviceId,
+      false
+    ),
+    await createControllerModule(
+      controllerBaseTemplatePath,
+      entityName,
+      entityType,
+      entityServiceModule,
+      entity,
+      dtos,
+      mapping,
+      controllerBaseId,
+      serviceId,
+      true
+    ),
+  ];
+}
 
-  const classDeclaration = getClassDeclarationById(file, controllerId);
-  const toManyRelationFields = entity.fields.filter(isToManyRelationField);
-  const toManyRelationMethods = (
-    await Promise.all(
-      toManyRelationFields.map((field) =>
-        createToManyRelationMethods(
-          field,
-          entityType,
-          entityDTOs.whereUniqueInput,
-          dtos,
-          serviceId
-        )
-      )
-    )
-  ).flat();
+async function createControllerModule(
+  templatePath: string,
+  entityName: string,
+  entityType: string,
+  entityServiceModule: string,
+  entity: Entity,
+  dtos: DTOs,
+  mapping: { [key: string]: ASTNode | undefined },
+  controllerBaseId: namedTypes.Identifier,
+  serviceId: namedTypes.Identifier,
+  isBaseClass: boolean
+): Promise<Module> {
+  const modulePath = `${SRC_DIRECTORY}/${entityName}/${entityName}.controller.ts`;
+  const moduleBasePath = `${SRC_DIRECTORY}/${entityName}/base/${entityName}.controller.base.ts`;
+  const file = await readFile(templatePath);
 
-  classDeclaration.body.body.push(...toManyRelationMethods);
+  const entityDTOs = dtos[entity.name];
+
+  interpolate(file, mapping);
 
   const serviceImport = importNames(
     [serviceId],
     relativeImportPath(modulePath, entityServiceModule)
   );
 
-  const dtoNameToPath = getDTONameToPath(dtos);
-  const dtoImports = importContainedIdentifiers(
-    file,
-    getImportableDTOs(modulePath, dtoNameToPath)
-  );
+  if (isBaseClass) {
+    const classDeclaration = getClassDeclarationById(file, controllerBaseId);
+    const toManyRelationFields = entity.fields.filter(isToManyRelationField);
+    const toManyRelationMethods = (
+      await Promise.all(
+        toManyRelationFields.map((field) =>
+          createToManyRelationMethods(
+            field,
+            entityType,
+            entityDTOs.whereUniqueInput,
+            dtos,
+            serviceId
+          )
+        )
+      )
+    ).flat();
 
-  addImports(file, [serviceImport, ...dtoImports]);
+    classDeclaration.body.body.push(...toManyRelationMethods);
+
+    const dtoNameToPath = getDTONameToPath(dtos);
+    const dtoImports = importContainedIdentifiers(
+      file,
+      getImportableDTOs(modulePath, dtoNameToPath)
+    );
+    addImports(file, [serviceImport, ...dtoImports]);
+  }
+
+  if (!isBaseClass) {
+    addImports(file, [
+      serviceImport,
+      importNames(
+        [controllerBaseId],
+        relativeImportPath(modulePath, moduleBasePath)
+      ),
+    ]);
+  }
+
   removeImportsTSIgnoreComments(file);
   removeESLintComments(file);
   removeTSVariableDeclares(file);
@@ -118,13 +180,19 @@ export async function createControllerModule(
   removeTSClassDeclares(file);
 
   return {
-    path: modulePath,
+    path: isBaseClass ? moduleBasePath : modulePath,
     code: print(file).code,
   };
 }
 
 export function createControllerId(entityType: string): namedTypes.Identifier {
   return builders.identifier(`${entityType}Controller`);
+}
+
+export function createControllerBaseId(
+  entityType: string
+): namedTypes.Identifier {
+  return builders.identifier(`${entityType}ControllerBase`);
 }
 
 async function createToManyRelationMethods(

--- a/packages/amplication-data-service-generator/src/server/resource/create-resource.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/create-resource.ts
@@ -10,7 +10,7 @@ import { createServiceModules } from "./service/create-service";
 import { createControllerModules } from "./controller/create-controller";
 import { createModule } from "./module/create-module";
 import { createControllerSpecModule } from "./test/create-controller-spec";
-import { createResolverModule } from "./resolver/create-resolver";
+import { createResolverModules } from "./resolver/create-resolver";
 
 export async function createResourcesModules(
   entities: Entity[],
@@ -55,13 +55,15 @@ async function createResourceModules(
   );
 
   const [controllerModule] = controllerModules;
-  const resolverModule = await createResolverModule(
+
+  const resolverModules = await createResolverModules(
     entityName,
     entityType,
     serviceModule.path,
     entity,
     dtos
   );
+  const [resolverModule] = resolverModules;
 
   const resourceModule = await createModule(
     entityName,
@@ -82,7 +84,7 @@ async function createResourceModules(
   return [
     ...serviceModules,
     ...controllerModules,
-    resolverModule,
+    ...resolverModules,
     resourceModule,
     testModule,
   ];

--- a/packages/amplication-data-service-generator/src/server/resource/create-resource.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/create-resource.ts
@@ -8,7 +8,7 @@ import { validateEntityName } from "../../util/entity";
 import { DTOs } from "./create-dtos";
 import { createServiceModules } from "./service/create-service";
 import { createControllerModules } from "./controller/create-controller";
-import { createModule } from "./module/create-module";
+import { createModules } from "./module/create-module";
 import { createControllerSpecModule } from "./test/create-controller-spec";
 import { createResolverModules } from "./resolver/create-resolver";
 
@@ -65,7 +65,7 @@ async function createResourceModules(
   );
   const [resolverModule] = resolverModules;
 
-  const resourceModule = await createModule(
+  const resourceModules = await createModules(
     entityName,
     entityType,
     serviceModule.path,
@@ -85,7 +85,7 @@ async function createResourceModules(
     ...serviceModules,
     ...controllerModules,
     ...resolverModules,
-    resourceModule,
+    ...resourceModules,
     testModule,
   ];
 }

--- a/packages/amplication-data-service-generator/src/server/resource/create-resource.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/create-resource.ts
@@ -6,7 +6,7 @@ import * as winston from "winston";
 import { Entity, Module } from "../../types";
 import { validateEntityName } from "../../util/entity";
 import { DTOs } from "./create-dtos";
-import { createServiceModule } from "./service/create-service";
+import { createServiceModules } from "./service/create-service";
 import { createControllerModule } from "./controller/create-controller";
 import { createModule } from "./module/create-module";
 import { createControllerSpecModule } from "./test/create-controller-spec";
@@ -37,11 +37,13 @@ async function createResourceModules(
   const entityName = camelCase(entityType);
   const resource = paramCase(plural(entityName));
 
-  const serviceModule = await createServiceModule(
+  const serviceModules = await createServiceModules(
     entityName,
     entityType,
     entity
   );
+
+  const [serviceModule] = serviceModules;
 
   const controllerModule = await createControllerModule(
     resource,
@@ -77,7 +79,7 @@ async function createResourceModules(
   );
 
   return [
-    serviceModule,
+    ...serviceModules,
     controllerModule,
     resolverModule,
     resourceModule,

--- a/packages/amplication-data-service-generator/src/server/resource/create-resource.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/create-resource.ts
@@ -7,7 +7,7 @@ import { Entity, Module } from "../../types";
 import { validateEntityName } from "../../util/entity";
 import { DTOs } from "./create-dtos";
 import { createServiceModules } from "./service/create-service";
-import { createControllerModule } from "./controller/create-controller";
+import { createControllerModules } from "./controller/create-controller";
 import { createModule } from "./module/create-module";
 import { createControllerSpecModule } from "./test/create-controller-spec";
 import { createResolverModule } from "./resolver/create-resolver";
@@ -45,7 +45,7 @@ async function createResourceModules(
 
   const [serviceModule] = serviceModules;
 
-  const controllerModule = await createControllerModule(
+  const controllerModules = await createControllerModules(
     resource,
     entityName,
     entityType,
@@ -54,6 +54,7 @@ async function createResourceModules(
     dtos
   );
 
+  const [controllerModule] = controllerModules;
   const resolverModule = await createResolverModule(
     entityName,
     entityType,
@@ -80,7 +81,7 @@ async function createResourceModules(
 
   return [
     ...serviceModules,
-    controllerModule,
+    ...controllerModules,
     resolverModule,
     resourceModule,
     testModule,

--- a/packages/amplication-data-service-generator/src/server/resource/dto/create-dto-module.spec.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/dto/create-dto-module.spec.ts
@@ -92,7 +92,7 @@ describe("createDTOModulePath", () => {
   test("creates path", () => {
     const dtoName = createCreateInputID(EXAMPLE_ENTITY_NAME).name;
     expect(createDTOModulePath(EXAMPLE_ENTITY_NAME_DIRECTORY, dtoName)).toEqual(
-      `${SRC_DIRECTORY}/${EXAMPLE_ENTITY_NAME_DIRECTORY}/${dtoName}.ts`
+      `${SRC_DIRECTORY}/${EXAMPLE_ENTITY_NAME_DIRECTORY}/base/${dtoName}.ts`
     );
   });
 });

--- a/packages/amplication-data-service-generator/src/server/resource/dto/create-dto-module.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/dto/create-dto-module.ts
@@ -108,5 +108,5 @@ export function createDTOModulePath(
   entityDirectory: string,
   dtoName: string
 ): string {
-  return `${SRC_DIRECTORY}/${entityDirectory}/${dtoName}.ts`;
+  return `${SRC_DIRECTORY}/${entityDirectory}/base/${dtoName}.ts`;
 }

--- a/packages/amplication-data-service-generator/src/server/resource/module/module.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/module/module.base.template.ts
@@ -1,0 +1,19 @@
+import { Module, forwardRef } from "@nestjs/common";
+import { MorganModule } from "nest-morgan";
+import { PrismaModule } from "nestjs-prisma";
+// @ts-ignore
+import { ACLModule } from "../../auth/acl.module";
+// @ts-ignore
+import { AuthModule } from "../../auth/auth.module";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+
+  exports: [ACLModule, AuthModule, MorganModule, PrismaModule],
+})
+export class MODULE_BASE {}

--- a/packages/amplication-data-service-generator/src/server/resource/module/module.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/module/module.template.ts
@@ -1,4 +1,4 @@
-import { Module, forwardRef } from "@nestjs/common";
+import { Module } from "@nestjs/common";
 
 declare class CONTROLLER {}
 declare class SERVICE {}

--- a/packages/amplication-data-service-generator/src/server/resource/module/module.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/module/module.template.ts
@@ -1,22 +1,12 @@
 import { Module, forwardRef } from "@nestjs/common";
-import { MorganModule } from "nest-morgan";
-import { PrismaModule } from "nestjs-prisma";
-// @ts-ignore
-import { ACLModule } from "../auth/acl.module";
-// @ts-ignore
-import { AuthModule } from "../auth/auth.module";
 
 declare class CONTROLLER {}
 declare class SERVICE {}
 declare class RESOLVER {}
+declare class MODULE_BASE {}
 
 @Module({
-  imports: [
-    ACLModule,
-    forwardRef(() => AuthModule),
-    MorganModule,
-    PrismaModule,
-  ],
+  imports: [MODULE_BASE],
   controllers: [CONTROLLER],
   providers: [SERVICE, RESOLVER],
   exports: [SERVICE],

--- a/packages/amplication-data-service-generator/src/server/resource/resolver/resolver.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/resolver/resolver.base.template.ts
@@ -1,0 +1,213 @@
+import * as common from "@nestjs/common";
+import * as graphql from "@nestjs/graphql";
+import * as apollo from "apollo-server-express";
+import * as nestAccessControl from "nest-access-control";
+// @ts-ignore
+import * as gqlBasicAuthGuard from "../../auth/gqlBasicAuth.guard";
+// @ts-ignore
+import * as gqlACGuard from "../../auth/gqlAC.guard";
+// @ts-ignore
+import * as gqlUserRoles from "../../auth/gqlUserRoles.decorator";
+// @ts-ignore
+import * as abacUtil from "../../auth/abac.util";
+// @ts-ignore
+import { isRecordNotFoundError } from "../../prisma.util";
+
+declare interface CREATE_INPUT {}
+declare interface WHERE_INPUT {}
+declare interface WHERE_UNIQUE_INPUT {}
+declare interface UPDATE_INPUT {}
+
+declare interface CREATE_ARGS {
+  data: CREATE_INPUT;
+}
+declare interface UPDATE_ARGS {
+  where: WHERE_INPUT;
+  data: UPDATE_INPUT;
+}
+declare interface DELETE_ARGS {
+  where: WHERE_UNIQUE_INPUT;
+}
+declare interface FIND_MANY_ARGS {
+  where: WHERE_INPUT;
+}
+declare interface FIND_ONE_ARGS {
+  where: WHERE_UNIQUE_INPUT;
+}
+
+declare class ENTITY {}
+
+declare const CREATE_DATA_MAPPING: CREATE_INPUT;
+declare const UPDATE_DATA_MAPPING: UPDATE_INPUT;
+
+declare interface SERVICE {
+  create(args: { data: CREATE_INPUT }): Promise<ENTITY>;
+  findMany(args: { where: WHERE_INPUT }): Promise<ENTITY[]>;
+  findOne(args: { where: WHERE_UNIQUE_INPUT }): Promise<ENTITY | null>;
+  update(args: {
+    where: WHERE_UNIQUE_INPUT;
+    data: UPDATE_INPUT;
+  }): Promise<ENTITY>;
+  delete(args: { where: WHERE_UNIQUE_INPUT }): Promise<ENTITY>;
+}
+
+declare const ENTITY_NAME: string;
+
+@graphql.Resolver(() => ENTITY)
+@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+export class RESOLVER_BASE {
+  constructor(
+    protected readonly service: SERVICE,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {}
+
+  @graphql.Query(() => [ENTITY])
+  @nestAccessControl.UseRoles({
+    resource: ENTITY_NAME,
+    action: "read",
+    possession: "any",
+  })
+  async ENTITIES_QUERY(
+    @graphql.Args() args: FIND_MANY_ARGS,
+    @gqlUserRoles.UserRoles() userRoles: string[]
+  ): Promise<ENTITY[]> {
+    const permission = this.rolesBuilder.permission({
+      role: userRoles,
+      action: "read",
+      possession: "any",
+      resource: ENTITY_NAME,
+    });
+    const results = await this.service.findMany(args);
+    return results.map((result) => permission.filter(result));
+  }
+
+  @graphql.Query(() => ENTITY, { nullable: true })
+  @nestAccessControl.UseRoles({
+    resource: ENTITY_NAME,
+    action: "read",
+    possession: "own",
+  })
+  async ENTITY_QUERY(
+    @graphql.Args() args: FIND_ONE_ARGS,
+    @gqlUserRoles.UserRoles() userRoles: string[]
+  ): Promise<ENTITY | null> {
+    const permission = this.rolesBuilder.permission({
+      role: userRoles,
+      action: "read",
+      possession: "own",
+      resource: ENTITY_NAME,
+    });
+    const result = await this.service.findOne(args);
+    if (result === null) {
+      return null;
+    }
+    return permission.filter(result);
+  }
+
+  @graphql.Mutation(() => ENTITY)
+  @nestAccessControl.UseRoles({
+    resource: ENTITY_NAME,
+    action: "create",
+    possession: "any",
+  })
+  async CREATE_MUTATION(
+    @graphql.Args() args: CREATE_ARGS,
+    @gqlUserRoles.UserRoles() userRoles: string[]
+  ): Promise<ENTITY> {
+    const permission = this.rolesBuilder.permission({
+      role: userRoles,
+      action: "create",
+      possession: "any",
+      resource: ENTITY_NAME,
+    });
+    const invalidAttributes = abacUtil.getInvalidAttributes(
+      permission,
+      args.data
+    );
+    if (invalidAttributes.length) {
+      const properties = invalidAttributes
+        .map((attribute: string) => JSON.stringify(attribute))
+        .join(", ");
+      const roles = userRoles
+        .map((role: string) => JSON.stringify(role))
+        .join(",");
+      throw new apollo.ApolloError(
+        `providing the properties: ${properties} on ${ENTITY_NAME} creation is forbidden for roles: ${roles}`
+      );
+    }
+    // @ts-ignore
+    return await this.service.create({
+      ...args,
+      data: CREATE_DATA_MAPPING,
+    });
+  }
+
+  @graphql.Mutation(() => ENTITY)
+  @nestAccessControl.UseRoles({
+    resource: ENTITY_NAME,
+    action: "update",
+    possession: "any",
+  })
+  async UPDATE_MUTATION(
+    @graphql.Args() args: UPDATE_ARGS,
+    @gqlUserRoles.UserRoles() userRoles: string[]
+  ): Promise<ENTITY | null> {
+    const permission = this.rolesBuilder.permission({
+      role: userRoles,
+      action: "update",
+      possession: "any",
+      resource: ENTITY_NAME,
+    });
+    const invalidAttributes = abacUtil.getInvalidAttributes(
+      permission,
+      args.data
+    );
+    if (invalidAttributes.length) {
+      const properties = invalidAttributes
+        .map((attribute: string) => JSON.stringify(attribute))
+        .join(", ");
+      const roles = userRoles
+        .map((role: string) => JSON.stringify(role))
+        .join(",");
+      throw new apollo.ApolloError(
+        `providing the properties: ${properties} on ${ENTITY_NAME} update is forbidden for roles: ${roles}`
+      );
+    }
+    try {
+      // @ts-ignore
+      return await this.service.update({
+        ...args,
+        data: UPDATE_DATA_MAPPING,
+      });
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new apollo.ApolloError(
+          `No resource was found for ${JSON.stringify(args.where)}`
+        );
+      }
+      throw error;
+    }
+  }
+
+  @graphql.Mutation(() => ENTITY)
+  @nestAccessControl.UseRoles({
+    resource: ENTITY_NAME,
+    action: "delete",
+    possession: "any",
+  })
+  async DELETE_MUTATION(
+    @graphql.Args() args: DELETE_ARGS
+  ): Promise<ENTITY | null> {
+    try {
+      // @ts-ignore
+      return await this.service.delete(args);
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new apollo.ApolloError(
+          `No resource was found for ${JSON.stringify(args.where)}`
+        );
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/amplication-data-service-generator/src/server/resource/resolver/resolver.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/resolver/resolver.template.ts
@@ -1,214 +1,31 @@
 import * as common from "@nestjs/common";
 import * as graphql from "@nestjs/graphql";
-import * as apollo from "apollo-server-express";
 import * as nestAccessControl from "nest-access-control";
 // @ts-ignore
 import * as gqlBasicAuthGuard from "../auth/gqlBasicAuth.guard";
 // @ts-ignore
 import * as gqlACGuard from "../auth/gqlAC.guard";
-// @ts-ignore
-import * as gqlUserRoles from "../auth/gqlUserRoles.decorator";
-// @ts-ignore
-import * as abacUtil from "../auth/abac.util";
-// @ts-ignore
-import { isRecordNotFoundError } from "../prisma.util";
-
-declare interface CREATE_INPUT {}
-declare interface WHERE_INPUT {}
-declare interface WHERE_UNIQUE_INPUT {}
-declare interface UPDATE_INPUT {}
-
-declare interface CREATE_ARGS {
-  data: CREATE_INPUT;
-}
-declare interface UPDATE_ARGS {
-  where: WHERE_INPUT;
-  data: UPDATE_INPUT;
-}
-declare interface DELETE_ARGS {
-  where: WHERE_UNIQUE_INPUT;
-}
-declare interface FIND_MANY_ARGS {
-  where: WHERE_INPUT;
-}
-declare interface FIND_ONE_ARGS {
-  where: WHERE_UNIQUE_INPUT;
-}
 
 declare class ENTITY {}
 
-declare const CREATE_DATA_MAPPING: CREATE_INPUT;
-declare const UPDATE_DATA_MAPPING: UPDATE_INPUT;
-
-declare interface SERVICE {
-  create(args: { data: CREATE_INPUT }): Promise<ENTITY>;
-  findMany(args: { where: WHERE_INPUT }): Promise<ENTITY[]>;
-  findOne(args: { where: WHERE_UNIQUE_INPUT }): Promise<ENTITY | null>;
-  update(args: {
-    where: WHERE_UNIQUE_INPUT;
-    data: UPDATE_INPUT;
-  }): Promise<ENTITY>;
-  delete(args: { where: WHERE_UNIQUE_INPUT }): Promise<ENTITY>;
-}
+declare interface SERVICE {}
 
 declare const ENTITY_NAME: string;
 
+declare class RESOLVER_BASE {
+  protected readonly service: SERVICE;
+  protected rolesBuilder: nestAccessControl.RolesBuilder;
+  constructor(service: SERVICE, rolesBuilder: nestAccessControl.RolesBuilder);
+}
+
 @graphql.Resolver(() => ENTITY)
 @common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
-export class RESOLVER {
+export class RESOLVER extends RESOLVER_BASE {
   constructor(
-    private readonly service: SERVICE,
+    protected readonly service: SERVICE,
     @nestAccessControl.InjectRolesBuilder()
-    private readonly rolesBuilder: nestAccessControl.RolesBuilder
-  ) {}
-
-  @graphql.Query(() => [ENTITY])
-  @nestAccessControl.UseRoles({
-    resource: ENTITY_NAME,
-    action: "read",
-    possession: "any",
-  })
-  async ENTITIES_QUERY(
-    @graphql.Args() args: FIND_MANY_ARGS,
-    @gqlUserRoles.UserRoles() userRoles: string[]
-  ): Promise<ENTITY[]> {
-    const permission = this.rolesBuilder.permission({
-      role: userRoles,
-      action: "read",
-      possession: "any",
-      resource: ENTITY_NAME,
-    });
-    const results = await this.service.findMany(args);
-    return results.map((result) => permission.filter(result));
-  }
-
-  @graphql.Query(() => ENTITY, { nullable: true })
-  @nestAccessControl.UseRoles({
-    resource: ENTITY_NAME,
-    action: "read",
-    possession: "own",
-  })
-  async ENTITY_QUERY(
-    @graphql.Args() args: FIND_ONE_ARGS,
-    @gqlUserRoles.UserRoles() userRoles: string[]
-  ): Promise<ENTITY | null> {
-    const permission = this.rolesBuilder.permission({
-      role: userRoles,
-      action: "read",
-      possession: "own",
-      resource: ENTITY_NAME,
-    });
-    const result = await this.service.findOne(args);
-    if (result === null) {
-      return null;
-    }
-    return permission.filter(result);
-  }
-
-  @graphql.Mutation(() => ENTITY)
-  @nestAccessControl.UseRoles({
-    resource: ENTITY_NAME,
-    action: "create",
-    possession: "any",
-  })
-  async CREATE_MUTATION(
-    @graphql.Args() args: CREATE_ARGS,
-    @gqlUserRoles.UserRoles() userRoles: string[]
-  ): Promise<ENTITY> {
-    const permission = this.rolesBuilder.permission({
-      role: userRoles,
-      action: "create",
-      possession: "any",
-      resource: ENTITY_NAME,
-    });
-    const invalidAttributes = abacUtil.getInvalidAttributes(
-      permission,
-      args.data
-    );
-    if (invalidAttributes.length) {
-      const properties = invalidAttributes
-        .map((attribute: string) => JSON.stringify(attribute))
-        .join(", ");
-      const roles = userRoles
-        .map((role: string) => JSON.stringify(role))
-        .join(",");
-      throw new apollo.ApolloError(
-        `providing the properties: ${properties} on ${ENTITY_NAME} creation is forbidden for roles: ${roles}`
-      );
-    }
-    // @ts-ignore
-    return await this.service.create({
-      ...args,
-      data: CREATE_DATA_MAPPING,
-    });
-  }
-
-  @graphql.Mutation(() => ENTITY)
-  @nestAccessControl.UseRoles({
-    resource: ENTITY_NAME,
-    action: "update",
-    possession: "any",
-  })
-  async UPDATE_MUTATION(
-    @graphql.Args() args: UPDATE_ARGS,
-    @gqlUserRoles.UserRoles() userRoles: string[]
-  ): Promise<ENTITY | null> {
-    const permission = this.rolesBuilder.permission({
-      role: userRoles,
-      action: "update",
-      possession: "any",
-      resource: ENTITY_NAME,
-    });
-    const invalidAttributes = abacUtil.getInvalidAttributes(
-      permission,
-      args.data
-    );
-    if (invalidAttributes.length) {
-      const properties = invalidAttributes
-        .map((attribute: string) => JSON.stringify(attribute))
-        .join(", ");
-      const roles = userRoles
-        .map((role: string) => JSON.stringify(role))
-        .join(",");
-      throw new apollo.ApolloError(
-        `providing the properties: ${properties} on ${ENTITY_NAME} update is forbidden for roles: ${roles}`
-      );
-    }
-    try {
-      // @ts-ignore
-      return await this.service.update({
-        ...args,
-        data: UPDATE_DATA_MAPPING,
-      });
-    } catch (error) {
-      if (isRecordNotFoundError(error)) {
-        throw new apollo.ApolloError(
-          `No resource was found for ${JSON.stringify(args.where)}`
-        );
-      }
-      throw error;
-    }
-  }
-
-  @graphql.Mutation(() => ENTITY)
-  @nestAccessControl.UseRoles({
-    resource: ENTITY_NAME,
-    action: "delete",
-    possession: "any",
-  })
-  async DELETE_MUTATION(
-    @graphql.Args() args: DELETE_ARGS
-  ): Promise<ENTITY | null> {
-    try {
-      // @ts-ignore
-      return await this.service.delete(args);
-    } catch (error) {
-      if (isRecordNotFoundError(error)) {
-        throw new apollo.ApolloError(
-          `No resource was found for ${JSON.stringify(args.where)}`
-        );
-      }
-      throw error;
-    }
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
   }
 }

--- a/packages/amplication-data-service-generator/src/server/resource/service/service.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/service/service.base.template.ts
@@ -1,0 +1,39 @@
+import { PrismaService } from "nestjs-prisma";
+import {
+  // @ts-ignore
+  FIND_ONE_ARGS,
+  // @ts-ignore
+  FIND_MANY_ARGS,
+  // @ts-ignore
+  CREATE_ARGS,
+  // @ts-ignore
+  UPDATE_ARGS,
+  // @ts-ignore
+  DELETE_ARGS,
+  // @ts-ignore
+  Subset,
+} from "@prisma/client";
+
+declare const CREATE_ARGS_MAPPING: CREATE_ARGS;
+declare const UPDATE_ARGS_MAPPING: UPDATE_ARGS;
+
+export class SERVICE_BASE {
+  constructor(protected readonly prisma: PrismaService) {}
+  findMany<T extends FIND_MANY_ARGS>(args: Subset<T, FIND_MANY_ARGS>) {
+    return this.prisma.DELEGATE.findMany(args);
+  }
+  findOne<T extends FIND_ONE_ARGS>(args: Subset<T, FIND_ONE_ARGS>) {
+    return this.prisma.DELEGATE.findOne(args);
+  }
+  create<T extends CREATE_ARGS>(args: Subset<T, CREATE_ARGS>) {
+    // @ts-ignore
+    return this.prisma.DELEGATE.create<T>(CREATE_ARGS_MAPPING);
+  }
+  update<T extends UPDATE_ARGS>(args: Subset<T, UPDATE_ARGS>) {
+    // @ts-ignore
+    return this.prisma.DELEGATE.update<T>(UPDATE_ARGS_MAPPING);
+  }
+  delete<T extends DELETE_ARGS>(args: Subset<T, DELETE_ARGS>) {
+    return this.prisma.DELEGATE.delete(args);
+  }
+}

--- a/packages/amplication-data-service-generator/src/server/resource/service/service.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/service/service.template.ts
@@ -1,41 +1,14 @@
 import { Injectable } from "@nestjs/common";
 import { PrismaService } from "nestjs-prisma";
-import {
-  // @ts-ignore
-  FIND_ONE_ARGS,
-  // @ts-ignore
-  FIND_MANY_ARGS,
-  // @ts-ignore
-  CREATE_ARGS,
-  // @ts-ignore
-  UPDATE_ARGS,
-  // @ts-ignore
-  DELETE_ARGS,
-  // @ts-ignore
-  Subset,
-} from "@prisma/client";
 
-declare const CREATE_ARGS_MAPPING: CREATE_ARGS;
-declare const UPDATE_ARGS_MAPPING: UPDATE_ARGS;
+declare class SERVICE_BASE {
+  protected readonly prisma: PrismaService;
+  constructor(prisma: PrismaService);
+}
 
 @Injectable()
-export class SERVICE {
-  constructor(private readonly prisma: PrismaService) {}
-  findMany<T extends FIND_MANY_ARGS>(args: Subset<T, FIND_MANY_ARGS>) {
-    return this.prisma.DELEGATE.findMany(args);
-  }
-  findOne<T extends FIND_ONE_ARGS>(args: Subset<T, FIND_ONE_ARGS>) {
-    return this.prisma.DELEGATE.findOne(args);
-  }
-  create<T extends CREATE_ARGS>(args: Subset<T, CREATE_ARGS>) {
-    // @ts-ignore
-    return this.prisma.DELEGATE.create<T>(CREATE_ARGS_MAPPING);
-  }
-  update<T extends UPDATE_ARGS>(args: Subset<T, UPDATE_ARGS>) {
-    // @ts-ignore
-    return this.prisma.DELEGATE.update<T>(UPDATE_ARGS_MAPPING);
-  }
-  delete<T extends DELETE_ARGS>(args: Subset<T, DELETE_ARGS>) {
-    return this.prisma.DELEGATE.delete(args);
+export class SERVICE extends SERVICE_BASE {
+  constructor(protected readonly prisma: PrismaService) {
+    super(prisma);
   }
 }

--- a/packages/amplication-data-service-generator/src/server/static/package-lock.json
+++ b/packages/amplication-data-service-generator/src/server/static/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "server-template",
-	"version": "0.2.0",
+	"version": "0.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/amplication-data-service-generator/src/server/static/package.json
+++ b/packages/amplication-data-service-generator/src/server/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-template",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "start": "nest start",

--- a/packages/amplication-data-service-generator/src/server/swagger/create-swagger.spec.ts
+++ b/packages/amplication-data-service-generator/src/server/swagger/create-swagger.spec.ts
@@ -10,6 +10,8 @@ const EXAMPLE_APP_INFO: AppInfo = {
   name: "EXAMPLE_NAME",
   version: "EXAMPLE_VERSION",
   description: EXAMPLE_DESCRIPTION,
+  id: "EXAMPLE_ID",
+  url: "EXAMPLE_URL",
 };
 
 describe("createDescription", () => {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -5415,6 +5415,24 @@ export class CustomerControllerBase {
   }
 }
 ",
+  "server/src/customer/base/customer.module.base.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../../auth/acl.module\\";
+import { AuthModule } from \\"../../auth/auth.module\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+
+  exports: [ACLModule, AuthModule, MorganModule, PrismaModule],
+})
+export class CustomerModuleBase {}
+",
   "server/src/customer/base/customer.resolver.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
@@ -5930,22 +5948,14 @@ export class CustomerController extends CustomerControllerBase {
   }
 }
 ",
-  "server/src/customer/customer.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { PrismaModule } from \\"nestjs-prisma\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { AuthModule } from \\"../auth/auth.module\\";
+  "server/src/customer/customer.module.ts": "import { Module } from \\"@nestjs/common\\";
+import { CustomerModuleBase } from \\"./base/customer.module.base\\";
 import { CustomerService } from \\"./customer.service\\";
 import { CustomerController } from \\"./customer.controller\\";
 import { CustomerResolver } from \\"./customer.resolver\\";
 
 @Module({
-  imports: [
-    ACLModule,
-    forwardRef(() => AuthModule),
-    MorganModule,
-    PrismaModule,
-  ],
+  imports: [CustomerModuleBase],
   controllers: [CustomerController],
   providers: [CustomerService, CustomerResolver],
   exports: [CustomerService],
@@ -6337,6 +6347,24 @@ export class EmptyControllerBase {
   }
 }
 ",
+  "server/src/empty/base/empty.module.base.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../../auth/acl.module\\";
+import { AuthModule } from \\"../../auth/auth.module\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+
+  exports: [ACLModule, AuthModule, MorganModule, PrismaModule],
+})
+export class EmptyModuleBase {}
+",
   "server/src/empty/base/empty.resolver.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
@@ -6617,22 +6645,14 @@ export class EmptyController extends EmptyControllerBase {
   }
 }
 ",
-  "server/src/empty/empty.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { PrismaModule } from \\"nestjs-prisma\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { AuthModule } from \\"../auth/auth.module\\";
+  "server/src/empty/empty.module.ts": "import { Module } from \\"@nestjs/common\\";
+import { EmptyModuleBase } from \\"./base/empty.module.base\\";
 import { EmptyService } from \\"./empty.service\\";
 import { EmptyController } from \\"./empty.controller\\";
 import { EmptyResolver } from \\"./empty.resolver\\";
 
 @Module({
-  imports: [
-    ACLModule,
-    forwardRef(() => AuthModule),
-    MorganModule,
-    PrismaModule,
-  ],
+  imports: [EmptyModuleBase],
   controllers: [EmptyController],
   providers: [EmptyService, EmptyResolver],
   exports: [EmptyService],
@@ -7327,6 +7347,24 @@ export class OrderControllerBase {
   }
 }
 ",
+  "server/src/order/base/order.module.base.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../../auth/acl.module\\";
+import { AuthModule } from \\"../../auth/auth.module\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+
+  exports: [ACLModule, AuthModule, MorganModule, PrismaModule],
+})
+export class OrderModuleBase {}
+",
   "server/src/order/base/order.resolver.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
@@ -7733,22 +7771,14 @@ export class OrderController extends OrderControllerBase {
   }
 }
 ",
-  "server/src/order/order.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { PrismaModule } from \\"nestjs-prisma\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { AuthModule } from \\"../auth/auth.module\\";
+  "server/src/order/order.module.ts": "import { Module } from \\"@nestjs/common\\";
+import { OrderModuleBase } from \\"./base/order.module.base\\";
 import { OrderService } from \\"./order.service\\";
 import { OrderController } from \\"./order.controller\\";
 import { OrderResolver } from \\"./order.resolver\\";
 
 @Module({
-  imports: [
-    ACLModule,
-    forwardRef(() => AuthModule),
-    MorganModule,
-    PrismaModule,
-  ],
+  imports: [OrderModuleBase],
   controllers: [OrderController],
   providers: [OrderService, OrderResolver],
   exports: [OrderService],
@@ -8755,6 +8785,24 @@ export class OrganizationControllerBase {
   }
 }
 ",
+  "server/src/organization/base/organization.module.base.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../../auth/acl.module\\";
+import { AuthModule } from \\"../../auth/auth.module\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+
+  exports: [ACLModule, AuthModule, MorganModule, PrismaModule],
+})
+export class OrganizationModuleBase {}
+",
   "server/src/organization/base/organization.resolver.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
@@ -9212,22 +9260,14 @@ export class OrganizationController extends OrganizationControllerBase {
   }
 }
 ",
-  "server/src/organization/organization.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { PrismaModule } from \\"nestjs-prisma\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { AuthModule } from \\"../auth/auth.module\\";
+  "server/src/organization/organization.module.ts": "import { Module } from \\"@nestjs/common\\";
+import { OrganizationModuleBase } from \\"./base/organization.module.base\\";
 import { OrganizationService } from \\"./organization.service\\";
 import { OrganizationController } from \\"./organization.controller\\";
 import { OrganizationResolver } from \\"./organization.resolver\\";
 
 @Module({
-  imports: [
-    ACLModule,
-    forwardRef(() => AuthModule),
-    MorganModule,
-    PrismaModule,
-  ],
+  imports: [OrganizationModuleBase],
   controllers: [OrganizationController],
   providers: [OrganizationService, OrganizationResolver],
   exports: [OrganizationService],
@@ -10646,6 +10686,24 @@ export class UserControllerBase {
   }
 }
 ",
+  "server/src/user/base/user.module.base.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../../auth/acl.module\\";
+import { AuthModule } from \\"../../auth/auth.module\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+
+  exports: [ACLModule, AuthModule, MorganModule, PrismaModule],
+})
+export class UserModuleBase {}
+",
   "server/src/user/base/user.resolver.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
@@ -11176,22 +11234,14 @@ export class UserController extends UserControllerBase {
   }
 }
 ",
-  "server/src/user/user.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { PrismaModule } from \\"nestjs-prisma\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { AuthModule } from \\"../auth/auth.module\\";
+  "server/src/user/user.module.ts": "import { Module } from \\"@nestjs/common\\";
+import { UserModuleBase } from \\"./base/user.module.base\\";
 import { UserService } from \\"./user.service\\";
 import { UserController } from \\"./user.controller\\";
 import { UserResolver } from \\"./user.resolver\\";
 
 @Module({
-  imports: [
-    ACLModule,
-    forwardRef(() => AuthModule),
-    MorganModule,
-    PrismaModule,
-  ],
+  imports: [UserModuleBase],
   controllers: [UserController],
   providers: [UserService, UserResolver],
   exports: [UserService],

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -3597,7 +3597,7 @@ WHERE n.nspname = 'public';
 import { PrismaClient } from \\"@prisma/client\\";
 import { Salt, parseSalt } from \\"../src/auth/password.service\\";
 import { hash } from \\"bcrypt\\";
-import { EnumUserPriority } from \\"../src/user/EnumUserPriority\\";
+import { EnumUserPriority } from \\"../src/user/base/EnumUserPriority\\";
 
 if (require.main === module) {
   dotenv.config();
@@ -4123,7 +4123,7 @@ export function parseSalt(value: string | undefined): Salt {
   return rounds;
 }
 ",
-  "server/src/customer/CreateCustomerArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/customer/base/CreateCustomerArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { CustomerCreateInput } from \\"./CustomerCreateInput\\";
 
 @ArgsType()
@@ -4134,7 +4134,7 @@ class CreateCustomerArgs {
 
 export { CreateCustomerArgs };
 ",
-  "server/src/customer/Customer.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
+  "server/src/customer/base/Customer.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 
 import {
@@ -4151,7 +4151,7 @@ import {
 import { Type } from \\"class-transformer\\";
 import { EnumCustomerFavoriteColors } from \\"./EnumCustomerFavoriteColors\\";
 import { EnumCustomerCustomerType } from \\"./EnumCustomerCustomerType\\";
-import { OrganizationWhereUniqueInput } from \\"../organization/OrganizationWhereUniqueInput\\";
+import { OrganizationWhereUniqueInput } from \\"../../organization/base/OrganizationWhereUniqueInput\\";
 @ObjectType()
 class Customer {
   @ApiProperty({
@@ -4304,7 +4304,7 @@ class Customer {
 }
 export { Customer };
 ",
-  "server/src/customer/CustomerCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/customer/base/CustomerCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 
 import {
@@ -4321,7 +4321,7 @@ import {
 import { Type } from \\"class-transformer\\";
 import { EnumCustomerFavoriteColors } from \\"./EnumCustomerFavoriteColors\\";
 import { EnumCustomerCustomerType } from \\"./EnumCustomerCustomerType\\";
-import { OrganizationWhereUniqueInput } from \\"../organization/OrganizationWhereUniqueInput\\";
+import { OrganizationWhereUniqueInput } from \\"../../organization/base/OrganizationWhereUniqueInput\\";
 @InputType()
 class CustomerCreateInput {
   @ApiProperty({
@@ -4459,7 +4459,7 @@ class CustomerCreateInput {
 }
 export { CustomerCreateInput };
 ",
-  "server/src/customer/CustomerUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/customer/base/CustomerUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 
 import {
@@ -4476,7 +4476,7 @@ import {
 import { Type } from \\"class-transformer\\";
 import { EnumCustomerFavoriteColors } from \\"./EnumCustomerFavoriteColors\\";
 import { EnumCustomerCustomerType } from \\"./EnumCustomerCustomerType\\";
-import { OrganizationWhereUniqueInput } from \\"../organization/OrganizationWhereUniqueInput\\";
+import { OrganizationWhereUniqueInput } from \\"../../organization/base/OrganizationWhereUniqueInput\\";
 @InputType()
 class CustomerUpdateInput {
   @ApiProperty({
@@ -4617,7 +4617,7 @@ class CustomerUpdateInput {
 }
 export { CustomerUpdateInput };
 ",
-  "server/src/customer/CustomerWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/customer/base/CustomerWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 
 import {
@@ -4633,7 +4633,7 @@ import {
 
 import { Type, Transform } from \\"class-transformer\\";
 import { EnumCustomerCustomerType } from \\"./EnumCustomerCustomerType\\";
-import { OrganizationWhereUniqueInput } from \\"../organization/OrganizationWhereUniqueInput\\";
+import { OrganizationWhereUniqueInput } from \\"../../organization/base/OrganizationWhereUniqueInput\\";
 @InputType()
 class CustomerWhereInput {
   @ApiProperty({
@@ -4787,7 +4787,7 @@ class CustomerWhereInput {
 }
 export { CustomerWhereInput };
 ",
-  "server/src/customer/CustomerWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/customer/base/CustomerWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsString } from \\"class-validator\\";
 @InputType()
@@ -4802,7 +4802,7 @@ class CustomerWhereUniqueInput {
 }
 export { CustomerWhereUniqueInput };
 ",
-  "server/src/customer/DeleteCustomerArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/customer/base/DeleteCustomerArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { CustomerWhereUniqueInput } from \\"./CustomerWhereUniqueInput\\";
 
 @ArgsType()
@@ -4813,7 +4813,7 @@ class DeleteCustomerArgs {
 
 export { DeleteCustomerArgs };
 ",
-  "server/src/customer/EnumCustomerCustomerType.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
+  "server/src/customer/base/EnumCustomerCustomerType.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
 
 export enum EnumCustomerCustomerType {
   Platinum = \\"platinum\\",
@@ -4826,7 +4826,7 @@ registerEnumType(EnumCustomerCustomerType, {
   name: \\"EnumCustomerCustomerType\\",
 });
 ",
-  "server/src/customer/EnumCustomerFavoriteColors.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
+  "server/src/customer/base/EnumCustomerFavoriteColors.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
 
 export enum EnumCustomerFavoriteColors {
   Red = \\"red\\",
@@ -4839,7 +4839,7 @@ registerEnumType(EnumCustomerFavoriteColors, {
   name: \\"EnumCustomerFavoriteColors\\",
 });
 ",
-  "server/src/customer/FindManyCustomerArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/customer/base/FindManyCustomerArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { CustomerWhereInput } from \\"./CustomerWhereInput\\";
 
 @ArgsType()
@@ -4850,7 +4850,7 @@ class FindManyCustomerArgs {
 
 export { FindManyCustomerArgs };
 ",
-  "server/src/customer/FindOneCustomerArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/customer/base/FindOneCustomerArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { CustomerWhereUniqueInput } from \\"./CustomerWhereUniqueInput\\";
 
 @ArgsType()
@@ -4861,7 +4861,7 @@ class FindOneCustomerArgs {
 
 export { FindOneCustomerArgs };
 ",
-  "server/src/customer/UpdateCustomerArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/customer/base/UpdateCustomerArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { CustomerWhereUniqueInput } from \\"./CustomerWhereUniqueInput\\";
 import { CustomerUpdateInput } from \\"./CustomerUpdateInput\\";
 
@@ -4875,213 +4875,27 @@ class UpdateCustomerArgs {
 
 export { UpdateCustomerArgs };
 ",
-  "server/src/customer/customer.controller.spec.ts": "import { Test } from \\"@nestjs/testing\\";
-import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
-import request from \\"supertest\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { ACGuard } from \\"nest-access-control\\";
-import { BasicAuthGuard } from \\"../auth/basicAuth.guard\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { CustomerController } from \\"./customer.controller\\";
-import { CustomerService } from \\"./customer.service\\";
-
-const nonExistingId = \\"nonExistingId\\";
-const existingId = \\"existingId\\";
-const CREATE_INPUT = {
-  id: \\"exampleId\\",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  email: \\"exampleEmail\\",
-  firstName: \\"exampleFirstName\\",
-  lastName: \\"exampleLastName\\",
-  isVip: \\"true\\",
-  birthData: new Date(),
-  averageSale: 42.42,
-  favoriteNumber: 42,
-  geoLocation: \\"exampleGeoLocation\\",
-  comments: \\"exampleComments\\",
-};
-const CREATE_RESULT = {
-  id: \\"exampleId\\",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  email: \\"exampleEmail\\",
-  firstName: \\"exampleFirstName\\",
-  lastName: \\"exampleLastName\\",
-  isVip: \\"true\\",
-  birthData: new Date(),
-  averageSale: 42.42,
-  favoriteNumber: 42,
-  geoLocation: \\"exampleGeoLocation\\",
-  comments: \\"exampleComments\\",
-};
-const FIND_MANY_RESULT = [
-  {
-    id: \\"exampleId\\",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    email: \\"exampleEmail\\",
-    firstName: \\"exampleFirstName\\",
-    lastName: \\"exampleLastName\\",
-    isVip: \\"true\\",
-    birthData: new Date(),
-    averageSale: 42.42,
-    favoriteNumber: 42,
-    geoLocation: \\"exampleGeoLocation\\",
-    comments: \\"exampleComments\\",
-  },
-];
-const FIND_ONE_RESULT = {
-  id: \\"exampleId\\",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  email: \\"exampleEmail\\",
-  firstName: \\"exampleFirstName\\",
-  lastName: \\"exampleLastName\\",
-  isVip: \\"true\\",
-  birthData: new Date(),
-  averageSale: 42.42,
-  favoriteNumber: 42,
-  geoLocation: \\"exampleGeoLocation\\",
-  comments: \\"exampleComments\\",
-};
-
-const service = {
-  create() {
-    return CREATE_RESULT;
-  },
-  findMany: () => FIND_MANY_RESULT,
-  findOne: ({ where }: { where: { id: string } }) => {
-    switch (where.id) {
-      case existingId:
-        return FIND_ONE_RESULT;
-      case nonExistingId:
-        return null;
-    }
-  },
-};
-
-const basicAuthGuard = {
-  canActivate: (context: ExecutionContext) => {
-    const argumentHost = context.switchToHttp();
-    const request = argumentHost.getRequest();
-    request.user = {
-      roles: [\\"user\\"],
-    };
-    return true;
-  },
-};
-
-const acGuard = {
-  canActivate: () => {
-    return true;
-  },
-};
-
-describe(\\"Customer\\", () => {
-  let app: INestApplication;
-
-  beforeAll(async () => {
-    const moduleRef = await Test.createTestingModule({
-      providers: [
-        {
-          provide: CustomerService,
-          useValue: service,
-        },
-      ],
-      controllers: [CustomerController],
-      imports: [MorganModule.forRoot(), ACLModule],
-    })
-      .overrideGuard(BasicAuthGuard)
-      .useValue(basicAuthGuard)
-      .overrideGuard(ACGuard)
-      .useValue(acGuard)
-      .compile();
-
-    app = moduleRef.createNestApplication();
-    await app.init();
-  });
-
-  test(\\"POST /customers\\", async () => {
-    await request(app.getHttpServer())
-      .post(\\"/customers\\")
-      .send(CREATE_INPUT)
-      .expect(HttpStatus.CREATED)
-      .expect({
-        ...CREATE_RESULT,
-        createdAt: CREATE_RESULT.createdAt.toISOString(),
-        updatedAt: CREATE_RESULT.updatedAt.toISOString(),
-        birthData: CREATE_RESULT.birthData.toISOString(),
-      });
-  });
-
-  test(\\"GET /customers\\", async () => {
-    await request(app.getHttpServer())
-      .get(\\"/customers\\")
-      .expect(HttpStatus.OK)
-      .expect([
-        {
-          ...FIND_MANY_RESULT[0],
-          createdAt: FIND_MANY_RESULT[0].createdAt.toISOString(),
-          updatedAt: FIND_MANY_RESULT[0].updatedAt.toISOString(),
-          birthData: FIND_MANY_RESULT[0].birthData.toISOString(),
-        },
-      ]);
-  });
-
-  test(\\"GET /customers/:id non existing\\", async () => {
-    await request(app.getHttpServer())
-      .get(\`\${\\"/customers\\"}/\${nonExistingId}\`)
-      .expect(404)
-      .expect({
-        statusCode: 404,
-        message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
-        error: \\"Not Found\\",
-      });
-  });
-
-  test(\\"GET /customers/:id existing\\", async () => {
-    await request(app.getHttpServer())
-      .get(\`\${\\"/customers\\"}/\${existingId}\`)
-      .expect(HttpStatus.OK)
-      .expect({
-        ...FIND_ONE_RESULT,
-        createdAt: FIND_ONE_RESULT.createdAt.toISOString(),
-        updatedAt: FIND_ONE_RESULT.updatedAt.toISOString(),
-        birthData: FIND_ONE_RESULT.birthData.toISOString(),
-      });
-  });
-
-  afterAll(async () => {
-    await app.close();
-  });
-});
-",
-  "server/src/customer/customer.controller.ts": "import * as common from \\"@nestjs/common\\";
+  "server/src/customer/base/customer.controller.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as swagger from \\"@nestjs/swagger\\";
 import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as basicAuthGuard from \\"../auth/basicAuth.guard\\";
-import * as abacUtil from \\"../auth/abac.util\\";
-import { isRecordNotFoundError } from \\"../prisma.util\\";
-import * as errors from \\"../errors\\";
-import { CustomerService } from \\"./customer.service\\";
+import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
+import * as abacUtil from \\"../../auth/abac.util\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
+import * as errors from \\"../../errors\\";
+import { CustomerService } from \\"../customer.service\\";
 import { CustomerCreateInput } from \\"./CustomerCreateInput\\";
 import { CustomerWhereInput } from \\"./CustomerWhereInput\\";
 import { CustomerWhereUniqueInput } from \\"./CustomerWhereUniqueInput\\";
 import { CustomerUpdateInput } from \\"./CustomerUpdateInput\\";
 import { Customer } from \\"./Customer\\";
-import { OrderWhereInput } from \\"../order/OrderWhereInput\\";
-import { Order } from \\"../order/Order\\";
+import { OrderWhereInput } from \\"../../order/base/OrderWhereInput\\";
+import { Order } from \\"../../order/base/Order\\";
 
-@swagger.ApiBasicAuth()
-@swagger.ApiTags(\\"customers\\")
-@common.Controller(\\"customers\\")
-export class CustomerController {
+export class CustomerControllerBase {
   constructor(
-    private readonly service: CustomerService,
-    @nestAccessControl.InjectRolesBuilder()
-    private readonly rolesBuilder: nestAccessControl.RolesBuilder
+    protected readonly service: CustomerService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
@@ -5601,55 +5415,32 @@ export class CustomerController {
   }
 }
 ",
-  "server/src/customer/customer.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { PrismaModule } from \\"nestjs-prisma\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { AuthModule } from \\"../auth/auth.module\\";
-import { CustomerService } from \\"./customer.service\\";
-import { CustomerController } from \\"./customer.controller\\";
-import { CustomerResolver } from \\"./customer.resolver\\";
-
-@Module({
-  imports: [
-    ACLModule,
-    forwardRef(() => AuthModule),
-    MorganModule,
-    PrismaModule,
-  ],
-  controllers: [CustomerController],
-  providers: [CustomerService, CustomerResolver],
-  exports: [CustomerService],
-})
-export class CustomerModule {}
-",
-  "server/src/customer/customer.resolver.ts": "import * as common from \\"@nestjs/common\\";
+  "server/src/customer/base/customer.resolver.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
-import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
-import * as gqlUserRoles from \\"../auth/gqlUserRoles.decorator\\";
-import * as abacUtil from \\"../auth/abac.util\\";
-import { isRecordNotFoundError } from \\"../prisma.util\\";
-import { CustomerService } from \\"./customer.service\\";
+import * as gqlBasicAuthGuard from \\"../../auth/gqlBasicAuth.guard\\";
+import * as gqlACGuard from \\"../../auth/gqlAC.guard\\";
+import * as gqlUserRoles from \\"../../auth/gqlUserRoles.decorator\\";
+import * as abacUtil from \\"../../auth/abac.util\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import { CreateCustomerArgs } from \\"./CreateCustomerArgs\\";
 import { UpdateCustomerArgs } from \\"./UpdateCustomerArgs\\";
 import { DeleteCustomerArgs } from \\"./DeleteCustomerArgs\\";
 import { FindManyCustomerArgs } from \\"./FindManyCustomerArgs\\";
 import { FindOneCustomerArgs } from \\"./FindOneCustomerArgs\\";
 import { Customer } from \\"./Customer\\";
-import { FindManyOrderArgs } from \\"../order/FindManyOrderArgs\\";
-import { Order } from \\"../order/Order\\";
-import { Organization } from \\"../organization/Organization\\";
+import { FindManyOrderArgs } from \\"../../order/base/FindManyOrderArgs\\";
+import { Order } from \\"../../order/base/Order\\";
+import { Organization } from \\"../../organization/base/Organization\\";
+import { CustomerService } from \\"../customer.service\\";
 
 @graphql.Resolver(() => Customer)
 @common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
-export class CustomerResolver {
+export class CustomerResolverBase {
   constructor(
-    private readonly service: CustomerService,
-    @nestAccessControl.InjectRolesBuilder()
-    private readonly rolesBuilder: nestAccessControl.RolesBuilder
+    protected readonly service: CustomerService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
   @graphql.Query(() => [Customer])
@@ -5907,8 +5698,7 @@ export class CustomerResolver {
   }
 }
 ",
-  "server/src/customer/customer.service.ts": "import { Injectable } from \\"@nestjs/common\\";
-import { PrismaService } from \\"nestjs-prisma\\";
+  "server/src/customer/base/customer.service.base.ts": "import { PrismaService } from \\"nestjs-prisma\\";
 import {
   FindOneCustomerArgs,
   FindManyCustomerArgs,
@@ -5918,9 +5708,8 @@ import {
   Subset,
 } from \\"@prisma/client\\";
 
-@Injectable()
-export class CustomerService {
-  constructor(private readonly prisma: PrismaService) {}
+export class CustomerServiceBase {
+  constructor(protected readonly prisma: PrismaService) {}
   findMany<T extends FindManyCustomerArgs>(
     args: Subset<T, FindManyCustomerArgs>
   ) {
@@ -5940,7 +5729,262 @@ export class CustomerService {
   }
 }
 ",
-  "server/src/empty/DeleteEmptyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/customer/customer.controller.spec.ts": "import { Test } from \\"@nestjs/testing\\";
+import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
+import request from \\"supertest\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { ACGuard } from \\"nest-access-control\\";
+import { BasicAuthGuard } from \\"../auth/basicAuth.guard\\";
+import { ACLModule } from \\"../auth/acl.module\\";
+import { CustomerController } from \\"./customer.controller\\";
+import { CustomerService } from \\"./customer.service\\";
+
+const nonExistingId = \\"nonExistingId\\";
+const existingId = \\"existingId\\";
+const CREATE_INPUT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  email: \\"exampleEmail\\",
+  firstName: \\"exampleFirstName\\",
+  lastName: \\"exampleLastName\\",
+  isVip: \\"true\\",
+  birthData: new Date(),
+  averageSale: 42.42,
+  favoriteNumber: 42,
+  geoLocation: \\"exampleGeoLocation\\",
+  comments: \\"exampleComments\\",
+};
+const CREATE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  email: \\"exampleEmail\\",
+  firstName: \\"exampleFirstName\\",
+  lastName: \\"exampleLastName\\",
+  isVip: \\"true\\",
+  birthData: new Date(),
+  averageSale: 42.42,
+  favoriteNumber: 42,
+  geoLocation: \\"exampleGeoLocation\\",
+  comments: \\"exampleComments\\",
+};
+const FIND_MANY_RESULT = [
+  {
+    id: \\"exampleId\\",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    email: \\"exampleEmail\\",
+    firstName: \\"exampleFirstName\\",
+    lastName: \\"exampleLastName\\",
+    isVip: \\"true\\",
+    birthData: new Date(),
+    averageSale: 42.42,
+    favoriteNumber: 42,
+    geoLocation: \\"exampleGeoLocation\\",
+    comments: \\"exampleComments\\",
+  },
+];
+const FIND_ONE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  email: \\"exampleEmail\\",
+  firstName: \\"exampleFirstName\\",
+  lastName: \\"exampleLastName\\",
+  isVip: \\"true\\",
+  birthData: new Date(),
+  averageSale: 42.42,
+  favoriteNumber: 42,
+  geoLocation: \\"exampleGeoLocation\\",
+  comments: \\"exampleComments\\",
+};
+
+const service = {
+  create() {
+    return CREATE_RESULT;
+  },
+  findMany: () => FIND_MANY_RESULT,
+  findOne: ({ where }: { where: { id: string } }) => {
+    switch (where.id) {
+      case existingId:
+        return FIND_ONE_RESULT;
+      case nonExistingId:
+        return null;
+    }
+  },
+};
+
+const basicAuthGuard = {
+  canActivate: (context: ExecutionContext) => {
+    const argumentHost = context.switchToHttp();
+    const request = argumentHost.getRequest();
+    request.user = {
+      roles: [\\"user\\"],
+    };
+    return true;
+  },
+};
+
+const acGuard = {
+  canActivate: () => {
+    return true;
+  },
+};
+
+describe(\\"Customer\\", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: CustomerService,
+          useValue: service,
+        },
+      ],
+      controllers: [CustomerController],
+      imports: [MorganModule.forRoot(), ACLModule],
+    })
+      .overrideGuard(BasicAuthGuard)
+      .useValue(basicAuthGuard)
+      .overrideGuard(ACGuard)
+      .useValue(acGuard)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  test(\\"POST /customers\\", async () => {
+    await request(app.getHttpServer())
+      .post(\\"/customers\\")
+      .send(CREATE_INPUT)
+      .expect(HttpStatus.CREATED)
+      .expect({
+        ...CREATE_RESULT,
+        createdAt: CREATE_RESULT.createdAt.toISOString(),
+        updatedAt: CREATE_RESULT.updatedAt.toISOString(),
+        birthData: CREATE_RESULT.birthData.toISOString(),
+      });
+  });
+
+  test(\\"GET /customers\\", async () => {
+    await request(app.getHttpServer())
+      .get(\\"/customers\\")
+      .expect(HttpStatus.OK)
+      .expect([
+        {
+          ...FIND_MANY_RESULT[0],
+          createdAt: FIND_MANY_RESULT[0].createdAt.toISOString(),
+          updatedAt: FIND_MANY_RESULT[0].updatedAt.toISOString(),
+          birthData: FIND_MANY_RESULT[0].birthData.toISOString(),
+        },
+      ]);
+  });
+
+  test(\\"GET /customers/:id non existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/customers\\"}/\${nonExistingId}\`)
+      .expect(404)
+      .expect({
+        statusCode: 404,
+        message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
+        error: \\"Not Found\\",
+      });
+  });
+
+  test(\\"GET /customers/:id existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/customers\\"}/\${existingId}\`)
+      .expect(HttpStatus.OK)
+      .expect({
+        ...FIND_ONE_RESULT,
+        createdAt: FIND_ONE_RESULT.createdAt.toISOString(),
+        updatedAt: FIND_ONE_RESULT.updatedAt.toISOString(),
+        birthData: FIND_ONE_RESULT.birthData.toISOString(),
+      });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});
+",
+  "server/src/customer/customer.controller.ts": "import * as common from \\"@nestjs/common\\";
+import * as swagger from \\"@nestjs/swagger\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { CustomerService } from \\"./customer.service\\";
+import { CustomerControllerBase } from \\"./base/customer.controller.base\\";
+
+@swagger.ApiBasicAuth()
+@swagger.ApiTags(\\"customers\\")
+@common.Controller(\\"customers\\")
+export class CustomerController extends CustomerControllerBase {
+  constructor(
+    protected readonly service: CustomerService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/customer/customer.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../auth/acl.module\\";
+import { AuthModule } from \\"../auth/auth.module\\";
+import { CustomerService } from \\"./customer.service\\";
+import { CustomerController } from \\"./customer.controller\\";
+import { CustomerResolver } from \\"./customer.resolver\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+  controllers: [CustomerController],
+  providers: [CustomerService, CustomerResolver],
+  exports: [CustomerService],
+})
+export class CustomerModule {}
+",
+  "server/src/customer/customer.resolver.ts": "import * as common from \\"@nestjs/common\\";
+import * as graphql from \\"@nestjs/graphql\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
+import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
+import { CustomerResolverBase } from \\"./base/customer.resolver.base\\";
+import { Customer } from \\"./base/Customer\\";
+import { CustomerService } from \\"./customer.service\\";
+
+@graphql.Resolver(() => Customer)
+@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+export class CustomerResolver extends CustomerResolverBase {
+  constructor(
+    protected readonly service: CustomerService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/customer/customer.service.ts": "import { Injectable } from \\"@nestjs/common\\";
+import { PrismaService } from \\"nestjs-prisma\\";
+import { CustomerServiceBase } from \\"./base/customer.service.base\\";
+
+@Injectable()
+export class CustomerService extends CustomerServiceBase {
+  constructor(protected readonly prisma: PrismaService) {
+    super(prisma);
+  }
+}
+",
+  "server/src/empty/base/DeleteEmptyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { EmptyWhereUniqueInput } from \\"./EmptyWhereUniqueInput\\";
 
 @ArgsType()
@@ -5951,7 +5995,7 @@ class DeleteEmptyArgs {
 
 export { DeleteEmptyArgs };
 ",
-  "server/src/empty/Empty.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
+  "server/src/empty/base/Empty.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsString, IsDate } from \\"class-validator\\";
 import { Type } from \\"class-transformer\\";
@@ -5981,13 +6025,13 @@ class Empty {
 }
 export { Empty };
 ",
-  "server/src/empty/EmptyCreateInput.ts": "class EmptyCreateInput {}
+  "server/src/empty/base/EmptyCreateInput.ts": "class EmptyCreateInput {}
 export { EmptyCreateInput };
 ",
-  "server/src/empty/EmptyUpdateInput.ts": "class EmptyUpdateInput {}
+  "server/src/empty/base/EmptyUpdateInput.ts": "class EmptyUpdateInput {}
 export { EmptyUpdateInput };
 ",
-  "server/src/empty/EmptyWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/empty/base/EmptyWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsString, IsOptional, IsDate } from \\"class-validator\\";
 import { Type } from \\"class-transformer\\";
@@ -6026,7 +6070,7 @@ class EmptyWhereInput {
 }
 export { EmptyWhereInput };
 ",
-  "server/src/empty/EmptyWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/empty/base/EmptyWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsString } from \\"class-validator\\";
 @InputType()
@@ -6041,7 +6085,7 @@ class EmptyWhereUniqueInput {
 }
 export { EmptyWhereUniqueInput };
 ",
-  "server/src/empty/FindManyEmptyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/empty/base/FindManyEmptyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { EmptyWhereInput } from \\"./EmptyWhereInput\\";
 
 @ArgsType()
@@ -6052,7 +6096,7 @@ class FindManyEmptyArgs {
 
 export { FindManyEmptyArgs };
 ",
-  "server/src/empty/FindOneEmptyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/empty/base/FindOneEmptyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { EmptyWhereUniqueInput } from \\"./EmptyWhereUniqueInput\\";
 
 @ArgsType()
@@ -6063,172 +6107,25 @@ class FindOneEmptyArgs {
 
 export { FindOneEmptyArgs };
 ",
-  "server/src/empty/empty.controller.spec.ts": "import { Test } from \\"@nestjs/testing\\";
-import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
-import request from \\"supertest\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { ACGuard } from \\"nest-access-control\\";
-import { BasicAuthGuard } from \\"../auth/basicAuth.guard\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { EmptyController } from \\"./empty.controller\\";
-import { EmptyService } from \\"./empty.service\\";
-
-const nonExistingId = \\"nonExistingId\\";
-const existingId = \\"existingId\\";
-const CREATE_INPUT = {
-  id: \\"exampleId\\",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-};
-const CREATE_RESULT = {
-  id: \\"exampleId\\",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-};
-const FIND_MANY_RESULT = [
-  {
-    id: \\"exampleId\\",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  },
-];
-const FIND_ONE_RESULT = {
-  id: \\"exampleId\\",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-};
-
-const service = {
-  create() {
-    return CREATE_RESULT;
-  },
-  findMany: () => FIND_MANY_RESULT,
-  findOne: ({ where }: { where: { id: string } }) => {
-    switch (where.id) {
-      case existingId:
-        return FIND_ONE_RESULT;
-      case nonExistingId:
-        return null;
-    }
-  },
-};
-
-const basicAuthGuard = {
-  canActivate: (context: ExecutionContext) => {
-    const argumentHost = context.switchToHttp();
-    const request = argumentHost.getRequest();
-    request.user = {
-      roles: [\\"user\\"],
-    };
-    return true;
-  },
-};
-
-const acGuard = {
-  canActivate: () => {
-    return true;
-  },
-};
-
-describe(\\"Empty\\", () => {
-  let app: INestApplication;
-
-  beforeAll(async () => {
-    const moduleRef = await Test.createTestingModule({
-      providers: [
-        {
-          provide: EmptyService,
-          useValue: service,
-        },
-      ],
-      controllers: [EmptyController],
-      imports: [MorganModule.forRoot(), ACLModule],
-    })
-      .overrideGuard(BasicAuthGuard)
-      .useValue(basicAuthGuard)
-      .overrideGuard(ACGuard)
-      .useValue(acGuard)
-      .compile();
-
-    app = moduleRef.createNestApplication();
-    await app.init();
-  });
-
-  test(\\"POST /empties\\", async () => {
-    await request(app.getHttpServer())
-      .post(\\"/empties\\")
-      .send(CREATE_INPUT)
-      .expect(HttpStatus.CREATED)
-      .expect({
-        ...CREATE_RESULT,
-        createdAt: CREATE_RESULT.createdAt.toISOString(),
-        updatedAt: CREATE_RESULT.updatedAt.toISOString(),
-      });
-  });
-
-  test(\\"GET /empties\\", async () => {
-    await request(app.getHttpServer())
-      .get(\\"/empties\\")
-      .expect(HttpStatus.OK)
-      .expect([
-        {
-          ...FIND_MANY_RESULT[0],
-          createdAt: FIND_MANY_RESULT[0].createdAt.toISOString(),
-          updatedAt: FIND_MANY_RESULT[0].updatedAt.toISOString(),
-        },
-      ]);
-  });
-
-  test(\\"GET /empties/:id non existing\\", async () => {
-    await request(app.getHttpServer())
-      .get(\`\${\\"/empties\\"}/\${nonExistingId}\`)
-      .expect(404)
-      .expect({
-        statusCode: 404,
-        message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
-        error: \\"Not Found\\",
-      });
-  });
-
-  test(\\"GET /empties/:id existing\\", async () => {
-    await request(app.getHttpServer())
-      .get(\`\${\\"/empties\\"}/\${existingId}\`)
-      .expect(HttpStatus.OK)
-      .expect({
-        ...FIND_ONE_RESULT,
-        createdAt: FIND_ONE_RESULT.createdAt.toISOString(),
-        updatedAt: FIND_ONE_RESULT.updatedAt.toISOString(),
-      });
-  });
-
-  afterAll(async () => {
-    await app.close();
-  });
-});
-",
-  "server/src/empty/empty.controller.ts": "import * as common from \\"@nestjs/common\\";
+  "server/src/empty/base/empty.controller.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as swagger from \\"@nestjs/swagger\\";
 import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as basicAuthGuard from \\"../auth/basicAuth.guard\\";
-import * as abacUtil from \\"../auth/abac.util\\";
-import { isRecordNotFoundError } from \\"../prisma.util\\";
-import * as errors from \\"../errors\\";
-import { EmptyService } from \\"./empty.service\\";
+import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
+import * as abacUtil from \\"../../auth/abac.util\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
+import * as errors from \\"../../errors\\";
+import { EmptyService } from \\"../empty.service\\";
 import { EmptyCreateInput } from \\"./EmptyCreateInput\\";
 import { EmptyWhereInput } from \\"./EmptyWhereInput\\";
 import { EmptyWhereUniqueInput } from \\"./EmptyWhereUniqueInput\\";
 import { EmptyUpdateInput } from \\"./EmptyUpdateInput\\";
 import { Empty } from \\"./Empty\\";
 
-@swagger.ApiBasicAuth()
-@swagger.ApiTags(\\"empties\\")
-@common.Controller(\\"empties\\")
-export class EmptyController {
+export class EmptyControllerBase {
   constructor(
-    private readonly service: EmptyService,
-    @nestAccessControl.InjectRolesBuilder()
-    private readonly rolesBuilder: nestAccessControl.RolesBuilder
+    protected readonly service: EmptyService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
@@ -6440,50 +6337,27 @@ export class EmptyController {
   }
 }
 ",
-  "server/src/empty/empty.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { PrismaModule } from \\"nestjs-prisma\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { AuthModule } from \\"../auth/auth.module\\";
-import { EmptyService } from \\"./empty.service\\";
-import { EmptyController } from \\"./empty.controller\\";
-import { EmptyResolver } from \\"./empty.resolver\\";
-
-@Module({
-  imports: [
-    ACLModule,
-    forwardRef(() => AuthModule),
-    MorganModule,
-    PrismaModule,
-  ],
-  controllers: [EmptyController],
-  providers: [EmptyService, EmptyResolver],
-  exports: [EmptyService],
-})
-export class EmptyModule {}
-",
-  "server/src/empty/empty.resolver.ts": "import * as common from \\"@nestjs/common\\";
+  "server/src/empty/base/empty.resolver.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
-import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
-import * as gqlUserRoles from \\"../auth/gqlUserRoles.decorator\\";
-import * as abacUtil from \\"../auth/abac.util\\";
-import { isRecordNotFoundError } from \\"../prisma.util\\";
-import { EmptyService } from \\"./empty.service\\";
+import * as gqlBasicAuthGuard from \\"../../auth/gqlBasicAuth.guard\\";
+import * as gqlACGuard from \\"../../auth/gqlAC.guard\\";
+import * as gqlUserRoles from \\"../../auth/gqlUserRoles.decorator\\";
+import * as abacUtil from \\"../../auth/abac.util\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import { DeleteEmptyArgs } from \\"./DeleteEmptyArgs\\";
 import { FindManyEmptyArgs } from \\"./FindManyEmptyArgs\\";
 import { FindOneEmptyArgs } from \\"./FindOneEmptyArgs\\";
 import { Empty } from \\"./Empty\\";
+import { EmptyService } from \\"../empty.service\\";
 
 @graphql.Resolver(() => Empty)
 @common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
-export class EmptyResolver {
+export class EmptyResolverBase {
   constructor(
-    private readonly service: EmptyService,
-    @nestAccessControl.InjectRolesBuilder()
-    private readonly rolesBuilder: nestAccessControl.RolesBuilder
+    protected readonly service: EmptyService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
   @graphql.Query(() => [Empty])
@@ -6552,8 +6426,7 @@ export class EmptyResolver {
   }
 }
 ",
-  "server/src/empty/empty.service.ts": "import { Injectable } from \\"@nestjs/common\\";
-import { PrismaService } from \\"nestjs-prisma\\";
+  "server/src/empty/base/empty.service.base.ts": "import { PrismaService } from \\"nestjs-prisma\\";
 import {
   FindOneEmptyArgs,
   FindManyEmptyArgs,
@@ -6563,9 +6436,8 @@ import {
   Subset,
 } from \\"@prisma/client\\";
 
-@Injectable()
-export class EmptyService {
-  constructor(private readonly prisma: PrismaService) {}
+export class EmptyServiceBase {
+  constructor(protected readonly prisma: PrismaService) {}
   findMany<T extends FindManyEmptyArgs>(args: Subset<T, FindManyEmptyArgs>) {
     return this.prisma.empty.findMany(args);
   }
@@ -6580,6 +6452,222 @@ export class EmptyService {
   }
   delete<T extends EmptyDeleteArgs>(args: Subset<T, EmptyDeleteArgs>) {
     return this.prisma.empty.delete(args);
+  }
+}
+",
+  "server/src/empty/empty.controller.spec.ts": "import { Test } from \\"@nestjs/testing\\";
+import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
+import request from \\"supertest\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { ACGuard } from \\"nest-access-control\\";
+import { BasicAuthGuard } from \\"../auth/basicAuth.guard\\";
+import { ACLModule } from \\"../auth/acl.module\\";
+import { EmptyController } from \\"./empty.controller\\";
+import { EmptyService } from \\"./empty.service\\";
+
+const nonExistingId = \\"nonExistingId\\";
+const existingId = \\"existingId\\";
+const CREATE_INPUT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+const CREATE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+const FIND_MANY_RESULT = [
+  {
+    id: \\"exampleId\\",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+const FIND_ONE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const service = {
+  create() {
+    return CREATE_RESULT;
+  },
+  findMany: () => FIND_MANY_RESULT,
+  findOne: ({ where }: { where: { id: string } }) => {
+    switch (where.id) {
+      case existingId:
+        return FIND_ONE_RESULT;
+      case nonExistingId:
+        return null;
+    }
+  },
+};
+
+const basicAuthGuard = {
+  canActivate: (context: ExecutionContext) => {
+    const argumentHost = context.switchToHttp();
+    const request = argumentHost.getRequest();
+    request.user = {
+      roles: [\\"user\\"],
+    };
+    return true;
+  },
+};
+
+const acGuard = {
+  canActivate: () => {
+    return true;
+  },
+};
+
+describe(\\"Empty\\", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: EmptyService,
+          useValue: service,
+        },
+      ],
+      controllers: [EmptyController],
+      imports: [MorganModule.forRoot(), ACLModule],
+    })
+      .overrideGuard(BasicAuthGuard)
+      .useValue(basicAuthGuard)
+      .overrideGuard(ACGuard)
+      .useValue(acGuard)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  test(\\"POST /empties\\", async () => {
+    await request(app.getHttpServer())
+      .post(\\"/empties\\")
+      .send(CREATE_INPUT)
+      .expect(HttpStatus.CREATED)
+      .expect({
+        ...CREATE_RESULT,
+        createdAt: CREATE_RESULT.createdAt.toISOString(),
+        updatedAt: CREATE_RESULT.updatedAt.toISOString(),
+      });
+  });
+
+  test(\\"GET /empties\\", async () => {
+    await request(app.getHttpServer())
+      .get(\\"/empties\\")
+      .expect(HttpStatus.OK)
+      .expect([
+        {
+          ...FIND_MANY_RESULT[0],
+          createdAt: FIND_MANY_RESULT[0].createdAt.toISOString(),
+          updatedAt: FIND_MANY_RESULT[0].updatedAt.toISOString(),
+        },
+      ]);
+  });
+
+  test(\\"GET /empties/:id non existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/empties\\"}/\${nonExistingId}\`)
+      .expect(404)
+      .expect({
+        statusCode: 404,
+        message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
+        error: \\"Not Found\\",
+      });
+  });
+
+  test(\\"GET /empties/:id existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/empties\\"}/\${existingId}\`)
+      .expect(HttpStatus.OK)
+      .expect({
+        ...FIND_ONE_RESULT,
+        createdAt: FIND_ONE_RESULT.createdAt.toISOString(),
+        updatedAt: FIND_ONE_RESULT.updatedAt.toISOString(),
+      });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});
+",
+  "server/src/empty/empty.controller.ts": "import * as common from \\"@nestjs/common\\";
+import * as swagger from \\"@nestjs/swagger\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { EmptyService } from \\"./empty.service\\";
+import { EmptyControllerBase } from \\"./base/empty.controller.base\\";
+
+@swagger.ApiBasicAuth()
+@swagger.ApiTags(\\"empties\\")
+@common.Controller(\\"empties\\")
+export class EmptyController extends EmptyControllerBase {
+  constructor(
+    protected readonly service: EmptyService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/empty/empty.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../auth/acl.module\\";
+import { AuthModule } from \\"../auth/auth.module\\";
+import { EmptyService } from \\"./empty.service\\";
+import { EmptyController } from \\"./empty.controller\\";
+import { EmptyResolver } from \\"./empty.resolver\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+  controllers: [EmptyController],
+  providers: [EmptyService, EmptyResolver],
+  exports: [EmptyService],
+})
+export class EmptyModule {}
+",
+  "server/src/empty/empty.resolver.ts": "import * as common from \\"@nestjs/common\\";
+import * as graphql from \\"@nestjs/graphql\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
+import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
+import { EmptyResolverBase } from \\"./base/empty.resolver.base\\";
+import { Empty } from \\"./base/Empty\\";
+import { EmptyService } from \\"./empty.service\\";
+
+@graphql.Resolver(() => Empty)
+@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+export class EmptyResolver extends EmptyResolverBase {
+  constructor(
+    protected readonly service: EmptyService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/empty/empty.service.ts": "import { Injectable } from \\"@nestjs/common\\";
+import { PrismaService } from \\"nestjs-prisma\\";
+import { EmptyServiceBase } from \\"./base/empty.service.base\\";
+
+@Injectable()
+export class EmptyService extends EmptyServiceBase {
+  constructor(protected readonly prisma: PrismaService) {
+    super(prisma);
   }
 }
 ",
@@ -6637,7 +6725,7 @@ async function main() {
 
 module.exports = main();
 ",
-  "server/src/order/CreateOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/order/base/CreateOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrderCreateInput } from \\"./OrderCreateInput\\";
 
 @ArgsType()
@@ -6648,7 +6736,7 @@ class CreateOrderArgs {
 
 export { CreateOrderArgs };
 ",
-  "server/src/order/DeleteOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/order/base/DeleteOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrderWhereUniqueInput } from \\"./OrderWhereUniqueInput\\";
 
 @ArgsType()
@@ -6659,7 +6747,7 @@ class DeleteOrderArgs {
 
 export { DeleteOrderArgs };
 ",
-  "server/src/order/EnumOrderLabel.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
+  "server/src/order/base/EnumOrderLabel.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
 
 export enum EnumOrderLabel {
   Fragile = \\"fragile\\",
@@ -6669,7 +6757,7 @@ registerEnumType(EnumOrderLabel, {
   name: \\"EnumOrderLabel\\",
 });
 ",
-  "server/src/order/EnumOrderStatus.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
+  "server/src/order/base/EnumOrderStatus.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
 
 export enum EnumOrderStatus {
   Pending = \\"pending\\",
@@ -6681,7 +6769,7 @@ registerEnumType(EnumOrderStatus, {
   name: \\"EnumOrderStatus\\",
 });
 ",
-  "server/src/order/FindManyOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/order/base/FindManyOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrderWhereInput } from \\"./OrderWhereInput\\";
 
 @ArgsType()
@@ -6692,7 +6780,7 @@ class FindManyOrderArgs {
 
 export { FindManyOrderArgs };
 ",
-  "server/src/order/FindOneOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/order/base/FindOneOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrderWhereUniqueInput } from \\"./OrderWhereUniqueInput\\";
 
 @ArgsType()
@@ -6703,7 +6791,7 @@ class FindOneOrderArgs {
 
 export { FindOneOrderArgs };
 ",
-  "server/src/order/Order.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
+  "server/src/order/base/Order.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import {
   IsString,
@@ -6713,7 +6801,7 @@ import {
   IsOptional,
 } from \\"class-validator\\";
 import { Type } from \\"class-transformer\\";
-import { CustomerWhereUniqueInput } from \\"../customer/CustomerWhereUniqueInput\\";
+import { CustomerWhereUniqueInput } from \\"../../customer/base/CustomerWhereUniqueInput\\";
 import { EnumOrderStatus } from \\"./EnumOrderStatus\\";
 import { EnumOrderLabel } from \\"./EnumOrderLabel\\";
 @ObjectType()
@@ -6766,9 +6854,9 @@ class Order {
 }
 export { Order };
 ",
-  "server/src/order/OrderCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/order/base/OrderCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
-import { CustomerWhereUniqueInput } from \\"../customer/CustomerWhereUniqueInput\\";
+import { CustomerWhereUniqueInput } from \\"../../customer/base/CustomerWhereUniqueInput\\";
 import { ValidateNested, IsEnum, IsOptional } from \\"class-validator\\";
 import { Type } from \\"class-transformer\\";
 import { EnumOrderStatus } from \\"./EnumOrderStatus\\";
@@ -6803,9 +6891,9 @@ class OrderCreateInput {
 }
 export { OrderCreateInput };
 ",
-  "server/src/order/OrderUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/order/base/OrderUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
-import { CustomerWhereUniqueInput } from \\"../customer/CustomerWhereUniqueInput\\";
+import { CustomerWhereUniqueInput } from \\"../../customer/base/CustomerWhereUniqueInput\\";
 import { ValidateNested, IsOptional, IsEnum } from \\"class-validator\\";
 import { Type } from \\"class-transformer\\";
 import { EnumOrderStatus } from \\"./EnumOrderStatus\\";
@@ -6846,7 +6934,7 @@ class OrderUpdateInput {
 }
 export { OrderUpdateInput };
 ",
-  "server/src/order/OrderWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/order/base/OrderWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import {
   IsString,
@@ -6856,7 +6944,7 @@ import {
   IsEnum,
 } from \\"class-validator\\";
 import { Type, Transform } from \\"class-transformer\\";
-import { CustomerWhereUniqueInput } from \\"../customer/CustomerWhereUniqueInput\\";
+import { CustomerWhereUniqueInput } from \\"../../customer/base/CustomerWhereUniqueInput\\";
 import { EnumOrderStatus } from \\"./EnumOrderStatus\\";
 import { EnumOrderLabel } from \\"./EnumOrderLabel\\";
 @InputType()
@@ -6923,7 +7011,7 @@ class OrderWhereInput {
 }
 export { OrderWhereInput };
 ",
-  "server/src/order/OrderWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/order/base/OrderWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsString } from \\"class-validator\\";
 @InputType()
@@ -6938,7 +7026,7 @@ class OrderWhereUniqueInput {
 }
 export { OrderWhereUniqueInput };
 ",
-  "server/src/order/UpdateOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/order/base/UpdateOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrderWhereUniqueInput } from \\"./OrderWhereUniqueInput\\";
 import { OrderUpdateInput } from \\"./OrderUpdateInput\\";
 
@@ -6952,172 +7040,25 @@ class UpdateOrderArgs {
 
 export { UpdateOrderArgs };
 ",
-  "server/src/order/order.controller.spec.ts": "import { Test } from \\"@nestjs/testing\\";
-import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
-import request from \\"supertest\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { ACGuard } from \\"nest-access-control\\";
-import { BasicAuthGuard } from \\"../auth/basicAuth.guard\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { OrderController } from \\"./order.controller\\";
-import { OrderService } from \\"./order.service\\";
-
-const nonExistingId = \\"nonExistingId\\";
-const existingId = \\"existingId\\";
-const CREATE_INPUT = {
-  id: \\"exampleId\\",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-};
-const CREATE_RESULT = {
-  id: \\"exampleId\\",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-};
-const FIND_MANY_RESULT = [
-  {
-    id: \\"exampleId\\",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  },
-];
-const FIND_ONE_RESULT = {
-  id: \\"exampleId\\",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-};
-
-const service = {
-  create() {
-    return CREATE_RESULT;
-  },
-  findMany: () => FIND_MANY_RESULT,
-  findOne: ({ where }: { where: { id: string } }) => {
-    switch (where.id) {
-      case existingId:
-        return FIND_ONE_RESULT;
-      case nonExistingId:
-        return null;
-    }
-  },
-};
-
-const basicAuthGuard = {
-  canActivate: (context: ExecutionContext) => {
-    const argumentHost = context.switchToHttp();
-    const request = argumentHost.getRequest();
-    request.user = {
-      roles: [\\"user\\"],
-    };
-    return true;
-  },
-};
-
-const acGuard = {
-  canActivate: () => {
-    return true;
-  },
-};
-
-describe(\\"Order\\", () => {
-  let app: INestApplication;
-
-  beforeAll(async () => {
-    const moduleRef = await Test.createTestingModule({
-      providers: [
-        {
-          provide: OrderService,
-          useValue: service,
-        },
-      ],
-      controllers: [OrderController],
-      imports: [MorganModule.forRoot(), ACLModule],
-    })
-      .overrideGuard(BasicAuthGuard)
-      .useValue(basicAuthGuard)
-      .overrideGuard(ACGuard)
-      .useValue(acGuard)
-      .compile();
-
-    app = moduleRef.createNestApplication();
-    await app.init();
-  });
-
-  test(\\"POST /orders\\", async () => {
-    await request(app.getHttpServer())
-      .post(\\"/orders\\")
-      .send(CREATE_INPUT)
-      .expect(HttpStatus.CREATED)
-      .expect({
-        ...CREATE_RESULT,
-        createdAt: CREATE_RESULT.createdAt.toISOString(),
-        updatedAt: CREATE_RESULT.updatedAt.toISOString(),
-      });
-  });
-
-  test(\\"GET /orders\\", async () => {
-    await request(app.getHttpServer())
-      .get(\\"/orders\\")
-      .expect(HttpStatus.OK)
-      .expect([
-        {
-          ...FIND_MANY_RESULT[0],
-          createdAt: FIND_MANY_RESULT[0].createdAt.toISOString(),
-          updatedAt: FIND_MANY_RESULT[0].updatedAt.toISOString(),
-        },
-      ]);
-  });
-
-  test(\\"GET /orders/:id non existing\\", async () => {
-    await request(app.getHttpServer())
-      .get(\`\${\\"/orders\\"}/\${nonExistingId}\`)
-      .expect(404)
-      .expect({
-        statusCode: 404,
-        message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
-        error: \\"Not Found\\",
-      });
-  });
-
-  test(\\"GET /orders/:id existing\\", async () => {
-    await request(app.getHttpServer())
-      .get(\`\${\\"/orders\\"}/\${existingId}\`)
-      .expect(HttpStatus.OK)
-      .expect({
-        ...FIND_ONE_RESULT,
-        createdAt: FIND_ONE_RESULT.createdAt.toISOString(),
-        updatedAt: FIND_ONE_RESULT.updatedAt.toISOString(),
-      });
-  });
-
-  afterAll(async () => {
-    await app.close();
-  });
-});
-",
-  "server/src/order/order.controller.ts": "import * as common from \\"@nestjs/common\\";
+  "server/src/order/base/order.controller.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as swagger from \\"@nestjs/swagger\\";
 import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as basicAuthGuard from \\"../auth/basicAuth.guard\\";
-import * as abacUtil from \\"../auth/abac.util\\";
-import { isRecordNotFoundError } from \\"../prisma.util\\";
-import * as errors from \\"../errors\\";
-import { OrderService } from \\"./order.service\\";
+import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
+import * as abacUtil from \\"../../auth/abac.util\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
+import * as errors from \\"../../errors\\";
+import { OrderService } from \\"../order.service\\";
 import { OrderCreateInput } from \\"./OrderCreateInput\\";
 import { OrderWhereInput } from \\"./OrderWhereInput\\";
 import { OrderWhereUniqueInput } from \\"./OrderWhereUniqueInput\\";
 import { OrderUpdateInput } from \\"./OrderUpdateInput\\";
 import { Order } from \\"./Order\\";
 
-@swagger.ApiBasicAuth()
-@swagger.ApiTags(\\"orders\\")
-@common.Controller(\\"orders\\")
-export class OrderController {
+export class OrderControllerBase {
   constructor(
-    private readonly service: OrderService,
-    @nestAccessControl.InjectRolesBuilder()
-    private readonly rolesBuilder: nestAccessControl.RolesBuilder
+    protected readonly service: OrderService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
@@ -7386,53 +7327,30 @@ export class OrderController {
   }
 }
 ",
-  "server/src/order/order.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { PrismaModule } from \\"nestjs-prisma\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { AuthModule } from \\"../auth/auth.module\\";
-import { OrderService } from \\"./order.service\\";
-import { OrderController } from \\"./order.controller\\";
-import { OrderResolver } from \\"./order.resolver\\";
-
-@Module({
-  imports: [
-    ACLModule,
-    forwardRef(() => AuthModule),
-    MorganModule,
-    PrismaModule,
-  ],
-  controllers: [OrderController],
-  providers: [OrderService, OrderResolver],
-  exports: [OrderService],
-})
-export class OrderModule {}
-",
-  "server/src/order/order.resolver.ts": "import * as common from \\"@nestjs/common\\";
+  "server/src/order/base/order.resolver.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
-import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
-import * as gqlUserRoles from \\"../auth/gqlUserRoles.decorator\\";
-import * as abacUtil from \\"../auth/abac.util\\";
-import { isRecordNotFoundError } from \\"../prisma.util\\";
-import { OrderService } from \\"./order.service\\";
+import * as gqlBasicAuthGuard from \\"../../auth/gqlBasicAuth.guard\\";
+import * as gqlACGuard from \\"../../auth/gqlAC.guard\\";
+import * as gqlUserRoles from \\"../../auth/gqlUserRoles.decorator\\";
+import * as abacUtil from \\"../../auth/abac.util\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import { CreateOrderArgs } from \\"./CreateOrderArgs\\";
 import { UpdateOrderArgs } from \\"./UpdateOrderArgs\\";
 import { DeleteOrderArgs } from \\"./DeleteOrderArgs\\";
 import { FindManyOrderArgs } from \\"./FindManyOrderArgs\\";
 import { FindOneOrderArgs } from \\"./FindOneOrderArgs\\";
 import { Order } from \\"./Order\\";
-import { Customer } from \\"../customer/Customer\\";
+import { Customer } from \\"../../customer/base/Customer\\";
+import { OrderService } from \\"../order.service\\";
 
 @graphql.Resolver(() => Order)
 @common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
-export class OrderResolver {
+export class OrderResolverBase {
   constructor(
-    private readonly service: OrderService,
-    @nestAccessControl.InjectRolesBuilder()
-    private readonly rolesBuilder: nestAccessControl.RolesBuilder
+    protected readonly service: OrderService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
   @graphql.Query(() => [Order])
@@ -7624,8 +7542,7 @@ export class OrderResolver {
   }
 }
 ",
-  "server/src/order/order.service.ts": "import { Injectable } from \\"@nestjs/common\\";
-import { PrismaService } from \\"nestjs-prisma\\";
+  "server/src/order/base/order.service.base.ts": "import { PrismaService } from \\"nestjs-prisma\\";
 import {
   FindOneOrderArgs,
   FindManyOrderArgs,
@@ -7635,9 +7552,8 @@ import {
   Subset,
 } from \\"@prisma/client\\";
 
-@Injectable()
-export class OrderService {
-  constructor(private readonly prisma: PrismaService) {}
+export class OrderServiceBase {
+  constructor(protected readonly prisma: PrismaService) {}
   findMany<T extends FindManyOrderArgs>(args: Subset<T, FindManyOrderArgs>) {
     return this.prisma.order.findMany(args);
   }
@@ -7655,7 +7571,223 @@ export class OrderService {
   }
 }
 ",
-  "server/src/organization/CreateOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/order/order.controller.spec.ts": "import { Test } from \\"@nestjs/testing\\";
+import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
+import request from \\"supertest\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { ACGuard } from \\"nest-access-control\\";
+import { BasicAuthGuard } from \\"../auth/basicAuth.guard\\";
+import { ACLModule } from \\"../auth/acl.module\\";
+import { OrderController } from \\"./order.controller\\";
+import { OrderService } from \\"./order.service\\";
+
+const nonExistingId = \\"nonExistingId\\";
+const existingId = \\"existingId\\";
+const CREATE_INPUT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+const CREATE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+const FIND_MANY_RESULT = [
+  {
+    id: \\"exampleId\\",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+const FIND_ONE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const service = {
+  create() {
+    return CREATE_RESULT;
+  },
+  findMany: () => FIND_MANY_RESULT,
+  findOne: ({ where }: { where: { id: string } }) => {
+    switch (where.id) {
+      case existingId:
+        return FIND_ONE_RESULT;
+      case nonExistingId:
+        return null;
+    }
+  },
+};
+
+const basicAuthGuard = {
+  canActivate: (context: ExecutionContext) => {
+    const argumentHost = context.switchToHttp();
+    const request = argumentHost.getRequest();
+    request.user = {
+      roles: [\\"user\\"],
+    };
+    return true;
+  },
+};
+
+const acGuard = {
+  canActivate: () => {
+    return true;
+  },
+};
+
+describe(\\"Order\\", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: OrderService,
+          useValue: service,
+        },
+      ],
+      controllers: [OrderController],
+      imports: [MorganModule.forRoot(), ACLModule],
+    })
+      .overrideGuard(BasicAuthGuard)
+      .useValue(basicAuthGuard)
+      .overrideGuard(ACGuard)
+      .useValue(acGuard)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  test(\\"POST /orders\\", async () => {
+    await request(app.getHttpServer())
+      .post(\\"/orders\\")
+      .send(CREATE_INPUT)
+      .expect(HttpStatus.CREATED)
+      .expect({
+        ...CREATE_RESULT,
+        createdAt: CREATE_RESULT.createdAt.toISOString(),
+        updatedAt: CREATE_RESULT.updatedAt.toISOString(),
+      });
+  });
+
+  test(\\"GET /orders\\", async () => {
+    await request(app.getHttpServer())
+      .get(\\"/orders\\")
+      .expect(HttpStatus.OK)
+      .expect([
+        {
+          ...FIND_MANY_RESULT[0],
+          createdAt: FIND_MANY_RESULT[0].createdAt.toISOString(),
+          updatedAt: FIND_MANY_RESULT[0].updatedAt.toISOString(),
+        },
+      ]);
+  });
+
+  test(\\"GET /orders/:id non existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/orders\\"}/\${nonExistingId}\`)
+      .expect(404)
+      .expect({
+        statusCode: 404,
+        message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
+        error: \\"Not Found\\",
+      });
+  });
+
+  test(\\"GET /orders/:id existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/orders\\"}/\${existingId}\`)
+      .expect(HttpStatus.OK)
+      .expect({
+        ...FIND_ONE_RESULT,
+        createdAt: FIND_ONE_RESULT.createdAt.toISOString(),
+        updatedAt: FIND_ONE_RESULT.updatedAt.toISOString(),
+      });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});
+",
+  "server/src/order/order.controller.ts": "import * as common from \\"@nestjs/common\\";
+import * as swagger from \\"@nestjs/swagger\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { OrderService } from \\"./order.service\\";
+import { OrderControllerBase } from \\"./base/order.controller.base\\";
+
+@swagger.ApiBasicAuth()
+@swagger.ApiTags(\\"orders\\")
+@common.Controller(\\"orders\\")
+export class OrderController extends OrderControllerBase {
+  constructor(
+    protected readonly service: OrderService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/order/order.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../auth/acl.module\\";
+import { AuthModule } from \\"../auth/auth.module\\";
+import { OrderService } from \\"./order.service\\";
+import { OrderController } from \\"./order.controller\\";
+import { OrderResolver } from \\"./order.resolver\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+  controllers: [OrderController],
+  providers: [OrderService, OrderResolver],
+  exports: [OrderService],
+})
+export class OrderModule {}
+",
+  "server/src/order/order.resolver.ts": "import * as common from \\"@nestjs/common\\";
+import * as graphql from \\"@nestjs/graphql\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
+import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
+import { OrderResolverBase } from \\"./base/order.resolver.base\\";
+import { Order } from \\"./base/Order\\";
+import { OrderService } from \\"./order.service\\";
+
+@graphql.Resolver(() => Order)
+@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+export class OrderResolver extends OrderResolverBase {
+  constructor(
+    protected readonly service: OrderService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/order/order.service.ts": "import { Injectable } from \\"@nestjs/common\\";
+import { PrismaService } from \\"nestjs-prisma\\";
+import { OrderServiceBase } from \\"./base/order.service.base\\";
+
+@Injectable()
+export class OrderService extends OrderServiceBase {
+  constructor(protected readonly prisma: PrismaService) {
+    super(prisma);
+  }
+}
+",
+  "server/src/organization/base/CreateOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrganizationCreateInput } from \\"./OrganizationCreateInput\\";
 
 @ArgsType()
@@ -7666,7 +7798,7 @@ class CreateOrganizationArgs {
 
 export { CreateOrganizationArgs };
 ",
-  "server/src/organization/DeleteOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/organization/base/DeleteOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrganizationWhereUniqueInput } from \\"./OrganizationWhereUniqueInput\\";
 
 @ArgsType()
@@ -7677,7 +7809,7 @@ class DeleteOrganizationArgs {
 
 export { DeleteOrganizationArgs };
 ",
-  "server/src/organization/FindManyOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/organization/base/FindManyOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrganizationWhereInput } from \\"./OrganizationWhereInput\\";
 
 @ArgsType()
@@ -7688,7 +7820,7 @@ class FindManyOrganizationArgs {
 
 export { FindManyOrganizationArgs };
 ",
-  "server/src/organization/FindOneOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/organization/base/FindOneOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrganizationWhereUniqueInput } from \\"./OrganizationWhereUniqueInput\\";
 
 @ArgsType()
@@ -7699,7 +7831,7 @@ class FindOneOrganizationArgs {
 
 export { FindOneOrganizationArgs };
 ",
-  "server/src/organization/Organization.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
+  "server/src/organization/base/Organization.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsString, IsDate } from \\"class-validator\\";
 import { Type } from \\"class-transformer\\";
@@ -7736,7 +7868,7 @@ class Organization {
 }
 export { Organization };
 ",
-  "server/src/organization/OrganizationCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/organization/base/OrganizationCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsString } from \\"class-validator\\";
 @InputType()
@@ -7751,7 +7883,7 @@ class OrganizationCreateInput {
 }
 export { OrganizationCreateInput };
 ",
-  "server/src/organization/OrganizationUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/organization/base/OrganizationUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsString, IsOptional } from \\"class-validator\\";
 @InputType()
@@ -7769,7 +7901,7 @@ class OrganizationUpdateInput {
 }
 export { OrganizationUpdateInput };
 ",
-  "server/src/organization/OrganizationWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/organization/base/OrganizationWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsString, IsOptional, IsDate } from \\"class-validator\\";
 import { Type } from \\"class-transformer\\";
@@ -7818,7 +7950,7 @@ class OrganizationWhereInput {
 }
 export { OrganizationWhereInput };
 ",
-  "server/src/organization/OrganizationWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/organization/base/OrganizationWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsString } from \\"class-validator\\";
 @InputType()
@@ -7833,7 +7965,7 @@ class OrganizationWhereUniqueInput {
 }
 export { OrganizationWhereUniqueInput };
 ",
-  "server/src/organization/UpdateOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/organization/base/UpdateOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrganizationWhereUniqueInput } from \\"./OrganizationWhereUniqueInput\\";
 import { OrganizationUpdateInput } from \\"./OrganizationUpdateInput\\";
 
@@ -7847,180 +7979,29 @@ class UpdateOrganizationArgs {
 
 export { UpdateOrganizationArgs };
 ",
-  "server/src/organization/organization.controller.spec.ts": "import { Test } from \\"@nestjs/testing\\";
-import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
-import request from \\"supertest\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { ACGuard } from \\"nest-access-control\\";
-import { BasicAuthGuard } from \\"../auth/basicAuth.guard\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { OrganizationController } from \\"./organization.controller\\";
-import { OrganizationService } from \\"./organization.service\\";
-
-const nonExistingId = \\"nonExistingId\\";
-const existingId = \\"existingId\\";
-const CREATE_INPUT = {
-  id: \\"exampleId\\",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  name: \\"exampleName\\",
-};
-const CREATE_RESULT = {
-  id: \\"exampleId\\",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  name: \\"exampleName\\",
-};
-const FIND_MANY_RESULT = [
-  {
-    id: \\"exampleId\\",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    name: \\"exampleName\\",
-  },
-];
-const FIND_ONE_RESULT = {
-  id: \\"exampleId\\",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  name: \\"exampleName\\",
-};
-
-const service = {
-  create() {
-    return CREATE_RESULT;
-  },
-  findMany: () => FIND_MANY_RESULT,
-  findOne: ({ where }: { where: { id: string } }) => {
-    switch (where.id) {
-      case existingId:
-        return FIND_ONE_RESULT;
-      case nonExistingId:
-        return null;
-    }
-  },
-};
-
-const basicAuthGuard = {
-  canActivate: (context: ExecutionContext) => {
-    const argumentHost = context.switchToHttp();
-    const request = argumentHost.getRequest();
-    request.user = {
-      roles: [\\"user\\"],
-    };
-    return true;
-  },
-};
-
-const acGuard = {
-  canActivate: () => {
-    return true;
-  },
-};
-
-describe(\\"Organization\\", () => {
-  let app: INestApplication;
-
-  beforeAll(async () => {
-    const moduleRef = await Test.createTestingModule({
-      providers: [
-        {
-          provide: OrganizationService,
-          useValue: service,
-        },
-      ],
-      controllers: [OrganizationController],
-      imports: [MorganModule.forRoot(), ACLModule],
-    })
-      .overrideGuard(BasicAuthGuard)
-      .useValue(basicAuthGuard)
-      .overrideGuard(ACGuard)
-      .useValue(acGuard)
-      .compile();
-
-    app = moduleRef.createNestApplication();
-    await app.init();
-  });
-
-  test(\\"POST /organizations\\", async () => {
-    await request(app.getHttpServer())
-      .post(\\"/organizations\\")
-      .send(CREATE_INPUT)
-      .expect(HttpStatus.CREATED)
-      .expect({
-        ...CREATE_RESULT,
-        createdAt: CREATE_RESULT.createdAt.toISOString(),
-        updatedAt: CREATE_RESULT.updatedAt.toISOString(),
-      });
-  });
-
-  test(\\"GET /organizations\\", async () => {
-    await request(app.getHttpServer())
-      .get(\\"/organizations\\")
-      .expect(HttpStatus.OK)
-      .expect([
-        {
-          ...FIND_MANY_RESULT[0],
-          createdAt: FIND_MANY_RESULT[0].createdAt.toISOString(),
-          updatedAt: FIND_MANY_RESULT[0].updatedAt.toISOString(),
-        },
-      ]);
-  });
-
-  test(\\"GET /organizations/:id non existing\\", async () => {
-    await request(app.getHttpServer())
-      .get(\`\${\\"/organizations\\"}/\${nonExistingId}\`)
-      .expect(404)
-      .expect({
-        statusCode: 404,
-        message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
-        error: \\"Not Found\\",
-      });
-  });
-
-  test(\\"GET /organizations/:id existing\\", async () => {
-    await request(app.getHttpServer())
-      .get(\`\${\\"/organizations\\"}/\${existingId}\`)
-      .expect(HttpStatus.OK)
-      .expect({
-        ...FIND_ONE_RESULT,
-        createdAt: FIND_ONE_RESULT.createdAt.toISOString(),
-        updatedAt: FIND_ONE_RESULT.updatedAt.toISOString(),
-      });
-  });
-
-  afterAll(async () => {
-    await app.close();
-  });
-});
-",
-  "server/src/organization/organization.controller.ts": "import * as common from \\"@nestjs/common\\";
+  "server/src/organization/base/organization.controller.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as swagger from \\"@nestjs/swagger\\";
 import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as basicAuthGuard from \\"../auth/basicAuth.guard\\";
-import * as abacUtil from \\"../auth/abac.util\\";
-import { isRecordNotFoundError } from \\"../prisma.util\\";
-import * as errors from \\"../errors\\";
-import { OrganizationService } from \\"./organization.service\\";
+import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
+import * as abacUtil from \\"../../auth/abac.util\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
+import * as errors from \\"../../errors\\";
+import { OrganizationService } from \\"../organization.service\\";
 import { OrganizationCreateInput } from \\"./OrganizationCreateInput\\";
 import { OrganizationWhereInput } from \\"./OrganizationWhereInput\\";
 import { OrganizationWhereUniqueInput } from \\"./OrganizationWhereUniqueInput\\";
 import { OrganizationUpdateInput } from \\"./OrganizationUpdateInput\\";
 import { Organization } from \\"./Organization\\";
-import { UserWhereInput } from \\"../user/UserWhereInput\\";
-import { User } from \\"../user/User\\";
-import { CustomerWhereInput } from \\"../customer/CustomerWhereInput\\";
-import { Customer } from \\"../customer/Customer\\";
+import { UserWhereInput } from \\"../../user/base/UserWhereInput\\";
+import { User } from \\"../../user/base/User\\";
+import { CustomerWhereInput } from \\"../../customer/base/CustomerWhereInput\\";
+import { Customer } from \\"../../customer/base/Customer\\";
 
-@swagger.ApiBasicAuth()
-@swagger.ApiTags(\\"organizations\\")
-@common.Controller(\\"organizations\\")
-export class OrganizationController {
+export class OrganizationControllerBase {
   constructor(
-    private readonly service: OrganizationService,
-    @nestAccessControl.InjectRolesBuilder()
-    private readonly rolesBuilder: nestAccessControl.RolesBuilder
+    protected readonly service: OrganizationService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
@@ -8774,56 +8755,33 @@ export class OrganizationController {
   }
 }
 ",
-  "server/src/organization/organization.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { PrismaModule } from \\"nestjs-prisma\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { AuthModule } from \\"../auth/auth.module\\";
-import { OrganizationService } from \\"./organization.service\\";
-import { OrganizationController } from \\"./organization.controller\\";
-import { OrganizationResolver } from \\"./organization.resolver\\";
-
-@Module({
-  imports: [
-    ACLModule,
-    forwardRef(() => AuthModule),
-    MorganModule,
-    PrismaModule,
-  ],
-  controllers: [OrganizationController],
-  providers: [OrganizationService, OrganizationResolver],
-  exports: [OrganizationService],
-})
-export class OrganizationModule {}
-",
-  "server/src/organization/organization.resolver.ts": "import * as common from \\"@nestjs/common\\";
+  "server/src/organization/base/organization.resolver.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
-import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
-import * as gqlUserRoles from \\"../auth/gqlUserRoles.decorator\\";
-import * as abacUtil from \\"../auth/abac.util\\";
-import { isRecordNotFoundError } from \\"../prisma.util\\";
-import { OrganizationService } from \\"./organization.service\\";
+import * as gqlBasicAuthGuard from \\"../../auth/gqlBasicAuth.guard\\";
+import * as gqlACGuard from \\"../../auth/gqlAC.guard\\";
+import * as gqlUserRoles from \\"../../auth/gqlUserRoles.decorator\\";
+import * as abacUtil from \\"../../auth/abac.util\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import { CreateOrganizationArgs } from \\"./CreateOrganizationArgs\\";
 import { UpdateOrganizationArgs } from \\"./UpdateOrganizationArgs\\";
 import { DeleteOrganizationArgs } from \\"./DeleteOrganizationArgs\\";
 import { FindManyOrganizationArgs } from \\"./FindManyOrganizationArgs\\";
 import { FindOneOrganizationArgs } from \\"./FindOneOrganizationArgs\\";
 import { Organization } from \\"./Organization\\";
-import { FindManyUserArgs } from \\"../user/FindManyUserArgs\\";
-import { User } from \\"../user/User\\";
-import { FindManyCustomerArgs } from \\"../customer/FindManyCustomerArgs\\";
-import { Customer } from \\"../customer/Customer\\";
+import { FindManyUserArgs } from \\"../../user/base/FindManyUserArgs\\";
+import { User } from \\"../../user/base/User\\";
+import { FindManyCustomerArgs } from \\"../../customer/base/FindManyCustomerArgs\\";
+import { Customer } from \\"../../customer/base/Customer\\";
+import { OrganizationService } from \\"../organization.service\\";
 
 @graphql.Resolver(() => Organization)
 @common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
-export class OrganizationResolver {
+export class OrganizationResolverBase {
   constructor(
-    private readonly service: OrganizationService,
-    @nestAccessControl.InjectRolesBuilder()
-    private readonly rolesBuilder: nestAccessControl.RolesBuilder
+    protected readonly service: OrganizationService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
   @graphql.Query(() => [Organization])
@@ -9049,8 +9007,7 @@ export class OrganizationResolver {
   }
 }
 ",
-  "server/src/organization/organization.service.ts": "import { Injectable } from \\"@nestjs/common\\";
-import { PrismaService } from \\"nestjs-prisma\\";
+  "server/src/organization/base/organization.service.base.ts": "import { PrismaService } from \\"nestjs-prisma\\";
 import {
   FindOneOrganizationArgs,
   FindManyOrganizationArgs,
@@ -9060,9 +9017,8 @@ import {
   Subset,
 } from \\"@prisma/client\\";
 
-@Injectable()
-export class OrganizationService {
-  constructor(private readonly prisma: PrismaService) {}
+export class OrganizationServiceBase {
+  constructor(protected readonly prisma: PrismaService) {}
   findMany<T extends FindManyOrganizationArgs>(
     args: Subset<T, FindManyOrganizationArgs>
   ) {
@@ -9087,6 +9043,226 @@ export class OrganizationService {
     args: Subset<T, OrganizationDeleteArgs>
   ) {
     return this.prisma.organization.delete(args);
+  }
+}
+",
+  "server/src/organization/organization.controller.spec.ts": "import { Test } from \\"@nestjs/testing\\";
+import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
+import request from \\"supertest\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { ACGuard } from \\"nest-access-control\\";
+import { BasicAuthGuard } from \\"../auth/basicAuth.guard\\";
+import { ACLModule } from \\"../auth/acl.module\\";
+import { OrganizationController } from \\"./organization.controller\\";
+import { OrganizationService } from \\"./organization.service\\";
+
+const nonExistingId = \\"nonExistingId\\";
+const existingId = \\"existingId\\";
+const CREATE_INPUT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  name: \\"exampleName\\",
+};
+const CREATE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  name: \\"exampleName\\",
+};
+const FIND_MANY_RESULT = [
+  {
+    id: \\"exampleId\\",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    name: \\"exampleName\\",
+  },
+];
+const FIND_ONE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  name: \\"exampleName\\",
+};
+
+const service = {
+  create() {
+    return CREATE_RESULT;
+  },
+  findMany: () => FIND_MANY_RESULT,
+  findOne: ({ where }: { where: { id: string } }) => {
+    switch (where.id) {
+      case existingId:
+        return FIND_ONE_RESULT;
+      case nonExistingId:
+        return null;
+    }
+  },
+};
+
+const basicAuthGuard = {
+  canActivate: (context: ExecutionContext) => {
+    const argumentHost = context.switchToHttp();
+    const request = argumentHost.getRequest();
+    request.user = {
+      roles: [\\"user\\"],
+    };
+    return true;
+  },
+};
+
+const acGuard = {
+  canActivate: () => {
+    return true;
+  },
+};
+
+describe(\\"Organization\\", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: OrganizationService,
+          useValue: service,
+        },
+      ],
+      controllers: [OrganizationController],
+      imports: [MorganModule.forRoot(), ACLModule],
+    })
+      .overrideGuard(BasicAuthGuard)
+      .useValue(basicAuthGuard)
+      .overrideGuard(ACGuard)
+      .useValue(acGuard)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  test(\\"POST /organizations\\", async () => {
+    await request(app.getHttpServer())
+      .post(\\"/organizations\\")
+      .send(CREATE_INPUT)
+      .expect(HttpStatus.CREATED)
+      .expect({
+        ...CREATE_RESULT,
+        createdAt: CREATE_RESULT.createdAt.toISOString(),
+        updatedAt: CREATE_RESULT.updatedAt.toISOString(),
+      });
+  });
+
+  test(\\"GET /organizations\\", async () => {
+    await request(app.getHttpServer())
+      .get(\\"/organizations\\")
+      .expect(HttpStatus.OK)
+      .expect([
+        {
+          ...FIND_MANY_RESULT[0],
+          createdAt: FIND_MANY_RESULT[0].createdAt.toISOString(),
+          updatedAt: FIND_MANY_RESULT[0].updatedAt.toISOString(),
+        },
+      ]);
+  });
+
+  test(\\"GET /organizations/:id non existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/organizations\\"}/\${nonExistingId}\`)
+      .expect(404)
+      .expect({
+        statusCode: 404,
+        message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
+        error: \\"Not Found\\",
+      });
+  });
+
+  test(\\"GET /organizations/:id existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/organizations\\"}/\${existingId}\`)
+      .expect(HttpStatus.OK)
+      .expect({
+        ...FIND_ONE_RESULT,
+        createdAt: FIND_ONE_RESULT.createdAt.toISOString(),
+        updatedAt: FIND_ONE_RESULT.updatedAt.toISOString(),
+      });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});
+",
+  "server/src/organization/organization.controller.ts": "import * as common from \\"@nestjs/common\\";
+import * as swagger from \\"@nestjs/swagger\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { OrganizationService } from \\"./organization.service\\";
+import { OrganizationControllerBase } from \\"./base/organization.controller.base\\";
+
+@swagger.ApiBasicAuth()
+@swagger.ApiTags(\\"organizations\\")
+@common.Controller(\\"organizations\\")
+export class OrganizationController extends OrganizationControllerBase {
+  constructor(
+    protected readonly service: OrganizationService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/organization/organization.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../auth/acl.module\\";
+import { AuthModule } from \\"../auth/auth.module\\";
+import { OrganizationService } from \\"./organization.service\\";
+import { OrganizationController } from \\"./organization.controller\\";
+import { OrganizationResolver } from \\"./organization.resolver\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+  controllers: [OrganizationController],
+  providers: [OrganizationService, OrganizationResolver],
+  exports: [OrganizationService],
+})
+export class OrganizationModule {}
+",
+  "server/src/organization/organization.resolver.ts": "import * as common from \\"@nestjs/common\\";
+import * as graphql from \\"@nestjs/graphql\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
+import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
+import { OrganizationResolverBase } from \\"./base/organization.resolver.base\\";
+import { Organization } from \\"./base/Organization\\";
+import { OrganizationService } from \\"./organization.service\\";
+
+@graphql.Resolver(() => Organization)
+@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+export class OrganizationResolver extends OrganizationResolverBase {
+  constructor(
+    protected readonly service: OrganizationService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/organization/organization.service.ts": "import { Injectable } from \\"@nestjs/common\\";
+import { PrismaService } from \\"nestjs-prisma\\";
+import { OrganizationServiceBase } from \\"./base/organization.service.base\\";
+
+@Injectable()
+export class OrganizationService extends OrganizationServiceBase {
+  constructor(protected readonly prisma: PrismaService) {
+    super(prisma);
   }
 }
 ",
@@ -9206,7 +9382,7 @@ export const swaggerSetupOptions = {
   customSiteTitle: \\"Sample Application\\",
 };
 ",
-  "server/src/user/CreateUserArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/user/base/CreateUserArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { UserCreateInput } from \\"./UserCreateInput\\";
 
 @ArgsType()
@@ -9217,7 +9393,7 @@ class CreateUserArgs {
 
 export { CreateUserArgs };
 ",
-  "server/src/user/DeleteUserArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/user/base/DeleteUserArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 
 @ArgsType()
@@ -9228,7 +9404,7 @@ class DeleteUserArgs {
 
 export { DeleteUserArgs };
 ",
-  "server/src/user/EnumUserInterests.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
+  "server/src/user/base/EnumUserInterests.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
 
 export enum EnumUserInterests {
   Programming = \\"programming\\",
@@ -9239,7 +9415,7 @@ registerEnumType(EnumUserInterests, {
   name: \\"EnumUserInterests\\",
 });
 ",
-  "server/src/user/EnumUserPriority.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
+  "server/src/user/base/EnumUserPriority.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
 
 export enum EnumUserPriority {
   High = \\"high\\",
@@ -9251,7 +9427,7 @@ registerEnumType(EnumUserPriority, {
   name: \\"EnumUserPriority\\",
 });
 ",
-  "server/src/user/FindManyUserArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/user/base/FindManyUserArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { UserWhereInput } from \\"./UserWhereInput\\";
 
 @ArgsType()
@@ -9262,7 +9438,7 @@ class FindManyUserArgs {
 
 export { FindManyUserArgs };
 ",
-  "server/src/user/FindOneUserArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/user/base/FindOneUserArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 
 @ArgsType()
@@ -9273,7 +9449,7 @@ class FindOneUserArgs {
 
 export { FindOneUserArgs };
 ",
-  "server/src/user/UpdateUserArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
+  "server/src/user/base/UpdateUserArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { UserUpdateInput } from \\"./UserUpdateInput\\";
 
@@ -9287,7 +9463,7 @@ class UpdateUserArgs {
 
 export { UpdateUserArgs };
 ",
-  "server/src/user/User.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
+  "server/src/user/base/User.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 
 import {
@@ -9303,7 +9479,7 @@ import {
 
 import { Type } from \\"class-transformer\\";
 import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
-import { OrganizationWhereUniqueInput } from \\"../organization/OrganizationWhereUniqueInput\\";
+import { OrganizationWhereUniqueInput } from \\"../../organization/base/OrganizationWhereUniqueInput\\";
 import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 @ObjectType()
@@ -9426,7 +9602,7 @@ class User {
 }
 export { User };
 ",
-  "server/src/user/UserCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/user/base/UserCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 
 import {
@@ -9442,7 +9618,7 @@ import {
 
 import { Type } from \\"class-transformer\\";
 import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
-import { OrganizationWhereUniqueInput } from \\"../organization/OrganizationWhereUniqueInput\\";
+import { OrganizationWhereUniqueInput } from \\"../../organization/base/OrganizationWhereUniqueInput\\";
 import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 @InputType()
@@ -9571,7 +9747,7 @@ class UserCreateInput {
 }
 export { UserCreateInput };
 ",
-  "server/src/user/UserUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/user/base/UserUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 
 import {
@@ -9587,7 +9763,7 @@ import {
 
 import { Type } from \\"class-transformer\\";
 import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
-import { OrganizationWhereUniqueInput } from \\"../organization/OrganizationWhereUniqueInput\\";
+import { OrganizationWhereUniqueInput } from \\"../../organization/base/OrganizationWhereUniqueInput\\";
 import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 @InputType()
@@ -9752,7 +9928,7 @@ class UserUpdateInput {
 }
 export { UserUpdateInput };
 ",
-  "server/src/user/UserWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/user/base/UserWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 
 import {
@@ -9768,7 +9944,7 @@ import {
 
 import { Type, Transform } from \\"class-transformer\\";
 import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
-import { OrganizationWhereUniqueInput } from \\"../organization/OrganizationWhereUniqueInput\\";
+import { OrganizationWhereUniqueInput } from \\"../../organization/base/OrganizationWhereUniqueInput\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 @InputType()
 class UserWhereInput {
@@ -9903,7 +10079,7 @@ class UserWhereInput {
 }
 export { UserWhereInput };
 ",
-  "server/src/user/UserWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
+  "server/src/user/base/UserWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsString } from \\"class-validator\\";
 @InputType()
@@ -9918,205 +10094,25 @@ class UserWhereUniqueInput {
 }
 export { UserWhereUniqueInput };
 ",
-  "server/src/user/user.controller.spec.ts": "import { Test } from \\"@nestjs/testing\\";
-import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
-import request from \\"supertest\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { ACGuard } from \\"nest-access-control\\";
-import { BasicAuthGuard } from \\"../auth/basicAuth.guard\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { UserController } from \\"./user.controller\\";
-import { UserService } from \\"./user.service\\";
-
-const nonExistingId = \\"nonExistingId\\";
-const existingId = \\"existingId\\";
-const CREATE_INPUT = {
-  username: \\"exampleUsername\\",
-  password: \\"examplePassword\\",
-  roles: [\\"exampleRoles\\"],
-  id: \\"exampleId\\",
-  name: \\"exampleName\\",
-  bio: \\"exampleBio\\",
-  email: \\"exampleEmail\\",
-  age: 42,
-  birthDate: new Date(),
-  score: 42.42,
-  isCurious: \\"true\\",
-  location: \\"exampleLocation\\",
-};
-const CREATE_RESULT = {
-  username: \\"exampleUsername\\",
-  password: \\"examplePassword\\",
-  roles: [\\"exampleRoles\\"],
-  id: \\"exampleId\\",
-  name: \\"exampleName\\",
-  bio: \\"exampleBio\\",
-  email: \\"exampleEmail\\",
-  age: 42,
-  birthDate: new Date(),
-  score: 42.42,
-  isCurious: \\"true\\",
-  location: \\"exampleLocation\\",
-};
-const FIND_MANY_RESULT = [
-  {
-    username: \\"exampleUsername\\",
-    password: \\"examplePassword\\",
-    roles: [\\"exampleRoles\\"],
-    id: \\"exampleId\\",
-    name: \\"exampleName\\",
-    bio: \\"exampleBio\\",
-    email: \\"exampleEmail\\",
-    age: 42,
-    birthDate: new Date(),
-    score: 42.42,
-    isCurious: \\"true\\",
-    location: \\"exampleLocation\\",
-  },
-];
-const FIND_ONE_RESULT = {
-  username: \\"exampleUsername\\",
-  password: \\"examplePassword\\",
-  roles: [\\"exampleRoles\\"],
-  id: \\"exampleId\\",
-  name: \\"exampleName\\",
-  bio: \\"exampleBio\\",
-  email: \\"exampleEmail\\",
-  age: 42,
-  birthDate: new Date(),
-  score: 42.42,
-  isCurious: \\"true\\",
-  location: \\"exampleLocation\\",
-};
-
-const service = {
-  create() {
-    return CREATE_RESULT;
-  },
-  findMany: () => FIND_MANY_RESULT,
-  findOne: ({ where }: { where: { id: string } }) => {
-    switch (where.id) {
-      case existingId:
-        return FIND_ONE_RESULT;
-      case nonExistingId:
-        return null;
-    }
-  },
-};
-
-const basicAuthGuard = {
-  canActivate: (context: ExecutionContext) => {
-    const argumentHost = context.switchToHttp();
-    const request = argumentHost.getRequest();
-    request.user = {
-      roles: [\\"user\\"],
-    };
-    return true;
-  },
-};
-
-const acGuard = {
-  canActivate: () => {
-    return true;
-  },
-};
-
-describe(\\"User\\", () => {
-  let app: INestApplication;
-
-  beforeAll(async () => {
-    const moduleRef = await Test.createTestingModule({
-      providers: [
-        {
-          provide: UserService,
-          useValue: service,
-        },
-      ],
-      controllers: [UserController],
-      imports: [MorganModule.forRoot(), ACLModule],
-    })
-      .overrideGuard(BasicAuthGuard)
-      .useValue(basicAuthGuard)
-      .overrideGuard(ACGuard)
-      .useValue(acGuard)
-      .compile();
-
-    app = moduleRef.createNestApplication();
-    await app.init();
-  });
-
-  test(\\"POST /users\\", async () => {
-    await request(app.getHttpServer())
-      .post(\\"/users\\")
-      .send(CREATE_INPUT)
-      .expect(HttpStatus.CREATED)
-      .expect({
-        ...CREATE_RESULT,
-        birthDate: CREATE_RESULT.birthDate.toISOString(),
-      });
-  });
-
-  test(\\"GET /users\\", async () => {
-    await request(app.getHttpServer())
-      .get(\\"/users\\")
-      .expect(HttpStatus.OK)
-      .expect([
-        {
-          ...FIND_MANY_RESULT[0],
-          birthDate: FIND_MANY_RESULT[0].birthDate.toISOString(),
-        },
-      ]);
-  });
-
-  test(\\"GET /users/:id non existing\\", async () => {
-    await request(app.getHttpServer())
-      .get(\`\${\\"/users\\"}/\${nonExistingId}\`)
-      .expect(404)
-      .expect({
-        statusCode: 404,
-        message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
-        error: \\"Not Found\\",
-      });
-  });
-
-  test(\\"GET /users/:id existing\\", async () => {
-    await request(app.getHttpServer())
-      .get(\`\${\\"/users\\"}/\${existingId}\`)
-      .expect(HttpStatus.OK)
-      .expect({
-        ...FIND_ONE_RESULT,
-        birthDate: FIND_ONE_RESULT.birthDate.toISOString(),
-      });
-  });
-
-  afterAll(async () => {
-    await app.close();
-  });
-});
-",
-  "server/src/user/user.controller.ts": "import * as common from \\"@nestjs/common\\";
+  "server/src/user/base/user.controller.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as swagger from \\"@nestjs/swagger\\";
 import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as basicAuthGuard from \\"../auth/basicAuth.guard\\";
-import * as abacUtil from \\"../auth/abac.util\\";
-import { isRecordNotFoundError } from \\"../prisma.util\\";
-import * as errors from \\"../errors\\";
-import { UserService } from \\"./user.service\\";
+import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
+import * as abacUtil from \\"../../auth/abac.util\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
+import * as errors from \\"../../errors\\";
+import { UserService } from \\"../user.service\\";
 import { UserCreateInput } from \\"./UserCreateInput\\";
 import { UserWhereInput } from \\"./UserWhereInput\\";
 import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { UserUpdateInput } from \\"./UserUpdateInput\\";
 import { User } from \\"./User\\";
 
-@swagger.ApiBasicAuth()
-@swagger.ApiTags(\\"users\\")
-@common.Controller(\\"users\\")
-export class UserController {
+export class UserControllerBase {
   constructor(
-    private readonly service: UserService,
-    @nestAccessControl.InjectRolesBuilder()
-    private readonly rolesBuilder: nestAccessControl.RolesBuilder
+    protected readonly service: UserService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
@@ -10650,53 +10646,30 @@ export class UserController {
   }
 }
 ",
-  "server/src/user/user.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
-import { MorganModule } from \\"nest-morgan\\";
-import { PrismaModule } from \\"nestjs-prisma\\";
-import { ACLModule } from \\"../auth/acl.module\\";
-import { AuthModule } from \\"../auth/auth.module\\";
-import { UserService } from \\"./user.service\\";
-import { UserController } from \\"./user.controller\\";
-import { UserResolver } from \\"./user.resolver\\";
-
-@Module({
-  imports: [
-    ACLModule,
-    forwardRef(() => AuthModule),
-    MorganModule,
-    PrismaModule,
-  ],
-  controllers: [UserController],
-  providers: [UserService, UserResolver],
-  exports: [UserService],
-})
-export class UserModule {}
-",
-  "server/src/user/user.resolver.ts": "import * as common from \\"@nestjs/common\\";
+  "server/src/user/base/user.resolver.base.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
-import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
-import * as gqlUserRoles from \\"../auth/gqlUserRoles.decorator\\";
-import * as abacUtil from \\"../auth/abac.util\\";
-import { isRecordNotFoundError } from \\"../prisma.util\\";
-import { UserService } from \\"./user.service\\";
+import * as gqlBasicAuthGuard from \\"../../auth/gqlBasicAuth.guard\\";
+import * as gqlACGuard from \\"../../auth/gqlAC.guard\\";
+import * as gqlUserRoles from \\"../../auth/gqlUserRoles.decorator\\";
+import * as abacUtil from \\"../../auth/abac.util\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import { CreateUserArgs } from \\"./CreateUserArgs\\";
 import { UpdateUserArgs } from \\"./UpdateUserArgs\\";
 import { DeleteUserArgs } from \\"./DeleteUserArgs\\";
 import { FindManyUserArgs } from \\"./FindManyUserArgs\\";
 import { FindOneUserArgs } from \\"./FindOneUserArgs\\";
 import { User } from \\"./User\\";
-import { Organization } from \\"../organization/Organization\\";
+import { Organization } from \\"../../organization/base/Organization\\";
+import { UserService } from \\"../user.service\\";
 
 @graphql.Resolver(() => User)
 @common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
-export class UserResolver {
+export class UserResolverBase {
   constructor(
-    private readonly service: UserService,
-    @nestAccessControl.InjectRolesBuilder()
-    private readonly rolesBuilder: nestAccessControl.RolesBuilder
+    protected readonly service: UserService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
   @graphql.Query(() => [User])
@@ -10952,8 +10925,7 @@ export class UserResolver {
   }
 }
 ",
-  "server/src/user/user.service.ts": "import { Injectable } from \\"@nestjs/common\\";
-import { PrismaService } from \\"nestjs-prisma\\";
+  "server/src/user/base/user.service.base.ts": "import { PrismaService } from \\"nestjs-prisma\\";
 
 import {
   FindOneUserArgs,
@@ -10964,14 +10936,13 @@ import {
   Subset,
 } from \\"@prisma/client\\";
 
-import { PasswordService } from \\"../auth/password.service\\";
-import { transformStringFieldUpdateInput } from \\"../prisma.util\\";
+import { PasswordService } from \\"../../auth/password.service\\";
+import { transformStringFieldUpdateInput } from \\"../../prisma.util\\";
 
-@Injectable()
-export class UserService {
+export class UserServiceBase {
   constructor(
-    private readonly prisma: PrismaService,
-    private readonly passwordService: PasswordService
+    protected readonly prisma: PrismaService,
+    protected readonly passwordService: PasswordService
   ) {}
   findMany<T extends FindManyUserArgs>(args: Subset<T, FindManyUserArgs>) {
     return this.prisma.user.findMany(args);
@@ -11007,6 +10978,259 @@ export class UserService {
   }
   delete<T extends UserDeleteArgs>(args: Subset<T, UserDeleteArgs>) {
     return this.prisma.user.delete(args);
+  }
+}
+",
+  "server/src/user/user.controller.spec.ts": "import { Test } from \\"@nestjs/testing\\";
+import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
+import request from \\"supertest\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { ACGuard } from \\"nest-access-control\\";
+import { BasicAuthGuard } from \\"../auth/basicAuth.guard\\";
+import { ACLModule } from \\"../auth/acl.module\\";
+import { UserController } from \\"./user.controller\\";
+import { UserService } from \\"./user.service\\";
+
+const nonExistingId = \\"nonExistingId\\";
+const existingId = \\"existingId\\";
+const CREATE_INPUT = {
+  username: \\"exampleUsername\\",
+  password: \\"examplePassword\\",
+  roles: [\\"exampleRoles\\"],
+  id: \\"exampleId\\",
+  name: \\"exampleName\\",
+  bio: \\"exampleBio\\",
+  email: \\"exampleEmail\\",
+  age: 42,
+  birthDate: new Date(),
+  score: 42.42,
+  isCurious: \\"true\\",
+  location: \\"exampleLocation\\",
+};
+const CREATE_RESULT = {
+  username: \\"exampleUsername\\",
+  password: \\"examplePassword\\",
+  roles: [\\"exampleRoles\\"],
+  id: \\"exampleId\\",
+  name: \\"exampleName\\",
+  bio: \\"exampleBio\\",
+  email: \\"exampleEmail\\",
+  age: 42,
+  birthDate: new Date(),
+  score: 42.42,
+  isCurious: \\"true\\",
+  location: \\"exampleLocation\\",
+};
+const FIND_MANY_RESULT = [
+  {
+    username: \\"exampleUsername\\",
+    password: \\"examplePassword\\",
+    roles: [\\"exampleRoles\\"],
+    id: \\"exampleId\\",
+    name: \\"exampleName\\",
+    bio: \\"exampleBio\\",
+    email: \\"exampleEmail\\",
+    age: 42,
+    birthDate: new Date(),
+    score: 42.42,
+    isCurious: \\"true\\",
+    location: \\"exampleLocation\\",
+  },
+];
+const FIND_ONE_RESULT = {
+  username: \\"exampleUsername\\",
+  password: \\"examplePassword\\",
+  roles: [\\"exampleRoles\\"],
+  id: \\"exampleId\\",
+  name: \\"exampleName\\",
+  bio: \\"exampleBio\\",
+  email: \\"exampleEmail\\",
+  age: 42,
+  birthDate: new Date(),
+  score: 42.42,
+  isCurious: \\"true\\",
+  location: \\"exampleLocation\\",
+};
+
+const service = {
+  create() {
+    return CREATE_RESULT;
+  },
+  findMany: () => FIND_MANY_RESULT,
+  findOne: ({ where }: { where: { id: string } }) => {
+    switch (where.id) {
+      case existingId:
+        return FIND_ONE_RESULT;
+      case nonExistingId:
+        return null;
+    }
+  },
+};
+
+const basicAuthGuard = {
+  canActivate: (context: ExecutionContext) => {
+    const argumentHost = context.switchToHttp();
+    const request = argumentHost.getRequest();
+    request.user = {
+      roles: [\\"user\\"],
+    };
+    return true;
+  },
+};
+
+const acGuard = {
+  canActivate: () => {
+    return true;
+  },
+};
+
+describe(\\"User\\", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: UserService,
+          useValue: service,
+        },
+      ],
+      controllers: [UserController],
+      imports: [MorganModule.forRoot(), ACLModule],
+    })
+      .overrideGuard(BasicAuthGuard)
+      .useValue(basicAuthGuard)
+      .overrideGuard(ACGuard)
+      .useValue(acGuard)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  test(\\"POST /users\\", async () => {
+    await request(app.getHttpServer())
+      .post(\\"/users\\")
+      .send(CREATE_INPUT)
+      .expect(HttpStatus.CREATED)
+      .expect({
+        ...CREATE_RESULT,
+        birthDate: CREATE_RESULT.birthDate.toISOString(),
+      });
+  });
+
+  test(\\"GET /users\\", async () => {
+    await request(app.getHttpServer())
+      .get(\\"/users\\")
+      .expect(HttpStatus.OK)
+      .expect([
+        {
+          ...FIND_MANY_RESULT[0],
+          birthDate: FIND_MANY_RESULT[0].birthDate.toISOString(),
+        },
+      ]);
+  });
+
+  test(\\"GET /users/:id non existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/users\\"}/\${nonExistingId}\`)
+      .expect(404)
+      .expect({
+        statusCode: 404,
+        message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
+        error: \\"Not Found\\",
+      });
+  });
+
+  test(\\"GET /users/:id existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/users\\"}/\${existingId}\`)
+      .expect(HttpStatus.OK)
+      .expect({
+        ...FIND_ONE_RESULT,
+        birthDate: FIND_ONE_RESULT.birthDate.toISOString(),
+      });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});
+",
+  "server/src/user/user.controller.ts": "import * as common from \\"@nestjs/common\\";
+import * as swagger from \\"@nestjs/swagger\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { UserService } from \\"./user.service\\";
+import { UserControllerBase } from \\"./base/user.controller.base\\";
+
+@swagger.ApiBasicAuth()
+@swagger.ApiTags(\\"users\\")
+@common.Controller(\\"users\\")
+export class UserController extends UserControllerBase {
+  constructor(
+    protected readonly service: UserService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/user/user.module.ts": "import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../auth/acl.module\\";
+import { AuthModule } from \\"../auth/auth.module\\";
+import { UserService } from \\"./user.service\\";
+import { UserController } from \\"./user.controller\\";
+import { UserResolver } from \\"./user.resolver\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+  controllers: [UserController],
+  providers: [UserService, UserResolver],
+  exports: [UserService],
+})
+export class UserModule {}
+",
+  "server/src/user/user.resolver.ts": "import * as common from \\"@nestjs/common\\";
+import * as graphql from \\"@nestjs/graphql\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
+import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
+import { UserResolverBase } from \\"./base/user.resolver.base\\";
+import { User } from \\"./base/User\\";
+import { UserService } from \\"./user.service\\";
+
+@graphql.Resolver(() => User)
+@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+export class UserResolver extends UserResolverBase {
+  constructor(
+    protected readonly service: UserService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/user/user.service.ts": "import { Injectable } from \\"@nestjs/common\\";
+import { PrismaService } from \\"nestjs-prisma\\";
+import { UserServiceBase } from \\"./base/user.service.base\\";
+import { PasswordService } from \\"../auth/password.service\\";
+
+@Injectable()
+export class UserService extends UserServiceBase {
+  constructor(
+    protected readonly prisma: PrismaService,
+    protected readonly passwordService: PasswordService
+  ) {
+    super(prisma, passwordService);
   }
 }
 ",

--- a/packages/amplication-data-service-generator/src/tests/appInfo.ts
+++ b/packages/amplication-data-service-generator/src/tests/appInfo.ts
@@ -4,6 +4,8 @@ const appInfo: AppInfo = {
   name: "Sample Application",
   description: "Sample application for testing",
   version: "0.1.1",
+  id: "ckl0ow1xj00763cjnch10k6mc",
+  url: "https://app.amplication.com/ckl0ow1xj00763cjnch10k6mc",
 };
 
 export default appInfo;

--- a/packages/amplication-data-service-generator/src/types.ts
+++ b/packages/amplication-data-service-generator/src/types.ts
@@ -24,6 +24,8 @@ export type AppInfo = {
   name: string;
   description: string;
   version: string;
+  id: string;
+  url: string;
 };
 
 export type Role = Omit<
@@ -125,4 +127,5 @@ export type Module = {
 
 export type AppGenerationConfig = {
   dataServiceGeneratorVersion: string;
+  appInfo: AppInfo;
 };

--- a/packages/amplication-data-service-generator/src/types.ts
+++ b/packages/amplication-data-service-generator/src/types.ts
@@ -122,3 +122,7 @@ export type Module = {
   path: string;
   code: string;
 };
+
+export type AppGenerationConfig = {
+  dataServiceGeneratorVersion: string;
+};

--- a/packages/amplication-data-service-generator/src/util/ast.ts
+++ b/packages/amplication-data-service-generator/src/util/ast.ts
@@ -610,6 +610,39 @@ export function findConstructor(
   );
 }
 
+/**
+ * Add and identifier to the super() call in the constructor
+ * @param classDeclaration
+ */
+export function addIdentifierToSuperCall(
+  ast: ASTNode,
+  identifier: namedTypes.Identifier
+): void {
+  recast.visit(ast, {
+    visitClassMethod(path) {
+      const classMethodNode = path.node;
+      console.log("constructor node", classMethodNode);
+      if (isConstructor(classMethodNode)) {
+        recast.visit(classMethodNode, {
+          visitCallExpression(path) {
+            const callExpressionNode = path.node;
+            console.log("visitCallExpression", callExpressionNode);
+
+            if (callExpressionNode.callee.type === "Super") {
+              callExpressionNode.arguments.push(identifier);
+            }
+            this.traverse(path);
+          },
+        });
+      }
+
+      this.traverse(path);
+    },
+  });
+
+  return undefined;
+}
+
 export function getMethods(
   classDeclaration: namedTypes.ClassDeclaration
 ): namedTypes.ClassMethod[] {

--- a/packages/amplication-data-service-generator/src/util/ast.ts
+++ b/packages/amplication-data-service-generator/src/util/ast.ts
@@ -611,22 +611,20 @@ export function findConstructor(
 }
 
 /**
- * Add and identifier to the super() call in the constructor
+ * Add an identifier to the super() call in the constructor
  * @param classDeclaration
  */
-export function addIdentifierToSuperCall(
+export function addIdentifierToConstructorSuperCall(
   ast: ASTNode,
   identifier: namedTypes.Identifier
 ): void {
   recast.visit(ast, {
     visitClassMethod(path) {
       const classMethodNode = path.node;
-      console.log("constructor node", classMethodNode);
       if (isConstructor(classMethodNode)) {
         recast.visit(classMethodNode, {
           visitCallExpression(path) {
             const callExpressionNode = path.node;
-            console.log("visitCallExpression", callExpressionNode);
 
             if (callExpressionNode.callee.type === "Super") {
               callExpressionNode.arguments.push(identifier);
@@ -639,8 +637,6 @@ export function addIdentifierToSuperCall(
       this.traverse(path);
     },
   });
-
-  return undefined;
 }
 
 export function getMethods(

--- a/packages/amplication-data-service-generator/src/util/module.ts
+++ b/packages/amplication-data-service-generator/src/util/module.ts
@@ -27,6 +27,10 @@ export const formatCode = (code: string): string => {
   return prettier.format(code, { parser: "typescript" });
 };
 
+export const formatJson = (code: string): string => {
+  return prettier.format(code, { parser: "json" });
+};
+
 /**
  * @param from filePath of the module to import from
  * @param to filePath of the module to import to

--- a/packages/amplication-data-service-generator/src/util/nestjs-code-generation.ts
+++ b/packages/amplication-data-service-generator/src/util/nestjs-code-generation.ts
@@ -14,7 +14,8 @@ import { findConstructor } from "./ast";
 export function addInjectableDependency(
   classDeclaration: namedTypes.ClassDeclaration,
   name: string,
-  typeId: namedTypes.Identifier
+  typeId: namedTypes.Identifier,
+  accessibility: "public" | "private" | "protected"
 ): void {
   const constructor = findConstructor(classDeclaration);
 
@@ -24,7 +25,7 @@ export function addInjectableDependency(
 
   constructor.params.push(
     builders.tsParameterProperty.from({
-      accessibility: "private",
+      accessibility: accessibility,
       readonly: true,
       parameter: builders.identifier.from({
         name: name,

--- a/packages/amplication-data-service-generator/src/version.ts
+++ b/packages/amplication-data-service-generator/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.4.0';
+export const version = "0.4.0";

--- a/packages/amplication-data-service-generator/src/version.ts
+++ b/packages/amplication-data-service-generator/src/version.ts
@@ -1,0 +1,1 @@
+export const version = '0.4.0';

--- a/packages/amplication-data/package-lock.json
+++ b/packages/amplication-data/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@amplication/data",
-	"version": "0.2.0",
+	"version": "0.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/amplication-data/package.json
+++ b/packages/amplication-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/data",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/amplication-data/src/models.ts
+++ b/packages/amplication-data/src/models.ts
@@ -156,6 +156,19 @@ export type AppUpdateInput = {
   color?: Maybe<Scalars["String"]>;
 };
 
+export enum AppValidationErrorTypes {
+  CannotMergeCodeToGitHubBreakingChanges = "CannotMergeCodeToGitHubBreakingChanges",
+  CannotMergeCodeToGitHubInvalidAppId = "CannotMergeCodeToGitHubInvalidAppId",
+  DataServiceGeneratorVersionMissing = "DataServiceGeneratorVersionMissing",
+  DataServiceGeneratorVersionInvalid = "DataServiceGeneratorVersionInvalid",
+}
+
+export type AppValidationResult = {
+  __typename?: "AppValidationResult";
+  isValid: Scalars["Boolean"];
+  messages: Array<AppValidationErrorTypes>;
+};
+
 export type AppWhereInput = {
   id?: Maybe<Scalars["String"]>;
   createdAt?: Maybe<DateTimeFilter>;
@@ -1086,6 +1099,7 @@ export type Mutation = {
   createEntityFieldByDisplayName: EntityField;
   deleteEntityField: EntityField;
   updateEntityField: EntityField;
+  createDefaultRelatedField: EntityField;
   createAppRole: AppRole;
   deleteAppRole?: Maybe<AppRole>;
   updateAppRole?: Maybe<AppRole>;
@@ -1185,6 +1199,12 @@ export type MutationDeleteEntityFieldArgs = {
 
 export type MutationUpdateEntityFieldArgs = {
   data: EntityFieldUpdateInput;
+  where: WhereUniqueInput;
+  relatedFieldName?: Maybe<Scalars["String"]>;
+  relatedFieldDisplayName?: Maybe<Scalars["String"]>;
+};
+
+export type MutationCreateDefaultRelatedFieldArgs = {
   where: WhereUniqueInput;
   relatedFieldName?: Maybe<Scalars["String"]>;
   relatedFieldDisplayName?: Maybe<Scalars["String"]>;
@@ -1379,6 +1399,7 @@ export type Query = {
   apps: Array<App>;
   pendingChanges: Array<PendingChange>;
   appAvailableGithubRepos: Array<GithubRepo>;
+  appValidateBeforeCommit: AppValidationResult;
   commit?: Maybe<Commit>;
   commits?: Maybe<Array<Commit>>;
   me: User;
@@ -1462,6 +1483,10 @@ export type QueryPendingChangesArgs = {
 
 export type QueryAppAvailableGithubReposArgs = {
   where: AvailableGithubReposFindInput;
+};
+
+export type QueryAppValidateBeforeCommitArgs = {
+  where: WhereUniqueInput;
 };
 
 export type QueryCommitArgs = {

--- a/packages/amplication-deployer/package-lock.json
+++ b/packages/amplication-deployer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@amplication/deployer",
-	"version": "0.2.0",
+	"version": "0.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/amplication-deployer/package.json
+++ b/packages/amplication-deployer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/deployer",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/amplication-design-system/package-lock.json
+++ b/packages/amplication-design-system/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/design-system",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/amplication-design-system/package.json
+++ b/packages/amplication-design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/design-system",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "main": "dist/index.js",
   "scripts": {
     "storybook": "start-storybook -p 6006",

--- a/packages/amplication-e2e-tester/package-lock.json
+++ b/packages/amplication-e2e-tester/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@amplication/e2e-tester",
-	"version": "0.2.0",
+	"version": "0.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/amplication-e2e-tester/package.json
+++ b/packages/amplication-e2e-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/e2e-tester",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "scripts": {
     "build": "tsc",
     "lint": "eslint --cache tests",

--- a/packages/amplication-scheduler/package-lock.json
+++ b/packages/amplication-scheduler/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@amplication/scheduler",
-	"version": "0.2.0",
+	"version": "0.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/amplication-scheduler/package.json
+++ b/packages/amplication-scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/scheduler",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "Simple HTTP cron job scheduler",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/amplication-server/package-lock.json
+++ b/packages/amplication-server/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@amplication/server",
-	"version": "0.2.0",
+	"version": "0.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/amplication-server/package-lock.json
+++ b/packages/amplication-server/package-lock.json
@@ -15719,14 +15719,6 @@
 				"pause": "0.0.1"
 			}
 		},
-		"passport-github": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/passport-github/-/passport-github-1.1.0.tgz",
-			"integrity": "sha1-jOHj/NYa11eOsd9ZWDnkrqEjVdQ=",
-			"requires": {
-				"passport-oauth2": "1.x.x"
-			}
-		},
 		"passport-github2": {
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/passport-github2/-/passport-github2-0.1.12.tgz",

--- a/packages/amplication-server/package.json
+++ b/packages/amplication-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/server",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "prebuild": "rimraf dist",
@@ -32,10 +32,10 @@
     "check-graphql-schema": "ts-node -r tsconfig-paths/register scripts/check-graphql-schema"
   },
   "dependencies": {
-    "@amplication/container-builder": "^0.2.0",
-    "@amplication/data": "^0.2.0",
-    "@amplication/data-service-generator": "^0.2.0",
-    "@amplication/deployer": "^0.2.0",
+    "@amplication/container-builder": "^0.4.0",
+    "@amplication/data": "^0.4.0",
+    "@amplication/data-service-generator": "^0.4.0",
+    "@amplication/deployer": "^0.4.0",
     "@codebrew/nestjs-storage": "^0.1.4",
     "@extra-set/difference": "^2.1.52",
     "@google-cloud/cloudbuild": "^2.0.3",

--- a/packages/amplication-server/src/core/app/app.resolver.ts
+++ b/packages/amplication-server/src/core/app/app.resolver.ts
@@ -15,7 +15,8 @@ import {
   FindPendingChangesArgs,
   FindAvailableGithubReposArgs,
   PendingChange,
-  AppEnableSyncWithGithubRepoArgs
+  AppEnableSyncWithGithubRepoArgs,
+  AppValidationResult
 } from './dto';
 import { FindOneArgs } from 'src/dto';
 import { App, Entity, User, Commit } from 'src/models';
@@ -232,5 +233,15 @@ export class AppResolver {
   @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.id')
   async appDisableSyncWithGithubRepo(@Args() args: FindOneArgs): Promise<App> {
     return this.appService.disableSyncWithGithubRepo(args);
+  }
+
+  @Query(() => AppValidationResult, {
+    nullable: false
+  })
+  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.id')
+  async appValidateBeforeCommit(
+    @Args() args: FindOneArgs
+  ): Promise<AppValidationResult> {
+    return this.appService.validateBeforeCommit(args);
   }
 }

--- a/packages/amplication-server/src/core/app/app.service.ts
+++ b/packages/amplication-server/src/core/app/app.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from 'nestjs-prisma';
+import * as semver from 'semver';
 import { isEmpty } from 'lodash';
 import { validateHTMLColorHex } from 'validate-color';
 import { App, User, Commit } from 'src/models';
@@ -22,9 +23,13 @@ import {
   FindPendingChangesArgs,
   PendingChange,
   FindAvailableGithubReposArgs,
-  AppEnableSyncWithGithubRepoArgs
+  AppEnableSyncWithGithubRepoArgs,
+  AppValidationResult,
+  AppValidationErrorTypes
 } from './dto';
 import { CompleteAuthorizeAppWithGithubArgs } from './dto/CompleteAuthorizeAppWithGithubArgs';
+
+import { AppGenerationConfig } from '@amplication/data-service-generator';
 
 import { EnvironmentService } from '../environment/environment.service';
 import { InvalidColorError } from './InvalidColorError';
@@ -43,6 +48,8 @@ export const DEFAULT_APP_COLOR = '#20A4F3';
 export const DEFAULT_APP_DATA = {
   color: DEFAULT_APP_COLOR
 };
+
+const APP_CONFIG_FILE_PATH = 'ampconfig.json';
 
 @Injectable()
 export class AppService {
@@ -413,6 +420,110 @@ export class AppService {
     );
   }
 
+  /**
+   * Runs validations on the app and returns a list of warnings.
+   * When the validation fails, a commit can still be executed and it is up to the user/client to decide how to handle the warnings.
+   * @todo: Add mechanism to run validation on the server before commit and prevent commit with errors
+   *
+   */
+  async validateBeforeCommit(args: FindOneArgs): Promise<AppValidationResult> {
+    const messages = [];
+    let isValid = true;
+
+    const app = await this.app({
+      where: {
+        id: args.where.id
+      }
+    });
+
+    if (!app.githubSyncEnabled) return { isValid, messages };
+    if (!app.githubLastSync) return { isValid, messages }; //if the repo was never synced before, skip the below validation as they are all related to GitHub sync
+
+    const config = await this.getAppGenerationConfigFromGitHub(args);
+
+    if (!config) {
+      isValid = false;
+      messages.push(AppValidationErrorTypes.DataServiceGeneratorVersionMissing);
+      //since the config is empty, return immediately
+      return { isValid, messages };
+    }
+
+    if (!config.dataServiceGeneratorVersion) {
+      isValid = false;
+      messages.push(AppValidationErrorTypes.DataServiceGeneratorVersionMissing);
+    }
+
+    if (
+      config.dataServiceGeneratorVersion &&
+      !semver.valid(config.dataServiceGeneratorVersion)
+    ) {
+      isValid = false;
+      messages.push(AppValidationErrorTypes.DataServiceGeneratorVersionInvalid);
+    }
+
+    if (
+      semver.valid(config.dataServiceGeneratorVersion) &&
+      semver.lt(config.dataServiceGeneratorVersion, '0.4.0')
+    ) {
+      isValid = false;
+      messages.push(
+        AppValidationErrorTypes.CannotMergeCodeToGitHubBreakingChanges
+      );
+    }
+
+    if (config?.appInfo?.id != app.id) {
+      isValid = false;
+      messages.push(
+        AppValidationErrorTypes.CannotMergeCodeToGitHubInvalidAppId
+      );
+    }
+
+    return {
+      isValid,
+      messages
+    };
+  }
+
+  async getAppGenerationConfigFromGitHub(
+    args: FindOneArgs
+  ): Promise<AppGenerationConfig | null> {
+    const app = await this.app({
+      where: {
+        id: args.where.id
+      }
+    });
+
+    if (isEmpty(app.githubToken)) {
+      throw new Error(`This app is not authorized with any GitHub repo`);
+    }
+    const [userName, repoName] = app.githubRepo.split('/');
+    let configFile;
+
+    try {
+      configFile = await this.githubService.getFile(
+        userName,
+        repoName,
+        APP_CONFIG_FILE_PATH,
+        app.githubBranch,
+        app.githubToken
+      );
+    } catch (error) {
+      //in case the file was not found on GitHub, return null
+      return null;
+    }
+
+    let config;
+    try {
+      config = JSON.parse(configFile.content);
+    } catch (error) {
+      throw new Error(
+        `Unexpected config file format in the linked GitHub repo. The file must be a valid JSON object`
+      );
+    }
+
+    return config;
+  }
+
   async enableSyncWithGithubRepo(
     args: AppEnableSyncWithGithubRepoArgs
   ): Promise<App> {
@@ -461,7 +572,8 @@ export class AppService {
       data: {
         githubRepo: null, //reset the repo and branch to allow the user to set another branch when needed
         githubBranch: null,
-        githubSyncEnabled: false
+        githubSyncEnabled: false,
+        githubLastSync: null
       }
     });
   }

--- a/packages/amplication-server/src/core/app/dto/AppValidationResult.ts
+++ b/packages/amplication-server/src/core/app/dto/AppValidationResult.ts
@@ -1,0 +1,25 @@
+import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
+
+export enum AppValidationErrorTypes {
+  CannotMergeCodeToGitHubBreakingChanges = 'CannotMergeCodeToGitHubBreakingChanges',
+  CannotMergeCodeToGitHubInvalidAppId = 'CannotMergeCodeToGitHubInvalidAppId',
+  DataServiceGeneratorVersionMissing = 'DataServiceGeneratorVersionMissing',
+  DataServiceGeneratorVersionInvalid = 'DataServiceGeneratorVersionInvalid'
+}
+
+registerEnumType(AppValidationErrorTypes, {
+  name: 'AppValidationErrorTypes',
+  description: undefined
+});
+
+@ObjectType({
+  isAbstract: true,
+  description: undefined
+})
+export class AppValidationResult {
+  @Field(() => Boolean)
+  isValid: boolean;
+
+  @Field(() => [AppValidationErrorTypes])
+  messages: AppValidationErrorTypes[];
+}

--- a/packages/amplication-server/src/core/app/dto/index.ts
+++ b/packages/amplication-server/src/core/app/dto/index.ts
@@ -17,3 +17,7 @@ export { EnumPendingChangeAction } from './EnumPendingChangeAction';
 export { FindManyCommitsArgs } from './FindManyCommitsArgs';
 export { FindAvailableGithubReposArgs } from './FindAvailableGithubReposArgs';
 export { AppEnableSyncWithGithubRepoArgs } from './AppEnableSyncWithGithubRepoArgs';
+export {
+  AppValidationResult,
+  AppValidationErrorTypes
+} from './AppValidationResult';

--- a/packages/amplication-server/src/core/build/build.service.spec.ts
+++ b/packages/amplication-server/src/core/build/build.service.spec.ts
@@ -72,7 +72,7 @@ const EXAMPLE_COMMIT_ID = 'exampleCommitId';
 const EXAMPLE_BUILD_ID = 'ExampleBuildId';
 const EXAMPLE_USER_ID = 'ExampleUserId';
 const EXAMPLE_ENTITY_VERSION_ID = 'ExampleEntityVersionId';
-const EXAMPLE_APP_ID = 'ExampleAppId';
+const EXAMPLE_APP_ID = 'exampleAppId';
 const EXAMPLE_DATE = new Date('2020-01-01');
 
 const JOB_STARTED_LOG = 'Build job started';
@@ -365,7 +365,7 @@ const EXAMPLE_LOCAL_DISK = {
 
 const localDiskServiceGetDiskMock = jest.fn(() => EXAMPLE_LOCAL_DISK);
 
-const EXAMPLED_HOST = 'http://localhost/';
+const EXAMPLED_HOST = 'http://localhost';
 const configServiceGetMock = jest.fn(() => EXAMPLED_HOST);
 
 const loggerErrorMock = jest.fn(error => {
@@ -618,7 +618,9 @@ describe('BuildService', () => {
       {
         name: EXAMPLE_APP.name,
         description: EXAMPLE_APP.description,
-        version: EXAMPLE_BUILD.version
+        version: EXAMPLE_BUILD.version,
+        id: EXAMPLE_APP.id,
+        url: `${EXAMPLED_HOST}/${EXAMPLE_APP.id}`
       },
       MOCK_LOGGER
     );

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -369,13 +369,19 @@ export class BuildService {
           logPromises
         ] = this.createDataServiceLogger(build, step);
 
+        const host = this.configService.get(HOST_VAR);
+
+        const url = `${host}/${build.appId}`;
+
         const modules = await DataServiceGenerator.createDataService(
           entities,
           roles,
           {
             name: app.name,
             description: app.description,
-            version: build.version
+            version: build.version,
+            id: build.appId,
+            url
           },
           dataServiceGeneratorLogger
         );

--- a/packages/amplication-server/src/core/github/dto/githubFile.ts
+++ b/packages/amplication-server/src/core/github/dto/githubFile.ts
@@ -1,0 +1,19 @@
+import { ObjectType, Field } from '@nestjs/graphql';
+
+@ObjectType({
+  isAbstract: true,
+  description: undefined
+})
+export class GithubFile {
+  @Field(() => String)
+  name: string | null;
+
+  @Field(() => String)
+  path: string | null;
+
+  @Field(() => String)
+  content: string;
+
+  @Field(() => String)
+  htmlUrl: string | null;
+}

--- a/packages/amplication-server/src/core/github/github.service.ts
+++ b/packages/amplication-server/src/core/github/github.service.ts
@@ -59,8 +59,30 @@ export class GithubService {
       auth: TOKEN
     });
 
+    //do not override files in 'server/src/[entity]/[entity].[controller/resolver/service].ts'
+    const doNotOverride = [
+      /^server\/src\/[^\/]+\/.+\.controller.ts$/,
+      /^server\/src\/[^\/]+\/.+\.resolver.ts$/,
+      /^server\/src\/[^\/]+\/.+\.service.ts$/,
+      /^server\/src\/[^\/]+\/.+\.module.ts$/
+    ];
+
     const files = Object.fromEntries(
-      modules.map(module => [module.path, module.code])
+      modules.map(module => {
+        if (doNotOverride.some(rx => rx.test(module.path))) {
+          return [
+            module.path,
+            ({ exists }) => {
+              // do not create the file if it already exist
+              if (exists) return null;
+
+              return module.code;
+            }
+          ];
+        }
+
+        return [module.path, module.code];
+      })
     );
 
     //console.log(files);

--- a/packages/amplication-server/src/core/github/github.service.ts
+++ b/packages/amplication-server/src/core/github/github.service.ts
@@ -59,7 +59,7 @@ export class GithubService {
       auth: TOKEN
     });
 
-    //do not override files in 'server/src/[entity]/[entity].[controller/resolver/service].ts'
+    //do not override files in 'server/src/[entity]/[entity].[controller/resolver/service/module].ts'
     const doNotOverride = [
       /^server\/src\/[^\/]+\/.+\.controller.ts$/,
       /^server\/src\/[^\/]+\/.+\.resolver.ts$/,
@@ -84,8 +84,6 @@ export class GithubService {
         return [module.path, module.code];
       })
     );
-
-    //console.log(files);
 
     //todo: delete files that are no longer part of the app
 

--- a/packages/amplication-server/src/core/github/github.service.ts
+++ b/packages/amplication-server/src/core/github/github.service.ts
@@ -2,11 +2,14 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Octokit } from '@octokit/rest';
 import { GithubRepo } from './dto/githubRepo';
+import { GithubFile } from './dto/githubFile';
 import { createPullRequest } from 'octokit-plugin-create-pull-request';
 import { GoogleSecretsManagerService } from 'src/services/googleSecretsManager.service';
 import { OAuthApp } from '@octokit/oauth-app';
 
 export const GCS_BUCKET_VAR = 'GCS_BUCKET';
+const GITHUB_FILE_TYPE = 'file';
+const GITHUB_FILE_ENCODING = 'base64';
 
 export const GITHUB_CLIENT_ID_VAR = 'GITHUB_CLIENT_ID';
 export const GITHUB_CLIENT_SECRET_VAR = 'GITHUB_CLIENT_SECRET';
@@ -14,6 +17,7 @@ export const GITHUB_SECRET_SECRET_NAME_VAR = 'GITHUB_SECRET_SECRET_NAME';
 export const GITHUB_APP_AUTH_REDIRECT_URI_VAR = 'GITHUB_APP_AUTH_REDIRECT_URI';
 export const GITHUB_APP_AUTH_SCOPE_VAR = 'GITHUB_APP_AUTH_SCOPE';
 export const MISSING_CLIENT_SECRET_ERROR = `Must provide either ${GITHUB_CLIENT_SECRET_VAR} or ${GITHUB_SECRET_SECRET_NAME_VAR}`;
+export const UNEXPECTED_FILE_TYPE_OR_ENCODING = `Unexpected file type or encoding received`;
 
 @Injectable()
 export class GithubService {
@@ -40,6 +44,52 @@ export class GithubService {
       fullName: repo.full_name,
       admin: repo.permissions.admin
     }));
+  }
+
+  /**
+   * Gets a file from GitHub - Currently only returns the content of a single file and only if it is base64 encoded . Otherwise, returns null
+   * @param userName
+   * @param repoName
+   * @param path
+   * @param baseBranchName
+   * @param token
+   */
+  async getFile(
+    userName: string,
+    repoName: string,
+    path: string,
+    baseBranchName: string,
+    token: string
+  ): Promise<GithubFile> {
+    const octokit = new Octokit({
+      auth: token
+    });
+
+    const content = await octokit.repos.getContent({
+      owner: userName,
+      repo: repoName,
+      path,
+      ref: baseBranchName ? baseBranchName : undefined
+    });
+
+    if (
+      content.data.encoding === GITHUB_FILE_ENCODING &&
+      content.data.type === GITHUB_FILE_TYPE
+    ) {
+      // Convert base64 results to UTF-8 string
+      const buff = Buffer.from(content.data.content, 'base64');
+
+      const file: GithubFile = {
+        content: buff.toString('utf-8'),
+        htmlUrl: content.data.html_url,
+        name: content.data.name,
+        path: content.data.path
+      };
+
+      return file;
+    }
+
+    throw new Error(UNEXPECTED_FILE_TYPE_OR_ENCODING);
   }
 
   async createPullRequest(

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -124,6 +124,18 @@ input AppUpdateInput {
   color: String
 }
 
+enum AppValidationErrorTypes {
+  CannotMergeCodeToGitHubBreakingChanges
+  CannotMergeCodeToGitHubInvalidAppId
+  DataServiceGeneratorVersionMissing
+  DataServiceGeneratorVersionInvalid
+}
+
+type AppValidationResult {
+  isValid: Boolean!
+  messages: [AppValidationErrorTypes!]!
+}
+
 input AppWhereInput {
   id: String
   createdAt: DateTimeFilter
@@ -1106,6 +1118,7 @@ type Query {
   apps(where: AppWhereInput, orderBy: AppOrderByInput, skip: Int, take: Int): [App!]!
   pendingChanges(where: PendingChangesFindInput!): [PendingChange!]!
   appAvailableGithubRepos(where: AvailableGithubReposFindInput!): [GithubRepo!]!
+  appValidateBeforeCommit(where: WhereUniqueInput!): AppValidationResult!
   commit(where: CommitWhereUniqueInput!): Commit
   commits(where: CommitWhereInput, orderBy: CommitOrderByInput, cursor: CommitWhereUniqueInput, take: Int, skip: Int): [Commit!]
   me: User!


### PR DESCRIPTION
Code generation with base classes for services, resolvers, and controllers based on RFC #1224 

- [x] Generate entity.controller.base.ts 
- [x] Generate entity.resolver.base.ts 
- [x] Generate entity.service.base.ts 
- [x] Generate entity.module.base.ts 
- [x] move args and Input types to /base
- [x] Prevent override of skeleton classes 'server/src/[entity]/[entity].[controller/resolver/service/module].ts'
- [x] Handle migration from previous versions 
