### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/amplication-data-service-generator/src/server/static/src/decorators/api-nested-query.decorator.ts
+++ b/packages/amplication-data-service-generator/src/server/static/src/decorators/api-nested-query.decorator.ts
@@ -52,7 +52,7 @@ export function ApiNestedQuery(query: Function) {
   const properties = Reflect.getMetadata(
     "swagger/apiModelPropertiesArray",
     constructor
-  ).map((prop: any) => prop.substr(1));
+  ).map((prop: any) => prop.slice(1));
 
   const decorators = properties
     .map((property: any) => {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -6034,7 +6034,7 @@ export function ApiNestedQuery(query: Function) {
   const properties = Reflect.getMetadata(
     \\"swagger/apiModelPropertiesArray\\",
     constructor
-  ).map((prop: any) => prop.substr(1));
+  ).map((prop: any) => prop.slice(1));
 
   const decorators = properties
     .map((property: any) => {

--- a/packages/amplication-data-service-generator/src/util/text-file-parser.ts
+++ b/packages/amplication-data-service-generator/src/util/text-file-parser.ts
@@ -9,7 +9,7 @@ export function replacePlaceholdersInCode(
   const regex = new RegExp(regexStr, "gi");
 
   return code.replace(regex, (matched) => {
-    const key = matched.substr(2, matched.length - 3);
+    const key = matched.slice(2, -1);
     if (mapping.hasOwnProperty(key)) {
       return mapping[key]?.toString() || "";
     } else {

--- a/packages/amplication-design-system/src/components/CircleBadge/CircleBadge.tsx
+++ b/packages/amplication-design-system/src/components/CircleBadge/CircleBadge.tsx
@@ -10,7 +10,7 @@ export type Props = {
 export function CircleBadge({ name, color }: Props) {
   return (
     <div className="circle-badge" style={{ backgroundColor: color }}>
-      {name && name.substr(0, 1).toUpperCase()}
+      {name && name.slice(0, 1).toUpperCase()}
     </div>
   );
 }

--- a/packages/amplication-design-system/src/components/UserAndTime/UserAndTime.tsx
+++ b/packages/amplication-design-system/src/components/UserAndTime/UserAndTime.tsx
@@ -49,8 +49,8 @@ export function UserAndTime({ loading, account, time }: Props) {
           className={classNames(`${CLASS_NAME}__initials`)}
           onMouseOver={(e) => changeTooltipDirection(e.pageY)}
         >
-          {!loading && firstName && firstName.substr(0, 1).toUpperCase()}
-          {!loading && lastName && lastName.substr(0, 1).toUpperCase()}
+          {!loading && firstName && firstName.slice(0, 1).toUpperCase()}
+          {!loading && lastName && lastName.slice(0, 1).toUpperCase()}
         </span>
       </Tooltip>
       {!loading && formattedTime}

--- a/packages/amplication-design-system/src/components/UserAvatar/UserAvatar.tsx
+++ b/packages/amplication-design-system/src/components/UserAvatar/UserAvatar.tsx
@@ -11,8 +11,8 @@ export function UserAvatar({ firstName, lastName }: Props) {
   return (
     <span className="user-avatar">
       <span className="user-avatar__initials">
-        {firstName && firstName.substr(0, 1).toUpperCase()}
-        {lastName && lastName.substr(0, 1).toUpperCase()}
+        {firstName && firstName.slice(0, 1).toUpperCase()}
+        {lastName && lastName.slice(0, 1).toUpperCase()}
       </span>
     </span>
   );

--- a/packages/amplication-server/src/core/auth/auth.service.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.ts
@@ -207,7 +207,7 @@ export class AuthService {
 
     const tokenId = cuid();
     const token = await this.prepareApiToken(user, tokenId);
-    const previewChars = token.substr(-TOKEN_PREVIEW_LENGTH);
+    const previewChars = token.slice(-TOKEN_PREVIEW_LENGTH);
     const hashedToken = await this.passwordService.hashPassword(token);
 
     const apiToken = await this.prismaService.apiToken.create({

--- a/script/setup.ts
+++ b/script/setup.ts
@@ -17,7 +17,7 @@ function preValidate() {
   const currentNpmVersionArray = npm_config_user_agent?.match(
     /npm\/[\^*\~*]*[\d\.]+/
   );
-  const currentNpmVersion = currentNpmVersionArray[0]?.substr(4);
+  const currentNpmVersion = currentNpmVersionArray[0]?.slice(4);
   if (!currentNpmVersionArray || !currentNpmVersion) {
     logger.error(
       "Mmmmm... it seems like you don't have permission to run the script. Try to run it as an administrator."


### PR DESCRIPTION
## PR Details

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
