### PR TITLE
fix(deps): update node.js back to previous values before changes by renovate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use node 14.15.1 as the base image
-FROM node@sha256:ce29683a885b9945d0de158574e6d3716f36e1fad38d8009f1da940d22231b6b AS node
+FROM node@sha256:2db193c4b9ffedea9419173b86e26d374c3085080d244bb389744299dd4e8dcf AS node
 FROM node
 
 FROM node as base

--- a/packages/amplication-data-service-generator/Dockerfile
+++ b/packages/amplication-data-service-generator/Dockerfile
@@ -1,5 +1,5 @@
 # Use node 14.15.3 as the base image
-FROM node@sha256:ce29683a885b9945d0de158574e6d3716f36e1fad38d8009f1da940d22231b6b AS node
+FROM node@sha256:2db193c4b9ffedea9419173b86e26d374c3085080d244bb389744299dd4e8dcf AS node
 FROM node
 
 # Hide Open Collective message from install logs


### PR DESCRIPTION
The change by Renovate causes an error in the staging environment. Reverting back to previous values
```
{
  "textPayload": "Uncaught signal: 6, pid=1, tid=1, fault_addr=0.",
  "insertId": "60e970dc000914bda3928896",
  "resource": {
    "type": "cloud_run_revision",
    "labels": {
      "service_name": "cloudrun-srv",
      "location": "us-east1",
      "revision_name": "cloudrun-srv-7bv9q",
      "configuration_name": "cloudrun-srv",
      "project_id": "amplication"
    }
  },
  "timestamp": "2021-07-10T10:05:16.595100299Z",
  "severity": "ERROR",
  "labels": {
    "instanceId": ""
  },
  "logName": "projects/amplication/logs/run.googleapis.com%2Fvarlog%2Fsystem",
  "receiveTimestamp": "2021-07-10T10:05:16.599293597Z"
}
```