### PR TITLE
fix(dsg): allow to upload .d.ts files to repo

### DIFF
--- a/packages/amplication-data-service-generator/.gitignore
+++ b/packages/amplication-data-service-generator/.gitignore
@@ -1,8 +1,9 @@
 dist/
 node_modules/
 coverage/
-generated/
-*.d.ts
+# the generated folder is the one how created after running the generate-test-data-service script
+generated/ 
+# *.d.ts
 *.map
 # ESLint
 .eslintcache

--- a/packages/amplication-data-service-generator/src/admin/static/src/react-app-env.d.ts
+++ b/packages/amplication-data-service-generator/src/admin/static/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />


### PR DESCRIPTION
Adding the options to upload .d.ts files to the repo for the admin UI, to prevent its generation in the npm I of the user