### PR TITLE
fix(deps): dsg mui version

### DIFF
--- a/packages/amplication-data-service-generator/src/admin/static/package.json
+++ b/packages/amplication-data-service-generator/src/admin/static/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "3.3.18",
-    "@material-ui/core": "4.12.1",
+    "@material-ui/core": "4.11.4",
     "gql": "1.1.2",
     "graphql": "14.7.0",
     "graphql-tag": "2.12.4",


### PR DESCRIPTION
Revert changes made by Renovate that caused the DSG e2e test to fail

- DSG e2e is not included in the CI before merge to decrease the CI run time. We should include the e2e test on PRs created by Renovate
