### PR TITLE
Chore: downgrade Prisma to 2.19 in generated app

### DIFF
--- a/packages/amplication-data-service-generator/package-lock.json
+++ b/packages/amplication-data-service-generator/package-lock.json
@@ -1387,11 +1387,11 @@
 			}
 		},
 		"@prisma/client": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.20.1.tgz",
-			"integrity": "sha512-/IYPubBi55rNMHfE0wwglA6eTWEZD77oz+x+3Mm9ji2lDKdS1lnYKZ0wZX0E3AB8gTNL/zsGtfzmfjgn3ePyIw==",
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.19.0.tgz",
+			"integrity": "sha512-QK4M8TjJh1QesyO9aLM7DeAQUi5+UnNHpEAm5kwqBO1cq/4Ag5yU9ladctJFJleEE5BLewXHwV2t9A+VfCZslg==",
 			"requires": {
-				"@prisma/engines-version": "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+				"@prisma/engines-version": "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
 			}
 		},
 		"@prisma/debug": {
@@ -1473,9 +1473,9 @@
 			"integrity": "sha512-F6RmUZ5JpPWxmGvVDji8c4gepHIGkvYbtuFi0IoDDJVaCVo8yS656stciKFyswI6/BLWXa0X47/MIMbz6nzw7g=="
 		},
 		"@prisma/engines-version": {
-			"version": "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e",
-			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e.tgz",
-			"integrity": "sha512-fJhbGZXm2SPs/RsI79Ew4SFe+6QmChNdgU2I/SIjmU18bUgK8f1TBEWnVtFdBqEDHYPGxbpaianF7lp04KN7EA=="
+			"version": "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d",
+			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d.tgz",
+			"integrity": "sha512-NzhbwC4iMbRQwJxdhNQX6eaVcOuNGtHRk6aesWE4KMf/YmlW5kfi3HDy7WZ/C4P0Iyn9oURDuk+xZV6QDUVjTw=="
 		},
 		"@prisma/fetch-engine": {
 			"version": "2.12.0",

--- a/packages/amplication-data-service-generator/package.json
+++ b/packages/amplication-data-service-generator/package.json
@@ -32,7 +32,7 @@
     "@nestjs/serve-static": "^2.1.3",
     "@nestjs/swagger": "^4.6.1",
     "@nestjs/testing": "^7.3.2",
-    "@prisma/client": "^2.20.1",
+    "@prisma/client": "^2.19.0",
     "@testing-library/react": "^11.1.1",
     "@types/bcrypt": "^3.0.0",
     "@types/express": "^4.17.7",

--- a/packages/amplication-data-service-generator/src/server/static/package-lock.json
+++ b/packages/amplication-data-service-generator/src/server/static/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "server-template",
-      "version": "0.4.0",
+      "version": "0.5.2",
       "dependencies": {
         "@nestjs/common": "^7.3.2",
         "@nestjs/config": "^0.6.1",
@@ -16,7 +16,7 @@
         "@nestjs/platform-express": "^7.3.2",
         "@nestjs/serve-static": "^2.1.3",
         "@nestjs/swagger": "^4.6.1",
-        "@prisma/client": "^2.20.1",
+        "@prisma/client": "^2.19.0",
         "@types/bcrypt": "^3.0.0",
         "@types/express": "^4.17.7",
         "@types/passport-http": "^0.3.8",
@@ -47,7 +47,7 @@
         "@types/normalize-path": "^3.0.0",
         "@types/supertest": "^2.0.10",
         "jest": "^26.1.0",
-        "prisma": "^2.20.1",
+        "prisma": "^2.19.0",
         "supertest": "^4.0.2",
         "ts-jest": "^26.1.3"
       }
@@ -1615,15 +1615,15 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.20.1.tgz",
-      "integrity": "sha512-/IYPubBi55rNMHfE0wwglA6eTWEZD77oz+x+3Mm9ji2lDKdS1lnYKZ0wZX0E3AB8gTNL/zsGtfzmfjgn3ePyIw==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.19.0.tgz",
+      "integrity": "sha512-QK4M8TjJh1QesyO9aLM7DeAQUi5+UnNHpEAm5kwqBO1cq/4Ag5yU9ladctJFJleEE5BLewXHwV2t9A+VfCZslg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+        "@prisma/engines-version": "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
       },
       "engines": {
-        "node": ">=10.16"
+        "node": ">=10.4"
       },
       "peerDependencies": {
         "prisma": "*"
@@ -1634,10 +1634,16 @@
         }
       }
     },
+    "node_modules/@prisma/engines": {
+      "version": "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d.tgz",
+      "integrity": "sha512-rEWpaG7wZvPuWJC5SwkBB/Iwue//oC5yv58Mse7r+ibtgkA7vGdWc1bFDQ32DT9tDL5WSC6bBwqEASGV/1Gm1Q==",
+      "hasInstallScript": true
+    },
     "node_modules/@prisma/engines-version": {
-      "version": "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e.tgz",
-      "integrity": "sha512-fJhbGZXm2SPs/RsI79Ew4SFe+6QmChNdgU2I/SIjmU18bUgK8f1TBEWnVtFdBqEDHYPGxbpaianF7lp04KN7EA=="
+      "version": "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d.tgz",
+      "integrity": "sha512-NzhbwC4iMbRQwJxdhNQX6eaVcOuNGtHRk6aesWE4KMf/YmlW5kfi3HDy7WZ/C4P0Iyn9oURDuk+xZV6QDUVjTw=="
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -9931,12 +9937,12 @@
       }
     },
     "node_modules/prisma": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.20.1.tgz",
-      "integrity": "sha512-zyPvJSUfJrmciP2D/4aUrsyIefiH8AIJUeuq1a0X1df1AFw9QQ+ata/7VQdoP+RIQHnCb6Kln9kqfUw/fieljw==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.19.0.tgz",
+      "integrity": "sha512-iartCNVrtR4XT20ABN3zrSi3R/pCBe75Y0ZH8681QIGm8qjRQzf3DnbscPZgZ9iY4KFuVxL8ZrBQVDmRhpN0EQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+        "@prisma/engines": "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -9945,12 +9951,6 @@
       "engines": {
         "node": ">=10.4"
       }
-    },
-    "node_modules/prisma/node_modules/@prisma/engines": {
-      "version": "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e.tgz",
-      "integrity": "sha512-zOWETm7DTRvlwf/CekPNSeJe6EC5bn2IFexd74wM9zgBXCZo+1sMDuNGtCqIt4Rzv8CcimEgyzrEFVq0LPV8qg==",
-      "hasInstallScript": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -14404,17 +14404,22 @@
       }
     },
     "@prisma/client": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.20.1.tgz",
-      "integrity": "sha512-/IYPubBi55rNMHfE0wwglA6eTWEZD77oz+x+3Mm9ji2lDKdS1lnYKZ0wZX0E3AB8gTNL/zsGtfzmfjgn3ePyIw==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.19.0.tgz",
+      "integrity": "sha512-QK4M8TjJh1QesyO9aLM7DeAQUi5+UnNHpEAm5kwqBO1cq/4Ag5yU9ladctJFJleEE5BLewXHwV2t9A+VfCZslg==",
       "requires": {
-        "@prisma/engines-version": "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+        "@prisma/engines-version": "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
       }
     },
+    "@prisma/engines": {
+      "version": "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d.tgz",
+      "integrity": "sha512-rEWpaG7wZvPuWJC5SwkBB/Iwue//oC5yv58Mse7r+ibtgkA7vGdWc1bFDQ32DT9tDL5WSC6bBwqEASGV/1Gm1Q=="
+    },
     "@prisma/engines-version": {
-      "version": "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e.tgz",
-      "integrity": "sha512-fJhbGZXm2SPs/RsI79Ew4SFe+6QmChNdgU2I/SIjmU18bUgK8f1TBEWnVtFdBqEDHYPGxbpaianF7lp04KN7EA=="
+      "version": "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d.tgz",
+      "integrity": "sha512-NzhbwC4iMbRQwJxdhNQX6eaVcOuNGtHRk6aesWE4KMf/YmlW5kfi3HDy7WZ/C4P0Iyn9oURDuk+xZV6QDUVjTw=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -20954,18 +20959,11 @@
       }
     },
     "prisma": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.20.1.tgz",
-      "integrity": "sha512-zyPvJSUfJrmciP2D/4aUrsyIefiH8AIJUeuq1a0X1df1AFw9QQ+ata/7VQdoP+RIQHnCb6Kln9kqfUw/fieljw==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.19.0.tgz",
+      "integrity": "sha512-iartCNVrtR4XT20ABN3zrSi3R/pCBe75Y0ZH8681QIGm8qjRQzf3DnbscPZgZ9iY4KFuVxL8ZrBQVDmRhpN0EQ==",
       "requires": {
-        "@prisma/engines": "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
-      },
-      "dependencies": {
-        "@prisma/engines": {
-          "version": "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e",
-          "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e.tgz",
-          "integrity": "sha512-zOWETm7DTRvlwf/CekPNSeJe6EC5bn2IFexd74wM9zgBXCZo+1sMDuNGtCqIt4Rzv8CcimEgyzrEFVq0LPV8qg=="
-        }
+        "@prisma/engines": "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
       }
     },
     "process-nextick-args": {

--- a/packages/amplication-data-service-generator/src/server/static/package.json
+++ b/packages/amplication-data-service-generator/src/server/static/package.json
@@ -26,7 +26,7 @@
     "@nestjs/platform-express": "^7.3.2",
     "@nestjs/serve-static": "^2.1.3",
     "@nestjs/swagger": "^4.6.1",
-    "@prisma/client": "^2.20.1",
+    "@prisma/client": "^2.19.0",
     "@types/bcrypt": "^3.0.0",
     "@types/express": "^4.17.7",
     "@types/passport-http": "^0.3.8",
@@ -57,7 +57,7 @@
     "@types/normalize-path": "^3.0.0",
     "@types/supertest": "^2.0.10",
     "jest": "^26.1.0",
-    "prisma": "^2.20.1",
+    "prisma": "^2.19.0",
     "supertest": "^4.0.2",
     "ts-jest": "^26.1.3"
   },


### PR DESCRIPTION
Downgrade from prisma@2.20.1 to prisma@2.19.0 to resolve conflict with TypeGraphQL
https://github.com/MichalLytek/typegraphql-prisma/issues/92

