### PR TITLE
fix: return empty array when parent resource does not exist

### DIFF
--- a/packages/amplication-data-service-generator/src/server/resource/resolver/to-many.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/resolver/to-many.template.ts
@@ -48,6 +48,11 @@ export class Mixin {
       resource: RELATED_ENTITY_NAME,
     });
     const results = await this.service.FIND_PROPERTY(parent.id, args);
+
+    if (!results) {
+      return [];
+    }
+    
     return results.map((result) => permission.filter(result));
   }
 }

--- a/packages/amplication-data-service-generator/src/server/resource/resolver/to-many.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/resolver/to-many.template.ts
@@ -3,7 +3,6 @@ import * as nestAccessControl from "nest-access-control";
 // @ts-ignore
 import * as gqlUserRoles from "../auth/gqlUserRoles.decorator";
 
-declare interface WHERE_UNIQUE_INPUT {}
 declare interface RELATED_ENTITY_WHERE_INPUT {}
 
 declare interface ENTITY {
@@ -52,7 +51,7 @@ export class Mixin {
     if (!results) {
       return [];
     }
-    
+
     return results.map((result) => permission.filter(result));
   }
 }

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -342,9 +342,8 @@ export type CustomerOrderByInput = {
   comments?: SortOrder;
   favoriteColors?: SortOrder;
   customerType?: SortOrder;
-  organization?: SortOrder;
-  vipOrganization?: SortOrder;
-  orders?: SortOrder;
+  organizationId?: SortOrder;
+  vipOrganizationId?: SortOrder;
 };
 ",
   "admin/src/api/customer/CustomerUpdateInput.ts": "import { OrganizationWhereUniqueInput } from \\"../organization/OrganizationWhereUniqueInput\\";
@@ -549,7 +548,7 @@ export type OrderOrderByInput = {
   id?: SortOrder;
   createdAt?: SortOrder;
   updatedAt?: SortOrder;
-  customer?: SortOrder;
+  customerId?: SortOrder;
   status?: SortOrder;
   label?: SortOrder;
 };
@@ -633,9 +632,6 @@ export type OrganizationOrderByInput = {
   createdAt?: SortOrder;
   updatedAt?: SortOrder;
   name?: SortOrder;
-  users?: SortOrder;
-  customers?: SortOrder;
-  vipCustomers?: SortOrder;
 };
 ",
   "admin/src/api/organization/OrganizationUpdateInput.ts": "export type OrganizationUpdateInput = {
@@ -770,9 +766,8 @@ export type UserOrderByInput = {
   age?: SortOrder;
   birthDate?: SortOrder;
   score?: SortOrder;
-  manager?: SortOrder;
-  employees?: SortOrder;
-  organization?: SortOrder;
+  managerId?: SortOrder;
+  organizationId?: SortOrder;
   interests?: SortOrder;
   priority?: SortOrder;
   isCurious?: SortOrder;
@@ -4815,7 +4810,7 @@ class CustomerOrderByInput {
   @Field(() => SortOrder, {
     nullable: true,
   })
-  organization?: SortOrder;
+  organizationId?: SortOrder;
 
   @ApiProperty({
     required: false,
@@ -4824,16 +4819,7 @@ class CustomerOrderByInput {
   @Field(() => SortOrder, {
     nullable: true,
   })
-  vipOrganization?: SortOrder;
-
-  @ApiProperty({
-    required: false,
-    enum: [\\"Asc\\", \\"Desc\\"],
-  })
-  @Field(() => SortOrder, {
-    nullable: true,
-  })
-  orders?: SortOrder;
+  vipOrganizationId?: SortOrder;
 }
 
 export { CustomerOrderByInput };
@@ -7483,7 +7469,7 @@ class OrderOrderByInput {
   @Field(() => SortOrder, {
     nullable: true,
   })
-  customer?: SortOrder;
+  customerId?: SortOrder;
 
   @ApiProperty({
     required: false,
@@ -8598,33 +8584,6 @@ class OrganizationOrderByInput {
     nullable: true,
   })
   name?: SortOrder;
-
-  @ApiProperty({
-    required: false,
-    enum: [\\"Asc\\", \\"Desc\\"],
-  })
-  @Field(() => SortOrder, {
-    nullable: true,
-  })
-  users?: SortOrder;
-
-  @ApiProperty({
-    required: false,
-    enum: [\\"Asc\\", \\"Desc\\"],
-  })
-  @Field(() => SortOrder, {
-    nullable: true,
-  })
-  customers?: SortOrder;
-
-  @ApiProperty({
-    required: false,
-    enum: [\\"Asc\\", \\"Desc\\"],
-  })
-  @Field(() => SortOrder, {
-    nullable: true,
-  })
-  vipCustomers?: SortOrder;
 }
 
 export { OrganizationOrderByInput };
@@ -10725,7 +10684,7 @@ class UserOrderByInput {
   @Field(() => SortOrder, {
     nullable: true,
   })
-  manager?: SortOrder;
+  managerId?: SortOrder;
 
   @ApiProperty({
     required: false,
@@ -10734,16 +10693,7 @@ class UserOrderByInput {
   @Field(() => SortOrder, {
     nullable: true,
   })
-  employees?: SortOrder;
-
-  @ApiProperty({
-    required: false,
-    enum: [\\"Asc\\", \\"Desc\\"],
-  })
-  @Field(() => SortOrder, {
-    nullable: true,
-  })
-  organization?: SortOrder;
+  organizationId?: SortOrder;
 
   @ApiProperty({
     required: false,

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -6212,6 +6212,11 @@ export class CustomerResolverBase {
       resource: \\"Order\\",
     });
     const results = await this.service.findOrders(parent.id, args);
+
+    if (!results) {
+      return [];
+    }
+
     return results.map((result) => permission.filter(result));
   }
 
@@ -9844,6 +9849,11 @@ export class OrganizationResolverBase {
       resource: \\"User\\",
     });
     const results = await this.service.findUsers(parent.id, args);
+
+    if (!results) {
+      return [];
+    }
+
     return results.map((result) => permission.filter(result));
   }
 
@@ -9865,6 +9875,11 @@ export class OrganizationResolverBase {
       resource: \\"Customer\\",
     });
     const results = await this.service.findCustomers(parent.id, args);
+
+    if (!results) {
+      return [];
+    }
+
     return results.map((result) => permission.filter(result));
   }
 
@@ -9886,6 +9901,11 @@ export class OrganizationResolverBase {
       resource: \\"Customer\\",
     });
     const results = await this.service.findVipCustomers(parent.id, args);
+
+    if (!results) {
+      return [];
+    }
+
     return results.map((result) => permission.filter(result));
   }
 }
@@ -12055,6 +12075,11 @@ export class UserResolverBase {
       resource: \\"User\\",
     });
     const results = await this.service.findEmployees(parent.id, args);
+
+    if (!results) {
+      return [];
+    }
+
     return results.map((result) => permission.filter(result));
   }
 


### PR DESCRIPTION
resolves #1218 

The delete mutation returns the deleted object.
When the entity has a to-many relation the resolveField function throws an error since the deleted object does not exist
