### PR TITLE
fix(dsg) admin ui added m2m relation

### DIFF
--- a/packages/amplication-data-service-generator/src/admin/entity/create-field-input.ts
+++ b/packages/amplication-data-service-generator/src/admin/entity/create-field-input.ts
@@ -7,6 +7,8 @@ import {
   LookupResolvedProperties,
 } from "../../types";
 import { jsxElement } from "../util";
+import { isToManyRelationField } from "../../util/field";
+import pluralize from "pluralize";
 
 /**
  * Creates an input element to be placed inside a Formik form for editing the given entity field
@@ -45,6 +47,17 @@ const DATA_TYPE_TO_FIELD_INPUT: {
 
   [EnumDataType.Lookup]: (field) => {
     const { relatedEntity } = field.properties as LookupResolvedProperties;
+    if (isToManyRelationField(field)) {
+      return jsxElement`<ReferenceArrayInput source="${pluralize(
+        relatedEntity.name.toLowerCase()
+      )}" 
+      reference="${relatedEntity.name}"
+      parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
+      format={(value: any) => value && value.map((v: any) => v.id)}
+      >
+        <SelectArrayInput optionText={${relatedEntity.name}Title} />
+      </ReferenceArrayInput>`;
+    }
     return jsxElement`<ReferenceInput source="${relatedEntity.name.toLowerCase()}.id" reference="${
       relatedEntity.name
     }" label="${field.displayName}">

--- a/packages/amplication-data-service-generator/src/admin/entity/entity-create-component/create-entity-create-component.ts
+++ b/packages/amplication-data-service-generator/src/admin/entity/entity-create-component/create-entity-create-component.ts
@@ -14,7 +14,6 @@ import {
   importNames,
   interpolate,
 } from "../../../util/ast";
-import { isToManyRelationField } from "../../../util/field";
 import { readFile, relativeImportPath } from "../../../util/module";
 import { EntityComponent } from "../../types";
 import { jsxFragment } from "../../util";
@@ -53,9 +52,9 @@ export async function createEntityCreateComponent(
   const fieldsByName = Object.fromEntries(
     entity.fields.map((field) => [field.name, field])
   );
-  const fields = dtoProperties
-    .map((property) => fieldsByName[property.key.name])
-    .filter((field) => !isToManyRelationField(field));
+  const fields = dtoProperties.map(
+    (property) => fieldsByName[property.key.name]
+  );
   const relationFields: EntityField[] = fields.filter(
     (field) => field.dataType === EnumDataType.Lookup
   );

--- a/packages/amplication-data-service-generator/src/admin/entity/entity-edit-component/create-edit-entity-component.ts
+++ b/packages/amplication-data-service-generator/src/admin/entity/entity-edit-component/create-edit-entity-component.ts
@@ -24,7 +24,6 @@ import {
   REACT_ADMIN_MODULE,
   REACT_ADMIN_COMPONENTS_ID,
 } from "../react-admin.util";
-import { isToManyRelationField } from "../../../util/field";
 const IMPORTABLE_IDS = {
   "../user/RolesOptions": [builders.identifier("ROLES_OPTIONS")],
   [REACT_ADMIN_MODULE]: REACT_ADMIN_COMPONENTS_ID,
@@ -44,9 +43,9 @@ export async function createEditEntityComponent(
   const fieldsByName = Object.fromEntries(
     entity.fields.map((field) => [field.name, field])
   );
-  const fields = dtoProperties
-    .map((property) => fieldsByName[property.key.name])
-    .filter((field) => !isToManyRelationField(field));
+  const fields = dtoProperties.map(
+    (property) => fieldsByName[property.key.name]
+  );
 
   const relationFields: EntityField[] = fields.filter(
     (field) => field.dataType === EnumDataType.Lookup

--- a/packages/amplication-data-service-generator/src/admin/entity/react-admin.util.ts
+++ b/packages/amplication-data-service-generator/src/admin/entity/react-admin.util.ts
@@ -20,6 +20,7 @@ export const REACT_ADMIN_COMPONENTS_ID = [
   builders.identifier("ReferenceField"),
   builders.identifier("BooleanField"),
   builders.identifier("ReferenceManyField"),
+  builders.identifier("ReferenceArrayInput"),
 
   builders.identifier("Datagrid"),
 ];

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -1140,9 +1140,11 @@ import {
   SelectArrayInput,
   SelectInput,
   ReferenceInput,
+  ReferenceArrayInput,
 } from \\"react-admin\\";
 
 import { OrganizationTitle } from \\"../organization/OrganizationTitle\\";
+import { OrderTitle } from \\"../order/OrderTitle\\";
 
 export const CustomerCreate = (props: CreateProps): React.ReactElement => {
   return (
@@ -1207,6 +1209,14 @@ export const CustomerCreate = (props: CreateProps): React.ReactElement => {
         >
           <SelectInput optionText={OrganizationTitle} />
         </ReferenceInput>
+        <ReferenceArrayInput
+          source=\\"orders\\"
+          reference=\\"Order\\"
+          parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
+          format={(value: any) => value && value.map((v: any) => v.id)}
+        >
+          <SelectArrayInput optionText={OrderTitle} />
+        </ReferenceArrayInput>
       </SimpleForm>
     </Create>
   );
@@ -1225,9 +1235,11 @@ import {
   SelectArrayInput,
   SelectInput,
   ReferenceInput,
+  ReferenceArrayInput,
 } from \\"react-admin\\";
 
 import { OrganizationTitle } from \\"../organization/OrganizationTitle\\";
+import { OrderTitle } from \\"../order/OrderTitle\\";
 
 export const CustomerEdit = (props: EditProps): React.ReactElement => {
   return (
@@ -1292,6 +1304,14 @@ export const CustomerEdit = (props: EditProps): React.ReactElement => {
         >
           <SelectInput optionText={OrganizationTitle} />
         </ReferenceInput>
+        <ReferenceArrayInput
+          source=\\"orders\\"
+          reference=\\"Order\\"
+          parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
+          format={(value: any) => value && value.map((v: any) => v.id)}
+        >
+          <SelectArrayInput optionText={OrderTitle} />
+        </ReferenceArrayInput>
       </SimpleForm>
     </Edit>
   );
@@ -1743,26 +1763,96 @@ export const OrderTitle = (record: TOrder): string => {
 };
 ",
   "admin-ui/src/organization/OrganizationCreate.tsx": "import * as React from \\"react\\";
-import { Create, SimpleForm, CreateProps, TextInput } from \\"react-admin\\";
+
+import {
+  Create,
+  SimpleForm,
+  CreateProps,
+  TextInput,
+  ReferenceArrayInput,
+  SelectArrayInput,
+} from \\"react-admin\\";
+
+import { UserTitle } from \\"../user/UserTitle\\";
+import { CustomerTitle } from \\"../customer/CustomerTitle\\";
 
 export const OrganizationCreate = (props: CreateProps): React.ReactElement => {
   return (
     <Create {...props}>
       <SimpleForm>
         <TextInput label=\\"Name\\" source=\\"name\\" />
+        <ReferenceArrayInput
+          source=\\"users\\"
+          reference=\\"User\\"
+          parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
+          format={(value: any) => value && value.map((v: any) => v.id)}
+        >
+          <SelectArrayInput optionText={UserTitle} />
+        </ReferenceArrayInput>
+        <ReferenceArrayInput
+          source=\\"customers\\"
+          reference=\\"Customer\\"
+          parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
+          format={(value: any) => value && value.map((v: any) => v.id)}
+        >
+          <SelectArrayInput optionText={CustomerTitle} />
+        </ReferenceArrayInput>
+        <ReferenceArrayInput
+          source=\\"customers\\"
+          reference=\\"Customer\\"
+          parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
+          format={(value: any) => value && value.map((v: any) => v.id)}
+        >
+          <SelectArrayInput optionText={CustomerTitle} />
+        </ReferenceArrayInput>
       </SimpleForm>
     </Create>
   );
 };
 ",
   "admin-ui/src/organization/OrganizationEdit.tsx": "import * as React from \\"react\\";
-import { Edit, SimpleForm, EditProps, TextInput } from \\"react-admin\\";
+
+import {
+  Edit,
+  SimpleForm,
+  EditProps,
+  TextInput,
+  ReferenceArrayInput,
+  SelectArrayInput,
+} from \\"react-admin\\";
+
+import { UserTitle } from \\"../user/UserTitle\\";
+import { CustomerTitle } from \\"../customer/CustomerTitle\\";
 
 export const OrganizationEdit = (props: EditProps): React.ReactElement => {
   return (
     <Edit {...props}>
       <SimpleForm>
         <TextInput label=\\"Name\\" source=\\"name\\" />
+        <ReferenceArrayInput
+          source=\\"users\\"
+          reference=\\"User\\"
+          parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
+          format={(value: any) => value && value.map((v: any) => v.id)}
+        >
+          <SelectArrayInput optionText={UserTitle} />
+        </ReferenceArrayInput>
+        <ReferenceArrayInput
+          source=\\"customers\\"
+          reference=\\"Customer\\"
+          parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
+          format={(value: any) => value && value.map((v: any) => v.id)}
+        >
+          <SelectArrayInput optionText={CustomerTitle} />
+        </ReferenceArrayInput>
+        <ReferenceArrayInput
+          source=\\"customers\\"
+          reference=\\"Customer\\"
+          parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
+          format={(value: any) => value && value.map((v: any) => v.id)}
+        >
+          <SelectArrayInput optionText={CustomerTitle} />
+        </ReferenceArrayInput>
       </SimpleForm>
     </Edit>
   );
@@ -2039,10 +2129,12 @@ import {
   DateTimeInput,
   ReferenceInput,
   SelectInput,
+  ReferenceArrayInput,
   BooleanInput,
 } from \\"react-admin\\";
 
 import { UserTitle } from \\"./UserTitle\\";
+import { OrganizationTitle } from \\"../organization/OrganizationTitle\\";
 import { ROLES_OPTIONS } from \\"../user/RolesOptions\\";
 
 export const UserCreate = (props: CreateProps): React.ReactElement => {
@@ -2066,6 +2158,22 @@ export const UserCreate = (props: CreateProps): React.ReactElement => {
         <ReferenceInput source=\\"user.id\\" reference=\\"User\\" label=\\"Manager\\">
           <SelectInput optionText={UserTitle} />
         </ReferenceInput>
+        <ReferenceArrayInput
+          source=\\"users\\"
+          reference=\\"User\\"
+          parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
+          format={(value: any) => value && value.map((v: any) => v.id)}
+        >
+          <SelectArrayInput optionText={UserTitle} />
+        </ReferenceArrayInput>
+        <ReferenceArrayInput
+          source=\\"organizations\\"
+          reference=\\"Organization\\"
+          parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
+          format={(value: any) => value && value.map((v: any) => v.id)}
+        >
+          <SelectArrayInput optionText={OrganizationTitle} />
+        </ReferenceArrayInput>
         <SelectArrayInput
           label=\\"Interests\\"
           source=\\"interests\\"
@@ -2108,10 +2216,12 @@ import {
   DateTimeInput,
   ReferenceInput,
   SelectInput,
+  ReferenceArrayInput,
   BooleanInput,
 } from \\"react-admin\\";
 
 import { UserTitle } from \\"./UserTitle\\";
+import { OrganizationTitle } from \\"../organization/OrganizationTitle\\";
 import { ROLES_OPTIONS } from \\"../user/RolesOptions\\";
 
 export const UserEdit = (props: EditProps): React.ReactElement => {
@@ -2135,6 +2245,22 @@ export const UserEdit = (props: EditProps): React.ReactElement => {
         <ReferenceInput source=\\"user.id\\" reference=\\"User\\" label=\\"Manager\\">
           <SelectInput optionText={UserTitle} />
         </ReferenceInput>
+        <ReferenceArrayInput
+          source=\\"users\\"
+          reference=\\"User\\"
+          parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
+          format={(value: any) => value && value.map((v: any) => v.id)}
+        >
+          <SelectArrayInput optionText={UserTitle} />
+        </ReferenceArrayInput>
+        <ReferenceArrayInput
+          source=\\"organizations\\"
+          reference=\\"Organization\\"
+          parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
+          format={(value: any) => value && value.map((v: any) => v.id)}
+        >
+          <SelectArrayInput optionText={OrganizationTitle} />
+        </ReferenceArrayInput>
         <SelectArrayInput
           label=\\"Interests\\"
           source=\\"interests\\"

--- a/packages/amplication-data-service-generator/src/version.ts
+++ b/packages/amplication-data-service-generator/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.11.4";
+export const version = "0.12.1";


### PR DESCRIPTION
fix #2225 
we should delete https://github.com/amplication/amplication/pull/2354

On admin UI, added the ability to make a reference between two entities in a form of many to many (one to many from the entity perspective).
For example,  an order can have many products and a product can be in many orders.

An order with its products
![image](https://user-images.githubusercontent.com/39680385/159116835-b115ea23-e2e6-4316-b37f-5e21c5b6a2e6.png)

A product with its orders
![image](https://user-images.githubusercontent.com/39680385/159116870-5ee2fc10-1c53-4364-8d79-720919a6bdfd.png)


To make it works I added the following block code on the edit entity and create entity files (post and tag for the example):

```
<ReferenceArrayInput
          source="tags"
          reference="Tag"
          parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
          format={(value: any) => value && value.map((v: any) => v.id)}
        >
          <SelectArrayInput optionText={TagTitle} />
 </ReferenceArrayInput>
```



## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
