### PR TITLE
chore: remove cache and scheduler from GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
         with:
-          driver-opt: image=moby/buildkit:master
+          driver-opts: image=moby/buildkit:master
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -87,13 +87,14 @@ jobs:
           registry: gcr.io
           username: _json_key
           password: ${{ secrets.GOOGLE_CREDENTIALS }}
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+      # cache was removed because it didn't reduce the runtime
+      # - name: Cache Docker layers
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: /tmp/.buildx-cache
+      #     key: ${{ runner.os }}-buildx-${{ github.sha }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-buildx-
       - name: "Build and push amplication/amplication Docker image"
         uses: docker/build-push-action@v2
         with:
@@ -105,21 +106,7 @@ jobs:
             amplication/amplication:latest
             amplication/amplication:${{ github.sha }}
             gcr.io/amplication/amplication:${{ github.sha }}
-      - name: "Build and push amplication/scheduler Docker image"
-        uses: docker/build-push-action@v2
-        with:
-          context: ./packages/amplication-scheduler
-          file: ./packages/amplication-scheduler/Dockerfile
-          pull: true
-          push: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          tags: |
-            amplication/scheduler:latest
-            amplication/scheduler:${{ github.sha }}
       - uses: hashicorp/setup-terraform@v1
-        # with:
-        # terraform_version: 0.13.5
       - run: terraform init -lock-timeout=1200s
         env:
           GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}


### PR DESCRIPTION
Resolves #1285 

[x] - Remove build docker for amplication/scheduler. The scheduler is not used on the cloud only no local deployment
[x] - Remove cache action. Container build time with and without cache is the same. Total execution time is faster without cache.  