### PR TITLE
fix(client): add scroll to sidebar menu when sidebar menu overflows

### DIFF
--- a/packages/amplication-client/src/Layout/MainLayout.scss
+++ b/packages/amplication-client/src/Layout/MainLayout.scss
@@ -76,7 +76,7 @@ $expand-button-padding: 4px;
       }
 
       .logo-container {
-        height: calc(var(--menu-width) + (var(--default-spacing)));
+        min-height: calc(var(--menu-width) + (var(--default-spacing)));
         width: 100%;
         overflow: hidden;
         transition: all var(--menu-expand-animation-duration) ease-in;
@@ -155,16 +155,31 @@ $expand-button-padding: 4px;
       }
       .menu-container {
         flex: 1;
-        @include scrollbars(5px, var(--black60), transparent);
+        @include scrollbars(5px, var(--black10), transparent);
         overflow-y: auto;
         overflow-x: hidden;
-        overflow: visible;
         padding: var(--default-spacing) 0;
+
+        &:hover {
+          @include scrollbars(5px, var(--black60), transparent);
+          overflow-y: auto;
+          overflow-x: hidden;
+        }
       }
       .bottom-menu-container {
         padding-bottom: var(--default-spacing);
         overflow: hidden;
         overflow: visible;
+        position: relative;
+
+        &:before {
+          content: "";
+          position: absolute;
+          top: 0;
+          left: var(--default-spacing);
+          right: var(--default-spacing);
+          border-top: $border-white-transparent;
+        }
       }
     }
   }


### PR DESCRIPTION
Issue Number: #2866 

## PR Details

Added scrollbar only when the sidebar menu overflows. See the attached screen recording for implementation

![Amplication](https://user-images.githubusercontent.com/20028628/172016121-4d91518d-8785-49e9-9b3d-d8879c199c03.gif)

Closes #2866 

## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error
