### PR TITLE
Fix/2423 info popup state always open

### DIFF
--- a/packages/amplication-client/src/Layout/MainLayout.tsx
+++ b/packages/amplication-client/src/Layout/MainLayout.tsx
@@ -93,7 +93,7 @@ const Menu = ({ children }: MenuProps) => {
             <Popover
               className="main-layout__menu__popover"
               content={<SupportMenu />}
-              open={supportMenuOpen}
+              onOpen={handleSupportClick}
               placement="right"
             >
               <MenuItem

--- a/packages/amplication-client/src/Layout/MainLayout.tsx
+++ b/packages/amplication-client/src/Layout/MainLayout.tsx
@@ -98,7 +98,6 @@ const Menu = ({ children }: MenuProps) => {
                 icon="help_outline"
                 hideTooltip
                 title="Help and support"
-                onClick={handleSupportClick}
               />
             </Popover>
             <MenuItem

--- a/packages/amplication-client/src/Layout/MainLayout.tsx
+++ b/packages/amplication-client/src/Layout/MainLayout.tsx
@@ -41,7 +41,6 @@ type MenuProps = {
 
 const Menu = ({ children }: MenuProps) => {
   const history = useHistory();
-  const [supportMenuOpen, setSupportMenuOpen] = React.useState(false);
   const { trackEvent } = useTracking();
 
   const apolloClient = useApolloClient();
@@ -62,8 +61,7 @@ const Menu = ({ children }: MenuProps) => {
     trackEvent({
       eventName: "supportButtonClick",
     });
-    setSupportMenuOpen(!supportMenuOpen);
-  }, [setSupportMenuOpen, supportMenuOpen, trackEvent]);
+  }, [trackEvent]);
 
   return (
     <div className={classNames("main-layout__menu")}>


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Issue Number: #2423 

## PR Details

1. Remove `open={supportMenuOpen}` from the Popover element. ( this will allow it to have default behavior)
2.  Added  `onOpen={handleSupportClick}` to the Popover element. ( this will make sure to fire the trackEvent)
3. Removed all `supportMenuOpen`  state related references. 

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
