### PR TITLE
fix(dsg): add default title to Entity title component admin-ui

### DIFF
--- a/packages/amplication-data-service-generator/src/admin/entity/entity-title-component/entity-title-component.template.tsx
+++ b/packages/amplication-data-service-generator/src/admin/entity/entity-title-component/entity-title-component.template.tsx
@@ -6,6 +6,6 @@ declare const ENTITY_TITLE_FIELD_NAME = "title";
 
 export const ENTITY_TITLE_FIELD_NAME_ID = ENTITY_TITLE_FIELD_NAME;
 
-export const ENTITY_TITLE = (record: ENTITY) => {
-  return record.ENTITY_TITLE_FIELD;
+export const ENTITY_TITLE = (record: ENTITY): string => {
+  return record.ENTITY_TITLE_FIELD || record.id;
 };

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -1236,7 +1236,7 @@ export const CustomerShow = (props: ShowProps): React.ReactElement => {
 
 export const CUSTOMER_TITLE_FIELD = \\"firstName\\";
 
-export const CustomerTitle = (record: TCustomer) => {
+export const CustomerTitle = (record: TCustomer): string => {
   return record.firstName || record.id;
 };
 ",
@@ -1341,7 +1341,7 @@ export const EmptyShow = (props: ShowProps): React.ReactElement => {
 
 export const EMPTY_TITLE_FIELD = \\"id\\";
 
-export const EmptyTitle = (record: TEmpty) => {
+export const EmptyTitle = (record: TEmpty): string => {
   return record.id || record.id;
 };
 ",
@@ -1529,7 +1529,7 @@ export const OrderShow = (props: ShowProps): React.ReactElement => {
 
 export const ORDER_TITLE_FIELD = \\"id\\";
 
-export const OrderTitle = (record: TOrder) => {
+export const OrderTitle = (record: TOrder): string => {
   return record.id || record.id;
 };
 ",
@@ -1711,7 +1711,7 @@ export const OrganizationShow = (props: ShowProps): React.ReactElement => {
 
 export const ORGANIZATION_TITLE_FIELD = \\"name\\";
 
-export const OrganizationTitle = (record: TOrganization) => {
+export const OrganizationTitle = (record: TOrganization): string => {
   return record.name || record.id;
 };
 ",
@@ -2026,7 +2026,7 @@ export const UserShow = (props: ShowProps): React.ReactElement => {
 
 export const USER_TITLE_FIELD = \\"username\\";
 
-export const UserTitle = (record: TUser) => {
+export const UserTitle = (record: TUser): string => {
   return record.username || record.id;
 };
 ",

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -1237,7 +1237,7 @@ export const CustomerShow = (props: ShowProps): React.ReactElement => {
 export const CUSTOMER_TITLE_FIELD = \\"firstName\\";
 
 export const CustomerTitle = (record: TCustomer) => {
-  return record.firstName;
+  return record.firstName || record.id;
 };
 ",
   "admin-ui/src/data-provider/graphqlDataProvider.ts": "import buildGraphQLProvider from \\"ra-data-graphql-amplication\\";
@@ -1342,7 +1342,7 @@ export const EmptyShow = (props: ShowProps): React.ReactElement => {
 export const EMPTY_TITLE_FIELD = \\"id\\";
 
 export const EmptyTitle = (record: TEmpty) => {
-  return record.id;
+  return record.id || record.id;
 };
 ",
   "admin-ui/src/index.tsx": "import React from \\"react\\";
@@ -1530,7 +1530,7 @@ export const OrderShow = (props: ShowProps): React.ReactElement => {
 export const ORDER_TITLE_FIELD = \\"id\\";
 
 export const OrderTitle = (record: TOrder) => {
-  return record.id;
+  return record.id || record.id;
 };
 ",
   "admin-ui/src/organization/OrganizationCreate.tsx": "import * as React from \\"react\\";
@@ -1712,7 +1712,7 @@ export const OrganizationShow = (props: ShowProps): React.ReactElement => {
 export const ORGANIZATION_TITLE_FIELD = \\"name\\";
 
 export const OrganizationTitle = (record: TOrganization) => {
-  return record.name;
+  return record.name || record.id;
 };
 ",
   "admin-ui/src/pages/Dashboard.tsx": "import * as React from \\"react\\";
@@ -2027,7 +2027,7 @@ export const UserShow = (props: ShowProps): React.ReactElement => {
 export const USER_TITLE_FIELD = \\"username\\";
 
 export const UserTitle = (record: TUser) => {
-  return record.username;
+  return record.username || record.id;
 };
 ",
   "admin-ui/src/user/roles.ts": "export const ROLES = [


### PR DESCRIPTION
adding recorde.id as a backup to the record.TITLE because the select of react admin not allow null