### PR TITLE
fix(server): wrong download icon in build screen

### DIFF
--- a/packages/amplication-client/src/VersionControl/BuildSteps.tsx
+++ b/packages/amplication-client/src/VersionControl/BuildSteps.tsx
@@ -114,7 +114,7 @@ const BuildSteps = ({ build, onError }: Props) => {
         <span className="spacer" />
         <Button
           buttonStyle={EnumButtonStyle.Clear}
-          icon="download"
+          icon="download1"
           disabled={
             stepGenerateCode.status !== models.EnumActionStepStatus.Success
           }
@@ -165,7 +165,7 @@ const BuildSteps = ({ build, onError }: Props) => {
         <Button
           className="hidden"
           buttonStyle={EnumButtonStyle.Clear}
-          icon="download"
+          icon="download1"
           disabled={data.build.status !== models.EnumBuildStatus.Completed}
           onClick={handleDownloadClick}
           eventData={{


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Issue Number: #2244 

## PR Details
wrong download icon in build screen
<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
