### PR TITLE
fix(client): tooltip text not visible in light mode

### DIFF
--- a/packages/amplication-design-system/src/components/Tooltip/Tooltip.scss
+++ b/packages/amplication-design-system/src/components/Tooltip/Tooltip.scss
@@ -5,7 +5,7 @@ $width-short: 100px;
 .amp-tooltip {
   &:after {
     background-color: var(--tooltip-background);
-    color: var(--tooltip-text-color);
+    color: var(--static-white);
   }
 
   &:before,

--- a/packages/amplication-design-system/src/components/Tooltip/Tooltip.scss
+++ b/packages/amplication-design-system/src/components/Tooltip/Tooltip.scss
@@ -5,6 +5,7 @@ $width-short: 100px;
 .amp-tooltip {
   &:after {
     background-color: var(--tooltip-background);
+    color: var(--tooltip-text-color);
   }
 
   &:before,

--- a/packages/amplication-design-system/src/style/css-variables.scss
+++ b/packages/amplication-design-system/src/style/css-variables.scss
@@ -44,6 +44,7 @@
   --negative: #e93c51;
 
   --tooltip-background: #1b1f23;
+  --tooltip-text-color: #ffffff;
 
   --panel-background: var(--white);
   --panel-hover-background: var(--black5);

--- a/packages/amplication-design-system/src/style/css-variables.scss
+++ b/packages/amplication-design-system/src/style/css-variables.scss
@@ -44,7 +44,6 @@
   --negative: #e93c51;
 
   --tooltip-background: #1b1f23;
-  --tooltip-text-color: #ffffff;
 
   --panel-background: var(--white);
   --panel-hover-background: var(--black5);


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Issue Number: #2323

## PR Details

Added tooltip text color so that tooltip text can be visible in light theme mode
