### PR TITLE
fix(dsg): resource not found error message instead of internal server…

### DIFF
--- a/packages/amplication-data-service-generator/src/server/resource/controller/to-many.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/to-many.template.ts
@@ -10,6 +10,8 @@ import { Request } from "express";
 // @ts-ignore
 import { ApiNestedQuery } from "../../decorators/api-nested-query.decorator";
 import { plainToClass } from "class-transformer";
+// @ts-ignore
+import * as errors from "../../errors";
 
 declare interface WHERE_UNIQUE_INPUT {
   id: string;
@@ -83,6 +85,11 @@ export class Mixin {
       ...query,
       select: SELECT,
     });
+    if (results === null) {
+      throw new errors.NotFoundException(
+        `No resource was found for ${JSON.stringify(params)}`
+      );
+    }
     return results.map((result) => permission.filter(result));
   }
 

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -5023,6 +5023,11 @@ export class CustomerControllerBase {
         label: true,
       },
     });
+    if (results === null) {
+      throw new errors.NotFoundException(
+        \`No resource was found for \${JSON.stringify(params)}\`
+      );
+    }
     return results.map((result) => permission.filter(result));
   }
 
@@ -9114,6 +9119,11 @@ export class OrganizationControllerBase {
         extendedProperties: true,
       },
     });
+    if (results === null) {
+      throw new errors.NotFoundException(
+        \`No resource was found for \${JSON.stringify(params)}\`
+      );
+    }
     return results.map((result) => permission.filter(result));
   }
 
@@ -9307,6 +9317,11 @@ export class OrganizationControllerBase {
         },
       },
     });
+    if (results === null) {
+      throw new errors.NotFoundException(
+        \`No resource was found for \${JSON.stringify(params)}\`
+      );
+    }
     return results.map((result) => permission.filter(result));
   }
 
@@ -9500,6 +9515,11 @@ export class OrganizationControllerBase {
         },
       },
     });
+    if (results === null) {
+      throw new errors.NotFoundException(
+        \`No resource was found for \${JSON.stringify(params)}\`
+      );
+    }
     return results.map((result) => permission.filter(result));
   }
 
@@ -12118,6 +12138,11 @@ export class UserControllerBase {
         extendedProperties: true,
       },
     });
+    if (results === null) {
+      throw new errors.NotFoundException(
+        \`No resource was found for \${JSON.stringify(params)}\`
+      );
+    }
     return results.map((result) => permission.filter(result));
   }
 
@@ -12289,6 +12314,11 @@ export class UserControllerBase {
         name: true,
       },
     });
+    if (results === null) {
+      throw new errors.NotFoundException(
+        \`No resource was found for \${JSON.stringify(params)}\`
+      );
+    }
     return results.map((result) => permission.filter(result));
   }
 


### PR DESCRIPTION
This pr will resolve #2274 
The previous pr: https://github.com/amplication/amplication/pull/2275 
should be closed as too many file changes somehow, especially different version on package.lock of the client package.

When a user makes a request to a nested entity: GET /api/{entity1}/{id}/{entity2}
and entity1 doesn't exist (entity1.id) he gets '500 internal server error' instead of 404 not found

I added the following code to 'to-many template'

if (results === null) {
      throw new errors.NotFoundException(
        `No resource was found for ${JSON.stringify(params)}`
      );
    }