### PR TITLE
fix:  width fix when error shown in git create repo

### DIFF
--- a/packages/amplication-client/src/Application/git/dialogs/GitCreateRepo/GitCreateRepo.scss
+++ b/packages/amplication-client/src/Application/git/dialogs/GitCreateRepo/GitCreateRepo.scss
@@ -17,7 +17,12 @@
     .input-label {
       margin-bottom: 0;
     }
+
+    ~ .amplication-label {
+      display: block;
+    }
   }
+
   &__progress {
     color: #ffffff !important;
   }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->
Width of create git repo dialog in error state remains same as in without error state
Issue Number: #2385 

## PR Details



https://user-images.githubusercontent.com/39362422/158685825-af285714-c1c1-4582-af14-ff7c5a5ae76c.mov



## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
