### PR TITLE
fix(client): cancel organization reset

### DIFF
--- a/packages/amplication-client/src/Application/git/AuthAppWithGit.tsx
+++ b/packages/amplication-client/src/Application/git/AuthAppWithGit.tsx
@@ -49,7 +49,7 @@ function AuthAppWithGit({ app, onDone }: Props) {
     } else if (gitOrganizations.length === 1) {
       setGitOrganization(gitOrganizations[0]);
     }
-  }, [gitOrganizations, gitRepository]);
+  }, [gitOrganizations, gitRepository?.gitOrganization]);
 
   const [selectRepoOpen, setSelectRepoOpen] = useState<boolean>(false);
   const [createNewRepoOpen, setCreateNewRepoOpen] = useState(false);
@@ -129,10 +129,7 @@ function AuthAppWithGit({ app, onDone }: Props) {
           }}
           onSelectRepository={handleSelectRepoDialogOpen}
           currentConnectedGitRepository={gitRepository}
-          isCreateShow={
-            gitOrganization?.type === EnumGitOrganizationType.Organization
-          }
-          isGitOrganizationSelected={Boolean(gitOrganization)}
+          selectedGitOrganization={gitOrganization}
         />
 
         <GitSyncNotes />

--- a/packages/amplication-client/src/Application/git/AuthAppWithGit.tsx
+++ b/packages/amplication-client/src/Application/git/AuthAppWithGit.tsx
@@ -42,15 +42,14 @@ function AuthAppWithGit({ app, onDone }: Props) {
     gitOrganization,
     setGitOrganization,
   ] = useState<GitOrganizationFromGitRepository | null>(null);
+
   useEffect(() => {
     if (gitRepository?.gitOrganization) {
       setGitOrganization(gitRepository?.gitOrganization);
     } else if (gitOrganizations.length === 1) {
       setGitOrganization(gitOrganizations[0]);
-    } else {
-      setGitOrganization(null);
     }
-  }, [gitOrganizations, gitRepository?.gitOrganization]);
+  }, [gitOrganizations, gitRepository]);
 
   const [selectRepoOpen, setSelectRepoOpen] = useState<boolean>(false);
   const [createNewRepoOpen, setCreateNewRepoOpen] = useState(false);
@@ -123,18 +122,19 @@ function AuthAppWithGit({ app, onDone }: Props) {
             onAddGitOrganization={handleAuthWithGitClick}
           />
         )}
-        {gitOrganization && (
-          <RepositoryActions
-            onCreateRepository={() => {
-              setCreateNewRepoOpen(true);
-            }}
-            onSelectRepository={handleSelectRepoDialogOpen}
-            currentConnectedGitRepository={gitRepository}
-            isCreateShow={
-              gitOrganization.type === EnumGitOrganizationType.Organization
-            }
-          />
-        )}
+
+        <RepositoryActions
+          onCreateRepository={() => {
+            setCreateNewRepoOpen(true);
+          }}
+          onSelectRepository={handleSelectRepoDialogOpen}
+          currentConnectedGitRepository={gitRepository}
+          isCreateShow={
+            gitOrganization?.type === EnumGitOrganizationType.Organization
+          }
+          isGitOrganizationSelected={Boolean(gitOrganization)}
+        />
+
         <GitSyncNotes />
       </Panel>
 

--- a/packages/amplication-client/src/Application/git/AuthAppWithGit.tsx
+++ b/packages/amplication-client/src/Application/git/AuthAppWithGit.tsx
@@ -2,11 +2,7 @@ import { EnumPanelStyle, Panel, Snackbar } from "@amplication/design-system";
 import { gql, useMutation } from "@apollo/client";
 import { isEmpty } from "lodash";
 import React, { useCallback, useEffect, useState } from "react";
-import {
-  AuthorizeAppWithGitResult,
-  EnumGitOrganizationType,
-  EnumGitProvider,
-} from "../../models";
+import { AuthorizeAppWithGitResult, EnumGitProvider } from "../../models";
 import { useTracking } from "../../util/analytics";
 import { formatError } from "../../util/error";
 import "./AuthAppWithGit.scss";

--- a/packages/amplication-client/src/Application/git/GitActions/RepositoryActions/RepositoryActions.scss
+++ b/packages/amplication-client/src/Application/git/GitActions/RepositoryActions/RepositoryActions.scss
@@ -1,8 +1,14 @@
 @import "../../../../style/index.scss";
 
+:root {
+  --min-height-of-banner: 70px;
+}
+
 .repository-actions {
   &__auth {
     margin: var(--double-spacing) 0;
+    min-height: var(--min-height-of-banner);
+    display: flex;
   }
   &__action {
     margin-left: var(--default-spacing-small);
@@ -14,7 +20,7 @@
   }
   &__select-repo {
     @include flexFullRowWithSpacing;
-
+    flex: 1;
     &__details {
       @include flexFullRowWithSpacing;
       .amp-icon {

--- a/packages/amplication-client/src/Application/git/GitActions/RepositoryActions/RepositoryActions.tsx
+++ b/packages/amplication-client/src/Application/git/GitActions/RepositoryActions/RepositoryActions.tsx
@@ -45,7 +45,7 @@ export default function RepositoryActions({
               No repository was selected
             </div>
             <div className={`${CLASS_NAME}__actions`}>
-              {Boolean(selectedGitOrganization) && (
+              {selectedGitOrganization && (
                 <>
                   <div className={`${CLASS_NAME}__action`}>
                     <Button
@@ -56,7 +56,7 @@ export default function RepositoryActions({
                       Select repository
                     </Button>
                   </div>
-                  {selectedGitOrganization?.type ===
+                  {selectedGitOrganization.type ===
                     EnumGitOrganizationType.Organization && (
                     <div className={`${CLASS_NAME}__action`}>
                       <Button

--- a/packages/amplication-client/src/Application/git/GitActions/RepositoryActions/RepositoryActions.tsx
+++ b/packages/amplication-client/src/Application/git/GitActions/RepositoryActions/RepositoryActions.tsx
@@ -15,6 +15,7 @@ type Props = {
   onSelectRepository: () => void;
   currentConnectedGitRepository: GitRepositoryWithGitOrganization | null;
   isCreateShow: boolean;
+  isGitOrganizationSelected: boolean;
 };
 
 const CLASS_NAME = "repository-actions";
@@ -23,6 +24,7 @@ export default function RepositoryActions({
   onSelectRepository,
   currentConnectedGitRepository,
   isCreateShow,
+  isGitOrganizationSelected,
 }: Props) {
   return (
     <div className={`${CLASS_NAME}`}>
@@ -31,11 +33,9 @@ export default function RepositoryActions({
         panelStyle={EnumPanelStyle.Bordered}
       >
         {currentConnectedGitRepository ? (
-          <div>
-            <GithubSyncDetails
-              gitRepositoryWithOrganization={currentConnectedGitRepository}
-            />
-          </div>
+          <GithubSyncDetails
+            gitRepositoryWithOrganization={currentConnectedGitRepository}
+          />
         ) : (
           <div className={`${CLASS_NAME}__select-repo`}>
             <div className={`${CLASS_NAME}__select-repo__details`}>
@@ -43,25 +43,29 @@ export default function RepositoryActions({
               No repository was selected
             </div>
             <div className={`${CLASS_NAME}__actions`}>
-              <div className={`${CLASS_NAME}__action`}>
-                <Button
-                  buttonStyle={EnumButtonStyle.Primary}
-                  onClick={onSelectRepository}
-                  icon="chevron_down"
-                >
-                  Select repository
-                </Button>
-              </div>
-              {isCreateShow && (
-                <div className={`${CLASS_NAME}__action`}>
-                  <Button
-                    buttonStyle={EnumButtonStyle.Primary}
-                    onClick={onCreateRepository}
-                    icon="plus"
-                  >
-                    Create repository
-                  </Button>
-                </div>
+              {isGitOrganizationSelected && (
+                <>
+                  <div className={`${CLASS_NAME}__action`}>
+                    <Button
+                      buttonStyle={EnumButtonStyle.Primary}
+                      onClick={onSelectRepository}
+                      icon="chevron_down"
+                    >
+                      Select repository
+                    </Button>
+                  </div>
+                  {isCreateShow && (
+                    <div className={`${CLASS_NAME}__action`}>
+                      <Button
+                        buttonStyle={EnumButtonStyle.Primary}
+                        onClick={onCreateRepository}
+                        icon="plus"
+                      >
+                        Create repository
+                      </Button>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </div>

--- a/packages/amplication-client/src/Application/git/GitActions/RepositoryActions/RepositoryActions.tsx
+++ b/packages/amplication-client/src/Application/git/GitActions/RepositoryActions/RepositoryActions.tsx
@@ -6,16 +6,19 @@ import {
   Panel,
 } from "@amplication/design-system";
 import React from "react";
-import GithubSyncDetails from "./GithubSyncDetails";
+import { EnumGitOrganizationType } from "../../../../models";
 import "../../AuthAppWithGit.scss";
-import { GitRepositoryWithGitOrganization } from "../../SyncWithGithubPage";
+import {
+  GitOrganizationFromGitRepository,
+  GitRepositoryWithGitOrganization,
+} from "../../SyncWithGithubPage";
+import GithubSyncDetails from "./GithubSyncDetails";
 import "./RepositoryActions.scss";
 type Props = {
   onCreateRepository: () => void;
   onSelectRepository: () => void;
   currentConnectedGitRepository: GitRepositoryWithGitOrganization | null;
-  isCreateShow: boolean;
-  isGitOrganizationSelected: boolean;
+  selectedGitOrganization: GitOrganizationFromGitRepository | null;
 };
 
 const CLASS_NAME = "repository-actions";
@@ -23,8 +26,7 @@ export default function RepositoryActions({
   onCreateRepository,
   onSelectRepository,
   currentConnectedGitRepository,
-  isCreateShow,
-  isGitOrganizationSelected,
+  selectedGitOrganization,
 }: Props) {
   return (
     <div className={`${CLASS_NAME}`}>
@@ -43,7 +45,7 @@ export default function RepositoryActions({
               No repository was selected
             </div>
             <div className={`${CLASS_NAME}__actions`}>
-              {isGitOrganizationSelected && (
+              {Boolean(selectedGitOrganization) && (
                 <>
                   <div className={`${CLASS_NAME}__action`}>
                     <Button
@@ -54,7 +56,8 @@ export default function RepositoryActions({
                       Select repository
                     </Button>
                   </div>
-                  {isCreateShow && (
+                  {selectedGitOrganization?.type ===
+                    EnumGitOrganizationType.Organization && (
                     <div className={`${CLASS_NAME}__action`}>
                       <Button
                         buttonStyle={EnumButtonStyle.Primary}


### PR DESCRIPTION
## fix #2384 

## PR Details

This pr cancel the reset of the git organization in the ui


## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
