### PR TITLE
Deps/ra data graphql amplication

### DIFF
--- a/packages/amplication-data-service-generator/package-lock.json
+++ b/packages/amplication-data-service-generator/package-lock.json
@@ -6,9 +6,9 @@
   "packages": {
     "": {
       "name": "@amplication/data-service-generator",
-      "version": "0.11.3",
+      "version": "0.12.1",
       "dependencies": {
-        "@amplication/data": "^0.11.3",
+        "@amplication/data": "^0.12.1",
         "@babel/parser": "7.14.7",
         "@extra-set/difference": "2.2.4",
         "camel-case": "4.1.2",
@@ -108,7 +108,7 @@
         "passport": "0.5.2",
         "passport-http": "0.3.0",
         "passport-jwt": "4.0.0",
-        "ra-data-graphql-amplication": "0.0.8",
+        "ra-data-graphql-amplication": "0.0.11",
         "react-admin": "3.17.0",
         "reflect-metadata": "0.1.13",
         "sleep-promise": "9.1.0",
@@ -121,7 +121,7 @@
     },
     "../amplication-data": {
       "name": "@amplication/data",
-      "version": "0.11.3",
+      "version": "0.12.1",
       "devDependencies": {
         "@types/jest": "26.0.19",
         "@types/json-schema": "7.0.9",
@@ -12614,18 +12614,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/apollo-cache": {
-      "version": "1.3.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "apollo-utilities": "^1.3.4",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
     "node_modules/apollo-cache-control": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.14.0.tgz",
@@ -12655,83 +12643,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/apollo-cache-inmemory": {
-      "version": "1.6.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "apollo-cache": "^1.3.5",
-        "apollo-utilities": "^1.3.4",
-        "optimism": "^0.10.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-cache-inmemory/node_modules/@wry/context": {
-      "version": "0.4.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": ">=6",
-        "tslib": "^1.9.3"
-      }
-    },
-    "node_modules/apollo-cache-inmemory/node_modules/optimism": {
-      "version": "0.10.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wry/context": "^0.4.0"
-      }
-    },
-    "node_modules/apollo-cache-inmemory/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/apollo-cache/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/apollo-client": {
-      "version": "2.6.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.5",
-        "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.4",
-        "symbol-observable": "^1.0.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-client-preset": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "apollo-cache-inmemory": "^1.1.7",
-        "apollo-client": "^2.2.2",
-        "apollo-link": "^1.0.6",
-        "apollo-link-http": "^1.3.1",
-        "graphql-tag": "^2.4.2"
-      }
-    },
-    "node_modules/apollo-client/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/apollo-datasource": {
       "version": "0.9.0",
@@ -12801,42 +12712,6 @@
       "peerDependencies": {
         "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
-    },
-    "node_modules/apollo-link-http": {
-      "version": "1.5.17",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-link-http-common": {
-      "version": "0.2.16",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "apollo-link": "^1.2.14",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-link-http-common/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/apollo-link-http/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/apollo-link/node_modules/tslib": {
       "version": "1.14.1",
@@ -16849,17 +16724,20 @@
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "15.5.0",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "dev": true,
-      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
     },
     "node_modules/graphql-ast-types-browser": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/graphql-ast-types-browser/-/graphql-ast-types-browser-1.0.2.tgz",
+      "integrity": "sha512-QuKZ+Et3dE7SyO5c41eNPlJc7+HwQxOzHfmIhqzj4cUgAGyhSwVkKb7K24zom8y6y0VnG7Xb3RRypjIVvfIevQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "graphql": "^0.11.7"
       }
@@ -16934,14 +16812,15 @@
       }
     },
     "node_modules/graphql-subscriptions": {
-      "version": "1.1.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.2.1.tgz",
+      "integrity": "sha512-95yD/tKi24q8xYa7Q9rhQN16AYj5wPbrb8tmHGM3WRc9EBmWrG/0kkMl+tQG8wcEuE9ibR4zyOM31p5Sdr2v4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "iterall": "^1.2.1"
+        "iterall": "^1.3.0"
       },
       "peerDependencies": {
-        "graphql": "^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0"
+        "graphql": "^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/graphql-tag": {
@@ -23315,51 +23194,42 @@
       "license": "MIT"
     },
     "node_modules/ra-data-graphql": {
-      "version": "3.11.4",
+      "version": "3.19.10",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql/-/ra-data-graphql-3.19.10.tgz",
+      "integrity": "sha512-cI3PQjBLXz+krT8i6YWYykESu7A/4AfBplJrexBAjO0nG7RZfwUKlq0OaJkNnB9x7g1i7lxwZ8H8V8qtpe4mhw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "apollo-client": "^2.6.3",
-        "apollo-client-preset": "^1.0.8",
-        "graphql-tag": "^2.10.1",
+        "@apollo/client": "^3.3.19",
         "lodash": "~4.17.5",
         "pluralize": "~7.0.0"
       },
       "peerDependencies": {
-        "graphql": "^14.1.1",
+        "graphql": "^15.6.0",
         "ra-core": "^3.9.0"
       }
     },
     "node_modules/ra-data-graphql-amplication": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.8.tgz",
-      "integrity": "sha512-MHKohIluSE1mbvCwK/7WudR75AkFE0ONVbG2WZz0uiSV/o9d3iDGV8QtPoMMcelD5UcH4FMOEyxp8SUMdOrRXg==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.11.tgz",
+      "integrity": "sha512-TBvJmZO5K5nktm1c6ucyTcfbkFMlqY9YQU3oxeVPaPOIdGQh24YqAtreAfSZb9JKXCZE4V6YZIagdWFCr79L/Q==",
       "dev": true,
       "dependencies": {
-        "camel-case": "^4.1.2",
-        "graphql": "^15.5.0",
-        "graphql-ast-types-browser": "~1.0.2",
-        "graphql-tag": "^2.10.1",
-        "lodash": "~4.17.5",
-        "pluralize": "~7.0.0",
-        "ra-data-graphql": "^3.11.4"
+        "camel-case": "4.1.2",
+        "graphql-ast-types-browser": "1.0.2",
+        "lodash": "4.17.21",
+        "pluralize": "8.0.0",
+        "ra-data-graphql": "3.19.10"
       },
       "peerDependencies": {
+        "graphql": "^15.6.0",
         "ra-core": "^3.9.0"
-      }
-    },
-    "node_modules/ra-data-graphql-amplication/node_modules/pluralize": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ra-data-graphql/node_modules/pluralize": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -34633,20 +34503,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "apollo-cache": {
-      "version": "1.3.5",
-      "dev": true,
-      "requires": {
-        "apollo-utilities": "^1.3.4",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
     "apollo-cache-control": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.14.0.tgz",
@@ -34667,69 +34523,6 @@
             "util.promisify": "^1.0.0"
           }
         }
-      }
-    },
-    "apollo-cache-inmemory": {
-      "version": "1.6.6",
-      "dev": true,
-      "requires": {
-        "apollo-cache": "^1.3.5",
-        "apollo-utilities": "^1.3.4",
-        "optimism": "^0.10.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "@wry/context": {
-          "version": "0.4.4",
-          "dev": true,
-          "requires": {
-            "@types/node": ">=6",
-            "tslib": "^1.9.3"
-          }
-        },
-        "optimism": {
-          "version": "0.10.3",
-          "dev": true,
-          "requires": {
-            "@wry/context": "^0.4.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
-    "apollo-client": {
-      "version": "2.6.10",
-      "dev": true,
-      "requires": {
-        "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.5",
-        "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.4",
-        "symbol-observable": "^1.0.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
-    "apollo-client-preset": {
-      "version": "1.0.8",
-      "dev": true,
-      "requires": {
-        "apollo-cache-inmemory": "^1.1.7",
-        "apollo-client": "^2.2.2",
-        "apollo-link": "^1.0.6",
-        "apollo-link-http": "^1.3.1",
-        "graphql-tag": "^2.4.2"
       }
     },
     "apollo-datasource": {
@@ -34782,36 +34575,6 @@
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
         "zen-observable-ts": "^0.8.21"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
-    "apollo-link-http": {
-      "version": "1.5.17",
-      "dev": true,
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
-    "apollo-link-http-common": {
-      "version": "0.2.16",
-      "dev": true,
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
       },
       "dependencies": {
         "tslib": {
@@ -37697,11 +37460,16 @@
       "version": "4.2.4"
     },
     "graphql": {
-      "version": "15.5.0",
-      "dev": true
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+      "dev": true,
+      "peer": true
     },
     "graphql-ast-types-browser": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/graphql-ast-types-browser/-/graphql-ast-types-browser-1.0.2.tgz",
+      "integrity": "sha512-QuKZ+Et3dE7SyO5c41eNPlJc7+HwQxOzHfmIhqzj4cUgAGyhSwVkKb7K24zom8y6y0VnG7Xb3RRypjIVvfIevQ==",
       "dev": true,
       "requires": {}
     },
@@ -37758,10 +37526,12 @@
       }
     },
     "graphql-subscriptions": {
-      "version": "1.1.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.2.1.tgz",
+      "integrity": "sha512-95yD/tKi24q8xYa7Q9rhQN16AYj5wPbrb8tmHGM3WRc9EBmWrG/0kkMl+tQG8wcEuE9ibR4zyOM31p5Sdr2v4g==",
       "dev": true,
       "requires": {
-        "iterall": "^1.2.1"
+        "iterall": "^1.3.0"
       }
     },
     "graphql-tag": {
@@ -42393,41 +42163,35 @@
       }
     },
     "ra-data-graphql": {
-      "version": "3.11.4",
+      "version": "3.19.10",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql/-/ra-data-graphql-3.19.10.tgz",
+      "integrity": "sha512-cI3PQjBLXz+krT8i6YWYykESu7A/4AfBplJrexBAjO0nG7RZfwUKlq0OaJkNnB9x7g1i7lxwZ8H8V8qtpe4mhw==",
       "dev": true,
       "requires": {
-        "apollo-client": "^2.6.3",
-        "apollo-client-preset": "^1.0.8",
-        "graphql-tag": "^2.10.1",
+        "@apollo/client": "^3.3.19",
         "lodash": "~4.17.5",
         "pluralize": "~7.0.0"
       },
       "dependencies": {
         "pluralize": {
           "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
           "dev": true
         }
       }
     },
     "ra-data-graphql-amplication": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.8.tgz",
-      "integrity": "sha512-MHKohIluSE1mbvCwK/7WudR75AkFE0ONVbG2WZz0uiSV/o9d3iDGV8QtPoMMcelD5UcH4FMOEyxp8SUMdOrRXg==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.11.tgz",
+      "integrity": "sha512-TBvJmZO5K5nktm1c6ucyTcfbkFMlqY9YQU3oxeVPaPOIdGQh24YqAtreAfSZb9JKXCZE4V6YZIagdWFCr79L/Q==",
       "dev": true,
       "requires": {
-        "camel-case": "^4.1.2",
-        "graphql": "^15.5.0",
-        "graphql-ast-types-browser": "~1.0.2",
-        "graphql-tag": "^2.10.1",
-        "lodash": "~4.17.5",
-        "pluralize": "~7.0.0",
-        "ra-data-graphql": "^3.11.4"
-      },
-      "dependencies": {
-        "pluralize": {
-          "version": "7.0.0",
-          "dev": true
-        }
+        "camel-case": "4.1.2",
+        "graphql-ast-types-browser": "1.0.2",
+        "lodash": "4.17.21",
+        "pluralize": "8.0.0",
+        "ra-data-graphql": "3.19.10"
       }
     },
     "ra-i18n-polyglot": {

--- a/packages/amplication-data-service-generator/package.json
+++ b/packages/amplication-data-service-generator/package.json
@@ -119,7 +119,7 @@
     "passport": "0.5.2",
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.0",
-    "ra-data-graphql-amplication": "0.0.8",
+    "ra-data-graphql-amplication": "0.0.11",
     "react-admin": "3.17.0",
     "reflect-metadata": "0.1.13",
     "sleep-promise": "9.1.0",

--- a/packages/amplication-data-service-generator/src/admin/static/package-lock.json
+++ b/packages/amplication-data-service-generator/src/admin/static/package-lock.json
@@ -18,7 +18,6 @@
         "ra-data-graphql-amplication": "0.0.8",
         "react": "16.14.0",
         "react-admin": "3.17.0",
-        "react-apollo": "3.1.5",
         "react-dom": "16.14.0",
         "react-scripts": "4.0.3",
         "sass": "^1.39.0",
@@ -109,66 +108,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-    },
-    "node_modules/@apollo/react-ssr": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.5.tgz",
-      "integrity": "sha512-wuLPkKlctNn3u8EU8rlECyktpOUCeekFfb0KhIKknpGY6Lza2Qu0bThx7D9MIbVEzhKadNNrzLcpk0Y8/5UuWg==",
-      "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0"
-      }
-    },
-    "node_modules/@apollo/react-ssr/node_modules/@apollo/react-common": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
-      "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
-      "dependencies": {
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0",
-        "apollo-client": "^2.6.4",
-        "apollo-utilities": "^1.3.2",
-        "graphql": "^14.3.1",
-        "react": "^16.8.0"
-      }
-    },
-    "node_modules/@apollo/react-ssr/node_modules/@apollo/react-hooks": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
-      "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
-      "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@wry/equality": "^0.1.9",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0",
-        "apollo-client": "^2.6.4",
-        "graphql": "^14.3.1",
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0"
-      }
-    },
-    "node_modules/@apollo/react-ssr/node_modules/graphql": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
-      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
-      "peer": true,
-      "dependencies": {
-        "iterall": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 6.x"
-      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.10.4",
@@ -3887,14 +3826,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
-    "node_modules/@wry/equality": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
-      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
-      "dependencies": {
-        "tslib": "^1.9.3"
-      }
-    },
     "node_modules/@wry/trie": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
@@ -4115,68 +4046,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/apollo-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
-      "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
-      "peer": true,
-      "dependencies": {
-        "apollo-utilities": "^1.3.4",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-client": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
-      "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
-      "peer": true,
-      "dependencies": {
-        "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.5",
-        "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.4",
-        "symbol-observable": "^1.0.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-link": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
-      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
-      "peer": true,
-      "dependencies": {
-        "apollo-utilities": "^1.3.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.21"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-utilities": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
-      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
-      "peer": true,
-      "dependencies": {
-        "@wry/equality": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/aproba": {
@@ -11311,12 +11180,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "peer": true
-    },
     "node_modules/jest": {
       "version": "26.6.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.0.tgz",
@@ -17267,100 +17130,6 @@
         "react-dom": "^16.9.0 || ^17.0.0"
       }
     },
-    "node_modules/react-apollo": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-3.1.5.tgz",
-      "integrity": "sha512-xOxMqxORps+WHrUYbjVHPliviomefOpu5Sh35oO3osuOyPTxvrljdfTLGCggMhcXBsDljtS5Oy4g+ijWg3D4JQ==",
-      "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-components": "^3.1.5",
-        "@apollo/react-hoc": "^3.1.5",
-        "@apollo/react-hooks": "^3.1.5",
-        "@apollo/react-ssr": "^3.1.5"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0",
-        "apollo-client": "^2.6.4",
-        "graphql": "^14.3.1",
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0"
-      }
-    },
-    "node_modules/react-apollo/node_modules/@apollo/react-common": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
-      "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
-      "dependencies": {
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0",
-        "apollo-client": "^2.6.4",
-        "apollo-utilities": "^1.3.2",
-        "graphql": "^14.3.1",
-        "react": "^16.8.0"
-      }
-    },
-    "node_modules/react-apollo/node_modules/@apollo/react-components": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.5.tgz",
-      "integrity": "sha512-c82VyUuE9VBnJB7bnX+3dmwpIPMhyjMwyoSLyQWPHxz8jK4ak30XszJtqFf4eC4hwvvLYa+Ou6X73Q8V8e2/jg==",
-      "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
-        "prop-types": "^15.7.2",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0",
-        "apollo-cache": "^1.3.2",
-        "apollo-client": "^2.6.4",
-        "apollo-link": "^1.2.12",
-        "apollo-utilities": "^1.3.2",
-        "graphql": "^14.3.1",
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0"
-      }
-    },
-    "node_modules/react-apollo/node_modules/@apollo/react-hoc": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.1.5.tgz",
-      "integrity": "sha512-jlZ2pvEnRevLa54H563BU0/xrYSgWQ72GksarxUzCHQW85nmn9wQln0kLBX7Ua7SBt9WgiuYQXQVechaaCulfQ==",
-      "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-components": "^3.1.5",
-        "hoist-non-react-statics": "^3.3.0",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0",
-        "apollo-client": "^2.6.4",
-        "graphql": "^14.3.1",
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0"
-      }
-    },
-    "node_modules/react-apollo/node_modules/@apollo/react-hooks": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
-      "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
-      "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@wry/equality": "^0.1.9",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0",
-        "apollo-client": "^2.6.4",
-        "graphql": "^14.3.1",
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0"
-      }
-    },
     "node_modules/react-app-polyfill": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-2.0.0.tgz",
@@ -20337,15 +20106,6 @@
         "domelementtype": "1"
       }
     },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -20807,14 +20567,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
-    },
-    "node_modules/ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
-      "dependencies": {
-        "tslib": "^1.9.3"
-      }
     },
     "node_modules/ts-pnp": {
       "version": "1.2.0",
@@ -23315,16 +23067,6 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "node_modules/zen-observable-ts": {
-      "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
-      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
-      }
     }
   },
   "dependencies": {
@@ -23381,47 +23123,6 @@
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
               "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
             }
-          }
-        }
-      }
-    },
-    "@apollo/react-ssr": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.5.tgz",
-      "integrity": "sha512-wuLPkKlctNn3u8EU8rlECyktpOUCeekFfb0KhIKknpGY6Lza2Qu0bThx7D9MIbVEzhKadNNrzLcpk0Y8/5UuWg==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "@apollo/react-common": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
-          "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
-          "requires": {
-            "ts-invariant": "^0.4.4",
-            "tslib": "^1.10.0"
-          }
-        },
-        "@apollo/react-hooks": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
-          "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
-          "requires": {
-            "@apollo/react-common": "^3.1.4",
-            "@wry/equality": "^0.1.9",
-            "ts-invariant": "^0.4.4",
-            "tslib": "^1.10.0"
-          }
-        },
-        "graphql": {
-          "version": "14.7.0",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
-          "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
-          "peer": true,
-          "requires": {
-            "iterall": "^1.2.2"
           }
         }
       }
@@ -26327,14 +26028,6 @@
         }
       }
     },
-    "@wry/equality": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
-      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
     "@wry/trie": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
@@ -26495,56 +26188,6 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
-      }
-    },
-    "apollo-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
-      "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
-      "peer": true,
-      "requires": {
-        "apollo-utilities": "^1.3.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "apollo-client": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
-      "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
-      "peer": true,
-      "requires": {
-        "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.5",
-        "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.4",
-        "symbol-observable": "^1.0.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.0"
-      }
-    },
-    "apollo-link": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
-      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
-      "peer": true,
-      "requires": {
-        "apollo-utilities": "^1.3.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.21"
-      }
-    },
-    "apollo-utilities": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
-      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
-      "peer": true,
-      "requires": {
-        "@wry/equality": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
       }
     },
     "aproba": {
@@ -32180,12 +31823,6 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
-    "iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "peer": true
-    },
     "jest": {
       "version": "26.6.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.0.tgz",
@@ -36844,64 +36481,6 @@
         "redux-saga": "^1.0.0"
       }
     },
-    "react-apollo": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-3.1.5.tgz",
-      "integrity": "sha512-xOxMqxORps+WHrUYbjVHPliviomefOpu5Sh35oO3osuOyPTxvrljdfTLGCggMhcXBsDljtS5Oy4g+ijWg3D4JQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-components": "^3.1.5",
-        "@apollo/react-hoc": "^3.1.5",
-        "@apollo/react-hooks": "^3.1.5",
-        "@apollo/react-ssr": "^3.1.5"
-      },
-      "dependencies": {
-        "@apollo/react-common": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
-          "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
-          "requires": {
-            "ts-invariant": "^0.4.4",
-            "tslib": "^1.10.0"
-          }
-        },
-        "@apollo/react-components": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.5.tgz",
-          "integrity": "sha512-c82VyUuE9VBnJB7bnX+3dmwpIPMhyjMwyoSLyQWPHxz8jK4ak30XszJtqFf4eC4hwvvLYa+Ou6X73Q8V8e2/jg==",
-          "requires": {
-            "@apollo/react-common": "^3.1.4",
-            "@apollo/react-hooks": "^3.1.5",
-            "prop-types": "^15.7.2",
-            "ts-invariant": "^0.4.4",
-            "tslib": "^1.10.0"
-          }
-        },
-        "@apollo/react-hoc": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.1.5.tgz",
-          "integrity": "sha512-jlZ2pvEnRevLa54H563BU0/xrYSgWQ72GksarxUzCHQW85nmn9wQln0kLBX7Ua7SBt9WgiuYQXQVechaaCulfQ==",
-          "requires": {
-            "@apollo/react-common": "^3.1.4",
-            "@apollo/react-components": "^3.1.5",
-            "hoist-non-react-statics": "^3.3.0",
-            "ts-invariant": "^0.4.4",
-            "tslib": "^1.10.0"
-          }
-        },
-        "@apollo/react-hooks": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
-          "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
-          "requires": {
-            "@apollo/react-common": "^3.1.4",
-            "@wry/equality": "^0.1.9",
-            "ts-invariant": "^0.4.4",
-            "tslib": "^1.10.0"
-          }
-        }
-      }
-    },
     "react-app-polyfill": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-2.0.0.tgz",
@@ -39250,12 +38829,6 @@
         }
       }
     },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "peer": true
-    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -39609,14 +39182,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
-    },
-    "ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
     },
     "ts-pnp": {
       "version": "1.2.0",
@@ -41641,16 +41206,6 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "zen-observable-ts": {
-      "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
-      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
-      "peer": true,
-      "requires": {
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
-      }
     }
   }
 }

--- a/packages/amplication-data-service-generator/src/admin/static/package-lock.json
+++ b/packages/amplication-data-service-generator/src/admin/static/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "admin-template",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "dependencies": {
         "@apollo/client": "3.3.18",
         "@material-ui/core": "4.12.1",
         "gql": "1.1.2",
-        "graphql": "14.7.0",
+        "graphql": "15.6.1",
         "graphql-tag": "2.12.4",
         "lodash": "4.17.21",
         "pluralize": "8.0.0",
@@ -70,22 +70,6 @@
         }
       }
     },
-    "node_modules/@apollo/client/node_modules/@wry/context": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
-      "integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@apollo/client/node_modules/@wry/context/node_modules/tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-    },
     "node_modules/@apollo/client/node_modules/@wry/equality": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.4.0.tgz",
@@ -101,15 +85,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-    },
-    "node_modules/@apollo/client/node_modules/optimism": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
-      "dependencies": {
-        "@wry/context": "^0.6.0",
-        "@wry/trie": "^0.3.0"
-      }
     },
     "node_modules/@apollo/client/node_modules/symbol-observable": {
       "version": "2.0.3",
@@ -135,7 +110,21 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
-    "node_modules/@apollo/react-common": {
+    "node_modules/@apollo/react-ssr": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.5.tgz",
+      "integrity": "sha512-wuLPkKlctNn3u8EU8rlECyktpOUCeekFfb0KhIKknpGY6Lza2Qu0bThx7D9MIbVEzhKadNNrzLcpk0Y8/5UuWg==",
+      "dependencies": {
+        "@apollo/react-common": "^3.1.4",
+        "@apollo/react-hooks": "^3.1.5",
+        "tslib": "^1.10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0",
+        "react-dom": "^16.8.0"
+      }
+    },
+    "node_modules/@apollo/react-ssr/node_modules/@apollo/react-common": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
       "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
@@ -151,48 +140,7 @@
         "react": "^16.8.0"
       }
     },
-    "node_modules/@apollo/react-components": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.5.tgz",
-      "integrity": "sha512-c82VyUuE9VBnJB7bnX+3dmwpIPMhyjMwyoSLyQWPHxz8jK4ak30XszJtqFf4eC4hwvvLYa+Ou6X73Q8V8e2/jg==",
-      "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
-        "prop-types": "^15.7.2",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0",
-        "apollo-cache": "^1.3.2",
-        "apollo-client": "^2.6.4",
-        "apollo-link": "^1.2.12",
-        "apollo-utilities": "^1.3.2",
-        "graphql": "^14.3.1",
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0"
-      }
-    },
-    "node_modules/@apollo/react-hoc": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.1.5.tgz",
-      "integrity": "sha512-jlZ2pvEnRevLa54H563BU0/xrYSgWQ72GksarxUzCHQW85nmn9wQln0kLBX7Ua7SBt9WgiuYQXQVechaaCulfQ==",
-      "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-components": "^3.1.5",
-        "hoist-non-react-statics": "^3.3.0",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0",
-        "apollo-client": "^2.6.4",
-        "graphql": "^14.3.1",
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0"
-      }
-    },
-    "node_modules/@apollo/react-hooks": {
+    "node_modules/@apollo/react-ssr/node_modules/@apollo/react-hooks": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
       "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
@@ -210,18 +158,16 @@
         "react-dom": "^16.8.0"
       }
     },
-    "node_modules/@apollo/react-ssr": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.5.tgz",
-      "integrity": "sha512-wuLPkKlctNn3u8EU8rlECyktpOUCeekFfb0KhIKknpGY6Lza2Qu0bThx7D9MIbVEzhKadNNrzLcpk0Y8/5UuWg==",
+    "node_modules/@apollo/react-ssr/node_modules/graphql": {
+      "version": "14.7.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
+      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+      "peer": true,
       "dependencies": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
-        "tslib": "^1.10.0"
+        "iterall": "^1.2.2"
       },
-      "peerDependencies": {
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0"
+      "engines": {
+        "node": ">= 6.x"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3926,13 +3872,20 @@
       }
     },
     "node_modules/@wry/context": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
-      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
+      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
       "dependencies": {
-        "@types/node": ">=6",
-        "tslib": "^1.9.3"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
+    },
+    "node_modules/@wry/context/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@wry/equality": {
       "version": "0.1.11",
@@ -4168,23 +4121,9 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
       "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
+      "peer": true,
       "dependencies": {
         "apollo-utilities": "^1.3.4",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-cache-inmemory": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
-      "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
-      "dependencies": {
-        "apollo-cache": "^1.3.5",
-        "apollo-utilities": "^1.3.4",
-        "optimism": "^0.10.0",
-        "ts-invariant": "^0.4.0",
         "tslib": "^1.10.0"
       },
       "peerDependencies": {
@@ -4195,6 +4134,7 @@
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
       "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
+      "peer": true,
       "dependencies": {
         "@types/zen-observable": "^0.8.0",
         "apollo-cache": "1.3.5",
@@ -4209,23 +4149,11 @@
         "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
-    "node_modules/apollo-client-preset": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/apollo-client-preset/-/apollo-client-preset-1.0.8.tgz",
-      "integrity": "sha512-vRrdBfoOBkSboUmkec/zDWK9dT22GoZ2NgTKxfPXaTRh82HGDejDAblMr7BuDtZQ6zxMUiD9kghmO+3HXsHKdQ==",
-      "deprecated": "for the best quick start with Apollo Client, please use apollo-boost instead",
-      "dependencies": {
-        "apollo-cache-inmemory": "^1.1.7",
-        "apollo-client": "^2.2.2",
-        "apollo-link": "^1.0.6",
-        "apollo-link-http": "^1.3.1",
-        "graphql-tag": "^2.4.2"
-      }
-    },
     "node_modules/apollo-link": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
       "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+      "peer": true,
       "dependencies": {
         "apollo-utilities": "^1.3.0",
         "ts-invariant": "^0.4.0",
@@ -4236,36 +4164,11 @@
         "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
-    "node_modules/apollo-link-http": {
-      "version": "1.5.17",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
-      "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
-      "dependencies": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-link-http-common": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
-      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
-      "dependencies": {
-        "apollo-link": "^1.2.14",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
     "node_modules/apollo-utilities": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
       "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+      "peer": true,
       "dependencies": {
         "@wry/equality": "^0.1.2",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9929,22 +9832,11 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "node_modules/graphql": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
-      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
-      "dependencies": {
-        "iterall": "^1.2.2"
-      },
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.6.1.tgz",
+      "integrity": "sha512-3i5lu0z6dRvJ48QP9kFxBkJ7h4Kso7PS8eahyTFz5Jm6CvQfLtNIE8LX9N6JLnXTuwR+sIYnXzaWp6anOg0QQw==",
       "engines": {
-        "node": ">= 6.x"
-      }
-    },
-    "node_modules/graphql-ast-types-browser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/graphql-ast-types-browser/-/graphql-ast-types-browser-1.0.2.tgz",
-      "integrity": "sha512-QuKZ+Et3dE7SyO5c41eNPlJc7+HwQxOzHfmIhqzj4cUgAGyhSwVkKb7K24zom8y6y0VnG7Xb3RRypjIVvfIevQ==",
-      "peerDependencies": {
-        "graphql": "^0.11.7"
+        "node": ">= 10.x"
       }
     },
     "node_modules/graphql-tag": {
@@ -11422,7 +11314,8 @@
     "node_modules/iterall": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+      "peer": true
     },
     "node_modules/jest": {
       "version": "26.6.0",
@@ -14994,11 +14887,12 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
-      "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
       "dependencies": {
-        "@wry/context": "^0.4.0"
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
       }
     },
     "node_modules/optimize-css-assets-webpack-plugin": {
@@ -17079,18 +16973,16 @@
       }
     },
     "node_modules/ra-data-graphql": {
-      "version": "3.11.4",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql/-/ra-data-graphql-3.11.4.tgz",
-      "integrity": "sha512-AZVQLscTQ99a6eLkALWiUFQR4l23unos4PjLwZRG8vqEN9DnwAdkZyvei7DOr/Nd0Tq90eaJm7Xi3+q9H3jtcw==",
+      "version": "3.19.10",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql/-/ra-data-graphql-3.19.10.tgz",
+      "integrity": "sha512-cI3PQjBLXz+krT8i6YWYykESu7A/4AfBplJrexBAjO0nG7RZfwUKlq0OaJkNnB9x7g1i7lxwZ8H8V8qtpe4mhw==",
       "dependencies": {
-        "apollo-client": "^2.6.3",
-        "apollo-client-preset": "^1.0.8",
-        "graphql-tag": "^2.10.1",
+        "@apollo/client": "^3.3.19",
         "lodash": "~4.17.5",
         "pluralize": "~7.0.0"
       },
       "peerDependencies": {
-        "graphql": "^14.1.1",
+        "graphql": "^15.6.0",
         "ra-core": "^3.9.0"
       }
     },
@@ -17111,12 +17003,12 @@
         "ra-core": "^3.9.0"
       }
     },
-    "node_modules/ra-data-graphql-amplication/node_modules/graphql": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
-      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
-      "engines": {
-        "node": ">= 10.x"
+    "node_modules/ra-data-graphql-amplication/node_modules/graphql-ast-types-browser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/graphql-ast-types-browser/-/graphql-ast-types-browser-1.0.2.tgz",
+      "integrity": "sha512-QuKZ+Et3dE7SyO5c41eNPlJc7+HwQxOzHfmIhqzj4cUgAGyhSwVkKb7K24zom8y6y0VnG7Xb3RRypjIVvfIevQ==",
+      "peerDependencies": {
+        "graphql": "^0.11.7"
       }
     },
     "node_modules/ra-data-graphql-amplication/node_modules/pluralize": {
@@ -17127,12 +17019,91 @@
         "node": ">=4"
       }
     },
+    "node_modules/ra-data-graphql/node_modules/@apollo/client": {
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.5.10.tgz",
+      "integrity": "sha512-tL3iSpFe9Oldq7gYikZK1dcYxp1c01nlSwtsMz75382HcI6fvQXyFXUCJTTK3wgO2/ckaBvRGw7VqjFREdVoRw==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "@wry/trie": "^0.3.0",
+        "graphql-tag": "^2.12.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.1",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.9.4",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ra-data-graphql/node_modules/@wry/equality": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
+      "integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ra-data-graphql/node_modules/pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ra-data-graphql/node_modules/symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/ra-data-graphql/node_modules/ts-invariant": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.4.tgz",
+      "integrity": "sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ra-data-graphql/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/ra-data-graphql/node_modules/zen-observable-ts": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz",
+      "integrity": "sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==",
+      "dependencies": {
+        "zen-observable": "0.8.15"
       }
     },
     "node_modules/ra-i18n-polyglot": {
@@ -17306,6 +17277,81 @@
         "@apollo/react-hoc": "^3.1.5",
         "@apollo/react-hooks": "^3.1.5",
         "@apollo/react-ssr": "^3.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0",
+        "apollo-client": "^2.6.4",
+        "graphql": "^14.3.1",
+        "react": "^16.8.0",
+        "react-dom": "^16.8.0"
+      }
+    },
+    "node_modules/react-apollo/node_modules/@apollo/react-common": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
+      "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
+      "dependencies": {
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0",
+        "apollo-client": "^2.6.4",
+        "apollo-utilities": "^1.3.2",
+        "graphql": "^14.3.1",
+        "react": "^16.8.0"
+      }
+    },
+    "node_modules/react-apollo/node_modules/@apollo/react-components": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.5.tgz",
+      "integrity": "sha512-c82VyUuE9VBnJB7bnX+3dmwpIPMhyjMwyoSLyQWPHxz8jK4ak30XszJtqFf4eC4hwvvLYa+Ou6X73Q8V8e2/jg==",
+      "dependencies": {
+        "@apollo/react-common": "^3.1.4",
+        "@apollo/react-hooks": "^3.1.5",
+        "prop-types": "^15.7.2",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0",
+        "apollo-cache": "^1.3.2",
+        "apollo-client": "^2.6.4",
+        "apollo-link": "^1.2.12",
+        "apollo-utilities": "^1.3.2",
+        "graphql": "^14.3.1",
+        "react": "^16.8.0",
+        "react-dom": "^16.8.0"
+      }
+    },
+    "node_modules/react-apollo/node_modules/@apollo/react-hoc": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.1.5.tgz",
+      "integrity": "sha512-jlZ2pvEnRevLa54H563BU0/xrYSgWQ72GksarxUzCHQW85nmn9wQln0kLBX7Ua7SBt9WgiuYQXQVechaaCulfQ==",
+      "dependencies": {
+        "@apollo/react-common": "^3.1.4",
+        "@apollo/react-components": "^3.1.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0",
+        "apollo-client": "^2.6.4",
+        "graphql": "^14.3.1",
+        "react": "^16.8.0",
+        "react-dom": "^16.8.0"
+      }
+    },
+    "node_modules/react-apollo/node_modules/@apollo/react-hooks": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
+      "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
+      "dependencies": {
+        "@apollo/react-common": "^3.1.4",
+        "@wry/equality": "^0.1.9",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
       },
       "peerDependencies": {
         "@types/react": "^16.8.0",
@@ -20295,6 +20341,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23273,6 +23320,7 @@
       "version": "0.8.21",
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
       "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
@@ -23300,21 +23348,6 @@
         "zen-observable": "^0.8.14"
       },
       "dependencies": {
-        "@wry/context": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
-          "integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
-          "requires": {
-            "tslib": "^2.1.0"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-              "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-            }
-          }
-        },
         "@wry/equality": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.4.0.tgz",
@@ -23328,15 +23361,6 @@
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
               "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
             }
-          }
-        },
-        "optimism": {
-          "version": "0.16.1",
-          "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-          "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
-          "requires": {
-            "@wry/context": "^0.6.0",
-            "@wry/trie": "^0.3.0"
           }
         },
         "symbol-observable": {
@@ -23361,50 +23385,6 @@
         }
       }
     },
-    "@apollo/react-common": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
-      "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
-      "requires": {
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@apollo/react-components": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.5.tgz",
-      "integrity": "sha512-c82VyUuE9VBnJB7bnX+3dmwpIPMhyjMwyoSLyQWPHxz8jK4ak30XszJtqFf4eC4hwvvLYa+Ou6X73Q8V8e2/jg==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
-        "prop-types": "^15.7.2",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@apollo/react-hoc": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.1.5.tgz",
-      "integrity": "sha512-jlZ2pvEnRevLa54H563BU0/xrYSgWQ72GksarxUzCHQW85nmn9wQln0kLBX7Ua7SBt9WgiuYQXQVechaaCulfQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-components": "^3.1.5",
-        "hoist-non-react-statics": "^3.3.0",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@apollo/react-hooks": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
-      "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@wry/equality": "^0.1.9",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      }
-    },
     "@apollo/react-ssr": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.5.tgz",
@@ -23413,6 +23393,37 @@
         "@apollo/react-common": "^3.1.4",
         "@apollo/react-hooks": "^3.1.5",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "@apollo/react-common": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
+          "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
+          "requires": {
+            "ts-invariant": "^0.4.4",
+            "tslib": "^1.10.0"
+          }
+        },
+        "@apollo/react-hooks": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
+          "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
+          "requires": {
+            "@apollo/react-common": "^3.1.4",
+            "@wry/equality": "^0.1.9",
+            "ts-invariant": "^0.4.4",
+            "tslib": "^1.10.0"
+          }
+        },
+        "graphql": {
+          "version": "14.7.0",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
+          "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+          "peer": true,
+          "requires": {
+            "iterall": "^1.2.2"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -26302,12 +26313,18 @@
       }
     },
     "@wry/context": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
-      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
+      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
       "requires": {
-        "@types/node": ">=6",
-        "tslib": "^1.9.3"
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "@wry/equality": {
@@ -26484,20 +26501,9 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
       "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
+      "peer": true,
       "requires": {
         "apollo-utilities": "^1.3.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "apollo-cache-inmemory": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
-      "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
-      "requires": {
-        "apollo-cache": "^1.3.5",
-        "apollo-utilities": "^1.3.4",
-        "optimism": "^0.10.0",
-        "ts-invariant": "^0.4.0",
         "tslib": "^1.10.0"
       }
     },
@@ -26505,6 +26511,7 @@
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
       "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
+      "peer": true,
       "requires": {
         "@types/zen-observable": "^0.8.0",
         "apollo-cache": "1.3.5",
@@ -26516,22 +26523,11 @@
         "zen-observable": "^0.8.0"
       }
     },
-    "apollo-client-preset": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/apollo-client-preset/-/apollo-client-preset-1.0.8.tgz",
-      "integrity": "sha512-vRrdBfoOBkSboUmkec/zDWK9dT22GoZ2NgTKxfPXaTRh82HGDejDAblMr7BuDtZQ6zxMUiD9kghmO+3HXsHKdQ==",
-      "requires": {
-        "apollo-cache-inmemory": "^1.1.7",
-        "apollo-client": "^2.2.2",
-        "apollo-link": "^1.0.6",
-        "apollo-link-http": "^1.3.1",
-        "graphql-tag": "^2.4.2"
-      }
-    },
     "apollo-link": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
       "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+      "peer": true,
       "requires": {
         "apollo-utilities": "^1.3.0",
         "ts-invariant": "^0.4.0",
@@ -26539,30 +26535,11 @@
         "zen-observable-ts": "^0.8.21"
       }
     },
-    "apollo-link-http": {
-      "version": "1.5.17",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
-      "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-http-common": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
-      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
-      }
-    },
     "apollo-utilities": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
       "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+      "peer": true,
       "requires": {
         "@wry/equality": "^0.1.2",
         "fast-json-stable-stringify": "^2.0.0",
@@ -31083,18 +31060,9 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "graphql": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
-      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
-      "requires": {
-        "iterall": "^1.2.2"
-      }
-    },
-    "graphql-ast-types-browser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/graphql-ast-types-browser/-/graphql-ast-types-browser-1.0.2.tgz",
-      "integrity": "sha512-QuKZ+Et3dE7SyO5c41eNPlJc7+HwQxOzHfmIhqzj4cUgAGyhSwVkKb7K24zom8y6y0VnG7Xb3RRypjIVvfIevQ==",
-      "requires": {}
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.6.1.tgz",
+      "integrity": "sha512-3i5lu0z6dRvJ48QP9kFxBkJ7h4Kso7PS8eahyTFz5Jm6CvQfLtNIE8LX9N6JLnXTuwR+sIYnXzaWp6anOg0QQw=="
     },
     "graphql-tag": {
       "version": "2.12.4",
@@ -32215,7 +32183,8 @@
     "iterall": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+      "peer": true
     },
     "jest": {
       "version": "26.6.0",
@@ -34960,11 +34929,12 @@
       }
     },
     "optimism": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
-      "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
       "requires": {
-        "@wry/context": "^0.4.0"
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
       }
     },
     "optimize-css-assets-webpack-plugin": {
@@ -36648,21 +36618,72 @@
       }
     },
     "ra-data-graphql": {
-      "version": "3.11.4",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql/-/ra-data-graphql-3.11.4.tgz",
-      "integrity": "sha512-AZVQLscTQ99a6eLkALWiUFQR4l23unos4PjLwZRG8vqEN9DnwAdkZyvei7DOr/Nd0Tq90eaJm7Xi3+q9H3jtcw==",
+      "version": "3.19.10",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql/-/ra-data-graphql-3.19.10.tgz",
+      "integrity": "sha512-cI3PQjBLXz+krT8i6YWYykESu7A/4AfBplJrexBAjO0nG7RZfwUKlq0OaJkNnB9x7g1i7lxwZ8H8V8qtpe4mhw==",
       "requires": {
-        "apollo-client": "^2.6.3",
-        "apollo-client-preset": "^1.0.8",
-        "graphql-tag": "^2.10.1",
+        "@apollo/client": "^3.3.19",
         "lodash": "~4.17.5",
         "pluralize": "~7.0.0"
       },
       "dependencies": {
+        "@apollo/client": {
+          "version": "3.5.10",
+          "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.5.10.tgz",
+          "integrity": "sha512-tL3iSpFe9Oldq7gYikZK1dcYxp1c01nlSwtsMz75382HcI6fvQXyFXUCJTTK3wgO2/ckaBvRGw7VqjFREdVoRw==",
+          "requires": {
+            "@graphql-typed-document-node/core": "^3.0.0",
+            "@wry/context": "^0.6.0",
+            "@wry/equality": "^0.5.0",
+            "@wry/trie": "^0.3.0",
+            "graphql-tag": "^2.12.3",
+            "hoist-non-react-statics": "^3.3.2",
+            "optimism": "^0.16.1",
+            "prop-types": "^15.7.2",
+            "symbol-observable": "^4.0.0",
+            "ts-invariant": "^0.9.4",
+            "tslib": "^2.3.0",
+            "zen-observable-ts": "^1.2.0"
+          }
+        },
+        "@wry/equality": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
+          "integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
         "pluralize": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
           "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+        },
+        "symbol-observable": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+          "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
+        },
+        "ts-invariant": {
+          "version": "0.9.4",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.4.tgz",
+          "integrity": "sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
+        "zen-observable-ts": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz",
+          "integrity": "sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==",
+          "requires": {
+            "zen-observable": "0.8.15"
+          }
         }
       }
     },
@@ -36680,10 +36701,11 @@
         "ra-data-graphql": "^3.11.4"
       },
       "dependencies": {
-        "graphql": {
-          "version": "15.5.0",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
-          "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
+        "graphql-ast-types-browser": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/graphql-ast-types-browser/-/graphql-ast-types-browser-1.0.2.tgz",
+          "integrity": "sha512-QuKZ+Et3dE7SyO5c41eNPlJc7+HwQxOzHfmIhqzj4cUgAGyhSwVkKb7K24zom8y6y0VnG7Xb3RRypjIVvfIevQ==",
+          "requires": {}
         },
         "pluralize": {
           "version": "7.0.0",
@@ -36832,6 +36854,52 @@
         "@apollo/react-hoc": "^3.1.5",
         "@apollo/react-hooks": "^3.1.5",
         "@apollo/react-ssr": "^3.1.5"
+      },
+      "dependencies": {
+        "@apollo/react-common": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
+          "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
+          "requires": {
+            "ts-invariant": "^0.4.4",
+            "tslib": "^1.10.0"
+          }
+        },
+        "@apollo/react-components": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.5.tgz",
+          "integrity": "sha512-c82VyUuE9VBnJB7bnX+3dmwpIPMhyjMwyoSLyQWPHxz8jK4ak30XszJtqFf4eC4hwvvLYa+Ou6X73Q8V8e2/jg==",
+          "requires": {
+            "@apollo/react-common": "^3.1.4",
+            "@apollo/react-hooks": "^3.1.5",
+            "prop-types": "^15.7.2",
+            "ts-invariant": "^0.4.4",
+            "tslib": "^1.10.0"
+          }
+        },
+        "@apollo/react-hoc": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.1.5.tgz",
+          "integrity": "sha512-jlZ2pvEnRevLa54H563BU0/xrYSgWQ72GksarxUzCHQW85nmn9wQln0kLBX7Ua7SBt9WgiuYQXQVechaaCulfQ==",
+          "requires": {
+            "@apollo/react-common": "^3.1.4",
+            "@apollo/react-components": "^3.1.5",
+            "hoist-non-react-statics": "^3.3.0",
+            "ts-invariant": "^0.4.4",
+            "tslib": "^1.10.0"
+          }
+        },
+        "@apollo/react-hooks": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
+          "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
+          "requires": {
+            "@apollo/react-common": "^3.1.4",
+            "@wry/equality": "^0.1.9",
+            "ts-invariant": "^0.4.4",
+            "tslib": "^1.10.0"
+          }
+        }
       }
     },
     "react-app-polyfill": {
@@ -39185,7 +39253,8 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "peer": true
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -41577,6 +41646,7 @@
       "version": "0.8.21",
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
       "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+      "peer": true,
       "requires": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"

--- a/packages/amplication-data-service-generator/src/admin/static/package-lock.json
+++ b/packages/amplication-data-service-generator/src/admin/static/package-lock.json
@@ -15,7 +15,7 @@
         "graphql-tag": "2.12.4",
         "lodash": "4.17.21",
         "pluralize": "8.0.0",
-        "ra-data-graphql-amplication": "0.0.8",
+        "ra-data-graphql-amplication": "0.0.11",
         "react": "16.14.0",
         "react-admin": "3.17.0",
         "react-dom": "16.14.0",
@@ -16850,19 +16850,18 @@
       }
     },
     "node_modules/ra-data-graphql-amplication": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.8.tgz",
-      "integrity": "sha512-MHKohIluSE1mbvCwK/7WudR75AkFE0ONVbG2WZz0uiSV/o9d3iDGV8QtPoMMcelD5UcH4FMOEyxp8SUMdOrRXg==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.11.tgz",
+      "integrity": "sha512-TBvJmZO5K5nktm1c6ucyTcfbkFMlqY9YQU3oxeVPaPOIdGQh24YqAtreAfSZb9JKXCZE4V6YZIagdWFCr79L/Q==",
       "dependencies": {
-        "camel-case": "^4.1.2",
-        "graphql": "^15.5.0",
-        "graphql-ast-types-browser": "~1.0.2",
-        "graphql-tag": "^2.10.1",
-        "lodash": "~4.17.5",
-        "pluralize": "~7.0.0",
-        "ra-data-graphql": "^3.11.4"
+        "camel-case": "4.1.2",
+        "graphql-ast-types-browser": "1.0.2",
+        "lodash": "4.17.21",
+        "pluralize": "8.0.0",
+        "ra-data-graphql": "3.19.10"
       },
       "peerDependencies": {
+        "graphql": "^15.6.0",
         "ra-core": "^3.9.0"
       }
     },
@@ -16872,14 +16871,6 @@
       "integrity": "sha512-QuKZ+Et3dE7SyO5c41eNPlJc7+HwQxOzHfmIhqzj4cUgAGyhSwVkKb7K24zom8y6y0VnG7Xb3RRypjIVvfIevQ==",
       "peerDependencies": {
         "graphql": "^0.11.7"
-      }
-    },
-    "node_modules/ra-data-graphql-amplication/node_modules/pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ra-data-graphql/node_modules/@apollo/client": {
@@ -36325,17 +36316,15 @@
       }
     },
     "ra-data-graphql-amplication": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.8.tgz",
-      "integrity": "sha512-MHKohIluSE1mbvCwK/7WudR75AkFE0ONVbG2WZz0uiSV/o9d3iDGV8QtPoMMcelD5UcH4FMOEyxp8SUMdOrRXg==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.11.tgz",
+      "integrity": "sha512-TBvJmZO5K5nktm1c6ucyTcfbkFMlqY9YQU3oxeVPaPOIdGQh24YqAtreAfSZb9JKXCZE4V6YZIagdWFCr79L/Q==",
       "requires": {
-        "camel-case": "^4.1.2",
-        "graphql": "^15.5.0",
-        "graphql-ast-types-browser": "~1.0.2",
-        "graphql-tag": "^2.10.1",
-        "lodash": "~4.17.5",
-        "pluralize": "~7.0.0",
-        "ra-data-graphql": "^3.11.4"
+        "camel-case": "4.1.2",
+        "graphql-ast-types-browser": "1.0.2",
+        "lodash": "4.17.21",
+        "pluralize": "8.0.0",
+        "ra-data-graphql": "3.19.10"
       },
       "dependencies": {
         "graphql-ast-types-browser": {
@@ -36343,11 +36332,6 @@
           "resolved": "https://registry.npmjs.org/graphql-ast-types-browser/-/graphql-ast-types-browser-1.0.2.tgz",
           "integrity": "sha512-QuKZ+Et3dE7SyO5c41eNPlJc7+HwQxOzHfmIhqzj4cUgAGyhSwVkKb7K24zom8y6y0VnG7Xb3RRypjIVvfIevQ==",
           "requires": {}
-        },
-        "pluralize": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
         }
       }
     },

--- a/packages/amplication-data-service-generator/src/admin/static/package.json
+++ b/packages/amplication-data-service-generator/src/admin/static/package.json
@@ -6,7 +6,7 @@
     "@apollo/client": "3.3.18",
     "@material-ui/core": "4.12.1",
     "gql": "1.1.2",
-    "graphql": "14.7.0",
+    "graphql": "15.6.1",
     "graphql-tag": "2.12.4",
     "lodash": "4.17.21",
     "pluralize": "8.0.0",

--- a/packages/amplication-data-service-generator/src/admin/static/package.json
+++ b/packages/amplication-data-service-generator/src/admin/static/package.json
@@ -13,7 +13,6 @@
     "ra-data-graphql-amplication": "0.0.8",
     "react": "16.14.0",
     "react-admin": "3.17.0",
-    "react-apollo": "3.1.5",
     "react-dom": "16.14.0",
     "react-scripts": "4.0.3",
     "sass": "^1.39.0",

--- a/packages/amplication-data-service-generator/src/admin/static/package.json
+++ b/packages/amplication-data-service-generator/src/admin/static/package.json
@@ -10,7 +10,7 @@
     "graphql-tag": "2.12.4",
     "lodash": "4.17.21",
     "pluralize": "8.0.0",
-    "ra-data-graphql-amplication": "0.0.8",
+    "ra-data-graphql-amplication": "0.0.11",
     "react": "16.14.0",
     "react-admin": "3.17.0",
     "react-dom": "16.14.0",


### PR DESCRIPTION
fix #2425

## PR Details

This pr is updating the graphql package and removing unused react-apollo package that is deprecated and still stuck on graphql 14

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
