### PR TITLE
Feat/default auth provider

### DIFF
--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
@@ -3,7 +3,7 @@ import * as swagger from "@nestjs/swagger";
 import * as nestMorgan from "nest-morgan";
 import * as nestAccessControl from "nest-access-control";
 // @ts-ignore
-import * as basicAuthGuard from "../../auth/basicAuth.guard";
+import * as defaultAuthGuard from "../../auth/defaultAuth.guard";
 // @ts-ignore
 import * as abacUtil from "../../auth/abac.util";
 // @ts-ignore
@@ -56,7 +56,10 @@ export class CONTROLLER_BASE {
   ) {}
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Post()
   @nestAccessControl.UseRoles({
     resource: ENTITY_NAME,
@@ -94,7 +97,10 @@ export class CONTROLLER_BASE {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get()
   @nestAccessControl.UseRoles({
     resource: ENTITY_NAME,
@@ -129,7 +135,10 @@ export class CONTROLLER_BASE {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get(FINE_ONE_PATH)
   @nestAccessControl.UseRoles({
     resource: ENTITY_NAME,
@@ -162,7 +171,10 @@ export class CONTROLLER_BASE {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Patch(UPDATE_PATH)
   @nestAccessControl.UseRoles({
     resource: ENTITY_NAME,
@@ -213,7 +225,10 @@ export class CONTROLLER_BASE {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Delete(DELETE_PATH)
   @nestAccessControl.UseRoles({
     resource: ENTITY_NAME,

--- a/packages/amplication-data-service-generator/src/server/resource/controller/to-many.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/to-many.template.ts
@@ -3,7 +3,7 @@ import * as swagger from "@nestjs/swagger";
 import * as nestMorgan from "nest-morgan";
 import * as nestAccessControl from "nest-access-control";
 // @ts-ignore
-import * as basicAuthGuard from "../auth/basicAuth.guard";
+import * as defaultAuthGuard from "../auth/defaultAuth.guard";
 // @ts-ignore
 import * as abacUtil from "../auth/abac.util";
 import { Request } from "express";
@@ -51,7 +51,10 @@ export class Mixin {
   ) {}
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get(FIND_MANY_PATH)
   @nestAccessControl.UseRoles({
     resource: ENTITY_NAME,
@@ -84,7 +87,10 @@ export class Mixin {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Post(CREATE_PATH)
   @nestAccessControl.UseRoles({
     resource: ENTITY_NAME,
@@ -124,7 +130,10 @@ export class Mixin {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Patch(UPDATE_PATH)
   @nestAccessControl.UseRoles({
     resource: ENTITY_NAME,
@@ -164,7 +173,10 @@ export class Mixin {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Delete(DELETE_PATH)
   @nestAccessControl.UseRoles({
     resource: ENTITY_NAME,

--- a/packages/amplication-data-service-generator/src/server/resource/resolver/resolver.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/resolver/resolver.base.template.ts
@@ -3,7 +3,7 @@ import * as graphql from "@nestjs/graphql";
 import * as apollo from "apollo-server-express";
 import * as nestAccessControl from "nest-access-control";
 // @ts-ignore
-import * as gqlBasicAuthGuard from "../../auth/gqlBasicAuth.guard";
+import * as gqlDefaultAuthGuard from "../../auth/gqlDefaultAuth.guard";
 // @ts-ignore
 import * as gqlACGuard from "../../auth/gqlAC.guard";
 // @ts-ignore
@@ -59,7 +59,10 @@ declare interface SERVICE {
 declare const ENTITY_NAME: string;
 
 @graphql.Resolver(() => ENTITY)
-@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+@common.UseGuards(
+  gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+  gqlACGuard.GqlACGuard
+)
 export class RESOLVER_BASE {
   constructor(
     protected readonly service: SERVICE,

--- a/packages/amplication-data-service-generator/src/server/resource/resolver/resolver.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/resolver/resolver.template.ts
@@ -2,7 +2,7 @@ import * as common from "@nestjs/common";
 import * as graphql from "@nestjs/graphql";
 import * as nestAccessControl from "nest-access-control";
 // @ts-ignore
-import * as gqlBasicAuthGuard from "../auth/gqlBasicAuth.guard";
+import * as gqlDefaultAuthGuard from "../auth/gqlDefaultAuth.guard";
 // @ts-ignore
 import * as gqlACGuard from "../auth/gqlAC.guard";
 
@@ -19,7 +19,10 @@ declare class RESOLVER_BASE {
 }
 
 @graphql.Resolver(() => ENTITY)
-@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+@common.UseGuards(
+  gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+  gqlACGuard.GqlACGuard
+)
 export class RESOLVER extends RESOLVER_BASE {
   constructor(
     protected readonly service: SERVICE,

--- a/packages/amplication-data-service-generator/src/server/static/src/auth/auth.resolver.ts
+++ b/packages/amplication-data-service-generator/src/server/static/src/auth/auth.resolver.ts
@@ -1,5 +1,5 @@
 import * as common from "@nestjs/common";
-import * as gqlBasicAuthGuard from "../auth/gqlBasicAuth.guard";
+import * as gqlDefaultAuthGuard from "../auth/gqlDefaultAuth.guard";
 import * as gqlACGuard from "../auth/gqlAC.guard";
 import { Args, Mutation, Resolver, Query } from "@nestjs/graphql";
 import { ApolloError } from "apollo-server-express";
@@ -24,7 +24,10 @@ export class AuthResolver {
   }
 
   @Query(() => UserInfo)
-  @common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+  @common.UseGuards(
+    gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+    gqlACGuard.GqlACGuard
+  )
   async userInfo(@UserData() userInfo: UserInfo): Promise<UserInfo> {
     return userInfo;
   }

--- a/packages/amplication-data-service-generator/src/server/static/src/auth/defaultAuth.guard.ts
+++ b/packages/amplication-data-service-generator/src/server/static/src/auth/defaultAuth.guard.ts
@@ -1,0 +1,3 @@
+import { BasicAuthGuard } from "./basicAuth.guard";
+
+export class DefaultAuthGuard extends BasicAuthGuard {}

--- a/packages/amplication-data-service-generator/src/server/static/src/auth/gqlDefaultAuth.guard.ts
+++ b/packages/amplication-data-service-generator/src/server/static/src/auth/gqlDefaultAuth.guard.ts
@@ -1,0 +1,3 @@
+import { GqlBasicAuthGuard } from "./gqlBasicAuth.guard";
+
+export class GqlDefaultAuthGuard extends GqlBasicAuthGuard {}

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -2929,7 +2929,7 @@ class CreateCustomerArgs {
   data!: CustomerCreateInput;
 }
 
-export { CreateCustomerArgs as CreateCustomerArgs };
+export { CreateCustomerArgs };
 ",
   "server/src/customer/base/Customer.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3124,7 +3124,7 @@ class Customer {
   @IsOptional()
   orders?: Array<Order>;
 }
-export { Customer as Customer };
+export { Customer };
 ",
   "server/src/customer/base/CustomerCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3291,7 +3291,7 @@ class CustomerCreateInput {
   })
   vipOrganization?: OrganizationWhereUniqueInput | null;
 }
-export { CustomerCreateInput as CustomerCreateInput };
+export { CustomerCreateInput };
 ",
   "server/src/customer/base/CustomerFindManyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3334,7 +3334,7 @@ class CustomerFindManyArgs {
   take?: number;
 }
 
-export { CustomerFindManyArgs as CustomerFindManyArgs };
+export { CustomerFindManyArgs };
 ",
   "server/src/customer/base/CustomerFindUniqueArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { CustomerWhereUniqueInput } from \\"./CustomerWhereUniqueInput\\";
@@ -3345,7 +3345,7 @@ class CustomerFindUniqueArgs {
   where!: CustomerWhereUniqueInput;
 }
 
-export { CustomerFindUniqueArgs as CustomerFindUniqueArgs };
+export { CustomerFindUniqueArgs };
 ",
   "server/src/customer/base/CustomerOrderByInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3501,7 +3501,7 @@ class CustomerOrderByInput {
   vipOrganizationId?: SortOrder;
 }
 
-export { CustomerOrderByInput as CustomerOrderByInput };
+export { CustomerOrderByInput };
 ",
   "server/src/customer/base/CustomerUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3671,7 +3671,7 @@ class CustomerUpdateInput {
   })
   vipOrganization?: OrganizationWhereUniqueInput | null;
 }
-export { CustomerUpdateInput as CustomerUpdateInput };
+export { CustomerUpdateInput };
 ",
   "server/src/customer/base/CustomerWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3855,7 +3855,7 @@ class CustomerWhereInput {
   })
   vipOrganization?: OrganizationWhereUniqueInput;
 }
-export { CustomerWhereInput as CustomerWhereInput };
+export { CustomerWhereInput };
 ",
   "server/src/customer/base/CustomerWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3870,7 +3870,7 @@ class CustomerWhereUniqueInput {
   @Field(() => String)
   id!: string;
 }
-export { CustomerWhereUniqueInput as CustomerWhereUniqueInput };
+export { CustomerWhereUniqueInput };
 ",
   "server/src/customer/base/DeleteCustomerArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { CustomerWhereUniqueInput } from \\"./CustomerWhereUniqueInput\\";
@@ -3881,7 +3881,7 @@ class DeleteCustomerArgs {
   where!: CustomerWhereUniqueInput;
 }
 
-export { DeleteCustomerArgs as DeleteCustomerArgs };
+export { DeleteCustomerArgs };
 ",
   "server/src/customer/base/EnumCustomerCustomerType.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
 
@@ -3921,7 +3921,7 @@ class UpdateCustomerArgs {
   data!: CustomerUpdateInput;
 }
 
-export { UpdateCustomerArgs as UpdateCustomerArgs };
+export { UpdateCustomerArgs };
 ",
   "server/src/customer/base/customer.controller.base.spec.ts": "import { Test } from \\"@nestjs/testing\\";
 import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
@@ -5143,7 +5143,7 @@ class DeleteEmptyArgs {
   where!: EmptyWhereUniqueInput;
 }
 
-export { DeleteEmptyArgs as DeleteEmptyArgs };
+export { DeleteEmptyArgs };
 ",
   "server/src/empty/base/Empty.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -5175,10 +5175,10 @@ class Empty {
   @Field(() => Date)
   updatedAt!: Date;
 }
-export { Empty as Empty };
+export { Empty };
 ",
   "server/src/empty/base/EmptyCreateInput.ts": "class EmptyCreateInput {}
-export { EmptyCreateInput as EmptyCreateInput };
+export { EmptyCreateInput };
 ",
   "server/src/empty/base/EmptyFindManyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -5221,7 +5221,7 @@ class EmptyFindManyArgs {
   take?: number;
 }
 
-export { EmptyFindManyArgs as EmptyFindManyArgs };
+export { EmptyFindManyArgs };
 ",
   "server/src/empty/base/EmptyFindUniqueArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { EmptyWhereUniqueInput } from \\"./EmptyWhereUniqueInput\\";
@@ -5232,7 +5232,7 @@ class EmptyFindUniqueArgs {
   where!: EmptyWhereUniqueInput;
 }
 
-export { EmptyFindUniqueArgs as EmptyFindUniqueArgs };
+export { EmptyFindUniqueArgs };
 ",
   "server/src/empty/base/EmptyOrderByInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -5271,10 +5271,10 @@ class EmptyOrderByInput {
   updatedAt?: SortOrder;
 }
 
-export { EmptyOrderByInput as EmptyOrderByInput };
+export { EmptyOrderByInput };
 ",
   "server/src/empty/base/EmptyUpdateInput.ts": "class EmptyUpdateInput {}
-export { EmptyUpdateInput as EmptyUpdateInput };
+export { EmptyUpdateInput };
 ",
   "server/src/empty/base/EmptyWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -5317,7 +5317,7 @@ class EmptyWhereInput {
   })
   updatedAt?: DateTimeFilter;
 }
-export { EmptyWhereInput as EmptyWhereInput };
+export { EmptyWhereInput };
 ",
   "server/src/empty/base/EmptyWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -5332,7 +5332,7 @@ class EmptyWhereUniqueInput {
   @Field(() => String)
   id!: string;
 }
-export { EmptyWhereUniqueInput as EmptyWhereUniqueInput };
+export { EmptyWhereUniqueInput };
 ",
   "server/src/empty/base/empty.controller.base.spec.ts": "import { Test } from \\"@nestjs/testing\\";
 import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
@@ -6022,7 +6022,7 @@ class CreateOrderArgs {
   data!: OrderCreateInput;
 }
 
-export { CreateOrderArgs as CreateOrderArgs };
+export { CreateOrderArgs };
 ",
   "server/src/order/base/DeleteOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrderWhereUniqueInput } from \\"./OrderWhereUniqueInput\\";
@@ -6033,7 +6033,7 @@ class DeleteOrderArgs {
   where!: OrderWhereUniqueInput;
 }
 
-export { DeleteOrderArgs as DeleteOrderArgs };
+export { DeleteOrderArgs };
 ",
   "server/src/order/base/EnumOrderLabel.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
 
@@ -6125,7 +6125,7 @@ class Order {
   })
   label?: \\"fragile\\" | null;
 }
-export { Order as Order };
+export { Order };
 ",
   "server/src/order/base/OrderCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -6164,7 +6164,7 @@ class OrderCreateInput {
   })
   label?: \\"fragile\\" | null;
 }
-export { OrderCreateInput as OrderCreateInput };
+export { OrderCreateInput };
 ",
   "server/src/order/base/OrderFindManyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -6207,7 +6207,7 @@ class OrderFindManyArgs {
   take?: number;
 }
 
-export { OrderFindManyArgs as OrderFindManyArgs };
+export { OrderFindManyArgs };
 ",
   "server/src/order/base/OrderFindUniqueArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrderWhereUniqueInput } from \\"./OrderWhereUniqueInput\\";
@@ -6218,7 +6218,7 @@ class OrderFindUniqueArgs {
   where!: OrderWhereUniqueInput;
 }
 
-export { OrderFindUniqueArgs as OrderFindUniqueArgs };
+export { OrderFindUniqueArgs };
 ",
   "server/src/order/base/OrderOrderByInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -6284,7 +6284,7 @@ class OrderOrderByInput {
   label?: SortOrder;
 }
 
-export { OrderOrderByInput as OrderOrderByInput };
+export { OrderOrderByInput };
 ",
   "server/src/order/base/OrderUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -6329,7 +6329,7 @@ class OrderUpdateInput {
   })
   label?: \\"fragile\\" | null;
 }
-export { OrderUpdateInput as OrderUpdateInput };
+export { OrderUpdateInput };
 ",
   "server/src/order/base/OrderWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -6409,7 +6409,7 @@ class OrderWhereInput {
   })
   label?: \\"fragile\\";
 }
-export { OrderWhereInput as OrderWhereInput };
+export { OrderWhereInput };
 ",
   "server/src/order/base/OrderWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -6424,7 +6424,7 @@ class OrderWhereUniqueInput {
   @Field(() => String)
   id!: string;
 }
-export { OrderWhereUniqueInput as OrderWhereUniqueInput };
+export { OrderWhereUniqueInput };
 ",
   "server/src/order/base/UpdateOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrderWhereUniqueInput } from \\"./OrderWhereUniqueInput\\";
@@ -6438,7 +6438,7 @@ class UpdateOrderArgs {
   data!: OrderUpdateInput;
 }
 
-export { UpdateOrderArgs as UpdateOrderArgs };
+export { UpdateOrderArgs };
 ",
   "server/src/order/base/order.controller.base.spec.ts": "import { Test } from \\"@nestjs/testing\\";
 import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
@@ -7263,7 +7263,7 @@ class CreateOrganizationArgs {
   data!: OrganizationCreateInput;
 }
 
-export { CreateOrganizationArgs as CreateOrganizationArgs };
+export { CreateOrganizationArgs };
 ",
   "server/src/organization/base/DeleteOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrganizationWhereUniqueInput } from \\"./OrganizationWhereUniqueInput\\";
@@ -7274,7 +7274,7 @@ class DeleteOrganizationArgs {
   where!: OrganizationWhereUniqueInput;
 }
 
-export { DeleteOrganizationArgs as DeleteOrganizationArgs };
+export { DeleteOrganizationArgs };
 ",
   "server/src/organization/base/Organization.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7343,7 +7343,7 @@ class Organization {
   @IsOptional()
   vipCustomers?: Array<Customer>;
 }
-export { Organization as Organization };
+export { Organization };
 ",
   "server/src/organization/base/OrganizationCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7358,7 +7358,7 @@ class OrganizationCreateInput {
   @Field(() => String)
   name!: string;
 }
-export { OrganizationCreateInput as OrganizationCreateInput };
+export { OrganizationCreateInput };
 ",
   "server/src/organization/base/OrganizationFindManyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7401,7 +7401,7 @@ class OrganizationFindManyArgs {
   take?: number;
 }
 
-export { OrganizationFindManyArgs as OrganizationFindManyArgs };
+export { OrganizationFindManyArgs };
 ",
   "server/src/organization/base/OrganizationFindUniqueArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrganizationWhereUniqueInput } from \\"./OrganizationWhereUniqueInput\\";
@@ -7412,7 +7412,7 @@ class OrganizationFindUniqueArgs {
   where!: OrganizationWhereUniqueInput;
 }
 
-export { OrganizationFindUniqueArgs as OrganizationFindUniqueArgs };
+export { OrganizationFindUniqueArgs };
 ",
   "server/src/organization/base/OrganizationOrderByInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7460,7 +7460,7 @@ class OrganizationOrderByInput {
   name?: SortOrder;
 }
 
-export { OrganizationOrderByInput as OrganizationOrderByInput };
+export { OrganizationOrderByInput };
 ",
   "server/src/organization/base/OrganizationUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7478,7 +7478,7 @@ class OrganizationUpdateInput {
   })
   name?: string;
 }
-export { OrganizationUpdateInput as OrganizationUpdateInput };
+export { OrganizationUpdateInput };
 ",
   "server/src/organization/base/OrganizationWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7532,7 +7532,7 @@ class OrganizationWhereInput {
   })
   name?: StringFilter;
 }
-export { OrganizationWhereInput as OrganizationWhereInput };
+export { OrganizationWhereInput };
 ",
   "server/src/organization/base/OrganizationWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7547,7 +7547,7 @@ class OrganizationWhereUniqueInput {
   @Field(() => String)
   id!: string;
 }
-export { OrganizationWhereUniqueInput as OrganizationWhereUniqueInput };
+export { OrganizationWhereUniqueInput };
 ",
   "server/src/organization/base/UpdateOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrganizationWhereUniqueInput } from \\"./OrganizationWhereUniqueInput\\";
@@ -7561,7 +7561,7 @@ class UpdateOrganizationArgs {
   data!: OrganizationUpdateInput;
 }
 
-export { UpdateOrganizationArgs as UpdateOrganizationArgs };
+export { UpdateOrganizationArgs };
 ",
   "server/src/organization/base/organization.controller.base.spec.ts": "import { Test } from \\"@nestjs/testing\\";
 import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
@@ -9114,7 +9114,7 @@ class CreateUserArgs {
   data!: UserCreateInput;
 }
 
-export { CreateUserArgs as CreateUserArgs };
+export { CreateUserArgs };
 ",
   "server/src/user/base/DeleteUserArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
@@ -9125,7 +9125,7 @@ class DeleteUserArgs {
   where!: UserWhereUniqueInput;
 }
 
-export { DeleteUserArgs as DeleteUserArgs };
+export { DeleteUserArgs };
 ",
   "server/src/user/base/EnumUserInterests.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
 
@@ -9162,7 +9162,7 @@ class UpdateUserArgs {
   data!: UserUpdateInput;
 }
 
-export { UpdateUserArgs as UpdateUserArgs };
+export { UpdateUserArgs };
 ",
   "server/src/user/base/User.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -9335,7 +9335,7 @@ class User {
   @Field(() => GraphQLJSONObject)
   extendedProperties!: JsonValue;
 }
-export { User as User };
+export { User };
 ",
   "server/src/user/base/UserCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -9491,7 +9491,7 @@ class UserCreateInput {
   @Field(() => GraphQLJSONObject)
   extendedProperties!: JsonValue;
 }
-export { UserCreateInput as UserCreateInput };
+export { UserCreateInput };
 ",
   "server/src/user/base/UserFindManyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -9534,7 +9534,7 @@ class UserFindManyArgs {
   take?: number;
 }
 
-export { UserFindManyArgs as UserFindManyArgs };
+export { UserFindManyArgs };
 ",
   "server/src/user/base/UserFindUniqueArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
@@ -9545,7 +9545,7 @@ class UserFindUniqueArgs {
   where!: UserWhereUniqueInput;
 }
 
-export { UserFindUniqueArgs as UserFindUniqueArgs };
+export { UserFindUniqueArgs };
 ",
   "server/src/user/base/UserOrderByInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -9701,7 +9701,7 @@ class UserOrderByInput {
   extendedProperties?: SortOrder;
 }
 
-export { UserOrderByInput as UserOrderByInput };
+export { UserOrderByInput };
 ",
   "server/src/user/base/UserUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -9896,7 +9896,7 @@ class UserUpdateInput {
   })
   extendedProperties?: JsonValue;
 }
-export { UserUpdateInput as UserUpdateInput };
+export { UserUpdateInput };
 ",
   "server/src/user/base/UserWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -10022,7 +10022,7 @@ class UserWhereInput {
   })
   extendedProperties?: JsonNullableFilter;
 }
-export { UserWhereInput as UserWhereInput };
+export { UserWhereInput };
 ",
   "server/src/user/base/UserWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -10037,7 +10037,7 @@ class UserWhereUniqueInput {
   @Field(() => String)
   id!: string;
 }
-export { UserWhereUniqueInput as UserWhereUniqueInput };
+export { UserWhereUniqueInput };
 ",
   "server/src/user/base/user.controller.base.spec.ts": "import { Test } from \\"@nestjs/testing\\";
 import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -2561,7 +2561,7 @@ import { PasswordService } from \\"./password.service\\";
 export class AuthModule {}
 ",
   "server/src/auth/auth.resolver.ts": "import * as common from \\"@nestjs/common\\";
-import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
+import * as gqlDefaultAuthGuard from \\"../auth/gqlDefaultAuth.guard\\";
 import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
 import { Args, Mutation, Resolver, Query } from \\"@nestjs/graphql\\";
 import { ApolloError } from \\"apollo-server-express\\";
@@ -2586,7 +2586,10 @@ export class AuthResolver {
   }
 
   @Query(() => UserInfo)
-  @common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+  @common.UseGuards(
+    gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+    gqlACGuard.GqlACGuard
+  )
   async userInfo(@UserData() userInfo: UserInfo): Promise<UserInfo> {
     return userInfo;
   }
@@ -2717,6 +2720,10 @@ export class BasicStrategy extends PassportStrategy(Strategy) {
 
 export class BasicAuthGuard extends AuthGuard(\\"basic\\") {}
 ",
+  "server/src/auth/defaultAuth.guard.ts": "import { BasicAuthGuard } from \\"./basicAuth.guard\\";
+
+export class DefaultAuthGuard extends BasicAuthGuard {}
+",
   "server/src/auth/gqlAC.guard.ts": "import { ExecutionContext } from \\"@nestjs/common\\";
 import { GqlExecutionContext } from \\"@nestjs/graphql\\";
 import { ACGuard } from \\"nest-access-control\\";
@@ -2742,6 +2749,10 @@ export class GqlBasicAuthGuard extends BasicAuthGuard {
     return ctx.getContext<{ req: Request }>().req;
   }
 }
+",
+  "server/src/auth/gqlDefaultAuth.guard.ts": "import { GqlBasicAuthGuard } from \\"./gqlBasicAuth.guard\\";
+
+export class GqlDefaultAuthGuard extends GqlBasicAuthGuard {}
 ",
   "server/src/auth/gqlUserData.decorator.ts": "import { createParamDecorator, ExecutionContext } from \\"@nestjs/common\\";
 import { GqlExecutionContext } from \\"@nestjs/graphql\\";
@@ -2918,7 +2929,7 @@ class CreateCustomerArgs {
   data!: CustomerCreateInput;
 }
 
-export { CreateCustomerArgs };
+export { CreateCustomerArgs as CreateCustomerArgs };
 ",
   "server/src/customer/base/Customer.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3113,7 +3124,7 @@ class Customer {
   @IsOptional()
   orders?: Array<Order>;
 }
-export { Customer };
+export { Customer as Customer };
 ",
   "server/src/customer/base/CustomerCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3280,7 +3291,7 @@ class CustomerCreateInput {
   })
   vipOrganization?: OrganizationWhereUniqueInput | null;
 }
-export { CustomerCreateInput };
+export { CustomerCreateInput as CustomerCreateInput };
 ",
   "server/src/customer/base/CustomerFindManyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3323,7 +3334,7 @@ class CustomerFindManyArgs {
   take?: number;
 }
 
-export { CustomerFindManyArgs };
+export { CustomerFindManyArgs as CustomerFindManyArgs };
 ",
   "server/src/customer/base/CustomerFindUniqueArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { CustomerWhereUniqueInput } from \\"./CustomerWhereUniqueInput\\";
@@ -3334,7 +3345,7 @@ class CustomerFindUniqueArgs {
   where!: CustomerWhereUniqueInput;
 }
 
-export { CustomerFindUniqueArgs };
+export { CustomerFindUniqueArgs as CustomerFindUniqueArgs };
 ",
   "server/src/customer/base/CustomerOrderByInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3490,7 +3501,7 @@ class CustomerOrderByInput {
   vipOrganizationId?: SortOrder;
 }
 
-export { CustomerOrderByInput };
+export { CustomerOrderByInput as CustomerOrderByInput };
 ",
   "server/src/customer/base/CustomerUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3660,7 +3671,7 @@ class CustomerUpdateInput {
   })
   vipOrganization?: OrganizationWhereUniqueInput | null;
 }
-export { CustomerUpdateInput };
+export { CustomerUpdateInput as CustomerUpdateInput };
 ",
   "server/src/customer/base/CustomerWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3844,7 +3855,7 @@ class CustomerWhereInput {
   })
   vipOrganization?: OrganizationWhereUniqueInput;
 }
-export { CustomerWhereInput };
+export { CustomerWhereInput as CustomerWhereInput };
 ",
   "server/src/customer/base/CustomerWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -3859,7 +3870,7 @@ class CustomerWhereUniqueInput {
   @Field(() => String)
   id!: string;
 }
-export { CustomerWhereUniqueInput };
+export { CustomerWhereUniqueInput as CustomerWhereUniqueInput };
 ",
   "server/src/customer/base/DeleteCustomerArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { CustomerWhereUniqueInput } from \\"./CustomerWhereUniqueInput\\";
@@ -3870,7 +3881,7 @@ class DeleteCustomerArgs {
   where!: CustomerWhereUniqueInput;
 }
 
-export { DeleteCustomerArgs };
+export { DeleteCustomerArgs as DeleteCustomerArgs };
 ",
   "server/src/customer/base/EnumCustomerCustomerType.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
 
@@ -3910,7 +3921,7 @@ class UpdateCustomerArgs {
   data!: CustomerUpdateInput;
 }
 
-export { UpdateCustomerArgs };
+export { UpdateCustomerArgs as UpdateCustomerArgs };
 ",
   "server/src/customer/base/customer.controller.base.spec.ts": "import { Test } from \\"@nestjs/testing\\";
 import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
@@ -4098,7 +4109,7 @@ describe(\\"Customer\\", () => {
 import * as swagger from \\"@nestjs/swagger\\";
 import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
+import * as defaultAuthGuard from \\"../../auth/defaultAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
 import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import * as errors from \\"../../errors\\";
@@ -4121,7 +4132,10 @@ export class CustomerControllerBase {
   ) {}
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Post()
   @nestAccessControl.UseRoles({
     resource: \\"Customer\\",
@@ -4200,7 +4214,10 @@ export class CustomerControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get()
   @nestAccessControl.UseRoles({
     resource: \\"Customer\\",
@@ -4261,7 +4278,10 @@ export class CustomerControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"Customer\\",
@@ -4321,7 +4341,10 @@ export class CustomerControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Patch(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"Customer\\",
@@ -4413,7 +4436,10 @@ export class CustomerControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Delete(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"Customer\\",
@@ -4469,7 +4495,10 @@ export class CustomerControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get(\\"/:id/orders\\")
   @nestAccessControl.UseRoles({
     resource: \\"Customer\\",
@@ -4514,7 +4543,10 @@ export class CustomerControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Post(\\"/:id/orders\\")
   @nestAccessControl.UseRoles({
     resource: \\"Customer\\",
@@ -4556,7 +4588,10 @@ export class CustomerControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Patch(\\"/:id/orders\\")
   @nestAccessControl.UseRoles({
     resource: \\"Customer\\",
@@ -4598,7 +4633,10 @@ export class CustomerControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Delete(\\"/:id/orders\\")
   @nestAccessControl.UseRoles({
     resource: \\"Customer\\",
@@ -4662,7 +4700,7 @@ export class CustomerModuleBase {}
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../../auth/gqlBasicAuth.guard\\";
+import * as gqlDefaultAuthGuard from \\"../../auth/gqlDefaultAuth.guard\\";
 import * as gqlACGuard from \\"../../auth/gqlAC.guard\\";
 import * as gqlUserRoles from \\"../../auth/gqlUserRoles.decorator\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
@@ -4680,7 +4718,10 @@ import { Organization } from \\"../../organization/base/Organization\\";
 import { CustomerService } from \\"../customer.service\\";
 
 @graphql.Resolver(() => Customer)
-@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+@common.UseGuards(
+  gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+  gqlACGuard.GqlACGuard
+)
 export class CustomerResolverBase {
   constructor(
     protected readonly service: CustomerService,
@@ -5061,14 +5102,17 @@ export class CustomerModule {}
   "server/src/customer/customer.resolver.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
+import * as gqlDefaultAuthGuard from \\"../auth/gqlDefaultAuth.guard\\";
 import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
 import { CustomerResolverBase } from \\"./base/customer.resolver.base\\";
 import { Customer } from \\"./base/Customer\\";
 import { CustomerService } from \\"./customer.service\\";
 
 @graphql.Resolver(() => Customer)
-@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+@common.UseGuards(
+  gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+  gqlACGuard.GqlACGuard
+)
 export class CustomerResolver extends CustomerResolverBase {
   constructor(
     protected readonly service: CustomerService,
@@ -5099,7 +5143,7 @@ class DeleteEmptyArgs {
   where!: EmptyWhereUniqueInput;
 }
 
-export { DeleteEmptyArgs };
+export { DeleteEmptyArgs as DeleteEmptyArgs };
 ",
   "server/src/empty/base/Empty.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -5131,10 +5175,10 @@ class Empty {
   @Field(() => Date)
   updatedAt!: Date;
 }
-export { Empty };
+export { Empty as Empty };
 ",
   "server/src/empty/base/EmptyCreateInput.ts": "class EmptyCreateInput {}
-export { EmptyCreateInput };
+export { EmptyCreateInput as EmptyCreateInput };
 ",
   "server/src/empty/base/EmptyFindManyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -5177,7 +5221,7 @@ class EmptyFindManyArgs {
   take?: number;
 }
 
-export { EmptyFindManyArgs };
+export { EmptyFindManyArgs as EmptyFindManyArgs };
 ",
   "server/src/empty/base/EmptyFindUniqueArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { EmptyWhereUniqueInput } from \\"./EmptyWhereUniqueInput\\";
@@ -5188,7 +5232,7 @@ class EmptyFindUniqueArgs {
   where!: EmptyWhereUniqueInput;
 }
 
-export { EmptyFindUniqueArgs };
+export { EmptyFindUniqueArgs as EmptyFindUniqueArgs };
 ",
   "server/src/empty/base/EmptyOrderByInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -5227,10 +5271,10 @@ class EmptyOrderByInput {
   updatedAt?: SortOrder;
 }
 
-export { EmptyOrderByInput };
+export { EmptyOrderByInput as EmptyOrderByInput };
 ",
   "server/src/empty/base/EmptyUpdateInput.ts": "class EmptyUpdateInput {}
-export { EmptyUpdateInput };
+export { EmptyUpdateInput as EmptyUpdateInput };
 ",
   "server/src/empty/base/EmptyWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -5273,7 +5317,7 @@ class EmptyWhereInput {
   })
   updatedAt?: DateTimeFilter;
 }
-export { EmptyWhereInput };
+export { EmptyWhereInput as EmptyWhereInput };
 ",
   "server/src/empty/base/EmptyWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -5288,7 +5332,7 @@ class EmptyWhereUniqueInput {
   @Field(() => String)
   id!: string;
 }
-export { EmptyWhereUniqueInput };
+export { EmptyWhereUniqueInput as EmptyWhereUniqueInput };
 ",
   "server/src/empty/base/empty.controller.base.spec.ts": "import { Test } from \\"@nestjs/testing\\";
 import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
@@ -5437,7 +5481,7 @@ describe(\\"Empty\\", () => {
 import * as swagger from \\"@nestjs/swagger\\";
 import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
+import * as defaultAuthGuard from \\"../../auth/defaultAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
 import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import * as errors from \\"../../errors\\";
@@ -5458,7 +5502,10 @@ export class EmptyControllerBase {
   ) {}
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Post()
   @nestAccessControl.UseRoles({
     resource: \\"Empty\\",
@@ -5500,7 +5547,10 @@ export class EmptyControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get()
   @nestAccessControl.UseRoles({
     resource: \\"Empty\\",
@@ -5538,7 +5588,10 @@ export class EmptyControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"Empty\\",
@@ -5575,7 +5628,10 @@ export class EmptyControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Patch(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"Empty\\",
@@ -5630,7 +5686,10 @@ export class EmptyControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Delete(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"Empty\\",
@@ -5685,7 +5744,7 @@ export class EmptyModuleBase {}
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../../auth/gqlBasicAuth.guard\\";
+import * as gqlDefaultAuthGuard from \\"../../auth/gqlDefaultAuth.guard\\";
 import * as gqlACGuard from \\"../../auth/gqlAC.guard\\";
 import * as gqlUserRoles from \\"../../auth/gqlUserRoles.decorator\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
@@ -5698,7 +5757,10 @@ import { Empty } from \\"./Empty\\";
 import { EmptyService } from \\"../empty.service\\";
 
 @graphql.Resolver(() => Empty)
-@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+@common.UseGuards(
+  gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+  gqlACGuard.GqlACGuard
+)
 export class EmptyResolverBase {
   constructor(
     protected readonly service: EmptyService,
@@ -5865,14 +5927,17 @@ export class EmptyModule {}
   "server/src/empty/empty.resolver.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
+import * as gqlDefaultAuthGuard from \\"../auth/gqlDefaultAuth.guard\\";
 import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
 import { EmptyResolverBase } from \\"./base/empty.resolver.base\\";
 import { Empty } from \\"./base/Empty\\";
 import { EmptyService } from \\"./empty.service\\";
 
 @graphql.Resolver(() => Empty)
-@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+@common.UseGuards(
+  gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+  gqlACGuard.GqlACGuard
+)
 export class EmptyResolver extends EmptyResolverBase {
   constructor(
     protected readonly service: EmptyService,
@@ -5957,7 +6022,7 @@ class CreateOrderArgs {
   data!: OrderCreateInput;
 }
 
-export { CreateOrderArgs };
+export { CreateOrderArgs as CreateOrderArgs };
 ",
   "server/src/order/base/DeleteOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrderWhereUniqueInput } from \\"./OrderWhereUniqueInput\\";
@@ -5968,7 +6033,7 @@ class DeleteOrderArgs {
   where!: OrderWhereUniqueInput;
 }
 
-export { DeleteOrderArgs };
+export { DeleteOrderArgs as DeleteOrderArgs };
 ",
   "server/src/order/base/EnumOrderLabel.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
 
@@ -6060,7 +6125,7 @@ class Order {
   })
   label?: \\"fragile\\" | null;
 }
-export { Order };
+export { Order as Order };
 ",
   "server/src/order/base/OrderCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -6099,7 +6164,7 @@ class OrderCreateInput {
   })
   label?: \\"fragile\\" | null;
 }
-export { OrderCreateInput };
+export { OrderCreateInput as OrderCreateInput };
 ",
   "server/src/order/base/OrderFindManyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -6142,7 +6207,7 @@ class OrderFindManyArgs {
   take?: number;
 }
 
-export { OrderFindManyArgs };
+export { OrderFindManyArgs as OrderFindManyArgs };
 ",
   "server/src/order/base/OrderFindUniqueArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrderWhereUniqueInput } from \\"./OrderWhereUniqueInput\\";
@@ -6153,7 +6218,7 @@ class OrderFindUniqueArgs {
   where!: OrderWhereUniqueInput;
 }
 
-export { OrderFindUniqueArgs };
+export { OrderFindUniqueArgs as OrderFindUniqueArgs };
 ",
   "server/src/order/base/OrderOrderByInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -6219,7 +6284,7 @@ class OrderOrderByInput {
   label?: SortOrder;
 }
 
-export { OrderOrderByInput };
+export { OrderOrderByInput as OrderOrderByInput };
 ",
   "server/src/order/base/OrderUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -6264,7 +6329,7 @@ class OrderUpdateInput {
   })
   label?: \\"fragile\\" | null;
 }
-export { OrderUpdateInput };
+export { OrderUpdateInput as OrderUpdateInput };
 ",
   "server/src/order/base/OrderWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -6344,7 +6409,7 @@ class OrderWhereInput {
   })
   label?: \\"fragile\\";
 }
-export { OrderWhereInput };
+export { OrderWhereInput as OrderWhereInput };
 ",
   "server/src/order/base/OrderWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -6359,7 +6424,7 @@ class OrderWhereUniqueInput {
   @Field(() => String)
   id!: string;
 }
-export { OrderWhereUniqueInput };
+export { OrderWhereUniqueInput as OrderWhereUniqueInput };
 ",
   "server/src/order/base/UpdateOrderArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrderWhereUniqueInput } from \\"./OrderWhereUniqueInput\\";
@@ -6373,7 +6438,7 @@ class UpdateOrderArgs {
   data!: OrderUpdateInput;
 }
 
-export { UpdateOrderArgs };
+export { UpdateOrderArgs as UpdateOrderArgs };
 ",
   "server/src/order/base/order.controller.base.spec.ts": "import { Test } from \\"@nestjs/testing\\";
 import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
@@ -6522,7 +6587,7 @@ describe(\\"Order\\", () => {
 import * as swagger from \\"@nestjs/swagger\\";
 import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
+import * as defaultAuthGuard from \\"../../auth/defaultAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
 import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import * as errors from \\"../../errors\\";
@@ -6543,7 +6608,10 @@ export class OrderControllerBase {
   ) {}
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Post()
   @nestAccessControl.UseRoles({
     resource: \\"Order\\",
@@ -6600,7 +6668,10 @@ export class OrderControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get()
   @nestAccessControl.UseRoles({
     resource: \\"Order\\",
@@ -6647,7 +6718,10 @@ export class OrderControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"Order\\",
@@ -6693,7 +6767,10 @@ export class OrderControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Patch(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"Order\\",
@@ -6763,7 +6840,10 @@ export class OrderControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Delete(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"Order\\",
@@ -6827,7 +6907,7 @@ export class OrderModuleBase {}
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../../auth/gqlBasicAuth.guard\\";
+import * as gqlDefaultAuthGuard from \\"../../auth/gqlDefaultAuth.guard\\";
 import * as gqlACGuard from \\"../../auth/gqlAC.guard\\";
 import * as gqlUserRoles from \\"../../auth/gqlUserRoles.decorator\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
@@ -6843,7 +6923,10 @@ import { Customer } from \\"../../customer/base/Customer\\";
 import { OrderService } from \\"../order.service\\";
 
 @graphql.Resolver(() => Order)
-@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+@common.UseGuards(
+  gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+  gqlACGuard.GqlACGuard
+)
 export class OrderResolverBase {
   constructor(
     protected readonly service: OrderService,
@@ -7139,14 +7222,17 @@ export class OrderModule {}
   "server/src/order/order.resolver.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
+import * as gqlDefaultAuthGuard from \\"../auth/gqlDefaultAuth.guard\\";
 import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
 import { OrderResolverBase } from \\"./base/order.resolver.base\\";
 import { Order } from \\"./base/Order\\";
 import { OrderService } from \\"./order.service\\";
 
 @graphql.Resolver(() => Order)
-@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+@common.UseGuards(
+  gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+  gqlACGuard.GqlACGuard
+)
 export class OrderResolver extends OrderResolverBase {
   constructor(
     protected readonly service: OrderService,
@@ -7177,7 +7263,7 @@ class CreateOrganizationArgs {
   data!: OrganizationCreateInput;
 }
 
-export { CreateOrganizationArgs };
+export { CreateOrganizationArgs as CreateOrganizationArgs };
 ",
   "server/src/organization/base/DeleteOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrganizationWhereUniqueInput } from \\"./OrganizationWhereUniqueInput\\";
@@ -7188,7 +7274,7 @@ class DeleteOrganizationArgs {
   where!: OrganizationWhereUniqueInput;
 }
 
-export { DeleteOrganizationArgs };
+export { DeleteOrganizationArgs as DeleteOrganizationArgs };
 ",
   "server/src/organization/base/Organization.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7257,7 +7343,7 @@ class Organization {
   @IsOptional()
   vipCustomers?: Array<Customer>;
 }
-export { Organization };
+export { Organization as Organization };
 ",
   "server/src/organization/base/OrganizationCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7272,7 +7358,7 @@ class OrganizationCreateInput {
   @Field(() => String)
   name!: string;
 }
-export { OrganizationCreateInput };
+export { OrganizationCreateInput as OrganizationCreateInput };
 ",
   "server/src/organization/base/OrganizationFindManyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7315,7 +7401,7 @@ class OrganizationFindManyArgs {
   take?: number;
 }
 
-export { OrganizationFindManyArgs };
+export { OrganizationFindManyArgs as OrganizationFindManyArgs };
 ",
   "server/src/organization/base/OrganizationFindUniqueArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrganizationWhereUniqueInput } from \\"./OrganizationWhereUniqueInput\\";
@@ -7326,7 +7412,7 @@ class OrganizationFindUniqueArgs {
   where!: OrganizationWhereUniqueInput;
 }
 
-export { OrganizationFindUniqueArgs };
+export { OrganizationFindUniqueArgs as OrganizationFindUniqueArgs };
 ",
   "server/src/organization/base/OrganizationOrderByInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7374,7 +7460,7 @@ class OrganizationOrderByInput {
   name?: SortOrder;
 }
 
-export { OrganizationOrderByInput };
+export { OrganizationOrderByInput as OrganizationOrderByInput };
 ",
   "server/src/organization/base/OrganizationUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7392,7 +7478,7 @@ class OrganizationUpdateInput {
   })
   name?: string;
 }
-export { OrganizationUpdateInput };
+export { OrganizationUpdateInput as OrganizationUpdateInput };
 ",
   "server/src/organization/base/OrganizationWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7446,7 +7532,7 @@ class OrganizationWhereInput {
   })
   name?: StringFilter;
 }
-export { OrganizationWhereInput };
+export { OrganizationWhereInput as OrganizationWhereInput };
 ",
   "server/src/organization/base/OrganizationWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -7461,7 +7547,7 @@ class OrganizationWhereUniqueInput {
   @Field(() => String)
   id!: string;
 }
-export { OrganizationWhereUniqueInput };
+export { OrganizationWhereUniqueInput as OrganizationWhereUniqueInput };
 ",
   "server/src/organization/base/UpdateOrganizationArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { OrganizationWhereUniqueInput } from \\"./OrganizationWhereUniqueInput\\";
@@ -7475,7 +7561,7 @@ class UpdateOrganizationArgs {
   data!: OrganizationUpdateInput;
 }
 
-export { UpdateOrganizationArgs };
+export { UpdateOrganizationArgs as UpdateOrganizationArgs };
 ",
   "server/src/organization/base/organization.controller.base.spec.ts": "import { Test } from \\"@nestjs/testing\\";
 import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
@@ -7628,7 +7714,7 @@ describe(\\"Organization\\", () => {
 import * as swagger from \\"@nestjs/swagger\\";
 import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
+import * as defaultAuthGuard from \\"../../auth/defaultAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
 import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import * as errors from \\"../../errors\\";
@@ -7653,7 +7739,10 @@ export class OrganizationControllerBase {
   ) {}
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Post()
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -7696,7 +7785,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get()
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -7735,7 +7827,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -7773,7 +7868,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Patch(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -7829,7 +7927,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Delete(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -7863,7 +7964,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get(\\"/:id/users\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -7917,7 +8021,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Post(\\"/:id/users\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -7959,7 +8066,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Patch(\\"/:id/users\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -8001,7 +8111,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Delete(\\"/:id/users\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -8043,7 +8156,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get(\\"/:id/customers\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -8102,7 +8218,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Post(\\"/:id/customers\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -8144,7 +8263,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Patch(\\"/:id/customers\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -8186,7 +8308,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Delete(\\"/:id/customers\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -8228,7 +8353,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get(\\"/:id/vipCustomers\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -8287,7 +8415,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Post(\\"/:id/vipCustomers\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -8329,7 +8460,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Patch(\\"/:id/vipCustomers\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -8371,7 +8505,10 @@ export class OrganizationControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Delete(\\"/:id/vipCustomers\\")
   @nestAccessControl.UseRoles({
     resource: \\"Organization\\",
@@ -8435,7 +8572,7 @@ export class OrganizationModuleBase {}
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../../auth/gqlBasicAuth.guard\\";
+import * as gqlDefaultAuthGuard from \\"../../auth/gqlDefaultAuth.guard\\";
 import * as gqlACGuard from \\"../../auth/gqlAC.guard\\";
 import * as gqlUserRoles from \\"../../auth/gqlUserRoles.decorator\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
@@ -8454,7 +8591,10 @@ import { Customer } from \\"../../customer/base/Customer\\";
 import { OrganizationService } from \\"../organization.service\\";
 
 @graphql.Resolver(() => Organization)
-@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+@common.UseGuards(
+  gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+  gqlACGuard.GqlACGuard
+)
 export class OrganizationResolverBase {
   constructor(
     protected readonly service: OrganizationService,
@@ -8817,14 +8957,17 @@ export class OrganizationModule {}
   "server/src/organization/organization.resolver.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
+import * as gqlDefaultAuthGuard from \\"../auth/gqlDefaultAuth.guard\\";
 import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
 import { OrganizationResolverBase } from \\"./base/organization.resolver.base\\";
 import { Organization } from \\"./base/Organization\\";
 import { OrganizationService } from \\"./organization.service\\";
 
 @graphql.Resolver(() => Organization)
-@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+@common.UseGuards(
+  gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+  gqlACGuard.GqlACGuard
+)
 export class OrganizationResolver extends OrganizationResolverBase {
   constructor(
     protected readonly service: OrganizationService,
@@ -8971,7 +9114,7 @@ class CreateUserArgs {
   data!: UserCreateInput;
 }
 
-export { CreateUserArgs };
+export { CreateUserArgs as CreateUserArgs };
 ",
   "server/src/user/base/DeleteUserArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
@@ -8982,7 +9125,7 @@ class DeleteUserArgs {
   where!: UserWhereUniqueInput;
 }
 
-export { DeleteUserArgs };
+export { DeleteUserArgs as DeleteUserArgs };
 ",
   "server/src/user/base/EnumUserInterests.ts": "import { registerEnumType } from \\"@nestjs/graphql\\";
 
@@ -9019,7 +9162,7 @@ class UpdateUserArgs {
   data!: UserUpdateInput;
 }
 
-export { UpdateUserArgs };
+export { UpdateUserArgs as UpdateUserArgs };
 ",
   "server/src/user/base/User.ts": "import { ObjectType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -9192,7 +9335,7 @@ class User {
   @Field(() => GraphQLJSONObject)
   extendedProperties!: JsonValue;
 }
-export { User };
+export { User as User };
 ",
   "server/src/user/base/UserCreateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -9348,7 +9491,7 @@ class UserCreateInput {
   @Field(() => GraphQLJSONObject)
   extendedProperties!: JsonValue;
 }
-export { UserCreateInput };
+export { UserCreateInput as UserCreateInput };
 ",
   "server/src/user/base/UserFindManyArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -9391,7 +9534,7 @@ class UserFindManyArgs {
   take?: number;
 }
 
-export { UserFindManyArgs };
+export { UserFindManyArgs as UserFindManyArgs };
 ",
   "server/src/user/base/UserFindUniqueArgs.ts": "import { ArgsType, Field } from \\"@nestjs/graphql\\";
 import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
@@ -9402,7 +9545,7 @@ class UserFindUniqueArgs {
   where!: UserWhereUniqueInput;
 }
 
-export { UserFindUniqueArgs };
+export { UserFindUniqueArgs as UserFindUniqueArgs };
 ",
   "server/src/user/base/UserOrderByInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -9558,7 +9701,7 @@ class UserOrderByInput {
   extendedProperties?: SortOrder;
 }
 
-export { UserOrderByInput };
+export { UserOrderByInput as UserOrderByInput };
 ",
   "server/src/user/base/UserUpdateInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -9753,7 +9896,7 @@ class UserUpdateInput {
   })
   extendedProperties?: JsonValue;
 }
-export { UserUpdateInput };
+export { UserUpdateInput as UserUpdateInput };
 ",
   "server/src/user/base/UserWhereInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -9879,7 +10022,7 @@ class UserWhereInput {
   })
   extendedProperties?: JsonNullableFilter;
 }
-export { UserWhereInput };
+export { UserWhereInput as UserWhereInput };
 ",
   "server/src/user/base/UserWhereUniqueInput.ts": "import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
@@ -9894,7 +10037,7 @@ class UserWhereUniqueInput {
   @Field(() => String)
   id!: string;
 }
-export { UserWhereUniqueInput };
+export { UserWhereUniqueInput as UserWhereUniqueInput };
 ",
   "server/src/user/base/user.controller.base.spec.ts": "import { Test } from \\"@nestjs/testing\\";
 import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
@@ -10076,7 +10219,7 @@ describe(\\"User\\", () => {
 import * as swagger from \\"@nestjs/swagger\\";
 import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as basicAuthGuard from \\"../../auth/basicAuth.guard\\";
+import * as defaultAuthGuard from \\"../../auth/defaultAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
 import { isRecordNotFoundError } from \\"../../prisma.util\\";
 import * as errors from \\"../../errors\\";
@@ -10099,7 +10242,10 @@ export class UserControllerBase {
   ) {}
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Post()
   @nestAccessControl.UseRoles({
     resource: \\"User\\",
@@ -10167,7 +10313,10 @@ export class UserControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get()
   @nestAccessControl.UseRoles({
     resource: \\"User\\",
@@ -10223,7 +10372,10 @@ export class UserControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"User\\",
@@ -10278,7 +10430,10 @@ export class UserControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Patch(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"User\\",
@@ -10359,7 +10514,10 @@ export class UserControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Delete(\\"/:id\\")
   @nestAccessControl.UseRoles({
     resource: \\"User\\",
@@ -10410,7 +10568,10 @@ export class UserControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get(\\"/:id/employees\\")
   @nestAccessControl.UseRoles({
     resource: \\"User\\",
@@ -10464,7 +10625,10 @@ export class UserControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Post(\\"/:id/employees\\")
   @nestAccessControl.UseRoles({
     resource: \\"User\\",
@@ -10506,7 +10670,10 @@ export class UserControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Patch(\\"/:id/employees\\")
   @nestAccessControl.UseRoles({
     resource: \\"User\\",
@@ -10548,7 +10715,10 @@ export class UserControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Delete(\\"/:id/employees\\")
   @nestAccessControl.UseRoles({
     resource: \\"User\\",
@@ -10590,7 +10760,10 @@ export class UserControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Get(\\"/:id/organizations\\")
   @nestAccessControl.UseRoles({
     resource: \\"User\\",
@@ -10627,7 +10800,10 @@ export class UserControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Post(\\"/:id/organizations\\")
   @nestAccessControl.UseRoles({
     resource: \\"User\\",
@@ -10669,7 +10845,10 @@ export class UserControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Patch(\\"/:id/organizations\\")
   @nestAccessControl.UseRoles({
     resource: \\"User\\",
@@ -10711,7 +10890,10 @@ export class UserControllerBase {
   }
 
   @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
-  @common.UseGuards(basicAuthGuard.BasicAuthGuard, nestAccessControl.ACGuard)
+  @common.UseGuards(
+    defaultAuthGuard.DefaultAuthGuard,
+    nestAccessControl.ACGuard
+  )
   @common.Delete(\\"/:id/organizations\\")
   @nestAccessControl.UseRoles({
     resource: \\"User\\",
@@ -10775,7 +10957,7 @@ export class UserModuleBase {}
 import * as graphql from \\"@nestjs/graphql\\";
 import * as apollo from \\"apollo-server-express\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../../auth/gqlBasicAuth.guard\\";
+import * as gqlDefaultAuthGuard from \\"../../auth/gqlDefaultAuth.guard\\";
 import * as gqlACGuard from \\"../../auth/gqlAC.guard\\";
 import * as gqlUserRoles from \\"../../auth/gqlUserRoles.decorator\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
@@ -10792,7 +10974,10 @@ import { Organization } from \\"../../organization/base/Organization\\";
 import { UserService } from \\"../user.service\\";
 
 @graphql.Resolver(() => User)
-@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+@common.UseGuards(
+  gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+  gqlACGuard.GqlACGuard
+)
 export class UserResolverBase {
   constructor(
     protected readonly service: UserService,
@@ -11189,14 +11374,17 @@ export class UserModule {}
   "server/src/user/user.resolver.ts": "import * as common from \\"@nestjs/common\\";
 import * as graphql from \\"@nestjs/graphql\\";
 import * as nestAccessControl from \\"nest-access-control\\";
-import * as gqlBasicAuthGuard from \\"../auth/gqlBasicAuth.guard\\";
+import * as gqlDefaultAuthGuard from \\"../auth/gqlDefaultAuth.guard\\";
 import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
 import { UserResolverBase } from \\"./base/user.resolver.base\\";
 import { User } from \\"./base/User\\";
 import { UserService } from \\"./user.service\\";
 
 @graphql.Resolver(() => User)
-@common.UseGuards(gqlBasicAuthGuard.GqlBasicAuthGuard, gqlACGuard.GqlACGuard)
+@common.UseGuards(
+  gqlDefaultAuthGuard.GqlDefaultAuthGuard,
+  gqlACGuard.GqlACGuard
+)
 export class UserResolver extends UserResolverBase {
   constructor(
     protected readonly service: UserService,


### PR DESCRIPTION
This PR includes the first step to support more auth providers. 
In this step, we build default guards that extend the basic guards. 

In the next step, we will be able to extend the default guard from any other guard instead of the basic guard without replacing the code in all controllers and resolvers. 

for any app that was generated before this version - When syncing with GitHub this change will be updated in all the files in the "basic" folder in the generated app but the customizable files still need to be updated manually when replacing auth providers.


- [x] Create default auth guards for REST and GQL
- [x] Use default guards instead of the basic guards in the controller and resolvers
