### PR TITLE
feat(server): Add @amplication/server Dockerfile

### DIFF
--- a/packages/amplication-server/Dockerfile
+++ b/packages/amplication-server/Dockerfile
@@ -1,0 +1,62 @@
+ARG ALPINE_VERSION=alpine3.14
+ARG NODE_VERSION=16.13.1
+
+FROM node:$NODE_VERSION-$ALPINE_VERSION AS base
+ARG NPM_VERSION=8.1.2
+ENV NPM_CONFIG_LOGLEVEL=silent
+ENV OPENCOLLECTIVE_HIDE=1
+
+RUN npm install --global npm@$NPM_VERSION
+RUN npm config set fund false
+
+WORKDIR /app
+COPY lerna.json /app
+COPY package*.json /app
+RUN npm ci --production
+
+FROM base AS build
+WORKDIR /app
+# Copy amplication/server and the its dependent packages
+COPY packages/amplication-server packages/amplication-server
+COPY packages/amplication-container-builder packages/amplication-container-builder
+COPY packages/amplication-data packages/amplication-data
+COPY packages/amplication-data-service-generator packages/amplication-data-service-generator
+COPY packages/amplication-deployer packages/amplication-deployer
+
+# Installs all copied package node_modules ; Preparation for build
+RUN npm run bootstrap -- --scope @amplication/server --include-dependencies
+RUN npm run prisma:generate
+# Build all distributions needed for amplicaiton/server
+RUN npm run build -- --scope @amplication/server --include-dependencies
+
+# Removes packages/*/node_modules
+# https://github.com/lerna/lerna/issues/2196#issuecomment-994882795
+RUN npm run clean -- --yes
+# Rebuild production node_modules
+RUN npm run bootstrap -- -- --production --scope @amplication/server --include-dependencies
+
+FROM base as server
+WORKDIR /app/packages/amplication-server
+# Copy all distributions and node_modules for amplication/server and its dependencies
+COPY --from=build /app/packages/amplication-server/package.json /app/packages/amplication-server/package.json
+COPY --from=build /app/packages/amplication-server/node_modules /app/packages/amplication-server/node_modules
+COPY --from=build /app/packages/amplication-server/dist /app/packages/amplication-server/dist
+
+COPY --from=build /app/packages/amplication-container-builder/package.json /app/packages/amplication-container-builder/package.json
+COPY --from=build /app/packages/amplication-container-builder/node_modules /app/packages/amplication-container-builder/node_modules
+COPY --from=build /app/packages/amplication-container-builder/dist /app/packages/amplication-container-builder/dist
+
+COPY --from=build /app/packages/amplication-data/package.json /app/packages/amplication-data/package.json
+COPY --from=build /app/packages/amplication-data/node_modules /app/packages/amplication-data/node_modules
+COPY --from=build /app/packages/amplication-data/dist /app/packages/amplication-data/dist
+
+COPY --from=build /app/packages/amplication-data-service-generator/package.json /app/packages/amplication-data-service-generator/package.json
+COPY --from=build /app/packages/amplication-data-service-generator/node_modules /app/packages/amplication-data-service-generator/node_modules
+COPY --from=build /app/packages/amplication-data-service-generator/dist /app/packages/amplication-data-service-generator/dist
+
+COPY --from=build /app/packages/amplication-deployer/package.json /app/packages/amplication-deployer/package.json
+COPY --from=build /app/packages/amplication-deployer/node_modules /app/packages/amplication-deployer/node_modules
+COPY --from=build /app/packages/amplication-deployer/dist /app/packages/amplication-deployer/dist
+
+EXPOSE 3000
+CMD [ "node", "dist/src/main"]


### PR DESCRIPTION
GH Issue: https://github.com/amplication/amplication/issues/2165

This PR separates `amplication`/server` into its own container image. The following improvements have been made...
1. Reduces image size from 2.45G+ to 984 MB
2. Reduces build time from 550+ Seconds to 330 Seconds.

Report from [Dive](https://github.com/wagoodman/dive)
```
Image name: 5d1f79b669c278d2a14a0b9805f5d21ffc972a3df9834f03fe8f6a0fca275f4f
Total Image size: 984 MB
Potential wasted space: 17 MB
Image efficiency score: 99 %
```

How to build the container image...
1. Go to root dir of amplication
2. run ` docker build -f packages/amplication-server/Dockerfile .` (This is telling Docker to set to the current context `.` and specifying the location of the dockerfile) 
3. run `docker run -p 3000:3000 <docker image sha>` (sha should be outputted to stdout after `docker build` is complete.