### PR TITLE
Fix a bug where generated markdown files were ignored

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,4 +28,4 @@ packages/**/lib
 **/*.spec.ts
 **/*.mock.ts
 
-!packages/amplication-data-service-generator/**/**/static
+!packages/amplication-data-service-generator/**/static

--- a/.dockerignore
+++ b/.dockerignore
@@ -28,5 +28,5 @@ packages/**/lib
 **/*.spec.ts
 **/*.mock.ts
 
-!packages/amplication-data-service-generator/src/server/static/README.md
-!packages/amplication-data-service-generator/src/admin/static
+!packages/amplication-data-service-generator/src/server/static/**.md
+!packages/amplication-data-service-generator/src/admin/static/**.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -27,3 +27,5 @@ packages/**/lib
 
 **/*.spec.ts
 **/*.mock.ts
+
+!packages/amplication-data-service-generator/dist/**/static

--- a/.dockerignore
+++ b/.dockerignore
@@ -16,8 +16,6 @@ packages/amplication-data-service-generator/generated
 
 
 **/node_modules
-# *.md
-# **/*.md
 *.yaml
 **/*.yaml
 
@@ -27,5 +25,3 @@ packages/**/lib
 
 **/*.spec.ts
 **/*.mock.ts
-
-# !packages/amplication-data-service-generator/dist/**/static

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-!packages/amplication-data-service-generator/**/static
 .git
 .github
 .vscode
@@ -28,3 +27,5 @@ packages/**/lib
 
 **/*.spec.ts
 **/*.mock.ts
+
+!packages/amplication-data-service-generator/**/static/**

--- a/.dockerignore
+++ b/.dockerignore
@@ -28,4 +28,4 @@ packages/**/lib
 **/*.spec.ts
 **/*.mock.ts
 
-!packages/amplication-data-service-generator/src/*/static/**/*
+!packages/amplication-data-service-generator/src/*/static

--- a/.dockerignore
+++ b/.dockerignore
@@ -16,8 +16,8 @@ packages/amplication-data-service-generator/generated
 
 
 **/node_modules
-*.md
-**/*.md
+# *.md
+# **/*.md
 *.yaml
 **/*.yaml
 
@@ -28,4 +28,4 @@ packages/**/lib
 **/*.spec.ts
 **/*.mock.ts
 
-!packages/amplication-data-service-generator/dist/**/static
+# !packages/amplication-data-service-generator/dist/**/static

--- a/.dockerignore
+++ b/.dockerignore
@@ -28,4 +28,5 @@ packages/**/lib
 **/*.spec.ts
 **/*.mock.ts
 
-!packages/amplication-data-service-generator/**/static/**
+!packages/amplication-data-service-generator/src/server/static/README.md
+!packages/amplication-data-service-generator/src/admin/static

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+!packages/amplication-data-service-generator/**/static
 .git
 .github
 .vscode
@@ -27,5 +28,3 @@ packages/**/lib
 
 **/*.spec.ts
 **/*.mock.ts
-
-!packages/amplication-data-service-generator/**/static

--- a/.dockerignore
+++ b/.dockerignore
@@ -28,4 +28,4 @@ packages/**/lib
 **/*.spec.ts
 **/*.mock.ts
 
-!packages/amplication-data-service-generator/src/**/static/*.md
+!packages/amplication-data-service-generator/src/*/static/*.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,8 @@ packages/amplication-data-service-generator/generated
 
 
 **/node_modules
+*.md
+**/*.md
 *.yaml
 **/*.yaml
 
@@ -25,3 +27,5 @@ packages/**/lib
 
 **/*.spec.ts
 **/*.mock.ts
+
+!packages/amplication-data-service-generator/**/**/static

--- a/.dockerignore
+++ b/.dockerignore
@@ -28,5 +28,4 @@ packages/**/lib
 **/*.spec.ts
 **/*.mock.ts
 
-!packages/amplication-data-service-generator/src/server/static/*.md
-!packages/amplication-data-service-generator/src/admin/static/*.md
+!packages/amplication-data-service-generator/src/**/static/*.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -28,5 +28,5 @@ packages/**/lib
 **/*.spec.ts
 **/*.mock.ts
 
-!packages/amplication-data-service-generator/src/server/static/**.md
-!packages/amplication-data-service-generator/src/admin/static/**.md
+!packages/amplication-data-service-generator/src/server/static/*.md
+!packages/amplication-data-service-generator/src/admin/static/*.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -28,4 +28,4 @@ packages/**/lib
 **/*.spec.ts
 **/*.mock.ts
 
-!packages/amplication-data-service-generator/src/*/static/*.md
+!packages/amplication-data-service-generator/src/*/static/**/*

--- a/packages/amplication-server/Dockerfile
+++ b/packages/amplication-server/Dockerfile
@@ -14,7 +14,7 @@ COPY lerna.json /app
 COPY package*.json /app/
 RUN npm ci --production
 
-FROM base AS build 
+FROM base AS build
 WORKDIR /app
 # Copy amplication/server and the its dependent packages
 COPY packages/amplication-server packages/amplication-server

--- a/packages/amplication-server/Dockerfile
+++ b/packages/amplication-server/Dockerfile
@@ -37,7 +37,7 @@ RUN npm run clean -- --yes
 # Rebuild production node_modules
 RUN npm run bootstrap -- -- --production --scope @amplication/server --include-dependencies
 
-FROM base as server 
+FROM base as server
 WORKDIR /app/packages/amplication-server
 # Copy all distributions and node_modules for amplication/server and its dependencies
 COPY --from=build /app/packages/amplication-server/package.json /app/packages/amplication-server/package.json

--- a/packages/amplication-server/Dockerfile
+++ b/packages/amplication-server/Dockerfile
@@ -37,7 +37,7 @@ RUN npm run clean -- --yes
 # Rebuild production node_modules
 RUN npm run bootstrap -- -- --production --scope @amplication/server --include-dependencies
 
-FROM base as server
+FROM base as server 
 WORKDIR /app/packages/amplication-server
 # Copy all distributions and node_modules for amplication/server and its dependencies
 COPY --from=build /app/packages/amplication-server/package.json /app/packages/amplication-server/package.json

--- a/packages/amplication-server/Dockerfile
+++ b/packages/amplication-server/Dockerfile
@@ -14,7 +14,7 @@ COPY lerna.json /app
 COPY package*.json /app/
 RUN npm ci --production
 
-FROM base AS build
+FROM base AS build 
 WORKDIR /app
 # Copy amplication/server and the its dependent packages
 COPY packages/amplication-server packages/amplication-server


### PR DESCRIPTION
closes: #3023 

## PR Details

The dockerignore file includes *.md files and we added the static folder as a must include 

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
