### PR TITLE
FIX#2983 - Fixed link in PR description to CLIENT_HOST

### DIFF
--- a/packages/amplication-server/.env
+++ b/packages/amplication-server/.env
@@ -13,6 +13,7 @@ SERVICE_DB_NAME=amplication-server
 CORS_ENABLE=1
 PORT=3000
 HOST=http://localhost:3000
+CLIENT_HOST=http://localhost:3001
 
 # GraphQL
 GRAPHQL_DEBUG=1

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -48,6 +48,7 @@ import { EnumGitProvider } from '../git/dto/enums/EnumGitProvider';
 import { CanUserAccessArgs } from './dto/CanUserAccessArgs';
 
 export const HOST_VAR = 'HOST';
+export const CLIENT_HOST_VAR = 'CLIENT_HOST';
 export const GENERATE_STEP_MESSAGE = 'Generating Application';
 export const GENERATE_STEP_NAME = 'GENERATE_APPLICATION';
 export const BUILD_DOCKER_IMAGE_STEP_MESSAGE = 'Building Docker image';
@@ -619,9 +620,9 @@ export class BuildService {
         `${commit.message} (Amplication build ${truncateBuildId})`) ||
       `Amplication build ${truncateBuildId}`;
 
-    const host = this.configService.get(HOST_VAR);
+    const clientHost = this.configService.get(CLIENT_HOST_VAR);
 
-    const url = `${host}/${build.appId}/builds/${build.id}`;
+    const url = `${clientHost}/${build.appId}/builds/${build.id}`;
 
     if (appRepository) {
       return this.actionService.run(


### PR DESCRIPTION
Issue Number: #2983

## PR Details

Wrong link in the PR description. Link was made using the server HOST .env variable instead of the client.

Created a CLIENT_HOST_VAR const and filled it up with the .env. Creating the URL using this const.
