### PR TITLE
bug(apmlication-client): no error message rename to an existing app name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ terraform/envs/production/.terraform.lock.hcl
 terraform/envs/dev/.terraform.lock.hcl
 lerna-debug.log
 .DS_Store
+.idea/

--- a/packages/amplication-client/src/Application/ApplicationForm.tsx
+++ b/packages/amplication-client/src/Application/ApplicationForm.tsx
@@ -138,7 +138,7 @@ function ApplicationForm({ match }: Props) {
           </div>
         </>
       )}
-      <Snackbar open={Boolean(error)} message={errorMessage} />
+      <Snackbar open={Boolean(error?.message || updateError?.message)} message={errorMessage} />
     </div>
   );
 }


### PR DESCRIPTION
No warning is shown when the user renames the app's name as same as that of the other app
https://github.com/amplication/amplication/issues/2080