### PR TITLE
fix(client): Vertically centers github message in the footer

### DIFF
--- a/packages/amplication-client/src/VersionControl/BuildSummary.scss
+++ b/packages/amplication-client/src/VersionControl/BuildSummary.scss
@@ -29,9 +29,6 @@ $step-min-height: 32px;
 
   &__message {
     @include flexFullRowWithSpacing;
-    justify-content: flex-start;
-    align-items: flex-start;
     color: var(--black60);
-    margin-bottom: var(--default-spacing);
   }
 }


### PR DESCRIPTION
Fixes #1208

Before : 
![Screenshot from 2021-10-15 15-23-34](https://user-images.githubusercontent.com/33841027/137497941-2e2e4f01-579e-46f6-9f79-208d5db9843a.png)

After :
![Screenshot from 2021-10-15 15-22-41](https://user-images.githubusercontent.com/33841027/137497949-ff8fd4e6-cbfc-4cae-82fa-cce4699a34bf.png)