### PR TITLE
Fix/3091 prisma resource type

### DIFF
--- a/packages/amplication-prisma-db/prisma/migrations/20220707120437_from_app_to_resource/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20220707120437_from_app_to_resource/migration.sql
@@ -63,6 +63,6 @@ ALTER INDEX "EntityPermissionRole.entityVersionId_action_appRoleId_unique" RENAM
 CREATE TYPE "EnumResourceType" AS ENUM ('Service');
 
 -- Add value to current resources
-ALTER TABLE "Resource" ADD COLUMN     "resourceType" "EnumResourceType" NULL;
-UPDATE "Resource" SET resourceType = 'Service';
-ALTER TABLE "Resource" ALTER COLUMN "resourceType" SET NOT NULL;
+ALTER TABLE "Resource" ADD COLUMN     "type" "EnumResourceType" NULL;
+UPDATE "Resource" SET type = 'Service';
+ALTER TABLE "Resource" ALTER COLUMN "type" SET NOT NULL;

--- a/packages/amplication-prisma-db/prisma/migrations/20220712125221_resource_type/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20220712125221_resource_type/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Resource" RENAME "type" TO "resourceType"
+


### PR DESCRIPTION
closes: #3091 
## PR Details

This pr revert the change of the resourceType in the SQL and do a separated SQL migration 

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
