### PR TITLE
deps(dsg): update ra

### DIFF
--- a/packages/amplication-data-service-generator/package-lock.json
+++ b/packages/amplication-data-service-generator/package-lock.json
@@ -6,9 +6,9 @@
   "packages": {
     "": {
       "name": "@amplication/data-service-generator",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "dependencies": {
-        "@amplication/data": "^0.12.1",
+        "@amplication/data": "^0.12.2",
         "@babel/parser": "7.14.7",
         "@extra-set/difference": "2.2.4",
         "camel-case": "4.1.2",
@@ -108,7 +108,7 @@
         "passport": "0.5.2",
         "passport-http": "0.3.0",
         "passport-jwt": "4.0.0",
-        "ra-data-graphql-amplication": "0.0.12",
+        "ra-data-graphql-amplication": "0.0.13",
         "react-admin": "3.17.0",
         "reflect-metadata": "0.1.13",
         "sleep-promise": "9.1.0",
@@ -121,7 +121,7 @@
     },
     "../amplication-data": {
       "name": "@amplication/data",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "devDependencies": {
         "@types/jest": "26.0.19",
         "@types/json-schema": "7.0.9",
@@ -23209,9 +23209,9 @@
       }
     },
     "node_modules/ra-data-graphql-amplication": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.12.tgz",
-      "integrity": "sha512-DCmgExYvTdkmx1rA9uzaheA7Y3o7Y0eWgadICVigFlqD5Bj3zrYWEO3PMNDx7nGnXsT/Ir84z0/+u9FfLu2rjg==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.13.tgz",
+      "integrity": "sha512-dfgPe8VlEOG/e33TasLFmKwd3z6MoAbCadQSRseUNOa5Y3BFpks2RK1UXZsGOsIqf9IBRda+Ox/46vH3j3Bx7w==",
       "dev": true,
       "dependencies": {
         "camel-case": "4.1.2",
@@ -42182,9 +42182,9 @@
       }
     },
     "ra-data-graphql-amplication": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.12.tgz",
-      "integrity": "sha512-DCmgExYvTdkmx1rA9uzaheA7Y3o7Y0eWgadICVigFlqD5Bj3zrYWEO3PMNDx7nGnXsT/Ir84z0/+u9FfLu2rjg==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.13.tgz",
+      "integrity": "sha512-dfgPe8VlEOG/e33TasLFmKwd3z6MoAbCadQSRseUNOa5Y3BFpks2RK1UXZsGOsIqf9IBRda+Ox/46vH3j3Bx7w==",
       "dev": true,
       "requires": {
         "camel-case": "4.1.2",

--- a/packages/amplication-data-service-generator/package.json
+++ b/packages/amplication-data-service-generator/package.json
@@ -119,7 +119,7 @@
     "passport": "0.5.2",
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.0",
-    "ra-data-graphql-amplication": "0.0.12",
+    "ra-data-graphql-amplication": "0.0.13",
     "react-admin": "3.17.0",
     "reflect-metadata": "0.1.13",
     "sleep-promise": "9.1.0",

--- a/packages/amplication-data-service-generator/src/admin/static/package-lock.json
+++ b/packages/amplication-data-service-generator/src/admin/static/package-lock.json
@@ -15,7 +15,7 @@
         "graphql-tag": "2.12.4",
         "lodash": "4.17.21",
         "pluralize": "8.0.0",
-        "ra-data-graphql-amplication": "0.0.12",
+        "ra-data-graphql-amplication": "0.0.13",
         "react": "16.14.0",
         "react-admin": "3.17.0",
         "react-dom": "16.14.0",
@@ -16850,9 +16850,9 @@
       }
     },
     "node_modules/ra-data-graphql-amplication": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.12.tgz",
-      "integrity": "sha512-DCmgExYvTdkmx1rA9uzaheA7Y3o7Y0eWgadICVigFlqD5Bj3zrYWEO3PMNDx7nGnXsT/Ir84z0/+u9FfLu2rjg==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.13.tgz",
+      "integrity": "sha512-dfgPe8VlEOG/e33TasLFmKwd3z6MoAbCadQSRseUNOa5Y3BFpks2RK1UXZsGOsIqf9IBRda+Ox/46vH3j3Bx7w==",
       "dependencies": {
         "camel-case": "4.1.2",
         "graphql-ast-types-browser": "1.0.2",
@@ -36316,9 +36316,9 @@
       }
     },
     "ra-data-graphql-amplication": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.12.tgz",
-      "integrity": "sha512-DCmgExYvTdkmx1rA9uzaheA7Y3o7Y0eWgadICVigFlqD5Bj3zrYWEO3PMNDx7nGnXsT/Ir84z0/+u9FfLu2rjg==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/ra-data-graphql-amplication/-/ra-data-graphql-amplication-0.0.13.tgz",
+      "integrity": "sha512-dfgPe8VlEOG/e33TasLFmKwd3z6MoAbCadQSRseUNOa5Y3BFpks2RK1UXZsGOsIqf9IBRda+Ox/46vH3j3Bx7w==",
       "requires": {
         "camel-case": "4.1.2",
         "graphql-ast-types-browser": "1.0.2",

--- a/packages/amplication-data-service-generator/src/admin/static/package.json
+++ b/packages/amplication-data-service-generator/src/admin/static/package.json
@@ -10,7 +10,7 @@
     "graphql-tag": "2.12.4",
     "lodash": "4.17.21",
     "pluralize": "8.0.0",
-    "ra-data-graphql-amplication": "0.0.12",
+    "ra-data-graphql-amplication": "0.0.13",
     "react": "16.14.0",
     "react-admin": "3.17.0",
     "react-dom": "16.14.0",

--- a/packages/amplication-server/src/util/jsonHelper.ts
+++ b/packages/amplication-server/src/util/jsonHelper.ts
@@ -45,7 +45,7 @@ export class JsonHelper {
       packageJson = {};
       packageJson[name] = value;
     }
-    this.packageJson = Promise.resolve(packageJson)
+    this.packageJson = Promise.resolve(packageJson);
     return await JsonHelper.write(this.path, packageJson);
   }
 

--- a/packages/amplication-server/src/util/sendServerLoadEvent.ts
+++ b/packages/amplication-server/src/util/sendServerLoadEvent.ts
@@ -48,7 +48,7 @@ export const sendServerLoadEvent = (): void => {
 };
 
 const getServerId: () => Promise<string> = async (): Promise<string> => {
-  const RUNTIME_ID = 'runtime_id'
+  const RUNTIME_ID = 'runtime_id';
   const packageJsonHelper = JsonHelper.getInstance(SERVER_ID_FILE_NAME);
   if (!(await packageJsonHelper.exists())) {
     await packageJsonHelper.updateValue(RUNTIME_ID, uuid());


### PR DESCRIPTION
fix: https://github.com/amplication/ra-data-graphql-amplication/issues/12

## PR Details


now when creating updating nested entities it gets updated (as before), but when it is an array of primitives like user roles (which is also not a relation nested input) - it is filtered out.

order and its products
![Screen Shot 2022-03-27 at 0 19 02](https://user-images.githubusercontent.com/39680385/160257691-57e85200-cca7-4fe8-8d62-7edf11f2040b.png)

user with his orders and roles
![Screen Shot 2022-03-27 at 0 20 00](https://user-images.githubusercontent.com/39680385/160257695-a9091b3d-f912-47b1-af57-7be9bc21c977.png)



## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
