### PR TITLE
feat(dsg) move nest morgan interceptor to be global and make it reque…

### DIFF
--- a/packages/amplication-data-service-generator/src/server/app-module/app.module.template.ts
+++ b/packages/amplication-data-service-generator/src/server/app-module/app.module.template.ts
@@ -1,10 +1,18 @@
-import { Module } from "@nestjs/common";
+import { Module, Scope } from "@nestjs/common";
+import { APP_INTERCEPTOR } from "@nestjs/core";
+import { MorganInterceptor } from "nest-morgan";
 
 declare const MODULES: any;
 
 @Module({
   controllers: [],
   imports: MODULES,
-  providers: [],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      scope: Scope.REQUEST,
+      useClass: MorganInterceptor("combined"),
+    },
+  ],
 })
 export class AppModule {}

--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
@@ -1,6 +1,5 @@
 import * as common from "@nestjs/common";
 import * as swagger from "@nestjs/swagger";
-import * as nestMorgan from "nest-morgan";
 import * as nestAccessControl from "nest-access-control";
 // @ts-ignore
 import * as defaultAuthGuard from "../../auth/defaultAuth.guard";
@@ -59,7 +58,6 @@ export class CONTROLLER_BASE {
     protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -100,7 +98,6 @@ export class CONTROLLER_BASE {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -133,7 +130,6 @@ export class CONTROLLER_BASE {
     return results.map((result) => permission.filter(result));
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -169,7 +165,6 @@ export class CONTROLLER_BASE {
     return permission.filter(result);
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -223,7 +218,6 @@ export class CONTROLLER_BASE {
     }
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard

--- a/packages/amplication-data-service-generator/src/server/resource/controller/to-many.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/to-many.template.ts
@@ -1,6 +1,4 @@
 import * as common from "@nestjs/common";
-import * as swagger from "@nestjs/swagger";
-import * as nestMorgan from "nest-morgan";
 import * as nestAccessControl from "nest-access-control";
 // @ts-ignore
 import * as defaultAuthGuard from "../auth/defaultAuth.guard";
@@ -57,7 +55,6 @@ export class Mixin {
     private readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -93,7 +90,6 @@ export class Mixin {
     return results.map((result) => permission.filter(result));
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -136,7 +132,6 @@ export class Mixin {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -179,7 +174,6 @@ export class Mixin {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor("combined"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -2783,7 +2783,9 @@ async function seed(bcryptSalt: Salt) {
   console.info(\\"Seeded database successfully\\");
 }
 ",
-  "server/src/app.module.ts": "import { Module } from \\"@nestjs/common\\";
+  "server/src/app.module.ts": "import { Module, Scope } from \\"@nestjs/common\\";
+import { APP_INTERCEPTOR } from \\"@nestjs/core\\";
+import { MorganInterceptor, MorganModule } from \\"nest-morgan\\";
 import { UserModule } from \\"./user/user.module\\";
 import { OrderModule } from \\"./order/order.module\\";
 import { OrganizationModule } from \\"./organization/organization.module\\";
@@ -2793,7 +2795,6 @@ import { ACLModule } from \\"./auth/acl.module\\";
 import { AuthModule } from \\"./auth/auth.module\\";
 import { HealthModule } from \\"./health/health.module\\";
 import { SecretsManagerModule } from \\"./providers/secrets/secretsManager.module\\";
-import { MorganModule } from \\"nest-morgan\\";
 import { ConfigModule, ConfigService } from \\"@nestjs/config\\";
 import { ServeStaticModule } from \\"@nestjs/serve-static\\";
 import { ServeStaticOptionsService } from \\"./serveStaticOptions.service\\";
@@ -2831,7 +2832,13 @@ import { GraphQLModule } from \\"@nestjs/graphql\\";
       imports: [ConfigModule],
     }),
   ],
-  providers: [],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      scope: Scope.REQUEST,
+      useClass: MorganInterceptor(\\"combined\\"),
+    },
+  ],
 })
 export class AppModule {}
 ",
@@ -5054,7 +5061,6 @@ https://docs.amplication.com/docs/how-to/custom-code
   */
 import * as common from \\"@nestjs/common\\";
 import * as swagger from \\"@nestjs/swagger\\";
-import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
 import * as defaultAuthGuard from \\"../../auth/defaultAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
@@ -5080,7 +5086,6 @@ export class CustomerControllerBase {
     protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -5162,7 +5167,6 @@ export class CustomerControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -5222,7 +5226,6 @@ export class CustomerControllerBase {
     return results.map((result) => permission.filter(result));
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -5285,7 +5288,6 @@ export class CustomerControllerBase {
     return permission.filter(result);
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -5380,7 +5382,6 @@ export class CustomerControllerBase {
     }
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -5439,7 +5440,6 @@ export class CustomerControllerBase {
     }
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -5488,7 +5488,6 @@ export class CustomerControllerBase {
     return results.map((result) => permission.filter(result));
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -5533,7 +5532,6 @@ export class CustomerControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -5578,7 +5576,6 @@ export class CustomerControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -6699,7 +6696,6 @@ https://docs.amplication.com/docs/how-to/custom-code
   */
 import * as common from \\"@nestjs/common\\";
 import * as swagger from \\"@nestjs/swagger\\";
-import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
 import * as defaultAuthGuard from \\"../../auth/defaultAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
@@ -6722,7 +6718,6 @@ export class EmptyControllerBase {
     protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -6767,7 +6762,6 @@ export class EmptyControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -6804,7 +6798,6 @@ export class EmptyControllerBase {
     return results.map((result) => permission.filter(result));
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -6844,7 +6837,6 @@ export class EmptyControllerBase {
     return permission.filter(result);
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -6902,7 +6894,6 @@ export class EmptyControllerBase {
     }
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -8110,7 +8101,6 @@ https://docs.amplication.com/docs/how-to/custom-code
   */
 import * as common from \\"@nestjs/common\\";
 import * as swagger from \\"@nestjs/swagger\\";
-import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
 import * as defaultAuthGuard from \\"../../auth/defaultAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
@@ -8133,7 +8123,6 @@ export class OrderControllerBase {
     protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -8193,7 +8182,6 @@ export class OrderControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -8239,7 +8227,6 @@ export class OrderControllerBase {
     return results.map((result) => permission.filter(result));
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -8288,7 +8275,6 @@ export class OrderControllerBase {
     return permission.filter(result);
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -8361,7 +8347,6 @@ export class OrderControllerBase {
     }
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -9709,7 +9694,6 @@ https://docs.amplication.com/docs/how-to/custom-code
   */
 import * as common from \\"@nestjs/common\\";
 import * as swagger from \\"@nestjs/swagger\\";
-import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
 import * as defaultAuthGuard from \\"../../auth/defaultAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
@@ -9738,7 +9722,6 @@ export class OrganizationControllerBase {
     protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -9784,7 +9767,6 @@ export class OrganizationControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -9822,7 +9804,6 @@ export class OrganizationControllerBase {
     return results.map((result) => permission.filter(result));
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -9863,7 +9844,6 @@ export class OrganizationControllerBase {
     return permission.filter(result);
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -9922,7 +9902,6 @@ export class OrganizationControllerBase {
     }
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -9959,7 +9938,6 @@ export class OrganizationControllerBase {
     }
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -10017,7 +9995,6 @@ export class OrganizationControllerBase {
     return results.map((result) => permission.filter(result));
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -10062,7 +10039,6 @@ export class OrganizationControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -10107,7 +10083,6 @@ export class OrganizationControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -10152,7 +10127,6 @@ export class OrganizationControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -10215,7 +10189,6 @@ export class OrganizationControllerBase {
     return results.map((result) => permission.filter(result));
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -10260,7 +10233,6 @@ export class OrganizationControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -10305,7 +10277,6 @@ export class OrganizationControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -10350,7 +10321,6 @@ export class OrganizationControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -10413,7 +10383,6 @@ export class OrganizationControllerBase {
     return results.map((result) => permission.filter(result));
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -10458,7 +10427,6 @@ export class OrganizationControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -10503,7 +10471,6 @@ export class OrganizationControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -12897,7 +12864,6 @@ https://docs.amplication.com/docs/how-to/custom-code
   */
 import * as common from \\"@nestjs/common\\";
 import * as swagger from \\"@nestjs/swagger\\";
-import * as nestMorgan from \\"nest-morgan\\";
 import * as nestAccessControl from \\"nest-access-control\\";
 import * as defaultAuthGuard from \\"../../auth/defaultAuth.guard\\";
 import * as abacUtil from \\"../../auth/abac.util\\";
@@ -12923,7 +12889,6 @@ export class UserControllerBase {
     protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {}
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -12994,7 +12959,6 @@ export class UserControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -13049,7 +13013,6 @@ export class UserControllerBase {
     return results.map((result) => permission.filter(result));
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -13107,7 +13070,6 @@ export class UserControllerBase {
     return permission.filter(result);
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -13191,7 +13153,6 @@ export class UserControllerBase {
     }
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -13245,7 +13206,6 @@ export class UserControllerBase {
     }
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -13303,7 +13263,6 @@ export class UserControllerBase {
     return results.map((result) => permission.filter(result));
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -13348,7 +13307,6 @@ export class UserControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -13393,7 +13351,6 @@ export class UserControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -13438,7 +13395,6 @@ export class UserControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -13479,7 +13435,6 @@ export class UserControllerBase {
     return results.map((result) => permission.filter(result));
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -13524,7 +13479,6 @@ export class UserControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard
@@ -13569,7 +13523,6 @@ export class UserControllerBase {
     });
   }
 
-  @common.UseInterceptors(nestMorgan.MorganInterceptor(\\"combined\\"))
   @common.UseGuards(
     defaultAuthGuard.DefaultAuthGuard,
     nestAccessControl.ACGuard


### PR DESCRIPTION
Issue Number: #2653 

## PR Details

removed nest morgan interceptor from every route handler to the global module scoped to Request (for not being executed on Graphql queries and mutations)

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
