### PR TITLE
Limit the number of destroy actions per cycle

### DIFF
--- a/packages/amplication-server/src/core/deployment/deployment.service.spec.ts
+++ b/packages/amplication-server/src/core/deployment/deployment.service.spec.ts
@@ -147,6 +147,7 @@ const EXAMPLE_LOGGER_FORMAT = Symbol('EXAMPLE_LOGGER_FORMAT');
 const prismaDeploymentCreateMock = jest.fn(() => EXAMPLE_DEPLOYMENT);
 
 const prismaDeploymentUpdateMock = jest.fn(() => EXAMPLE_DEPLOYMENT);
+const prismaDeploymentUpdateManyMock = jest.fn(() => [EXAMPLE_DEPLOYMENT]);
 
 const prismaDeploymentFindOneMock = jest.fn(() => EXAMPLE_DEPLOYMENT);
 
@@ -234,7 +235,8 @@ describe('DeploymentService', () => {
               create: prismaDeploymentCreateMock,
               findMany: prismaDeploymentFindManyMock,
               findUnique: prismaDeploymentFindOneMock,
-              update: prismaDeploymentUpdateMock
+              update: prismaDeploymentUpdateMock,
+              updateMany: prismaDeploymentUpdateManyMock
             },
             environment: {
               update: environmentServiceUpdateMock
@@ -475,11 +477,9 @@ describe('DeploymentService', () => {
     };
     const loggerMessage = `Deployment ${EXAMPLE_DEPLOYMENT_ID}: current status ${EXAMPLE_COMPLETED_DEPLOY_RESULT.status}`;
     expect(await service.updateRunningDeploymentsStatus()).toEqual(undefined);
-    expect(prismaDeploymentFindManyMock).toBeCalledTimes(2);
+    expect(prismaDeploymentFindManyMock).toBeCalledTimes(1);
     expect(prismaDeploymentFindManyMock).toBeCalledWith(findManyArgs);
-    expect(prismaDeploymentFindManyMock).toBeCalledWith({
-      where: { environmentId: EXAMPLE_DEPLOYMENT.environmentId }
-    });
+
     expect(actionServiceGetStepsMock).toBeCalledTimes(1);
     expect(actionServiceGetStepsMock).toBeCalledWith(EXAMPLE_ACTION_ID);
     expect(deployerServiceGetStatusMock).toBeCalledTimes(1);
@@ -493,11 +493,17 @@ describe('DeploymentService', () => {
       EXAMPLE_ACTION_STEP,
       DEPLOY_STEP_FINISH_LOG
     );
-    expect(prismaDeploymentUpdateMock).toBeCalledTimes(2);
-    expect(prismaDeploymentUpdateMock).toBeCalledWith({
-      where: { id: EXAMPLE_DEPLOYMENT_ID },
-      data: { status: EnumDeploymentStatus.Removed }
+    expect(prismaDeploymentUpdateManyMock).toBeCalledTimes(1);
+    expect(prismaDeploymentUpdateManyMock).toBeCalledWith({
+      where: {
+        environmentId: EXAMPLE_DEPLOYMENT.environmentId,
+        status: EnumDeploymentStatus.Completed
+      },
+      data: {
+        status: EnumDeploymentStatus.Removed
+      }
     });
+    expect(prismaDeploymentUpdateMock).toBeCalledTimes(1);
     expect(prismaDeploymentUpdateMock).toBeCalledWith({
       where: { id: EXAMPLE_DEPLOYMENT_ID },
       data: { status: EnumDeploymentStatus.Completed }


### PR DESCRIPTION
Limit the number of "destroy" actions per cycle not to block the build queue and to avoid exhausting the resources limit