### PR TITLE
add public to EnumEntityPermissionType on the schema and run migration

### DIFF
--- a/packages/amplication-prisma-db/prisma/migrations/20220509210537_public_routes_for_version_13/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20220509210537_public_routes_for_version_13/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[provider,installationId]` on the table `GitOrganization` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterEnum
+ALTER TYPE "EnumEntityPermissionType" ADD VALUE 'Public';
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GitOrganization_provider_installationId_key" ON "GitOrganization"("provider", "installationId");

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -406,6 +406,7 @@ enum EnumEntityPermissionType {
   AllRoles
   Granular
   Disabled
+  Public
 }
 
 enum EnumDataType {


### PR DESCRIPTION
Issue Number: #2708 

## PR Details

add public to EnumEntityPermissionType on the schema and run migration

## PR Checklist
- [ ] Tests for the changes have been added
- [X] `npm test` doesn't throw any error
