### PR TITLE
fix(dsg): use HttpStatus.NOT_FOUND in controller test for testing 404s

### DIFF
--- a/packages/amplication-data-service-generator/src/server/resource/test/controller.spec.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/test/controller.spec.template.ts
@@ -118,9 +118,9 @@ describe(TEST_NAME, () => {
   test(`GET ${FIND_ONE_PATHNAME} non existing`, async () => {
     await request(app.getHttpServer())
       .get(`${RESOURCE}/${NON_EXISTING_PARAM_ID}`)
-      .expect(404)
+      .expect(HttpStatus.NOT_FOUND)
       .expect({
-        statusCode: 404,
+        statusCode: HttpStatus.NOT_FOUND,
         message: `No resource was found for {"${FIND_ONE_PARAM_NAME}":"${NON_EXISTING_PARAM_ID}"}`,
         error: "Not Found",
       });

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -4890,9 +4890,9 @@ describe(\\"Customer\\", () => {
   test(\\"GET /customers/:id non existing\\", async () => {
     await request(app.getHttpServer())
       .get(\`\${\\"/customers\\"}/\${nonExistingId}\`)
-      .expect(404)
+      .expect(HttpStatus.NOT_FOUND)
       .expect({
-        statusCode: 404,
+        statusCode: HttpStatus.NOT_FOUND,
         message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
         error: \\"Not Found\\",
       });
@@ -6536,9 +6536,9 @@ describe(\\"Empty\\", () => {
   test(\\"GET /empties/:id non existing\\", async () => {
     await request(app.getHttpServer())
       .get(\`\${\\"/empties\\"}/\${nonExistingId}\`)
-      .expect(404)
+      .expect(HttpStatus.NOT_FOUND)
       .expect({
-        statusCode: 404,
+        statusCode: HttpStatus.NOT_FOUND,
         message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
         error: \\"Not Found\\",
       });
@@ -7947,9 +7947,9 @@ describe(\\"Order\\", () => {
   test(\\"GET /orders/:id non existing\\", async () => {
     await request(app.getHttpServer())
       .get(\`\${\\"/orders\\"}/\${nonExistingId}\`)
-      .expect(404)
+      .expect(HttpStatus.NOT_FOUND)
       .expect({
-        statusCode: 404,
+        statusCode: HttpStatus.NOT_FOUND,
         message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
         error: \\"Not Found\\",
       });
@@ -9546,9 +9546,9 @@ describe(\\"Organization\\", () => {
   test(\\"GET /organizations/:id non existing\\", async () => {
     await request(app.getHttpServer())
       .get(\`\${\\"/organizations\\"}/\${nonExistingId}\`)
-      .expect(404)
+      .expect(HttpStatus.NOT_FOUND)
       .expect({
-        statusCode: 404,
+        statusCode: HttpStatus.NOT_FOUND,
         message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
         error: \\"Not Found\\",
       });
@@ -12735,9 +12735,9 @@ describe(\\"User\\", () => {
   test(\\"GET /users/:id non existing\\", async () => {
     await request(app.getHttpServer())
       .get(\`\${\\"/users\\"}/\${nonExistingId}\`)
-      .expect(404)
+      .expect(HttpStatus.NOT_FOUND)
       .expect({
-        statusCode: 404,
+        statusCode: HttpStatus.NOT_FOUND,
         message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
         error: \\"Not Found\\",
       });

--- a/packages/amplication-data-service-generator/src/version.ts
+++ b/packages/amplication-data-service-generator/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.11.4";
+export const version = "0.12.1";


### PR DESCRIPTION
Issue Number: #2387 

## PR Details

- This fixes issue #2387 wherein HTTP status code for not found is added directly instead of referencing the enum HttpStatus. 
- This also updates the corresponding Jest snapshot for the test.
- The `version` field in `packages/amplication-data-service-generator/src/version.ts` seems to have been auto-updated during the build process and I kept it for the reason that it matches the version in the corresponding package.json file.

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error