### PR TITLE
Update ra-data-graphql-amplication test's

### DIFF
--- a/packages/amplication-data-service-generator/package-lock.json
+++ b/packages/amplication-data-service-generator/package-lock.json
@@ -108,7 +108,7 @@
         "passport": "0.5.2",
         "passport-http": "0.3.0",
         "passport-jwt": "4.0.0",
-        "ra-data-graphql-amplication": "0.0.11",
+        "ra-data-graphql-amplication": "0.0.12",
         "react-admin": "3.17.0",
         "reflect-metadata": "0.1.13",
         "sleep-promise": "9.1.0",
@@ -23209,9 +23209,9 @@
       }
     },
     "node_modules/ra-data-graphql-amplication": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.11.tgz",
-      "integrity": "sha512-TBvJmZO5K5nktm1c6ucyTcfbkFMlqY9YQU3oxeVPaPOIdGQh24YqAtreAfSZb9JKXCZE4V6YZIagdWFCr79L/Q==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.12.tgz",
+      "integrity": "sha512-DCmgExYvTdkmx1rA9uzaheA7Y3o7Y0eWgadICVigFlqD5Bj3zrYWEO3PMNDx7nGnXsT/Ir84z0/+u9FfLu2rjg==",
       "dev": true,
       "dependencies": {
         "camel-case": "4.1.2",
@@ -42182,9 +42182,9 @@
       }
     },
     "ra-data-graphql-amplication": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.11.tgz",
-      "integrity": "sha512-TBvJmZO5K5nktm1c6ucyTcfbkFMlqY9YQU3oxeVPaPOIdGQh24YqAtreAfSZb9JKXCZE4V6YZIagdWFCr79L/Q==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.12.tgz",
+      "integrity": "sha512-DCmgExYvTdkmx1rA9uzaheA7Y3o7Y0eWgadICVigFlqD5Bj3zrYWEO3PMNDx7nGnXsT/Ir84z0/+u9FfLu2rjg==",
       "dev": true,
       "requires": {
         "camel-case": "4.1.2",

--- a/packages/amplication-data-service-generator/package.json
+++ b/packages/amplication-data-service-generator/package.json
@@ -119,7 +119,7 @@
     "passport": "0.5.2",
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.0",
-    "ra-data-graphql-amplication": "0.0.11",
+    "ra-data-graphql-amplication": "0.0.12",
     "react-admin": "3.17.0",
     "reflect-metadata": "0.1.13",
     "sleep-promise": "9.1.0",

--- a/packages/amplication-data-service-generator/src/admin/static/package-lock.json
+++ b/packages/amplication-data-service-generator/src/admin/static/package-lock.json
@@ -15,7 +15,7 @@
         "graphql-tag": "2.12.4",
         "lodash": "4.17.21",
         "pluralize": "8.0.0",
-        "ra-data-graphql-amplication": "0.0.11",
+        "ra-data-graphql-amplication": "0.0.12",
         "react": "16.14.0",
         "react-admin": "3.17.0",
         "react-dom": "16.14.0",
@@ -16850,9 +16850,9 @@
       }
     },
     "node_modules/ra-data-graphql-amplication": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.11.tgz",
-      "integrity": "sha512-TBvJmZO5K5nktm1c6ucyTcfbkFMlqY9YQU3oxeVPaPOIdGQh24YqAtreAfSZb9JKXCZE4V6YZIagdWFCr79L/Q==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.12.tgz",
+      "integrity": "sha512-DCmgExYvTdkmx1rA9uzaheA7Y3o7Y0eWgadICVigFlqD5Bj3zrYWEO3PMNDx7nGnXsT/Ir84z0/+u9FfLu2rjg==",
       "dependencies": {
         "camel-case": "4.1.2",
         "graphql-ast-types-browser": "1.0.2",
@@ -36316,9 +36316,9 @@
       }
     },
     "ra-data-graphql-amplication": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.11.tgz",
-      "integrity": "sha512-TBvJmZO5K5nktm1c6ucyTcfbkFMlqY9YQU3oxeVPaPOIdGQh24YqAtreAfSZb9JKXCZE4V6YZIagdWFCr79L/Q==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.12.tgz",
+      "integrity": "sha512-DCmgExYvTdkmx1rA9uzaheA7Y3o7Y0eWgadICVigFlqD5Bj3zrYWEO3PMNDx7nGnXsT/Ir84z0/+u9FfLu2rjg==",
       "requires": {
         "camel-case": "4.1.2",
         "graphql-ast-types-browser": "1.0.2",

--- a/packages/amplication-data-service-generator/src/admin/static/package.json
+++ b/packages/amplication-data-service-generator/src/admin/static/package.json
@@ -10,7 +10,7 @@
     "graphql-tag": "2.12.4",
     "lodash": "4.17.21",
     "pluralize": "8.0.0",
-    "ra-data-graphql-amplication": "0.0.11",
+    "ra-data-graphql-amplication": "0.0.12",
     "react": "16.14.0",
     "react-admin": "3.17.0",
     "react-dom": "16.14.0",


### PR DESCRIPTION
fix: #2426 

## PR Details

This pr is updating the ra-data-graphql-amplication to version 0.0.12 that have a new and updated tests

## PR Checklist
- [x] Tests for the changes have been added
- [X] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
