### PR TITLE
DSG: make relation property on entity DTO optional

### DIFF
--- a/packages/amplication-data-service-generator/src/server/resource/dto/create-field-class-property.spec.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/dto/create-field-class-property.spec.ts
@@ -161,8 +161,8 @@ describe("createFieldClassProperty", () => {
             createWhereUniqueInputID(EXAMPLE_OTHER_ENTITY.name)
           )
         ),
-        true,
         false,
+        true,
         null,
         [
           builders.decorator(

--- a/packages/amplication-data-service-generator/src/server/resource/dto/create-field-class-property.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/dto/create-field-class-property.ts
@@ -106,7 +106,9 @@ export function createFieldClassProperty(
     optional = true;
   }
   const optionalProperty =
-    optional && (isInput || prismaField.kind === FieldKind.Object);
+    //all relation fields on entity dto (not input) are optional
+    (prismaField.kind === FieldKind.Object && !isInput) ||
+    (optional && (isInput || prismaField.kind === FieldKind.Object));
   const definitive = !optionalProperty;
 
   if (prismaField.kind === FieldKind.Scalar) {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -478,8 +478,8 @@ export type Order = {
   id: string;
   createdAt: Date;
   updatedAt: Date;
-  customer: CustomerWhereUniqueInput;
-  status: \\"pending\\" | \\"inProgress\\" | \\"done\\";
+  customer?: CustomerWhereUniqueInput;
+  status?: \\"pending\\" | \\"inProgress\\" | \\"done\\";
   label?: \\"fragile\\" | null;
 };
 ",
@@ -639,7 +639,7 @@ export type User = {
   manager?: UserWhereUniqueInput | null;
   organization?: OrganizationWhereUniqueInput | null;
   interests?: Array<\\"programming\\" | \\"design\\">;
-  priority: \\"high\\" | \\"medium\\" | \\"low\\";
+  priority?: \\"high\\" | \\"medium\\" | \\"low\\";
   isCurious: boolean;
   location: string;
 };
@@ -6900,14 +6900,14 @@ class Order {
   })
   @ValidateNested()
   @Type(() => CustomerWhereUniqueInput)
-  customer!: CustomerWhereUniqueInput;
+  customer?: CustomerWhereUniqueInput;
   @ApiProperty({
     required: true,
     enum: EnumOrderStatus,
   })
   @IsEnum(EnumOrderStatus)
   @Field(() => EnumOrderStatus)
-  status!: \\"pending\\" | \\"inProgress\\" | \\"done\\";
+  status?: \\"pending\\" | \\"inProgress\\" | \\"done\\";
   @ApiProperty({
     required: false,
     enum: EnumOrderLabel,
@@ -9719,7 +9719,7 @@ class User {
   })
   @IsEnum(EnumUserPriority)
   @Field(() => EnumUserPriority)
-  priority!: \\"high\\" | \\"medium\\" | \\"low\\";
+  priority?: \\"high\\" | \\"medium\\" | \\"low\\";
   @ApiProperty({
     required: true,
     type: Boolean,


### PR DESCRIPTION
Relation property on entity DTO should always be optional since the developer may request just the parent object without the child object (online Input DTO where it must be required when the field is required)
