### PR TITLE
fix(main): add .server-id to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ lerna-debug.log
 .idea/
 *.tgz
 values-secret*
+packages/.server-id


### PR DESCRIPTION
fix #2672 

## PR Details

This pr add the .server-id to gitognore

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
