### PR TITLE
(client): AuthResourceWithGit => fix AuthorizeResourceWithGitResult n…

### DIFF
--- a/packages/amplication-client/src/Resource/git/AuthResourceWithGit.tsx
+++ b/packages/amplication-client/src/Resource/git/AuthResourceWithGit.tsx
@@ -17,7 +17,7 @@ import {
 } from "./SyncWithGithubPage";
 
 type DType = {
-  getGitAppInstallationUrl: AuthorizeResourceWithGitResult;
+  getGitResourceInstallationUrl: AuthorizeResourceWithGitResult;
 };
 
 // eslint-disable-next-line
@@ -55,7 +55,10 @@ function AuthResourceWithGit({ resource, onDone }: Props) {
     START_AUTH_APP_WITH_GITHUB,
     {
       onCompleted: (data) => {
-        openSignInWindow(data.getGitAppInstallationUrl.url, "auth with git");
+        openSignInWindow(
+          data.getGitResourceInstallationUrl.url,
+          "auth with git"
+        );
       },
     }
   );
@@ -139,8 +142,8 @@ function AuthResourceWithGit({ resource, onDone }: Props) {
 export default AuthResourceWithGit;
 
 const START_AUTH_APP_WITH_GITHUB = gql`
-  mutation getGitAppInstallationUrl($gitProvider: EnumGitProvider!) {
-    getGitAppInstallationUrl(data: { gitProvider: $gitProvider }) {
+  mutation getGitResourceInstallationUrl($gitProvider: EnumGitProvider!) {
+    getGitResourceInstallationUrl(data: { gitProvider: $gitProvider }) {
       url
     }
   }


### PR DESCRIPTION

Issue Number: #3048 

## PR Details
getGitResourceInstallationUrl Mutation broke after changing app to resource in client mutation.
update the mutation and return object names to fix this issue.  

## PR Checklist
- [x ] Tests for the changes have been added
- [ x] `npm test` doesn't throw any error
