### PR TITLE
fix npm run migrate:up on amplication server

### DIFF
--- a/ee/packages/amplication-git-pull-service/README.md
+++ b/ee/packages/amplication-git-pull-service/README.md
@@ -38,9 +38,7 @@ export class GitPullEventController {
   }
 }
 ```
-
 The properties that this microservice is expecting to get in the event message:
-
 ```ts
 provider:GitProviderEnum,
 repositoryOwner: string,

--- a/ee/packages/amplication-git-pull-service/src/core/gitPullEvent/gitPullEvent.service.ts
+++ b/ee/packages/amplication-git-pull-service/src/core/gitPullEvent/gitPullEvent.service.ts
@@ -39,13 +39,8 @@ export class GitPullEventService implements IGitPullEvent {
   }
 
   async handlePushEvent(pushEventMessage: PushEventMessage): Promise<void> {
-    const {
-      provider,
-      repositoryOwner,
-      repositoryName,
-      branch,
-      commit,
-    } = pushEventMessage;
+    const { provider, repositoryOwner, repositoryName, branch, commit } =
+      pushEventMessage;
 
     const repositoryDir = `${this.rootStorageDir}/git-remote/${provider}/${repositoryOwner}/${repositoryName}/${branch}`;
     const currentCommitDir = `${repositoryDir}/${commit}`;
@@ -117,21 +112,17 @@ export class GitPullEventService implements IGitPullEvent {
   private async findPreviousReadyCommit(
     pushEventMessage: PushEventMessage
   ): Promise<EventData | undefined> {
-    const {
-      provider,
-      repositoryOwner,
-      repositoryName,
-      branch,
-      pushedAt,
-    } = pushEventMessage;
-    const previousReadyCommit = await this.gitPullEventRepository.findByPreviousReadyCommit(
-      provider,
-      repositoryOwner,
-      repositoryName,
-      branch,
-      pushedAt,
-      this.skipPrismaValue
-    );
+    const { provider, repositoryOwner, repositoryName, branch, pushedAt } =
+      pushEventMessage;
+    const previousReadyCommit =
+      await this.gitPullEventRepository.findByPreviousReadyCommit(
+        provider,
+        repositoryOwner,
+        repositoryName,
+        branch,
+        pushedAt,
+        this.skipPrismaValue
+      );
 
     this.logger.log(
       LoggerMessages.log.FOUND_PREVIOUS_READY_COMMIT,

--- a/ee/packages/amplication-git-pull-service/src/providers/gitClient/gitClient.service.ts
+++ b/ee/packages/amplication-git-pull-service/src/providers/gitClient/gitClient.service.ts
@@ -67,13 +67,8 @@ export class GitClientService implements IGitClient {
     accessToken: string
   ): Promise<void> {
     try {
-      const {
-        provider,
-        repositoryOwner,
-        repositoryName,
-        branch,
-        commit,
-      } = pushEventMessage;
+      const { provider, repositoryOwner, repositoryName, branch, commit } =
+        pushEventMessage;
       fs.mkdirSync(baseDir, { recursive: true });
       const repository = `https://${repositoryOwner}:${accessToken}@${this.gitHostDomains[provider]}/${repositoryOwner}/${repositoryName}.git`;
       // TODO: filter out assets and files > 250KB
@@ -93,13 +88,8 @@ export class GitClientService implements IGitClient {
     baseDir: string,
     accessToken: string
   ): Promise<void> {
-    const {
-      provider,
-      repositoryOwner,
-      repositoryName,
-      branch,
-      commit,
-    } = pushEventMessage;
+    const { provider, repositoryOwner, repositoryName, branch, commit } =
+      pushEventMessage;
 
     const repository = `https://${repositoryOwner}:${accessToken}@${this.gitHostDomains[provider]}/${repositoryOwner}/${repositoryName}.git`;
     try {


### PR DESCRIPTION

Issue Number: #2852

## PR Details

fix npm run migrate:up on amplication server in order amplication server helm to run without errors when running npm run migrate:up 

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

