### PR TITLE
feat(dsg admin ui saved changes on m2m relation

### DIFF
--- a/packages/amplication-data-service-generator/src/admin/entity/create-field-input.ts
+++ b/packages/amplication-data-service-generator/src/admin/entity/create-field-input.ts
@@ -8,7 +8,6 @@ import {
 } from "../../types";
 import { jsxElement } from "../util";
 import { isToManyRelationField } from "../../util/field";
-import pluralize from "pluralize";
 
 /**
  * Creates an input element to be placed inside a Formik form for editing the given entity field
@@ -48,9 +47,7 @@ const DATA_TYPE_TO_FIELD_INPUT: {
   [EnumDataType.Lookup]: (field) => {
     const { relatedEntity } = field.properties as LookupResolvedProperties;
     if (isToManyRelationField(field)) {
-      return jsxElement`<ReferenceArrayInput source="${pluralize(
-        relatedEntity.name.toLowerCase()
-      )}" 
+      return jsxElement`<ReferenceArrayInput source="${relatedEntity.name.toLowerCase()}" 
       reference="${relatedEntity.name}"
       parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
       format={(value: any) => value && value.map((v: any) => v.id)}

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -1210,7 +1210,7 @@ export const CustomerCreate = (props: CreateProps): React.ReactElement => {
           <SelectInput optionText={OrganizationTitle} />
         </ReferenceInput>
         <ReferenceArrayInput
-          source=\\"orders\\"
+          source=\\"order\\"
           reference=\\"Order\\"
           parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
           format={(value: any) => value && value.map((v: any) => v.id)}
@@ -1305,7 +1305,7 @@ export const CustomerEdit = (props: EditProps): React.ReactElement => {
           <SelectInput optionText={OrganizationTitle} />
         </ReferenceInput>
         <ReferenceArrayInput
-          source=\\"orders\\"
+          source=\\"order\\"
           reference=\\"Order\\"
           parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
           format={(value: any) => value && value.map((v: any) => v.id)}
@@ -1782,7 +1782,7 @@ export const OrganizationCreate = (props: CreateProps): React.ReactElement => {
       <SimpleForm>
         <TextInput label=\\"Name\\" source=\\"name\\" />
         <ReferenceArrayInput
-          source=\\"users\\"
+          source=\\"user\\"
           reference=\\"User\\"
           parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
           format={(value: any) => value && value.map((v: any) => v.id)}
@@ -1790,7 +1790,7 @@ export const OrganizationCreate = (props: CreateProps): React.ReactElement => {
           <SelectArrayInput optionText={UserTitle} />
         </ReferenceArrayInput>
         <ReferenceArrayInput
-          source=\\"customers\\"
+          source=\\"customer\\"
           reference=\\"Customer\\"
           parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
           format={(value: any) => value && value.map((v: any) => v.id)}
@@ -1798,7 +1798,7 @@ export const OrganizationCreate = (props: CreateProps): React.ReactElement => {
           <SelectArrayInput optionText={CustomerTitle} />
         </ReferenceArrayInput>
         <ReferenceArrayInput
-          source=\\"customers\\"
+          source=\\"customer\\"
           reference=\\"Customer\\"
           parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
           format={(value: any) => value && value.map((v: any) => v.id)}
@@ -1830,7 +1830,7 @@ export const OrganizationEdit = (props: EditProps): React.ReactElement => {
       <SimpleForm>
         <TextInput label=\\"Name\\" source=\\"name\\" />
         <ReferenceArrayInput
-          source=\\"users\\"
+          source=\\"user\\"
           reference=\\"User\\"
           parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
           format={(value: any) => value && value.map((v: any) => v.id)}
@@ -1838,7 +1838,7 @@ export const OrganizationEdit = (props: EditProps): React.ReactElement => {
           <SelectArrayInput optionText={UserTitle} />
         </ReferenceArrayInput>
         <ReferenceArrayInput
-          source=\\"customers\\"
+          source=\\"customer\\"
           reference=\\"Customer\\"
           parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
           format={(value: any) => value && value.map((v: any) => v.id)}
@@ -1846,7 +1846,7 @@ export const OrganizationEdit = (props: EditProps): React.ReactElement => {
           <SelectArrayInput optionText={CustomerTitle} />
         </ReferenceArrayInput>
         <ReferenceArrayInput
-          source=\\"customers\\"
+          source=\\"customer\\"
           reference=\\"Customer\\"
           parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
           format={(value: any) => value && value.map((v: any) => v.id)}
@@ -2159,7 +2159,7 @@ export const UserCreate = (props: CreateProps): React.ReactElement => {
           <SelectInput optionText={UserTitle} />
         </ReferenceInput>
         <ReferenceArrayInput
-          source=\\"users\\"
+          source=\\"user\\"
           reference=\\"User\\"
           parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
           format={(value: any) => value && value.map((v: any) => v.id)}
@@ -2167,7 +2167,7 @@ export const UserCreate = (props: CreateProps): React.ReactElement => {
           <SelectArrayInput optionText={UserTitle} />
         </ReferenceArrayInput>
         <ReferenceArrayInput
-          source=\\"organizations\\"
+          source=\\"organization\\"
           reference=\\"Organization\\"
           parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
           format={(value: any) => value && value.map((v: any) => v.id)}
@@ -2246,7 +2246,7 @@ export const UserEdit = (props: EditProps): React.ReactElement => {
           <SelectInput optionText={UserTitle} />
         </ReferenceInput>
         <ReferenceArrayInput
-          source=\\"users\\"
+          source=\\"user\\"
           reference=\\"User\\"
           parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
           format={(value: any) => value && value.map((v: any) => v.id)}
@@ -2254,7 +2254,7 @@ export const UserEdit = (props: EditProps): React.ReactElement => {
           <SelectArrayInput optionText={UserTitle} />
         </ReferenceArrayInput>
         <ReferenceArrayInput
-          source=\\"organizations\\"
+          source=\\"organization\\"
           reference=\\"Organization\\"
           parse={(value: any) => value && value.map((v: any) => ({ id: v }))}
           format={(value: any) => value && value.map((v: any) => v.id)}


### PR DESCRIPTION
resolved #2493 

the problem was the pluralized utility function.

![image](https://user-images.githubusercontent.com/39680385/159648389-ac0eca9e-5f6b-4eb8-bb37-a0889c42c3cb.png)

The source attribute of ReferenceArrayInput expect to get an unpluralized version of the entity
(maybe after the change we did on ra-data-graphql-amplication package because I remember that before it didn't work with the unpluralized version)

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

