### PR TITLE
Fix/swagger types

### DIFF
--- a/packages/amplication-data-service-generator/package.json
+++ b/packages/amplication-data-service-generator/package.json
@@ -30,7 +30,7 @@
     "@nestjs/passport": "^7.1.0",
     "@nestjs/platform-express": "^7.2.0",
     "@nestjs/serve-static": "^2.1.3",
-    "@nestjs/swagger": "^4.6.1",
+    "@nestjs/swagger": "^4.7.8",
     "@nestjs/testing": "^7.3.2",
     "@prisma/client": "^2.19.0",
     "@testing-library/react": "^11.1.1",

--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
@@ -12,10 +12,6 @@ import { isRecordNotFoundError } from "../../prisma.util";
 import * as errors from "../../errors";
 import { Request } from "express";
 
-declare interface CREATE_QUERY {}
-declare interface UPDATE_QUERY {}
-declare interface DELETE_QUERY {}
-
 declare interface CREATE_INPUT {}
 declare interface WHERE_INPUT {}
 declare interface WHERE_UNIQUE_INPUT {}
@@ -24,7 +20,6 @@ declare interface UPDATE_INPUT {}
 declare const FINE_ONE_PATH: string;
 declare const UPDATE_PATH: string;
 declare const DELETE_PATH: string;
-declare interface FIND_ONE_QUERY {}
 
 declare class ENTITY {}
 declare interface Select {}
@@ -66,19 +61,10 @@ export class CONTROLLER_BASE {
   })
   @swagger.ApiCreatedResponse({ type: ENTITY })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    //@ts-ignore
-    type: () => CREATE_QUERY,
-    style: "deepObject",
-    explode: true,
-  })
   async create(
-    @common.Req() request: Request,
     @common.Body() data: CREATE_INPUT,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<ENTITY> {
-    const query: CREATE_QUERY = request.query;
-
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: "create",
@@ -97,9 +83,7 @@ export class CONTROLLER_BASE {
         `providing the properties: ${properties} on ${ENTITY_NAME} creation is forbidden for roles: ${roles}`
       );
     }
-    // @ts-ignore
     return await this.service.create({
-      ...query,
       data: CREATE_DATA_MAPPING,
       select: SELECT,
     });
@@ -151,19 +135,10 @@ export class CONTROLLER_BASE {
   @swagger.ApiOkResponse({ type: ENTITY })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    //@ts-ignore
-    type: () => FIND_ONE_QUERY,
-    style: "deepObject",
-    explode: true,
-  })
   async findOne(
-    @common.Req() request: Request,
     @common.Param() params: WHERE_UNIQUE_INPUT,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<ENTITY | null> {
-    const query: FIND_ONE_QUERY = request.query;
-
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: "read",
@@ -171,7 +146,6 @@ export class CONTROLLER_BASE {
       resource: ENTITY_NAME,
     });
     const result = await this.service.findOne({
-      ...query,
       where: params,
       select: SELECT,
     });
@@ -194,20 +168,12 @@ export class CONTROLLER_BASE {
   @swagger.ApiOkResponse({ type: ENTITY })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    //@ts-ignore
-    type: () => UPDATE_QUERY,
-    style: "deepObject",
-    explode: true,
-  })
   async update(
-    @common.Req() request: Request,
     @common.Param() params: WHERE_UNIQUE_INPUT,
     @common.Body()
     data: UPDATE_INPUT,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<ENTITY | null> {
-    const query: UPDATE_QUERY = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: "update",
@@ -227,9 +193,7 @@ export class CONTROLLER_BASE {
       );
     }
     try {
-      // @ts-ignore
       return await this.service.update({
-        ...query,
         where: params,
         data: UPDATE_DATA_MAPPING,
         select: SELECT,
@@ -255,21 +219,11 @@ export class CONTROLLER_BASE {
   @swagger.ApiOkResponse({ type: ENTITY })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    //@ts-ignore
-    type: () => DELETE_QUERY,
-    style: "deepObject",
-    explode: true,
-  })
   async delete(
-    @common.Req() request: Request,
     @common.Param() params: WHERE_UNIQUE_INPUT
   ): Promise<ENTITY | null> {
-    const query: DELETE_QUERY = request.query;
-
     try {
       return await this.service.delete({
-        ...query,
         where: params,
         select: SELECT,
       });

--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
@@ -10,6 +10,7 @@ import * as abacUtil from "../../auth/abac.util";
 import { isRecordNotFoundError } from "../../prisma.util";
 // @ts-ignore
 import * as errors from "../../errors";
+import { Request } from "express";
 
 declare interface CREATE_QUERY {}
 declare interface UPDATE_QUERY {}
@@ -65,11 +66,19 @@ export class CONTROLLER_BASE {
   })
   @swagger.ApiCreatedResponse({ type: ENTITY })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => CREATE_QUERY,
+    style: "deepObject",
+    explode: true,
+  })
   async create(
-    @common.Query() query: CREATE_QUERY,
+    @common.Req() request: Request,
     @common.Body() data: CREATE_INPUT,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<ENTITY> {
+    const query: CREATE_QUERY = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: "create",
@@ -106,10 +115,18 @@ export class CONTROLLER_BASE {
   })
   @swagger.ApiOkResponse({ type: [ENTITY] })
   @swagger.ApiForbiddenResponse()
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => WHERE_INPUT,
+    style: "deepObject",
+    explode: true,
+  })
   async findMany(
-    @common.Query() query: WHERE_INPUT,
+    @common.Req() request: Request,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<ENTITY[]> {
+    const query: WHERE_INPUT = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: "read",
@@ -134,11 +151,19 @@ export class CONTROLLER_BASE {
   @swagger.ApiOkResponse({ type: ENTITY })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => FIND_ONE_QUERY,
+    style: "deepObject",
+    explode: true,
+  })
   async findOne(
-    @common.Query() query: FIND_ONE_QUERY,
+    @common.Req() request: Request,
     @common.Param() params: WHERE_UNIQUE_INPUT,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<ENTITY | null> {
+    const query: FIND_ONE_QUERY = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: "read",
@@ -169,13 +194,20 @@ export class CONTROLLER_BASE {
   @swagger.ApiOkResponse({ type: ENTITY })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => UPDATE_QUERY,
+    style: "deepObject",
+    explode: true,
+  })
   async update(
-    @common.Query() query: UPDATE_QUERY,
+    @common.Req() request: Request,
     @common.Param() params: WHERE_UNIQUE_INPUT,
     @common.Body()
     data: UPDATE_INPUT,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<ENTITY | null> {
+    const query: UPDATE_QUERY = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: "update",
@@ -223,10 +255,18 @@ export class CONTROLLER_BASE {
   @swagger.ApiOkResponse({ type: ENTITY })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => DELETE_QUERY,
+    style: "deepObject",
+    explode: true,
+  })
   async delete(
-    @common.Query() query: DELETE_QUERY,
+    @common.Req() request: Request,
     @common.Param() params: WHERE_UNIQUE_INPUT
   ): Promise<ENTITY | null> {
+    const query: DELETE_QUERY = request.query;
+
     try {
       return await this.service.delete({
         ...query,

--- a/packages/amplication-data-service-generator/src/server/resource/controller/create-controller.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/create-controller.ts
@@ -13,7 +13,6 @@ import {
   getClassDeclarationById,
   removeESLintComments,
   importContainedIdentifiers,
-  removeImportsTSIgnoreComments,
   getMethods,
   NamedClassDeclaration,
   removeTSIgnoreComments,
@@ -61,10 +60,7 @@ export async function createControllerModules(
     ENTITY: entityDTO.id,
     ENTITY_NAME: builders.stringLiteral(entityType),
     SELECT: createSelect(entityDTO, entity),
-    /** @todo replace */
-    CREATE_QUERY: builders.tsTypeLiteral([]),
-    UPDATE_QUERY: builders.tsTypeLiteral([]),
-    DELETE_QUERY: builders.tsTypeLiteral([]),
+
     CREATE_INPUT: entityDTOs.createInput.id,
     CREATE_DATA_MAPPING: createDataMapping(
       entity,
@@ -83,8 +79,6 @@ export async function createControllerModules(
     FINE_ONE_PATH: builders.stringLiteral("/:id"),
     UPDATE_PATH: builders.stringLiteral("/:id"),
     DELETE_PATH: builders.stringLiteral("/:id"),
-    /** @todo replace */
-    FIND_ONE_QUERY: builders.tsTypeLiteral([]),
     WHERE_UNIQUE_INPUT: entityDTOs.whereUniqueInput.id,
   };
   return [

--- a/packages/amplication-data-service-generator/src/server/resource/controller/create-controller.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/create-controller.ts
@@ -16,6 +16,7 @@ import {
   removeImportsTSIgnoreComments,
   getMethods,
   NamedClassDeclaration,
+  removeTSIgnoreComments,
 } from "../../../util/ast";
 import { isToManyRelationField } from "../../../util/field";
 import { SRC_DIRECTORY } from "../../constants";
@@ -179,7 +180,7 @@ async function createControllerModule(
     ]);
   }
 
-  removeImportsTSIgnoreComments(file);
+  removeTSIgnoreComments(file);
   removeESLintComments(file);
   removeTSVariableDeclares(file);
   removeTSInterfaceDeclares(file);

--- a/packages/amplication-data-service-generator/src/server/resource/controller/to-many.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/to-many.template.ts
@@ -1,10 +1,12 @@
 import * as common from "@nestjs/common";
+import * as swagger from "@nestjs/swagger";
 import * as nestMorgan from "nest-morgan";
 import * as nestAccessControl from "nest-access-control";
 // @ts-ignore
 import * as basicAuthGuard from "../auth/basicAuth.guard";
 // @ts-ignore
 import * as abacUtil from "../auth/abac.util";
+import { Request } from "express";
 
 declare interface WHERE_UNIQUE_INPUT {
   id: string;
@@ -56,11 +58,18 @@ export class Mixin {
     action: "read",
     possession: "any",
   })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => RELATED_ENTITY_WHERE_INPUT,
+    style: "deepObject",
+    explode: true,
+  })
   async FIND_MANY(
+    @common.Req() request: Request,
     @common.Param() params: WHERE_UNIQUE_INPUT,
-    @common.Query() query: RELATED_ENTITY_WHERE_INPUT,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<RELATED_ENTITY[]> {
+    const query: RELATED_ENTITY_WHERE_INPUT = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: "read",

--- a/packages/amplication-data-service-generator/src/server/static/package.json
+++ b/packages/amplication-data-service-generator/src/server/static/package.json
@@ -25,7 +25,7 @@
     "@nestjs/passport": "^7.1.0",
     "@nestjs/platform-express": "^7.3.2",
     "@nestjs/serve-static": "^2.1.3",
-    "@nestjs/swagger": "^4.6.1",
+    "@nestjs/swagger": "^4.7.8",
     "@prisma/client": "^2.19.0",
     "@types/bcrypt": "^3.0.0",
     "@types/express": "^4.17.7",

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -5092,6 +5092,7 @@ import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
 import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import * as errors from \\"../../errors\\";
+import { Request } from \\"express\\";
 import { CustomerService } from \\"../customer.service\\";
 import { CustomerCreateInput } from \\"./CustomerCreateInput\\";
 import { CustomerWhereInput } from \\"./CustomerWhereInput\\";
@@ -5117,11 +5118,19 @@ export class CustomerControllerBase {
   })
   @swagger.ApiCreatedResponse({ type: Customer })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async create(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Body() data: CustomerCreateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Customer> {
+    const query: {} = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"create\\",
@@ -5199,10 +5208,18 @@ export class CustomerControllerBase {
   })
   @swagger.ApiOkResponse({ type: [Customer] })
   @swagger.ApiForbiddenResponse()
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => CustomerWhereInput,
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findMany(
-    @common.Query() query: CustomerWhereInput,
+    @common.Req() request: Request,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Customer[]> {
+    const query: CustomerWhereInput = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -5254,11 +5271,19 @@ export class CustomerControllerBase {
   @swagger.ApiOkResponse({ type: Customer })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findOne(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: CustomerWhereUniqueInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Customer | null> {
+    const query: {} = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -5316,13 +5341,20 @@ export class CustomerControllerBase {
   @swagger.ApiOkResponse({ type: Customer })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async update(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: CustomerWhereUniqueInput,
     @common.Body()
     data: CustomerUpdateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Customer | null> {
+    const query: {} = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"update\\",
@@ -5411,10 +5443,18 @@ export class CustomerControllerBase {
   @swagger.ApiOkResponse({ type: Customer })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async delete(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: CustomerWhereUniqueInput
   ): Promise<Customer | null> {
+    const query: {} = request.query;
+
     try {
       return await this.service.delete({
         ...query,
@@ -6317,6 +6357,7 @@ import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
 import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import * as errors from \\"../../errors\\";
+import { Request } from \\"express\\";
 import { EmptyService } from \\"../empty.service\\";
 import { EmptyCreateInput } from \\"./EmptyCreateInput\\";
 import { EmptyWhereInput } from \\"./EmptyWhereInput\\";
@@ -6340,11 +6381,19 @@ export class EmptyControllerBase {
   })
   @swagger.ApiCreatedResponse({ type: Empty })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async create(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Body() data: EmptyCreateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Empty> {
+    const query: {} = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"create\\",
@@ -6385,10 +6434,18 @@ export class EmptyControllerBase {
   })
   @swagger.ApiOkResponse({ type: [Empty] })
   @swagger.ApiForbiddenResponse()
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => EmptyWhereInput,
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findMany(
-    @common.Query() query: EmptyWhereInput,
+    @common.Req() request: Request,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Empty[]> {
+    const query: EmptyWhereInput = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -6417,11 +6474,19 @@ export class EmptyControllerBase {
   @swagger.ApiOkResponse({ type: Empty })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findOne(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: EmptyWhereUniqueInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Empty | null> {
+    const query: {} = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -6456,13 +6521,20 @@ export class EmptyControllerBase {
   @swagger.ApiOkResponse({ type: Empty })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async update(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: EmptyWhereUniqueInput,
     @common.Body()
     data: EmptyUpdateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Empty | null> {
+    const query: {} = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"update\\",
@@ -6514,10 +6586,18 @@ export class EmptyControllerBase {
   @swagger.ApiOkResponse({ type: Empty })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async delete(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: EmptyWhereUniqueInput
   ): Promise<Empty | null> {
+    const query: {} = request.query;
+
     try {
       return await this.service.delete({
         ...query,
@@ -7267,6 +7347,7 @@ import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
 import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import * as errors from \\"../../errors\\";
+import { Request } from \\"express\\";
 import { OrderService } from \\"../order.service\\";
 import { OrderCreateInput } from \\"./OrderCreateInput\\";
 import { OrderWhereInput } from \\"./OrderWhereInput\\";
@@ -7290,11 +7371,19 @@ export class OrderControllerBase {
   })
   @swagger.ApiCreatedResponse({ type: Order })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async create(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Body() data: OrderCreateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Order> {
+    const query: {} = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"create\\",
@@ -7350,10 +7439,18 @@ export class OrderControllerBase {
   })
   @swagger.ApiOkResponse({ type: [Order] })
   @swagger.ApiForbiddenResponse()
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => OrderWhereInput,
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findMany(
-    @common.Query() query: OrderWhereInput,
+    @common.Req() request: Request,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Order[]> {
+    const query: OrderWhereInput = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -7391,11 +7488,19 @@ export class OrderControllerBase {
   @swagger.ApiOkResponse({ type: Order })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findOne(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: OrderWhereUniqueInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Order | null> {
+    const query: {} = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -7439,13 +7544,20 @@ export class OrderControllerBase {
   @swagger.ApiOkResponse({ type: Order })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async update(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: OrderWhereUniqueInput,
     @common.Body()
     data: OrderUpdateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Order | null> {
+    const query: {} = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"update\\",
@@ -7512,10 +7624,18 @@ export class OrderControllerBase {
   @swagger.ApiOkResponse({ type: Order })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async delete(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: OrderWhereUniqueInput
   ): Promise<Order | null> {
+    const query: {} = request.query;
+
     try {
       return await this.service.delete({
         ...query,
@@ -8230,6 +8350,7 @@ import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
 import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import * as errors from \\"../../errors\\";
+import { Request } from \\"express\\";
 import { OrganizationService } from \\"../organization.service\\";
 import { OrganizationCreateInput } from \\"./OrganizationCreateInput\\";
 import { OrganizationWhereInput } from \\"./OrganizationWhereInput\\";
@@ -8257,11 +8378,19 @@ export class OrganizationControllerBase {
   })
   @swagger.ApiCreatedResponse({ type: Organization })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async create(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Body() data: OrganizationCreateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Organization> {
+    const query: {} = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"create\\",
@@ -8303,10 +8432,18 @@ export class OrganizationControllerBase {
   })
   @swagger.ApiOkResponse({ type: [Organization] })
   @swagger.ApiForbiddenResponse()
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => OrganizationWhereInput,
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findMany(
-    @common.Query() query: OrganizationWhereInput,
+    @common.Req() request: Request,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Organization[]> {
+    const query: OrganizationWhereInput = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -8336,11 +8473,19 @@ export class OrganizationControllerBase {
   @swagger.ApiOkResponse({ type: Organization })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findOne(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: OrganizationWhereUniqueInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Organization | null> {
+    const query: {} = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -8376,13 +8521,20 @@ export class OrganizationControllerBase {
   @swagger.ApiOkResponse({ type: Organization })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async update(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: OrganizationWhereUniqueInput,
     @common.Body()
     data: OrganizationUpdateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Organization | null> {
+    const query: {} = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"update\\",
@@ -8435,10 +8587,18 @@ export class OrganizationControllerBase {
   @swagger.ApiOkResponse({ type: Organization })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async delete(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: OrganizationWhereUniqueInput
   ): Promise<Organization | null> {
+    const query: {} = request.query;
+
     try {
       return await this.service.delete({
         ...query,
@@ -10450,6 +10610,7 @@ import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
 import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import * as errors from \\"../../errors\\";
+import { Request } from \\"express\\";
 import { UserService } from \\"../user.service\\";
 import { UserCreateInput } from \\"./UserCreateInput\\";
 import { UserWhereInput } from \\"./UserWhereInput\\";
@@ -10473,11 +10634,19 @@ export class UserControllerBase {
   })
   @swagger.ApiCreatedResponse({ type: User })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async create(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Body() data: UserCreateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<User> {
+    const query: {} = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"create\\",
@@ -10556,10 +10725,18 @@ export class UserControllerBase {
   })
   @swagger.ApiOkResponse({ type: [User] })
   @swagger.ApiForbiddenResponse()
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => UserWhereInput,
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findMany(
-    @common.Query() query: UserWhereInput,
+    @common.Req() request: Request,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<User[]> {
+    const query: UserWhereInput = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -10612,11 +10789,19 @@ export class UserControllerBase {
   @swagger.ApiOkResponse({ type: User })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findOne(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: UserWhereUniqueInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<User | null> {
+    const query: {} = request.query;
+
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -10675,13 +10860,20 @@ export class UserControllerBase {
   @swagger.ApiOkResponse({ type: User })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async update(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: UserWhereUniqueInput,
     @common.Body()
     data: UserUpdateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<User | null> {
+    const query: {} = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"update\\",
@@ -10771,10 +10963,18 @@ export class UserControllerBase {
   @swagger.ApiOkResponse({ type: User })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  @swagger.ApiQuery({
+    //@ts-ignore
+    type: () => {},
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async delete(
-    @common.Query() query: {},
+    @common.Req() request: Request,
     @common.Param() params: UserWhereUniqueInput
   ): Promise<User | null> {
+    const query: {} = request.query;
+
     try {
       return await this.service.delete({
         ...query,

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -5118,18 +5118,10 @@ export class CustomerControllerBase {
   })
   @swagger.ApiCreatedResponse({ type: Customer })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async create(
-    @common.Req() request: Request,
     @common.Body() data: CustomerCreateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Customer> {
-    const query: {} = request.query;
-
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"create\\",
@@ -5149,7 +5141,6 @@ export class CustomerControllerBase {
       );
     }
     return await this.service.create({
-      ...query,
       data: {
         ...data,
 
@@ -5268,18 +5259,10 @@ export class CustomerControllerBase {
   @swagger.ApiOkResponse({ type: Customer })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async findOne(
-    @common.Req() request: Request,
     @common.Param() params: CustomerWhereUniqueInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Customer | null> {
-    const query: {} = request.query;
-
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -5287,7 +5270,6 @@ export class CustomerControllerBase {
       resource: \\"Customer\\",
     });
     const result = await this.service.findOne({
-      ...query,
       where: params,
       select: {
         id: true,
@@ -5337,19 +5319,12 @@ export class CustomerControllerBase {
   @swagger.ApiOkResponse({ type: Customer })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async update(
-    @common.Req() request: Request,
     @common.Param() params: CustomerWhereUniqueInput,
     @common.Body()
     data: CustomerUpdateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Customer | null> {
-    const query: {} = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"update\\",
@@ -5370,7 +5345,6 @@ export class CustomerControllerBase {
     }
     try {
       return await this.service.update({
-        ...query,
         where: params,
         data: {
           ...data,
@@ -5437,20 +5411,11 @@ export class CustomerControllerBase {
   @swagger.ApiOkResponse({ type: Customer })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async delete(
-    @common.Req() request: Request,
     @common.Param() params: CustomerWhereUniqueInput
   ): Promise<Customer | null> {
-    const query: {} = request.query;
-
     try {
       return await this.service.delete({
-        ...query,
         where: params,
         select: {
           id: true,
@@ -6380,18 +6345,10 @@ export class EmptyControllerBase {
   })
   @swagger.ApiCreatedResponse({ type: Empty })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async create(
-    @common.Req() request: Request,
     @common.Body() data: EmptyCreateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Empty> {
-    const query: {} = request.query;
-
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"create\\",
@@ -6411,7 +6368,6 @@ export class EmptyControllerBase {
       );
     }
     return await this.service.create({
-      ...query,
       data: data,
       select: {
         id: true,
@@ -6470,18 +6426,10 @@ export class EmptyControllerBase {
   @swagger.ApiOkResponse({ type: Empty })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async findOne(
-    @common.Req() request: Request,
     @common.Param() params: EmptyWhereUniqueInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Empty | null> {
-    const query: {} = request.query;
-
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -6489,7 +6437,6 @@ export class EmptyControllerBase {
       resource: \\"Empty\\",
     });
     const result = await this.service.findOne({
-      ...query,
       where: params,
       select: {
         id: true,
@@ -6516,19 +6463,12 @@ export class EmptyControllerBase {
   @swagger.ApiOkResponse({ type: Empty })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async update(
-    @common.Req() request: Request,
     @common.Param() params: EmptyWhereUniqueInput,
     @common.Body()
     data: EmptyUpdateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Empty | null> {
-    const query: {} = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"update\\",
@@ -6549,7 +6489,6 @@ export class EmptyControllerBase {
     }
     try {
       return await this.service.update({
-        ...query,
         where: params,
         data: data,
         select: {
@@ -6579,20 +6518,11 @@ export class EmptyControllerBase {
   @swagger.ApiOkResponse({ type: Empty })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async delete(
-    @common.Req() request: Request,
     @common.Param() params: EmptyWhereUniqueInput
   ): Promise<Empty | null> {
-    const query: {} = request.query;
-
     try {
       return await this.service.delete({
-        ...query,
         where: params,
         select: {
           id: true,
@@ -7363,18 +7293,10 @@ export class OrderControllerBase {
   })
   @swagger.ApiCreatedResponse({ type: Order })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async create(
-    @common.Req() request: Request,
     @common.Body() data: OrderCreateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Order> {
-    const query: {} = request.query;
-
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"create\\",
@@ -7394,7 +7316,6 @@ export class OrderControllerBase {
       );
     }
     return await this.service.create({
-      ...query,
       data: {
         ...data,
 
@@ -7477,18 +7398,10 @@ export class OrderControllerBase {
   @swagger.ApiOkResponse({ type: Order })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async findOne(
-    @common.Req() request: Request,
     @common.Param() params: OrderWhereUniqueInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Order | null> {
-    const query: {} = request.query;
-
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -7496,7 +7409,6 @@ export class OrderControllerBase {
       resource: \\"Order\\",
     });
     const result = await this.service.findOne({
-      ...query,
       where: params,
       select: {
         id: true,
@@ -7532,19 +7444,12 @@ export class OrderControllerBase {
   @swagger.ApiOkResponse({ type: Order })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async update(
-    @common.Req() request: Request,
     @common.Param() params: OrderWhereUniqueInput,
     @common.Body()
     data: OrderUpdateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Order | null> {
-    const query: {} = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"update\\",
@@ -7565,7 +7470,6 @@ export class OrderControllerBase {
     }
     try {
       return await this.service.update({
-        ...query,
         where: params,
         data: {
           ...data,
@@ -7610,20 +7514,11 @@ export class OrderControllerBase {
   @swagger.ApiOkResponse({ type: Order })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async delete(
-    @common.Req() request: Request,
     @common.Param() params: OrderWhereUniqueInput
   ): Promise<Order | null> {
-    const query: {} = request.query;
-
     try {
       return await this.service.delete({
-        ...query,
         where: params,
         select: {
           id: true,
@@ -8363,18 +8258,10 @@ export class OrganizationControllerBase {
   })
   @swagger.ApiCreatedResponse({ type: Organization })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async create(
-    @common.Req() request: Request,
     @common.Body() data: OrganizationCreateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Organization> {
-    const query: {} = request.query;
-
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"create\\",
@@ -8394,7 +8281,6 @@ export class OrganizationControllerBase {
       );
     }
     return await this.service.create({
-      ...query,
       data: data,
       select: {
         id: true,
@@ -8455,18 +8341,10 @@ export class OrganizationControllerBase {
   @swagger.ApiOkResponse({ type: Organization })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async findOne(
-    @common.Req() request: Request,
     @common.Param() params: OrganizationWhereUniqueInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Organization | null> {
-    const query: {} = request.query;
-
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -8474,7 +8352,6 @@ export class OrganizationControllerBase {
       resource: \\"Organization\\",
     });
     const result = await this.service.findOne({
-      ...query,
       where: params,
       select: {
         id: true,
@@ -8502,19 +8379,12 @@ export class OrganizationControllerBase {
   @swagger.ApiOkResponse({ type: Organization })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async update(
-    @common.Req() request: Request,
     @common.Param() params: OrganizationWhereUniqueInput,
     @common.Body()
     data: OrganizationUpdateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Organization | null> {
-    const query: {} = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"update\\",
@@ -8535,7 +8405,6 @@ export class OrganizationControllerBase {
     }
     try {
       return await this.service.update({
-        ...query,
         where: params,
         data: data,
         select: {
@@ -8566,20 +8435,11 @@ export class OrganizationControllerBase {
   @swagger.ApiOkResponse({ type: Organization })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async delete(
-    @common.Req() request: Request,
     @common.Param() params: OrganizationWhereUniqueInput
   ): Promise<Organization | null> {
-    const query: {} = request.query;
-
     try {
       return await this.service.delete({
-        ...query,
         where: params,
         select: {
           id: true,
@@ -10630,18 +10490,10 @@ export class UserControllerBase {
   })
   @swagger.ApiCreatedResponse({ type: User })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async create(
-    @common.Req() request: Request,
     @common.Body() data: UserCreateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<User> {
-    const query: {} = request.query;
-
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"create\\",
@@ -10661,7 +10513,6 @@ export class UserControllerBase {
       );
     }
     return await this.service.create({
-      ...query,
       data: {
         ...data,
 
@@ -10782,18 +10633,10 @@ export class UserControllerBase {
   @swagger.ApiOkResponse({ type: User })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async findOne(
-    @common.Req() request: Request,
     @common.Param() params: UserWhereUniqueInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<User | null> {
-    const query: {} = request.query;
-
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -10801,7 +10644,6 @@ export class UserControllerBase {
       resource: \\"User\\",
     });
     const result = await this.service.findOne({
-      ...query,
       where: params,
       select: {
         username: true,
@@ -10852,19 +10694,12 @@ export class UserControllerBase {
   @swagger.ApiOkResponse({ type: User })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async update(
-    @common.Req() request: Request,
     @common.Param() params: UserWhereUniqueInput,
     @common.Body()
     data: UserUpdateInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<User | null> {
-    const query: {} = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"update\\",
@@ -10885,7 +10720,6 @@ export class UserControllerBase {
     }
     try {
       return await this.service.update({
-        ...query,
         where: params,
         data: {
           ...data,
@@ -10953,20 +10787,11 @@ export class UserControllerBase {
   @swagger.ApiOkResponse({ type: User })
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  @swagger.ApiQuery({
-    type: () => {},
-    style: \\"deepObject\\",
-    explode: true,
-  })
   async delete(
-    @common.Req() request: Request,
     @common.Param() params: UserWhereUniqueInput
   ): Promise<User | null> {
-    const query: {} = request.query;
-
     try {
       return await this.service.delete({
-        ...query,
         where: params,
         select: {
           username: true,

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -5119,7 +5119,6 @@ export class CustomerControllerBase {
   @swagger.ApiCreatedResponse({ type: Customer })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -5149,7 +5148,6 @@ export class CustomerControllerBase {
         \`providing the properties: \${properties} on \${\\"Customer\\"} creation is forbidden for roles: \${roles}\`
       );
     }
-    // @ts-ignore
     return await this.service.create({
       ...query,
       data: {
@@ -5209,7 +5207,6 @@ export class CustomerControllerBase {
   @swagger.ApiOkResponse({ type: [Customer] })
   @swagger.ApiForbiddenResponse()
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => CustomerWhereInput,
     style: \\"deepObject\\",
     explode: true,
@@ -5272,7 +5269,6 @@ export class CustomerControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -5342,7 +5338,6 @@ export class CustomerControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -5374,7 +5369,6 @@ export class CustomerControllerBase {
       );
     }
     try {
-      // @ts-ignore
       return await this.service.update({
         ...query,
         where: params,
@@ -5444,7 +5438,6 @@ export class CustomerControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -5506,11 +5499,17 @@ export class CustomerControllerBase {
     action: \\"read\\",
     possession: \\"any\\",
   })
+  @swagger.ApiQuery({
+    type: () => OrderWhereInput,
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findManyOrders(
+    @common.Req() request: Request,
     @common.Param() params: CustomerWhereUniqueInput,
-    @common.Query() query: OrderWhereInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Order[]> {
+    const query: OrderWhereInput = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -6382,7 +6381,6 @@ export class EmptyControllerBase {
   @swagger.ApiCreatedResponse({ type: Empty })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -6412,7 +6410,6 @@ export class EmptyControllerBase {
         \`providing the properties: \${properties} on \${\\"Empty\\"} creation is forbidden for roles: \${roles}\`
       );
     }
-    // @ts-ignore
     return await this.service.create({
       ...query,
       data: data,
@@ -6435,7 +6432,6 @@ export class EmptyControllerBase {
   @swagger.ApiOkResponse({ type: [Empty] })
   @swagger.ApiForbiddenResponse()
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => EmptyWhereInput,
     style: \\"deepObject\\",
     explode: true,
@@ -6475,7 +6471,6 @@ export class EmptyControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -6522,7 +6517,6 @@ export class EmptyControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -6554,7 +6548,6 @@ export class EmptyControllerBase {
       );
     }
     try {
-      // @ts-ignore
       return await this.service.update({
         ...query,
         where: params,
@@ -6587,7 +6580,6 @@ export class EmptyControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -7372,7 +7364,6 @@ export class OrderControllerBase {
   @swagger.ApiCreatedResponse({ type: Order })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -7402,7 +7393,6 @@ export class OrderControllerBase {
         \`providing the properties: \${properties} on \${\\"Order\\"} creation is forbidden for roles: \${roles}\`
       );
     }
-    // @ts-ignore
     return await this.service.create({
       ...query,
       data: {
@@ -7440,7 +7430,6 @@ export class OrderControllerBase {
   @swagger.ApiOkResponse({ type: [Order] })
   @swagger.ApiForbiddenResponse()
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => OrderWhereInput,
     style: \\"deepObject\\",
     explode: true,
@@ -7489,7 +7478,6 @@ export class OrderControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -7545,7 +7533,6 @@ export class OrderControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -7577,7 +7564,6 @@ export class OrderControllerBase {
       );
     }
     try {
-      // @ts-ignore
       return await this.service.update({
         ...query,
         where: params,
@@ -7625,7 +7611,6 @@ export class OrderControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -8379,7 +8364,6 @@ export class OrganizationControllerBase {
   @swagger.ApiCreatedResponse({ type: Organization })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -8409,7 +8393,6 @@ export class OrganizationControllerBase {
         \`providing the properties: \${properties} on \${\\"Organization\\"} creation is forbidden for roles: \${roles}\`
       );
     }
-    // @ts-ignore
     return await this.service.create({
       ...query,
       data: data,
@@ -8433,7 +8416,6 @@ export class OrganizationControllerBase {
   @swagger.ApiOkResponse({ type: [Organization] })
   @swagger.ApiForbiddenResponse()
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => OrganizationWhereInput,
     style: \\"deepObject\\",
     explode: true,
@@ -8474,7 +8456,6 @@ export class OrganizationControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -8522,7 +8503,6 @@ export class OrganizationControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -8554,7 +8534,6 @@ export class OrganizationControllerBase {
       );
     }
     try {
-      // @ts-ignore
       return await this.service.update({
         ...query,
         where: params,
@@ -8588,7 +8567,6 @@ export class OrganizationControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -8628,11 +8606,17 @@ export class OrganizationControllerBase {
     action: \\"read\\",
     possession: \\"any\\",
   })
+  @swagger.ApiQuery({
+    type: () => UserWhereInput,
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findManyUsers(
+    @common.Req() request: Request,
     @common.Param() params: OrganizationWhereUniqueInput,
-    @common.Query() query: UserWhereInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<User[]> {
+    const query: UserWhereInput = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -8808,11 +8792,17 @@ export class OrganizationControllerBase {
     action: \\"read\\",
     possession: \\"any\\",
   })
+  @swagger.ApiQuery({
+    type: () => CustomerWhereInput,
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findManyCustomers(
+    @common.Req() request: Request,
     @common.Param() params: OrganizationWhereUniqueInput,
-    @common.Query() query: CustomerWhereInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Customer[]> {
+    const query: CustomerWhereInput = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -8987,11 +8977,17 @@ export class OrganizationControllerBase {
     action: \\"read\\",
     possession: \\"any\\",
   })
+  @swagger.ApiQuery({
+    type: () => CustomerWhereInput,
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findManyVipCustomers(
+    @common.Req() request: Request,
     @common.Param() params: OrganizationWhereUniqueInput,
-    @common.Query() query: CustomerWhereInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<Customer[]> {
+    const query: CustomerWhereInput = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",
@@ -10635,7 +10631,6 @@ export class UserControllerBase {
   @swagger.ApiCreatedResponse({ type: User })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -10665,7 +10660,6 @@ export class UserControllerBase {
         \`providing the properties: \${properties} on \${\\"User\\"} creation is forbidden for roles: \${roles}\`
       );
     }
-    // @ts-ignore
     return await this.service.create({
       ...query,
       data: {
@@ -10726,7 +10720,6 @@ export class UserControllerBase {
   @swagger.ApiOkResponse({ type: [User] })
   @swagger.ApiForbiddenResponse()
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => UserWhereInput,
     style: \\"deepObject\\",
     explode: true,
@@ -10790,7 +10783,6 @@ export class UserControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -10861,7 +10853,6 @@ export class UserControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -10893,7 +10884,6 @@ export class UserControllerBase {
       );
     }
     try {
-      // @ts-ignore
       return await this.service.update({
         ...query,
         where: params,
@@ -10964,7 +10954,6 @@ export class UserControllerBase {
   @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   @swagger.ApiQuery({
-    //@ts-ignore
     type: () => {},
     style: \\"deepObject\\",
     explode: true,
@@ -11027,11 +11016,17 @@ export class UserControllerBase {
     action: \\"read\\",
     possession: \\"any\\",
   })
+  @swagger.ApiQuery({
+    type: () => UserWhereInput,
+    style: \\"deepObject\\",
+    explode: true,
+  })
   async findManyEmployees(
+    @common.Req() request: Request,
     @common.Param() params: UserWhereUniqueInput,
-    @common.Query() query: UserWhereInput,
     @nestAccessControl.UserRoles() userRoles: string[]
   ): Promise<User[]> {
+    const query: UserWhereInput = request.query;
     const permission = this.rolesBuilder.permission({
       role: userRoles,
       action: \\"read\\",

--- a/packages/amplication-data-service-generator/src/version.ts
+++ b/packages/amplication-data-service-generator/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.5.2";
+export const version = "0.5.3";


### PR DESCRIPTION
 Resolved #1314 

- [x] use `@ApiQuery` instead of `@Query` to generate swagger docs with deep properties
- [x] remove unused query parameters from findOne, create, update, delete
