### PR TITLE
Fix Prisma one to one relation

### DIFF
--- a/packages/amplication-data-service-generator/src/server/prisma/create-prisma-schema.spec.ts
+++ b/packages/amplication-data-service-generator/src/server/prisma/create-prisma-schema.spec.ts
@@ -148,7 +148,7 @@ model ${EXAMPLE_ENTITY_NAME} {
 
 model ${EXAMPLE_LOOKUP_ENTITY_NAME} {
   ${EXAMPLE_LOOKUP_FIELD_NAME}   ${EXAMPLE_ENTITY_NAME} @relation(fields: [${EXAMPLE_LOOKUP_FIELD_NAME}Id], references: [id])
-  ${EXAMPLE_LOOKUP_FIELD_NAME}Id String
+  ${EXAMPLE_LOOKUP_FIELD_NAME}Id String            @unique
 }`,
     ],
   ];

--- a/packages/amplication-data-service-generator/src/server/prisma/create-prisma-schema.ts
+++ b/packages/amplication-data-service-generator/src/server/prisma/create-prisma-schema.ts
@@ -218,7 +218,7 @@ export function createPrismaFields(
             name,
             relatedEntity.name,
             !isOneToOneWithoutForeignKey,
-            true,
+            allowMultipleSelection || false,
             relationName
           ),
         ];
@@ -244,7 +244,11 @@ export function createPrismaFields(
           PrismaSchemaDSL.ScalarType.String,
           false,
           field.required,
-          field.unique
+          !field.properties.allowMultipleSelection &&
+            !relatedField.properties.allowMultipleSelection &&
+            !isOneToOneWithoutForeignKey
+            ? true
+            : field.unique
         ),
       ];
     }

--- a/packages/amplication-data-service-generator/src/server/prisma/create-prisma-schema.ts
+++ b/packages/amplication-data-service-generator/src/server/prisma/create-prisma-schema.ts
@@ -245,7 +245,7 @@ export function createPrismaFields(
           false,
           field.required,
           !field.properties.allowMultipleSelection &&
-            !relatedField.properties.allowMultipleSelection &&
+            !relatedField?.properties.allowMultipleSelection &&
             !isOneToOneWithoutForeignKey
             ? true
             : field.unique

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -15,6 +15,10 @@ import { UserList } from \\"./user/UserList\\";
 import { UserCreate } from \\"./user/UserCreate\\";
 import { UserEdit } from \\"./user/UserEdit\\";
 import { UserShow } from \\"./user/UserShow\\";
+import { ProfileList } from \\"./profile/ProfileList\\";
+import { ProfileCreate } from \\"./profile/ProfileCreate\\";
+import { ProfileEdit } from \\"./profile/ProfileEdit\\";
+import { ProfileShow } from \\"./profile/ProfileShow\\";
 import { OrderList } from \\"./order/OrderList\\";
 import { OrderCreate } from \\"./order/OrderCreate\\";
 import { OrderEdit } from \\"./order/OrderEdit\\";
@@ -63,6 +67,13 @@ const App = (): React.ReactElement => {
           edit={UserEdit}
           create={UserCreate}
           show={UserShow}
+        />
+        <Resource
+          name=\\"Profile\\"
+          list={ProfileList}
+          edit={ProfileEdit}
+          create={ProfileCreate}
+          show={ProfileShow}
         />
         <Resource
           name=\\"Order\\"
@@ -719,6 +730,100 @@ export type UserUpdateManyWithoutOrganizationsInput = {
   set?: Array<UserWhereUniqueInput>;
 };
 ",
+  "test-ui/src/api/profile/CreateProfileArgs.ts": "import { ProfileCreateInput } from \\"./ProfileCreateInput\\";
+
+export type CreateProfileArgs = {
+  data: ProfileCreateInput;
+};
+",
+  "test-ui/src/api/profile/DeleteProfileArgs.ts": "import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+export type DeleteProfileArgs = {
+  where: ProfileWhereUniqueInput;
+};
+",
+  "test-ui/src/api/profile/Profile.ts": "import { User } from \\"../user/User\\";
+
+export type Profile = {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  email: string;
+  user?: User | null;
+};
+",
+  "test-ui/src/api/profile/ProfileCreateInput.ts": "import { UserWhereUniqueInput } from \\"../user/UserWhereUniqueInput\\";
+
+export type ProfileCreateInput = {
+  email: string;
+  user?: UserWhereUniqueInput | null;
+};
+",
+  "test-ui/src/api/profile/ProfileFindManyArgs.ts": "import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { ProfileOrderByInput } from \\"./ProfileOrderByInput\\";
+
+export type ProfileFindManyArgs = {
+  where?: ProfileWhereInput;
+  orderBy?: Array<ProfileOrderByInput>;
+  skip?: number;
+  take?: number;
+};
+",
+  "test-ui/src/api/profile/ProfileFindUniqueArgs.ts": "import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+export type ProfileFindUniqueArgs = {
+  where: ProfileWhereUniqueInput;
+};
+",
+  "test-ui/src/api/profile/ProfileListRelationFilter.ts": "import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+
+export type ProfileListRelationFilter = {
+  every?: ProfileWhereInput;
+  some?: ProfileWhereInput;
+  none?: ProfileWhereInput;
+};
+",
+  "test-ui/src/api/profile/ProfileOrderByInput.ts": "import { SortOrder } from \\"../../util/SortOrder\\";
+
+export type ProfileOrderByInput = {
+  id?: SortOrder;
+  createdAt?: SortOrder;
+  updatedAt?: SortOrder;
+  email?: SortOrder;
+  userId?: SortOrder;
+};
+",
+  "test-ui/src/api/profile/ProfileUpdateInput.ts": "import { UserWhereUniqueInput } from \\"../user/UserWhereUniqueInput\\";
+
+export type ProfileUpdateInput = {
+  email?: string;
+  user?: UserWhereUniqueInput | null;
+};
+",
+  "test-ui/src/api/profile/ProfileWhereInput.ts": "import { StringFilter } from \\"../../util/StringFilter\\";
+import { DateTimeFilter } from \\"../../util/DateTimeFilter\\";
+import { UserWhereUniqueInput } from \\"../user/UserWhereUniqueInput\\";
+
+export type ProfileWhereInput = {
+  id?: StringFilter;
+  createdAt?: DateTimeFilter;
+  updatedAt?: DateTimeFilter;
+  email?: StringFilter;
+  user?: UserWhereUniqueInput;
+};
+",
+  "test-ui/src/api/profile/ProfileWhereUniqueInput.ts": "export type ProfileWhereUniqueInput = {
+  id: string;
+};
+",
+  "test-ui/src/api/profile/UpdateProfileArgs.ts": "import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+import { ProfileUpdateInput } from \\"./ProfileUpdateInput\\";
+
+export type UpdateProfileArgs = {
+  where: ProfileWhereUniqueInput;
+  data: ProfileUpdateInput;
+};
+",
   "test-ui/src/api/user/CreateUserArgs.ts": "import { UserCreateInput } from \\"./UserCreateInput\\";
 
 export type CreateUserArgs = {
@@ -766,6 +871,7 @@ export type UpdateUserArgs = {
 ",
   "test-ui/src/api/user/User.ts": "import { Organization } from \\"../organization/Organization\\";
 import { JsonValue } from \\"type-fest\\";
+import { Profile } from \\"../profile/Profile\\";
 
 export type User = {
   username: string;
@@ -785,12 +891,14 @@ export type User = {
   isCurious: boolean;
   location: string;
   extendedProperties: JsonValue;
+  profile?: Profile | null;
 };
 ",
   "test-ui/src/api/user/UserCreateInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { UserCreateNestedManyWithoutUsersInput } from \\"./UserCreateNestedManyWithoutUsersInput\\";
 import { OrganizationCreateNestedManyWithoutUsersInput } from \\"./OrganizationCreateNestedManyWithoutUsersInput\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../profile/ProfileWhereUniqueInput\\";
 
 export type UserCreateInput = {
   username: string;
@@ -810,6 +918,7 @@ export type UserCreateInput = {
   isCurious: boolean;
   location: string;
   extendedProperties: InputJsonValue;
+  profile?: ProfileWhereUniqueInput | null;
 };
 ",
   "test-ui/src/api/user/UserCreateNestedManyWithoutUsersInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
@@ -861,12 +970,14 @@ export type UserOrderByInput = {
   isCurious?: SortOrder;
   location?: SortOrder;
   extendedProperties?: SortOrder;
+  profileId?: SortOrder;
 };
 ",
   "test-ui/src/api/user/UserUpdateInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { UserUpdateManyWithoutUsersInput } from \\"./UserUpdateManyWithoutUsersInput\\";
 import { OrganizationUpdateManyWithoutUsersInput } from \\"./OrganizationUpdateManyWithoutUsersInput\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../profile/ProfileWhereUniqueInput\\";
 
 export type UserUpdateInput = {
   username?: string;
@@ -886,6 +997,7 @@ export type UserUpdateInput = {
   isCurious?: boolean;
   location?: string;
   extendedProperties?: InputJsonValue;
+  profile?: ProfileWhereUniqueInput | null;
 };
 ",
   "test-ui/src/api/user/UserUpdateManyWithoutUsersInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
@@ -903,6 +1015,7 @@ import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { OrganizationListRelationFilter } from \\"../organization/OrganizationListRelationFilter\\";
 import { BooleanFilter } from \\"../../util/BooleanFilter\\";
 import { JsonFilter } from \\"../../util/JsonFilter\\";
+import { ProfileWhereUniqueInput } from \\"../profile/ProfileWhereUniqueInput\\";
 
 export type UserWhereInput = {
   id?: StringFilter;
@@ -916,6 +1029,7 @@ export type UserWhereInput = {
   isCurious?: BooleanFilter;
   location?: StringFilter;
   extendedProperties?: JsonFilter;
+  profile?: ProfileWhereUniqueInput;
 };
 ",
   "test-ui/src/api/user/UserWhereUniqueInput.ts": "export type UserWhereUniqueInput = {
@@ -2012,6 +2126,123 @@ const Dashboard = () => (
 
 export default Dashboard;
 ",
+  "test-ui/src/profile/ProfileCreate.tsx": "import * as React from \\"react\\";
+import {
+  Create,
+  SimpleForm,
+  CreateProps,
+  TextInput,
+  ReferenceInput,
+  SelectInput,
+} from \\"react-admin\\";
+import { UserTitle } from \\"../user/UserTitle\\";
+
+export const ProfileCreate = (props: CreateProps): React.ReactElement => {
+  return (
+    <Create {...props}>
+      <SimpleForm>
+        <TextInput label=\\"Email\\" source=\\"email\\" type=\\"email\\" />
+        <ReferenceInput source=\\"user.id\\" reference=\\"User\\" label=\\"User\\">
+          <SelectInput optionText={UserTitle} />
+        </ReferenceInput>
+      </SimpleForm>
+    </Create>
+  );
+};
+",
+  "test-ui/src/profile/ProfileEdit.tsx": "import * as React from \\"react\\";
+import {
+  Edit,
+  SimpleForm,
+  EditProps,
+  TextInput,
+  ReferenceInput,
+  SelectInput,
+} from \\"react-admin\\";
+import { UserTitle } from \\"../user/UserTitle\\";
+
+export const ProfileEdit = (props: EditProps): React.ReactElement => {
+  return (
+    <Edit {...props}>
+      <SimpleForm>
+        <TextInput label=\\"Email\\" source=\\"email\\" type=\\"email\\" />
+        <ReferenceInput source=\\"user.id\\" reference=\\"User\\" label=\\"User\\">
+          <SelectInput optionText={UserTitle} />
+        </ReferenceInput>
+      </SimpleForm>
+    </Edit>
+  );
+};
+",
+  "test-ui/src/profile/ProfileList.tsx": "import * as React from \\"react\\";
+import {
+  List,
+  Datagrid,
+  ListProps,
+  TextField,
+  DateField,
+  ReferenceField,
+} from \\"react-admin\\";
+import Pagination from \\"../Components/Pagination\\";
+import { USER_TITLE_FIELD } from \\"../user/UserTitle\\";
+
+export const ProfileList = (props: ListProps): React.ReactElement => {
+  return (
+    <List
+      {...props}
+      bulkActionButtons={false}
+      title={\\"Profiles\\"}
+      perPage={50}
+      pagination={<Pagination />}
+    >
+      <Datagrid rowClick=\\"show\\">
+        <TextField label=\\"Id\\" source=\\"id\\" />
+        <DateField source=\\"createdAt\\" label=\\"Created At\\" />
+        <DateField source=\\"updatedAt\\" label=\\"Updated At\\" />
+        <TextField label=\\"Email\\" source=\\"email\\" />
+        <ReferenceField label=\\"User\\" source=\\"user.id\\" reference=\\"User\\">
+          <TextField source={USER_TITLE_FIELD} />
+        </ReferenceField>
+      </Datagrid>
+    </List>
+  );
+};
+",
+  "test-ui/src/profile/ProfileShow.tsx": "import * as React from \\"react\\";
+import {
+  Show,
+  SimpleShowLayout,
+  ShowProps,
+  TextField,
+  DateField,
+  ReferenceField,
+} from \\"react-admin\\";
+import { USER_TITLE_FIELD } from \\"../user/UserTitle\\";
+
+export const ProfileShow = (props: ShowProps): React.ReactElement => {
+  return (
+    <Show {...props}>
+      <SimpleShowLayout>
+        <TextField label=\\"Id\\" source=\\"id\\" />
+        <DateField source=\\"createdAt\\" label=\\"Created At\\" />
+        <DateField source=\\"updatedAt\\" label=\\"Updated At\\" />
+        <TextField label=\\"Email\\" source=\\"email\\" />
+        <ReferenceField label=\\"User\\" source=\\"user.id\\" reference=\\"User\\">
+          <TextField source={USER_TITLE_FIELD} />
+        </ReferenceField>
+      </SimpleShowLayout>
+    </Show>
+  );
+};
+",
+  "test-ui/src/profile/ProfileTitle.ts": "import { Profile as TProfile } from \\"../api/profile/Profile\\";
+
+export const PROFILE_TITLE_FIELD = \\"id\\";
+
+export const ProfileTitle = (record: TProfile): string => {
+  return record.id || record.id;
+};
+",
   "test-ui/src/reportWebVitals.ts": "import { ReportHandler } from \\"web-vitals\\";
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
@@ -2120,6 +2351,7 @@ import {
 
 import { UserTitle } from \\"./UserTitle\\";
 import { OrganizationTitle } from \\"../organization/OrganizationTitle\\";
+import { ProfileTitle } from \\"../profile/ProfileTitle\\";
 import { ROLES_OPTIONS } from \\"../user/RolesOptions\\";
 
 export const UserCreate = (props: CreateProps): React.ReactElement => {
@@ -2183,6 +2415,9 @@ export const UserCreate = (props: CreateProps): React.ReactElement => {
         <BooleanInput label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextInput label=\\"Location\\" source=\\"location\\" />
         <div />
+        <ReferenceInput source=\\"profile.id\\" reference=\\"Profile\\" label=\\"Profile\\">
+          <SelectInput optionText={ProfileTitle} />
+        </ReferenceInput>
       </SimpleForm>
     </Create>
   );
@@ -2207,6 +2442,7 @@ import {
 
 import { UserTitle } from \\"./UserTitle\\";
 import { OrganizationTitle } from \\"../organization/OrganizationTitle\\";
+import { ProfileTitle } from \\"../profile/ProfileTitle\\";
 import { ROLES_OPTIONS } from \\"../user/RolesOptions\\";
 
 export const UserEdit = (props: EditProps): React.ReactElement => {
@@ -2270,6 +2506,9 @@ export const UserEdit = (props: EditProps): React.ReactElement => {
         <BooleanInput label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextInput label=\\"Location\\" source=\\"location\\" />
         <div />
+        <ReferenceInput source=\\"profile.id\\" reference=\\"Profile\\" label=\\"Profile\\">
+          <SelectInput optionText={ProfileTitle} />
+        </ReferenceInput>
       </SimpleForm>
     </Edit>
   );
@@ -2286,6 +2525,7 @@ import {
 } from \\"react-admin\\";
 import Pagination from \\"../Components/Pagination\\";
 import { USER_TITLE_FIELD } from \\"./UserTitle\\";
+import { PROFILE_TITLE_FIELD } from \\"../profile/ProfileTitle\\";
 
 export const UserList = (props: ListProps): React.ReactElement => {
   return (
@@ -2314,6 +2554,9 @@ export const UserList = (props: ListProps): React.ReactElement => {
         <BooleanField label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextField label=\\"Location\\" source=\\"location\\" />
         <TextField label=\\"Extended Properties\\" source=\\"extendedProperties\\" />
+        <ReferenceField label=\\"Profile\\" source=\\"profile.id\\" reference=\\"Profile\\">
+          <TextField source={PROFILE_TITLE_FIELD} />
+        </ReferenceField>
       </Datagrid>
     </List>
   );
@@ -2329,6 +2572,7 @@ import {
   BooleanField,
 } from \\"react-admin\\";
 import { USER_TITLE_FIELD } from \\"./UserTitle\\";
+import { PROFILE_TITLE_FIELD } from \\"../profile/ProfileTitle\\";
 
 export const UserShow = (props: ShowProps): React.ReactElement => {
   return (
@@ -2351,6 +2595,9 @@ export const UserShow = (props: ShowProps): React.ReactElement => {
         <BooleanField label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextField label=\\"Location\\" source=\\"location\\" />
         <TextField label=\\"Extended Properties\\" source=\\"extendedProperties\\" />
+        <ReferenceField label=\\"Profile\\" source=\\"profile.id\\" reference=\\"Profile\\">
+          <TextField source={PROFILE_TITLE_FIELD} />
+        </ReferenceField>
       </SimpleShowLayout>
     </Show>
   );
@@ -2620,6 +2867,16 @@ model User {
   isCurious          Boolean
   location           String
   extendedProperties Json
+  profile            Profile?            @relation(fields: [profileId], references: [id])
+  profileId          String?             @unique
+}
+
+model Profile {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  email     String
+  user      User?
 }
 
 model Order {
@@ -2841,6 +3098,7 @@ async function seed(bcryptSalt: Salt) {
 import { APP_INTERCEPTOR } from \\"@nestjs/core\\";
 import { MorganInterceptor, MorganModule } from \\"nest-morgan\\";
 import { UserModule } from \\"./user/user.module\\";
+import { ProfileModule } from \\"./profile/profile.module\\";
 import { OrderModule } from \\"./order/order.module\\";
 import { OrganizationModule } from \\"./organization/organization.module\\";
 import { CustomerModule } from \\"./customer/customer.module\\";
@@ -2858,6 +3116,7 @@ import { GraphQLModule } from \\"@nestjs/graphql\\";
   controllers: [],
   imports: [
     UserModule,
+    ProfileModule,
     OrderModule,
     OrganizationModule,
     CustomerModule,
@@ -9583,6 +9842,12 @@ export class OrganizationControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
     if (results === null) {
@@ -10340,6 +10605,1229 @@ export async function transformStringFieldUpdateInput<
   return input;
 }
 ",
+  "test/src/profile/base/CreateProfileArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileCreateInput } from \\"./ProfileCreateInput\\";
+
+@ArgsType()
+class CreateProfileArgs {
+  @Field(() => ProfileCreateInput, { nullable: false })
+  data!: ProfileCreateInput;
+}
+
+export { CreateProfileArgs };
+",
+  "test/src/profile/base/DeleteProfileArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+@ArgsType()
+class DeleteProfileArgs {
+  @Field(() => ProfileWhereUniqueInput, { nullable: false })
+  where!: ProfileWhereUniqueInput;
+}
+
+export { DeleteProfileArgs };
+",
+  "test/src/profile/base/Profile.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ObjectType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString, IsDate, ValidateNested, IsOptional } from \\"class-validator\\";
+import { Type } from \\"class-transformer\\";
+import { User } from \\"../../user/base/User\\";
+@ObjectType()
+class Profile {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  id!: string;
+
+  @ApiProperty({
+    required: true,
+  })
+  @IsDate()
+  @Type(() => Date)
+  @Field(() => Date)
+  createdAt!: Date;
+
+  @ApiProperty({
+    required: true,
+  })
+  @IsDate()
+  @Type(() => Date)
+  @Field(() => Date)
+  updatedAt!: Date;
+
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  email!: string;
+
+  @ApiProperty({
+    required: false,
+    type: () => User,
+  })
+  @ValidateNested()
+  @Type(() => User)
+  @IsOptional()
+  user?: User | null;
+}
+export { Profile };
+",
+  "test/src/profile/base/ProfileCreateInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString, ValidateNested, IsOptional } from \\"class-validator\\";
+import { UserWhereUniqueInput } from \\"../../user/base/UserWhereUniqueInput\\";
+import { Type } from \\"class-transformer\\";
+@InputType()
+class ProfileCreateInput {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  email!: string;
+
+  @ApiProperty({
+    required: false,
+    type: () => UserWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => UserWhereUniqueInput)
+  @IsOptional()
+  @Field(() => UserWhereUniqueInput, {
+    nullable: true,
+  })
+  user?: UserWhereUniqueInput | null;
+}
+export { ProfileCreateInput };
+",
+  "test/src/profile/base/ProfileFindManyArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { Type } from \\"class-transformer\\";
+import { ProfileOrderByInput } from \\"./ProfileOrderByInput\\";
+
+@ArgsType()
+class ProfileFindManyArgs {
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @Field(() => ProfileWhereInput, { nullable: true })
+  @Type(() => ProfileWhereInput)
+  where?: ProfileWhereInput;
+
+  @ApiProperty({
+    required: false,
+    type: [ProfileOrderByInput],
+  })
+  @Field(() => [ProfileOrderByInput], { nullable: true })
+  @Type(() => ProfileOrderByInput)
+  orderBy?: Array<ProfileOrderByInput>;
+
+  @ApiProperty({
+    required: false,
+    type: Number,
+  })
+  @Field(() => Number, { nullable: true })
+  @Type(() => Number)
+  skip?: number;
+
+  @ApiProperty({
+    required: false,
+    type: Number,
+  })
+  @Field(() => Number, { nullable: true })
+  @Type(() => Number)
+  take?: number;
+}
+
+export { ProfileFindManyArgs };
+",
+  "test/src/profile/base/ProfileFindUniqueArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+@ArgsType()
+class ProfileFindUniqueArgs {
+  @Field(() => ProfileWhereUniqueInput, { nullable: false })
+  where!: ProfileWhereUniqueInput;
+}
+
+export { ProfileFindUniqueArgs };
+",
+  "test/src/profile/base/ProfileListRelationFilter.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { ValidateNested, IsOptional } from \\"class-validator\\";
+import { Type } from \\"class-transformer\\";
+
+@InputType()
+class ProfileListRelationFilter {
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereInput)
+  @IsOptional()
+  @Field(() => ProfileWhereInput, {
+    nullable: true,
+  })
+  every?: ProfileWhereInput;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereInput)
+  @IsOptional()
+  @Field(() => ProfileWhereInput, {
+    nullable: true,
+  })
+  some?: ProfileWhereInput;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereInput)
+  @IsOptional()
+  @Field(() => ProfileWhereInput, {
+    nullable: true,
+  })
+  none?: ProfileWhereInput;
+}
+export { ProfileListRelationFilter };
+",
+  "test/src/profile/base/ProfileOrderByInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { SortOrder } from \\"../../util/SortOrder\\";
+
+@InputType({
+  isAbstract: true,
+  description: undefined,
+})
+class ProfileOrderByInput {
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  id?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  createdAt?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  updatedAt?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  email?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  userId?: SortOrder;
+}
+
+export { ProfileOrderByInput };
+",
+  "test/src/profile/base/ProfileUpdateInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString, IsOptional, ValidateNested } from \\"class-validator\\";
+import { UserWhereUniqueInput } from \\"../../user/base/UserWhereUniqueInput\\";
+import { Type } from \\"class-transformer\\";
+@InputType()
+class ProfileUpdateInput {
+  @ApiProperty({
+    required: false,
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  @Field(() => String, {
+    nullable: true,
+  })
+  email?: string;
+
+  @ApiProperty({
+    required: false,
+    type: () => UserWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => UserWhereUniqueInput)
+  @IsOptional()
+  @Field(() => UserWhereUniqueInput, {
+    nullable: true,
+  })
+  user?: UserWhereUniqueInput | null;
+}
+export { ProfileUpdateInput };
+",
+  "test/src/profile/base/ProfileWhereInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { StringFilter } from \\"../../util/StringFilter\\";
+import { Type } from \\"class-transformer\\";
+import { IsOptional, ValidateNested } from \\"class-validator\\";
+import { DateTimeFilter } from \\"../../util/DateTimeFilter\\";
+import { UserWhereUniqueInput } from \\"../../user/base/UserWhereUniqueInput\\";
+@InputType()
+class ProfileWhereInput {
+  @ApiProperty({
+    required: false,
+    type: StringFilter,
+  })
+  @Type(() => StringFilter)
+  @IsOptional()
+  @Field(() => StringFilter, {
+    nullable: true,
+  })
+  id?: StringFilter;
+
+  @ApiProperty({
+    required: false,
+    type: DateTimeFilter,
+  })
+  @Type(() => DateTimeFilter)
+  @IsOptional()
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+  })
+  createdAt?: DateTimeFilter;
+
+  @ApiProperty({
+    required: false,
+    type: DateTimeFilter,
+  })
+  @Type(() => DateTimeFilter)
+  @IsOptional()
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+  })
+  updatedAt?: DateTimeFilter;
+
+  @ApiProperty({
+    required: false,
+    type: StringFilter,
+  })
+  @Type(() => StringFilter)
+  @IsOptional()
+  @Field(() => StringFilter, {
+    nullable: true,
+  })
+  email?: StringFilter;
+
+  @ApiProperty({
+    required: false,
+    type: () => UserWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => UserWhereUniqueInput)
+  @IsOptional()
+  @Field(() => UserWhereUniqueInput, {
+    nullable: true,
+  })
+  user?: UserWhereUniqueInput;
+}
+export { ProfileWhereInput };
+",
+  "test/src/profile/base/ProfileWhereUniqueInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString } from \\"class-validator\\";
+@InputType()
+class ProfileWhereUniqueInput {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  id!: string;
+}
+export { ProfileWhereUniqueInput };
+",
+  "test/src/profile/base/UpdateProfileArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+import { ProfileUpdateInput } from \\"./ProfileUpdateInput\\";
+
+@ArgsType()
+class UpdateProfileArgs {
+  @Field(() => ProfileWhereUniqueInput, { nullable: false })
+  where!: ProfileWhereUniqueInput;
+  @Field(() => ProfileUpdateInput, { nullable: false })
+  data!: ProfileUpdateInput;
+}
+
+export { UpdateProfileArgs };
+",
+  "test/src/profile/base/profile.controller.base.spec.ts": "import { Test } from \\"@nestjs/testing\\";
+import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
+import request from \\"supertest\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { ACGuard } from \\"nest-access-control\\";
+import { DefaultAuthGuard } from \\"../../auth/defaultAuth.guard\\";
+import { ACLModule } from \\"../../auth/acl.module\\";
+import { ProfileController } from \\"../profile.controller\\";
+import { ProfileService } from \\"../profile.service\\";
+
+const nonExistingId = \\"nonExistingId\\";
+const existingId = \\"existingId\\";
+const CREATE_INPUT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  email: \\"exampleEmail\\",
+};
+const CREATE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  email: \\"exampleEmail\\",
+};
+const FIND_MANY_RESULT = [
+  {
+    id: \\"exampleId\\",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    email: \\"exampleEmail\\",
+  },
+];
+const FIND_ONE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  email: \\"exampleEmail\\",
+};
+
+const service = {
+  create() {
+    return CREATE_RESULT;
+  },
+  findMany: () => FIND_MANY_RESULT,
+  findOne: ({ where }: { where: { id: string } }) => {
+    switch (where.id) {
+      case existingId:
+        return FIND_ONE_RESULT;
+      case nonExistingId:
+        return null;
+    }
+  },
+};
+
+const basicAuthGuard = {
+  canActivate: (context: ExecutionContext) => {
+    const argumentHost = context.switchToHttp();
+    const request = argumentHost.getRequest();
+    request.user = {
+      roles: [\\"user\\"],
+    };
+    return true;
+  },
+};
+
+const acGuard = {
+  canActivate: () => {
+    return true;
+  },
+};
+
+describe(\\"Profile\\", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: ProfileService,
+          useValue: service,
+        },
+      ],
+      controllers: [ProfileController],
+      imports: [MorganModule.forRoot(), ACLModule],
+    })
+      .overrideGuard(DefaultAuthGuard)
+      .useValue(basicAuthGuard)
+      .overrideGuard(ACGuard)
+      .useValue(acGuard)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  test(\\"POST /profiles\\", async () => {
+    await request(app.getHttpServer())
+      .post(\\"/profiles\\")
+      .send(CREATE_INPUT)
+      .expect(HttpStatus.CREATED)
+      .expect({
+        ...CREATE_RESULT,
+        createdAt: CREATE_RESULT.createdAt.toISOString(),
+        updatedAt: CREATE_RESULT.updatedAt.toISOString(),
+      });
+  });
+
+  test(\\"GET /profiles\\", async () => {
+    await request(app.getHttpServer())
+      .get(\\"/profiles\\")
+      .expect(HttpStatus.OK)
+      .expect([
+        {
+          ...FIND_MANY_RESULT[0],
+          createdAt: FIND_MANY_RESULT[0].createdAt.toISOString(),
+          updatedAt: FIND_MANY_RESULT[0].updatedAt.toISOString(),
+        },
+      ]);
+  });
+
+  test(\\"GET /profiles/:id non existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/profiles\\"}/\${nonExistingId}\`)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        statusCode: HttpStatus.NOT_FOUND,
+        message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
+        error: \\"Not Found\\",
+      });
+  });
+
+  test(\\"GET /profiles/:id existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/profiles\\"}/\${existingId}\`)
+      .expect(HttpStatus.OK)
+      .expect({
+        ...FIND_ONE_RESULT,
+        createdAt: FIND_ONE_RESULT.createdAt.toISOString(),
+        updatedAt: FIND_ONE_RESULT.updatedAt.toISOString(),
+      });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});
+",
+  "test/src/profile/base/profile.controller.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import * as common from \\"@nestjs/common\\";
+import * as swagger from \\"@nestjs/swagger\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import * as defaultAuthGuard from \\"../../auth/defaultAuth.guard\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
+import * as errors from \\"../../errors\\";
+import { Request } from \\"express\\";
+import { plainToClass } from \\"class-transformer\\";
+import { ApiNestedQuery } from \\"../../decorators/api-nested-query.decorator\\";
+import { ProfileService } from \\"../profile.service\\";
+import { AclValidateRequestInterceptor } from \\"../../interceptors/aclValidateRequest.interceptor\\";
+import { AclFilterResponseInterceptor } from \\"../../interceptors/aclFilterResponse.interceptor\\";
+import { ProfileCreateInput } from \\"./ProfileCreateInput\\";
+import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+import { ProfileFindManyArgs } from \\"./ProfileFindManyArgs\\";
+import { ProfileUpdateInput } from \\"./ProfileUpdateInput\\";
+import { Profile } from \\"./Profile\\";
+@swagger.ApiBasicAuth()
+@common.UseGuards(defaultAuthGuard.DefaultAuthGuard, nestAccessControl.ACGuard)
+export class ProfileControllerBase {
+  constructor(
+    protected readonly service: ProfileService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {}
+
+  @common.UseInterceptors(AclValidateRequestInterceptor)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"create\\",
+    possession: \\"any\\",
+  })
+  @common.Post()
+  @swagger.ApiCreatedResponse({ type: Profile })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async create(@common.Body() data: ProfileCreateInput): Promise<Profile> {
+    return await this.service.create({
+      data: {
+        ...data,
+
+        user: data.user
+          ? {
+              connect: data.user,
+            }
+          : undefined,
+      },
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        email: true,
+
+        user: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  @common.Get()
+  @swagger.ApiOkResponse({ type: [Profile] })
+  @swagger.ApiForbiddenResponse()
+  @ApiNestedQuery(ProfileFindManyArgs)
+  async findMany(@common.Req() request: Request): Promise<Profile[]> {
+    const args = plainToClass(ProfileFindManyArgs, request.query);
+    return this.service.findMany({
+      ...args,
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        email: true,
+
+        user: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"own\\",
+  })
+  @common.Get(\\"/:id\\")
+  @swagger.ApiOkResponse({ type: Profile })
+  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async findOne(
+    @common.Param() params: ProfileWhereUniqueInput
+  ): Promise<Profile | null> {
+    const result = await this.service.findOne({
+      where: params,
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        email: true,
+
+        user: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+    if (result === null) {
+      throw new errors.NotFoundException(
+        \`No resource was found for \${JSON.stringify(params)}\`
+      );
+    }
+    return result;
+  }
+
+  @common.UseInterceptors(AclValidateRequestInterceptor)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"update\\",
+    possession: \\"any\\",
+  })
+  @common.Patch(\\"/:id\\")
+  @swagger.ApiOkResponse({ type: Profile })
+  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async update(
+    @common.Param() params: ProfileWhereUniqueInput,
+    @common.Body() data: ProfileUpdateInput
+  ): Promise<Profile | null> {
+    try {
+      return await this.service.update({
+        where: params,
+        data: {
+          ...data,
+
+          user: data.user
+            ? {
+                connect: data.user,
+              }
+            : undefined,
+        },
+        select: {
+          id: true,
+          createdAt: true,
+          updatedAt: true,
+          email: true,
+
+          user: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      });
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new errors.NotFoundException(
+          \`No resource was found for \${JSON.stringify(params)}\`
+        );
+      }
+      throw error;
+    }
+  }
+
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"delete\\",
+    possession: \\"any\\",
+  })
+  @common.Delete(\\"/:id\\")
+  @swagger.ApiOkResponse({ type: Profile })
+  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async delete(
+    @common.Param() params: ProfileWhereUniqueInput
+  ): Promise<Profile | null> {
+    try {
+      return await this.service.delete({
+        where: params,
+        select: {
+          id: true,
+          createdAt: true,
+          updatedAt: true,
+          email: true,
+
+          user: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      });
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new errors.NotFoundException(
+          \`No resource was found for \${JSON.stringify(params)}\`
+        );
+      }
+      throw error;
+    }
+  }
+}
+",
+  "test/src/profile/base/profile.module.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../../auth/acl.module\\";
+import { AuthModule } from \\"../../auth/auth.module\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+
+  exports: [ACLModule, AuthModule, MorganModule, PrismaModule],
+})
+export class ProfileModuleBase {}
+",
+  "test/src/profile/base/profile.resolver.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import * as common from \\"@nestjs/common\\";
+import * as graphql from \\"@nestjs/graphql\\";
+import * as apollo from \\"apollo-server-express\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { GqlDefaultAuthGuard } from \\"../../auth/gqlDefaultAuth.guard\\";
+import * as gqlACGuard from \\"../../auth/gqlAC.guard\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
+import { MetaQueryPayload } from \\"../../util/MetaQueryPayload\\";
+import { AclFilterResponseInterceptor } from \\"../../interceptors/aclFilterResponse.interceptor\\";
+import { AclValidateRequestInterceptor } from \\"../../interceptors/aclValidateRequest.interceptor\\";
+import { CreateProfileArgs } from \\"./CreateProfileArgs\\";
+import { UpdateProfileArgs } from \\"./UpdateProfileArgs\\";
+import { DeleteProfileArgs } from \\"./DeleteProfileArgs\\";
+import { ProfileFindManyArgs } from \\"./ProfileFindManyArgs\\";
+import { ProfileFindUniqueArgs } from \\"./ProfileFindUniqueArgs\\";
+import { Profile } from \\"./Profile\\";
+import { User } from \\"../../user/base/User\\";
+import { ProfileService } from \\"../profile.service\\";
+
+@graphql.Resolver(() => Profile)
+@common.UseGuards(GqlDefaultAuthGuard, gqlACGuard.GqlACGuard)
+export class ProfileResolverBase {
+  constructor(
+    protected readonly service: ProfileService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {}
+
+  @graphql.Query(() => MetaQueryPayload)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  async _profilesMeta(
+    @graphql.Args() args: ProfileFindManyArgs
+  ): Promise<MetaQueryPayload> {
+    const results = await this.service.count({
+      ...args,
+      skip: undefined,
+      take: undefined,
+    });
+    return {
+      count: results,
+    };
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @graphql.Query(() => [Profile])
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  async profiles(
+    @graphql.Args() args: ProfileFindManyArgs
+  ): Promise<Profile[]> {
+    return this.service.findMany(args);
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @graphql.Query(() => Profile, { nullable: true })
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"own\\",
+  })
+  async profile(
+    @graphql.Args() args: ProfileFindUniqueArgs
+  ): Promise<Profile | null> {
+    const result = await this.service.findOne(args);
+    if (result === null) {
+      return null;
+    }
+    return result;
+  }
+
+  @common.UseInterceptors(AclValidateRequestInterceptor)
+  @graphql.Mutation(() => Profile)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"create\\",
+    possession: \\"any\\",
+  })
+  async createProfile(
+    @graphql.Args() args: CreateProfileArgs
+  ): Promise<Profile> {
+    return await this.service.create({
+      ...args,
+      data: {
+        ...args.data,
+
+        user: args.data.user
+          ? {
+              connect: args.data.user,
+            }
+          : undefined,
+      },
+    });
+  }
+
+  @common.UseInterceptors(AclValidateRequestInterceptor)
+  @graphql.Mutation(() => Profile)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"update\\",
+    possession: \\"any\\",
+  })
+  async updateProfile(
+    @graphql.Args() args: UpdateProfileArgs
+  ): Promise<Profile | null> {
+    try {
+      return await this.service.update({
+        ...args,
+        data: {
+          ...args.data,
+
+          user: args.data.user
+            ? {
+                connect: args.data.user,
+              }
+            : undefined,
+        },
+      });
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new apollo.ApolloError(
+          \`No resource was found for \${JSON.stringify(args.where)}\`
+        );
+      }
+      throw error;
+    }
+  }
+
+  @graphql.Mutation(() => Profile)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"delete\\",
+    possession: \\"any\\",
+  })
+  async deleteProfile(
+    @graphql.Args() args: DeleteProfileArgs
+  ): Promise<Profile | null> {
+    try {
+      return await this.service.delete(args);
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new apollo.ApolloError(
+          \`No resource was found for \${JSON.stringify(args.where)}\`
+        );
+      }
+      throw error;
+    }
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @graphql.ResolveField(() => User, { nullable: true })
+  @nestAccessControl.UseRoles({
+    resource: \\"User\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  async user(@graphql.Parent() parent: Profile): Promise<User | null> {
+    const result = await this.service.getUser(parent.id);
+
+    if (!result) {
+      return null;
+    }
+    return result;
+  }
+}
+",
+  "test/src/profile/base/profile.service.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { PrismaService } from \\"nestjs-prisma\\";
+import { Prisma, Profile, User } from \\"@prisma/client\\";
+
+export class ProfileServiceBase {
+  constructor(protected readonly prisma: PrismaService) {}
+
+  async count<T extends Prisma.ProfileFindManyArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
+  ): Promise<number> {
+    return this.prisma.profile.count(args);
+  }
+
+  async findMany<T extends Prisma.ProfileFindManyArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
+  ): Promise<Profile[]> {
+    return this.prisma.profile.findMany(args);
+  }
+  async findOne<T extends Prisma.ProfileFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
+  ): Promise<Profile | null> {
+    return this.prisma.profile.findUnique(args);
+  }
+  async create<T extends Prisma.ProfileCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileCreateArgs>
+  ): Promise<Profile> {
+    return this.prisma.profile.create<T>(args);
+  }
+  async update<T extends Prisma.ProfileUpdateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileUpdateArgs>
+  ): Promise<Profile> {
+    return this.prisma.profile.update<T>(args);
+  }
+  async delete<T extends Prisma.ProfileDeleteArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileDeleteArgs>
+  ): Promise<Profile> {
+    return this.prisma.profile.delete(args);
+  }
+
+  async getUser(parentId: string): Promise<User | null> {
+    return this.prisma.profile
+      .findUnique({
+        where: { id: parentId },
+      })
+      .user();
+  }
+}
+",
+  "test/src/profile/profile.controller.ts": "import * as common from \\"@nestjs/common\\";
+import * as swagger from \\"@nestjs/swagger\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { ProfileService } from \\"./profile.service\\";
+import { ProfileControllerBase } from \\"./base/profile.controller.base\\";
+
+@swagger.ApiTags(\\"profiles\\")
+@common.Controller(\\"profiles\\")
+export class ProfileController extends ProfileControllerBase {
+  constructor(
+    protected readonly service: ProfileService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "test/src/profile/profile.module.ts": "import { Module } from \\"@nestjs/common\\";
+import { ProfileModuleBase } from \\"./base/profile.module.base\\";
+import { ProfileService } from \\"./profile.service\\";
+import { ProfileController } from \\"./profile.controller\\";
+import { ProfileResolver } from \\"./profile.resolver\\";
+
+@Module({
+  imports: [ProfileModuleBase],
+  controllers: [ProfileController],
+  providers: [ProfileService, ProfileResolver],
+  exports: [ProfileService],
+})
+export class ProfileModule {}
+",
+  "test/src/profile/profile.resolver.ts": "import * as common from \\"@nestjs/common\\";
+import * as graphql from \\"@nestjs/graphql\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { GqlDefaultAuthGuard } from \\"../auth/gqlDefaultAuth.guard\\";
+import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
+import { ProfileResolverBase } from \\"./base/profile.resolver.base\\";
+import { Profile } from \\"./base/Profile\\";
+import { ProfileService } from \\"./profile.service\\";
+
+@graphql.Resolver(() => Profile)
+@common.UseGuards(GqlDefaultAuthGuard, gqlACGuard.GqlACGuard)
+export class ProfileResolver extends ProfileResolverBase {
+  constructor(
+    protected readonly service: ProfileService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "test/src/profile/profile.service.ts": "import { Injectable } from \\"@nestjs/common\\";
+import { PrismaService } from \\"nestjs-prisma\\";
+import { ProfileServiceBase } from \\"./base/profile.service.base\\";
+
+@Injectable()
+export class ProfileService extends ProfileServiceBase {
+  constructor(protected readonly prisma: PrismaService) {
+    super(prisma);
+  }
+}
+",
   "test/src/providers/secrets/base/secretsManager.service.base.spec.ts": "import { ConfigService } from \\"@nestjs/config\\";
 import { mock } from \\"jest-mock-extended\\";
 import { SecretsManagerServiceBase } from \\"./secretsManager.service.base\\";
@@ -10854,6 +12342,7 @@ import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { GraphQLJSONObject } from \\"graphql-type-json\\";
 import { JsonValue } from \\"type-fest\\";
+import { Profile } from \\"../../profile/base/Profile\\";
 @ObjectType()
 class User {
   @ApiProperty({
@@ -11003,6 +12492,15 @@ class User {
   @IsJSON()
   @Field(() => GraphQLJSONObject)
   extendedProperties!: JsonValue;
+
+  @ApiProperty({
+    required: false,
+    type: () => Profile,
+  })
+  @ValidateNested()
+  @Type(() => Profile)
+  @IsOptional()
+  profile?: Profile | null;
 }
 export { User };
 ",
@@ -11040,6 +12538,7 @@ import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { GraphQLJSONObject } from \\"graphql-type-json\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../../profile/base/ProfileWhereUniqueInput\\";
 @InputType()
 class UserCreateInput {
   @ApiProperty({
@@ -11196,6 +12695,18 @@ class UserCreateInput {
   @IsJSON()
   @Field(() => GraphQLJSONObject)
   extendedProperties!: InputJsonValue;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereUniqueInput)
+  @IsOptional()
+  @Field(() => ProfileWhereUniqueInput, {
+    nullable: true,
+  })
+  profile?: ProfileWhereUniqueInput | null;
 }
 export { UserCreateInput };
 ",
@@ -11522,6 +13033,15 @@ class UserOrderByInput {
     nullable: true,
   })
   extendedProperties?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  profileId?: SortOrder;
 }
 
 export { UserOrderByInput };
@@ -11560,6 +13080,7 @@ import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { GraphQLJSONObject } from \\"graphql-type-json\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../../profile/base/ProfileWhereUniqueInput\\";
 @InputType()
 class UserUpdateInput {
   @ApiProperty({
@@ -11755,6 +13276,18 @@ class UserUpdateInput {
     nullable: true,
   })
   extendedProperties?: InputJsonValue;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereUniqueInput)
+  @IsOptional()
+  @Field(() => ProfileWhereUniqueInput, {
+    nullable: true,
+  })
+  profile?: ProfileWhereUniqueInput | null;
 }
 export { UserUpdateInput };
 ",
@@ -11826,6 +13359,7 @@ import { OrganizationListRelationFilter } from \\"../../organization/base/Organi
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { BooleanFilter } from \\"../../util/BooleanFilter\\";
 import { JsonFilter } from \\"../../util/JsonFilter\\";
+import { ProfileWhereUniqueInput } from \\"../../profile/base/ProfileWhereUniqueInput\\";
 @InputType()
 class UserWhereInput {
   @ApiProperty({
@@ -11950,6 +13484,18 @@ class UserWhereInput {
     nullable: true,
   })
   extendedProperties?: JsonFilter;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereUniqueInput)
+  @IsOptional()
+  @Field(() => ProfileWhereUniqueInput, {
+    nullable: true,
+  })
+  profile?: ProfileWhereUniqueInput;
 }
 export { UserWhereInput };
 ",
@@ -12214,6 +13760,12 @@ export class UserControllerBase {
               connect: data.manager,
             }
           : undefined,
+
+        profile: data.profile
+          ? {
+              connect: data.profile,
+            }
+          : undefined,
       },
       select: {
         username: true,
@@ -12237,6 +13789,12 @@ export class UserControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
   }
@@ -12277,6 +13835,12 @@ export class UserControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
   }
@@ -12318,6 +13882,12 @@ export class UserControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
     if (result === null) {
@@ -12353,6 +13923,12 @@ export class UserControllerBase {
                 connect: data.manager,
               }
             : undefined,
+
+          profile: data.profile
+            ? {
+                connect: data.profile,
+              }
+            : undefined,
         },
         select: {
           username: true,
@@ -12376,6 +13952,12 @@ export class UserControllerBase {
           isCurious: true,
           location: true,
           extendedProperties: true,
+
+          profile: {
+            select: {
+              id: true,
+            },
+          },
         },
       });
     } catch (error) {
@@ -12425,6 +14007,12 @@ export class UserControllerBase {
           isCurious: true,
           location: true,
           extendedProperties: true,
+
+          profile: {
+            select: {
+              id: true,
+            },
+          },
         },
       });
     } catch (error) {
@@ -12474,6 +14062,12 @@ export class UserControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
     if (results === null) {
@@ -12705,6 +14299,7 @@ import { UserFindUniqueArgs } from \\"./UserFindUniqueArgs\\";
 import { User } from \\"./User\\";
 import { OrganizationFindManyArgs } from \\"../../organization/base/OrganizationFindManyArgs\\";
 import { Organization } from \\"../../organization/base/Organization\\";
+import { Profile } from \\"../../profile/base/Profile\\";
 import { UserService } from \\"../user.service\\";
 
 @graphql.Resolver(() => User)
@@ -12778,6 +14373,12 @@ export class UserResolverBase {
               connect: args.data.manager,
             }
           : undefined,
+
+        profile: args.data.profile
+          ? {
+              connect: args.data.profile,
+            }
+          : undefined,
       },
     });
   }
@@ -12799,6 +14400,12 @@ export class UserResolverBase {
           manager: args.data.manager
             ? {
                 connect: args.data.manager,
+              }
+            : undefined,
+
+          profile: args.data.profile
+            ? {
+                connect: args.data.profile,
               }
             : undefined,
         },
@@ -12887,6 +14494,22 @@ export class UserResolverBase {
     }
     return result;
   }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @graphql.ResolveField(() => Profile, { nullable: true })
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  async profile(@graphql.Parent() parent: User): Promise<Profile | null> {
+    const result = await this.service.getProfile(parent.id);
+
+    if (!result) {
+      return null;
+    }
+    return result;
+  }
 }
 ",
   "test/src/user/base/user.service.base.ts": "/*
@@ -12901,7 +14524,7 @@ https://docs.amplication.com/docs/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from \\"nestjs-prisma\\";
-import { Prisma, User, Organization } from \\"@prisma/client\\";
+import { Prisma, User, Organization, Profile } from \\"@prisma/client\\";
 import { PasswordService } from \\"../../auth/password.service\\";
 import { transformStringFieldUpdateInput } from \\"../../prisma.util\\";
 
@@ -12991,6 +14614,14 @@ export class UserServiceBase {
         where: { id: parentId },
       })
       .manager();
+  }
+
+  async getProfile(parentId: string): Promise<Profile | null> {
+    return this.prisma.user
+      .findUnique({
+        where: { id: parentId },
+      })
+      .profile();
   }
 }
 ",

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -15,6 +15,10 @@ import { UserList } from \\"./user/UserList\\";
 import { UserCreate } from \\"./user/UserCreate\\";
 import { UserEdit } from \\"./user/UserEdit\\";
 import { UserShow } from \\"./user/UserShow\\";
+import { ProfileList } from \\"./profile/ProfileList\\";
+import { ProfileCreate } from \\"./profile/ProfileCreate\\";
+import { ProfileEdit } from \\"./profile/ProfileEdit\\";
+import { ProfileShow } from \\"./profile/ProfileShow\\";
 import { OrderList } from \\"./order/OrderList\\";
 import { OrderCreate } from \\"./order/OrderCreate\\";
 import { OrderEdit } from \\"./order/OrderEdit\\";
@@ -63,6 +67,13 @@ const App = (): React.ReactElement => {
           edit={UserEdit}
           create={UserCreate}
           show={UserShow}
+        />
+        <Resource
+          name=\\"Profile\\"
+          list={ProfileList}
+          edit={ProfileEdit}
+          create={ProfileCreate}
+          show={ProfileShow}
         />
         <Resource
           name=\\"Order\\"
@@ -719,6 +730,100 @@ export type UserUpdateManyWithoutOrganizationsInput = {
   set?: Array<UserWhereUniqueInput>;
 };
 ",
+  "admin-ui/src/api/profile/CreateProfileArgs.ts": "import { ProfileCreateInput } from \\"./ProfileCreateInput\\";
+
+export type CreateProfileArgs = {
+  data: ProfileCreateInput;
+};
+",
+  "admin-ui/src/api/profile/DeleteProfileArgs.ts": "import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+export type DeleteProfileArgs = {
+  where: ProfileWhereUniqueInput;
+};
+",
+  "admin-ui/src/api/profile/Profile.ts": "import { User } from \\"../user/User\\";
+
+export type Profile = {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  email: string;
+  user?: User | null;
+};
+",
+  "admin-ui/src/api/profile/ProfileCreateInput.ts": "import { UserWhereUniqueInput } from \\"../user/UserWhereUniqueInput\\";
+
+export type ProfileCreateInput = {
+  email: string;
+  user?: UserWhereUniqueInput | null;
+};
+",
+  "admin-ui/src/api/profile/ProfileFindManyArgs.ts": "import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { ProfileOrderByInput } from \\"./ProfileOrderByInput\\";
+
+export type ProfileFindManyArgs = {
+  where?: ProfileWhereInput;
+  orderBy?: Array<ProfileOrderByInput>;
+  skip?: number;
+  take?: number;
+};
+",
+  "admin-ui/src/api/profile/ProfileFindUniqueArgs.ts": "import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+export type ProfileFindUniqueArgs = {
+  where: ProfileWhereUniqueInput;
+};
+",
+  "admin-ui/src/api/profile/ProfileListRelationFilter.ts": "import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+
+export type ProfileListRelationFilter = {
+  every?: ProfileWhereInput;
+  some?: ProfileWhereInput;
+  none?: ProfileWhereInput;
+};
+",
+  "admin-ui/src/api/profile/ProfileOrderByInput.ts": "import { SortOrder } from \\"../../util/SortOrder\\";
+
+export type ProfileOrderByInput = {
+  id?: SortOrder;
+  createdAt?: SortOrder;
+  updatedAt?: SortOrder;
+  email?: SortOrder;
+  userId?: SortOrder;
+};
+",
+  "admin-ui/src/api/profile/ProfileUpdateInput.ts": "import { UserWhereUniqueInput } from \\"../user/UserWhereUniqueInput\\";
+
+export type ProfileUpdateInput = {
+  email?: string;
+  user?: UserWhereUniqueInput | null;
+};
+",
+  "admin-ui/src/api/profile/ProfileWhereInput.ts": "import { StringFilter } from \\"../../util/StringFilter\\";
+import { DateTimeFilter } from \\"../../util/DateTimeFilter\\";
+import { UserWhereUniqueInput } from \\"../user/UserWhereUniqueInput\\";
+
+export type ProfileWhereInput = {
+  id?: StringFilter;
+  createdAt?: DateTimeFilter;
+  updatedAt?: DateTimeFilter;
+  email?: StringFilter;
+  user?: UserWhereUniqueInput;
+};
+",
+  "admin-ui/src/api/profile/ProfileWhereUniqueInput.ts": "export type ProfileWhereUniqueInput = {
+  id: string;
+};
+",
+  "admin-ui/src/api/profile/UpdateProfileArgs.ts": "import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+import { ProfileUpdateInput } from \\"./ProfileUpdateInput\\";
+
+export type UpdateProfileArgs = {
+  where: ProfileWhereUniqueInput;
+  data: ProfileUpdateInput;
+};
+",
   "admin-ui/src/api/user/CreateUserArgs.ts": "import { UserCreateInput } from \\"./UserCreateInput\\";
 
 export type CreateUserArgs = {
@@ -766,6 +871,7 @@ export type UpdateUserArgs = {
 ",
   "admin-ui/src/api/user/User.ts": "import { Organization } from \\"../organization/Organization\\";
 import { JsonValue } from \\"type-fest\\";
+import { Profile } from \\"../profile/Profile\\";
 
 export type User = {
   username: string;
@@ -785,12 +891,14 @@ export type User = {
   isCurious: boolean;
   location: string;
   extendedProperties: JsonValue;
+  profile?: Profile | null;
 };
 ",
   "admin-ui/src/api/user/UserCreateInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { UserCreateNestedManyWithoutUsersInput } from \\"./UserCreateNestedManyWithoutUsersInput\\";
 import { OrganizationCreateNestedManyWithoutUsersInput } from \\"./OrganizationCreateNestedManyWithoutUsersInput\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../profile/ProfileWhereUniqueInput\\";
 
 export type UserCreateInput = {
   username: string;
@@ -810,6 +918,7 @@ export type UserCreateInput = {
   isCurious: boolean;
   location: string;
   extendedProperties: InputJsonValue;
+  profile?: ProfileWhereUniqueInput | null;
 };
 ",
   "admin-ui/src/api/user/UserCreateNestedManyWithoutUsersInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
@@ -861,12 +970,14 @@ export type UserOrderByInput = {
   isCurious?: SortOrder;
   location?: SortOrder;
   extendedProperties?: SortOrder;
+  profileId?: SortOrder;
 };
 ",
   "admin-ui/src/api/user/UserUpdateInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { UserUpdateManyWithoutUsersInput } from \\"./UserUpdateManyWithoutUsersInput\\";
 import { OrganizationUpdateManyWithoutUsersInput } from \\"./OrganizationUpdateManyWithoutUsersInput\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../profile/ProfileWhereUniqueInput\\";
 
 export type UserUpdateInput = {
   username?: string;
@@ -886,6 +997,7 @@ export type UserUpdateInput = {
   isCurious?: boolean;
   location?: string;
   extendedProperties?: InputJsonValue;
+  profile?: ProfileWhereUniqueInput | null;
 };
 ",
   "admin-ui/src/api/user/UserUpdateManyWithoutUsersInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
@@ -903,6 +1015,7 @@ import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { OrganizationListRelationFilter } from \\"../organization/OrganizationListRelationFilter\\";
 import { BooleanFilter } from \\"../../util/BooleanFilter\\";
 import { JsonFilter } from \\"../../util/JsonFilter\\";
+import { ProfileWhereUniqueInput } from \\"../profile/ProfileWhereUniqueInput\\";
 
 export type UserWhereInput = {
   id?: StringFilter;
@@ -916,6 +1029,7 @@ export type UserWhereInput = {
   isCurious?: BooleanFilter;
   location?: StringFilter;
   extendedProperties?: JsonFilter;
+  profile?: ProfileWhereUniqueInput;
 };
 ",
   "admin-ui/src/api/user/UserWhereUniqueInput.ts": "export type UserWhereUniqueInput = {
@@ -2012,6 +2126,123 @@ const Dashboard = () => (
 
 export default Dashboard;
 ",
+  "admin-ui/src/profile/ProfileCreate.tsx": "import * as React from \\"react\\";
+import {
+  Create,
+  SimpleForm,
+  CreateProps,
+  TextInput,
+  ReferenceInput,
+  SelectInput,
+} from \\"react-admin\\";
+import { UserTitle } from \\"../user/UserTitle\\";
+
+export const ProfileCreate = (props: CreateProps): React.ReactElement => {
+  return (
+    <Create {...props}>
+      <SimpleForm>
+        <TextInput label=\\"Email\\" source=\\"email\\" type=\\"email\\" />
+        <ReferenceInput source=\\"user.id\\" reference=\\"User\\" label=\\"User\\">
+          <SelectInput optionText={UserTitle} />
+        </ReferenceInput>
+      </SimpleForm>
+    </Create>
+  );
+};
+",
+  "admin-ui/src/profile/ProfileEdit.tsx": "import * as React from \\"react\\";
+import {
+  Edit,
+  SimpleForm,
+  EditProps,
+  TextInput,
+  ReferenceInput,
+  SelectInput,
+} from \\"react-admin\\";
+import { UserTitle } from \\"../user/UserTitle\\";
+
+export const ProfileEdit = (props: EditProps): React.ReactElement => {
+  return (
+    <Edit {...props}>
+      <SimpleForm>
+        <TextInput label=\\"Email\\" source=\\"email\\" type=\\"email\\" />
+        <ReferenceInput source=\\"user.id\\" reference=\\"User\\" label=\\"User\\">
+          <SelectInput optionText={UserTitle} />
+        </ReferenceInput>
+      </SimpleForm>
+    </Edit>
+  );
+};
+",
+  "admin-ui/src/profile/ProfileList.tsx": "import * as React from \\"react\\";
+import {
+  List,
+  Datagrid,
+  ListProps,
+  TextField,
+  DateField,
+  ReferenceField,
+} from \\"react-admin\\";
+import Pagination from \\"../Components/Pagination\\";
+import { USER_TITLE_FIELD } from \\"../user/UserTitle\\";
+
+export const ProfileList = (props: ListProps): React.ReactElement => {
+  return (
+    <List
+      {...props}
+      bulkActionButtons={false}
+      title={\\"Profiles\\"}
+      perPage={50}
+      pagination={<Pagination />}
+    >
+      <Datagrid rowClick=\\"show\\">
+        <TextField label=\\"Id\\" source=\\"id\\" />
+        <DateField source=\\"createdAt\\" label=\\"Created At\\" />
+        <DateField source=\\"updatedAt\\" label=\\"Updated At\\" />
+        <TextField label=\\"Email\\" source=\\"email\\" />
+        <ReferenceField label=\\"User\\" source=\\"user.id\\" reference=\\"User\\">
+          <TextField source={USER_TITLE_FIELD} />
+        </ReferenceField>
+      </Datagrid>
+    </List>
+  );
+};
+",
+  "admin-ui/src/profile/ProfileShow.tsx": "import * as React from \\"react\\";
+import {
+  Show,
+  SimpleShowLayout,
+  ShowProps,
+  TextField,
+  DateField,
+  ReferenceField,
+} from \\"react-admin\\";
+import { USER_TITLE_FIELD } from \\"../user/UserTitle\\";
+
+export const ProfileShow = (props: ShowProps): React.ReactElement => {
+  return (
+    <Show {...props}>
+      <SimpleShowLayout>
+        <TextField label=\\"Id\\" source=\\"id\\" />
+        <DateField source=\\"createdAt\\" label=\\"Created At\\" />
+        <DateField source=\\"updatedAt\\" label=\\"Updated At\\" />
+        <TextField label=\\"Email\\" source=\\"email\\" />
+        <ReferenceField label=\\"User\\" source=\\"user.id\\" reference=\\"User\\">
+          <TextField source={USER_TITLE_FIELD} />
+        </ReferenceField>
+      </SimpleShowLayout>
+    </Show>
+  );
+};
+",
+  "admin-ui/src/profile/ProfileTitle.ts": "import { Profile as TProfile } from \\"../api/profile/Profile\\";
+
+export const PROFILE_TITLE_FIELD = \\"id\\";
+
+export const ProfileTitle = (record: TProfile): string => {
+  return record.id || record.id;
+};
+",
   "admin-ui/src/reportWebVitals.ts": "import { ReportHandler } from \\"web-vitals\\";
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
@@ -2120,6 +2351,7 @@ import {
 
 import { UserTitle } from \\"./UserTitle\\";
 import { OrganizationTitle } from \\"../organization/OrganizationTitle\\";
+import { ProfileTitle } from \\"../profile/ProfileTitle\\";
 import { ROLES_OPTIONS } from \\"../user/RolesOptions\\";
 
 export const UserCreate = (props: CreateProps): React.ReactElement => {
@@ -2183,6 +2415,9 @@ export const UserCreate = (props: CreateProps): React.ReactElement => {
         <BooleanInput label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextInput label=\\"Location\\" source=\\"location\\" />
         <div />
+        <ReferenceInput source=\\"profile.id\\" reference=\\"Profile\\" label=\\"Profile\\">
+          <SelectInput optionText={ProfileTitle} />
+        </ReferenceInput>
       </SimpleForm>
     </Create>
   );
@@ -2207,6 +2442,7 @@ import {
 
 import { UserTitle } from \\"./UserTitle\\";
 import { OrganizationTitle } from \\"../organization/OrganizationTitle\\";
+import { ProfileTitle } from \\"../profile/ProfileTitle\\";
 import { ROLES_OPTIONS } from \\"../user/RolesOptions\\";
 
 export const UserEdit = (props: EditProps): React.ReactElement => {
@@ -2270,6 +2506,9 @@ export const UserEdit = (props: EditProps): React.ReactElement => {
         <BooleanInput label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextInput label=\\"Location\\" source=\\"location\\" />
         <div />
+        <ReferenceInput source=\\"profile.id\\" reference=\\"Profile\\" label=\\"Profile\\">
+          <SelectInput optionText={ProfileTitle} />
+        </ReferenceInput>
       </SimpleForm>
     </Edit>
   );
@@ -2286,6 +2525,7 @@ import {
 } from \\"react-admin\\";
 import Pagination from \\"../Components/Pagination\\";
 import { USER_TITLE_FIELD } from \\"./UserTitle\\";
+import { PROFILE_TITLE_FIELD } from \\"../profile/ProfileTitle\\";
 
 export const UserList = (props: ListProps): React.ReactElement => {
   return (
@@ -2314,6 +2554,9 @@ export const UserList = (props: ListProps): React.ReactElement => {
         <BooleanField label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextField label=\\"Location\\" source=\\"location\\" />
         <TextField label=\\"Extended Properties\\" source=\\"extendedProperties\\" />
+        <ReferenceField label=\\"Profile\\" source=\\"profile.id\\" reference=\\"Profile\\">
+          <TextField source={PROFILE_TITLE_FIELD} />
+        </ReferenceField>
       </Datagrid>
     </List>
   );
@@ -2329,6 +2572,7 @@ import {
   BooleanField,
 } from \\"react-admin\\";
 import { USER_TITLE_FIELD } from \\"./UserTitle\\";
+import { PROFILE_TITLE_FIELD } from \\"../profile/ProfileTitle\\";
 
 export const UserShow = (props: ShowProps): React.ReactElement => {
   return (
@@ -2351,6 +2595,9 @@ export const UserShow = (props: ShowProps): React.ReactElement => {
         <BooleanField label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextField label=\\"Location\\" source=\\"location\\" />
         <TextField label=\\"Extended Properties\\" source=\\"extendedProperties\\" />
+        <ReferenceField label=\\"Profile\\" source=\\"profile.id\\" reference=\\"Profile\\">
+          <TextField source={PROFILE_TITLE_FIELD} />
+        </ReferenceField>
       </SimpleShowLayout>
     </Show>
   );
@@ -2620,6 +2867,16 @@ model User {
   isCurious          Boolean
   location           String
   extendedProperties Json
+  profile            Profile?            @relation(fields: [profileId], references: [id])
+  profileId          String?             @unique
+}
+
+model Profile {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  email     String
+  user      User?
 }
 
 model Order {
@@ -2841,6 +3098,7 @@ async function seed(bcryptSalt: Salt) {
 import { APP_INTERCEPTOR } from \\"@nestjs/core\\";
 import { MorganInterceptor, MorganModule } from \\"nest-morgan\\";
 import { UserModule } from \\"./user/user.module\\";
+import { ProfileModule } from \\"./profile/profile.module\\";
 import { OrderModule } from \\"./order/order.module\\";
 import { OrganizationModule } from \\"./organization/organization.module\\";
 import { CustomerModule } from \\"./customer/customer.module\\";
@@ -2858,6 +3116,7 @@ import { GraphQLModule } from \\"@nestjs/graphql\\";
   controllers: [],
   imports: [
     UserModule,
+    ProfileModule,
     OrderModule,
     OrganizationModule,
     CustomerModule,
@@ -9036,6 +9295,12 @@ export class OrganizationControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
     if (results === null) {
@@ -9558,6 +9823,1025 @@ export async function transformStringFieldUpdateInput<
   return input;
 }
 ",
+  "server/src/profile/base/CreateProfileArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileCreateInput } from \\"./ProfileCreateInput\\";
+
+@ArgsType()
+class CreateProfileArgs {
+  @Field(() => ProfileCreateInput, { nullable: false })
+  data!: ProfileCreateInput;
+}
+
+export { CreateProfileArgs };
+",
+  "server/src/profile/base/DeleteProfileArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+@ArgsType()
+class DeleteProfileArgs {
+  @Field(() => ProfileWhereUniqueInput, { nullable: false })
+  where!: ProfileWhereUniqueInput;
+}
+
+export { DeleteProfileArgs };
+",
+  "server/src/profile/base/Profile.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ObjectType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString, IsDate, ValidateNested, IsOptional } from \\"class-validator\\";
+import { Type } from \\"class-transformer\\";
+import { User } from \\"../../user/base/User\\";
+@ObjectType()
+class Profile {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  id!: string;
+
+  @ApiProperty({
+    required: true,
+  })
+  @IsDate()
+  @Type(() => Date)
+  @Field(() => Date)
+  createdAt!: Date;
+
+  @ApiProperty({
+    required: true,
+  })
+  @IsDate()
+  @Type(() => Date)
+  @Field(() => Date)
+  updatedAt!: Date;
+
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  email!: string;
+
+  @ApiProperty({
+    required: false,
+    type: () => User,
+  })
+  @ValidateNested()
+  @Type(() => User)
+  @IsOptional()
+  user?: User | null;
+}
+export { Profile };
+",
+  "server/src/profile/base/ProfileCreateInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString, ValidateNested, IsOptional } from \\"class-validator\\";
+import { UserWhereUniqueInput } from \\"../../user/base/UserWhereUniqueInput\\";
+import { Type } from \\"class-transformer\\";
+@InputType()
+class ProfileCreateInput {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  email!: string;
+
+  @ApiProperty({
+    required: false,
+    type: () => UserWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => UserWhereUniqueInput)
+  @IsOptional()
+  @Field(() => UserWhereUniqueInput, {
+    nullable: true,
+  })
+  user?: UserWhereUniqueInput | null;
+}
+export { ProfileCreateInput };
+",
+  "server/src/profile/base/ProfileFindManyArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { Type } from \\"class-transformer\\";
+import { ProfileOrderByInput } from \\"./ProfileOrderByInput\\";
+
+@ArgsType()
+class ProfileFindManyArgs {
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @Field(() => ProfileWhereInput, { nullable: true })
+  @Type(() => ProfileWhereInput)
+  where?: ProfileWhereInput;
+
+  @ApiProperty({
+    required: false,
+    type: [ProfileOrderByInput],
+  })
+  @Field(() => [ProfileOrderByInput], { nullable: true })
+  @Type(() => ProfileOrderByInput)
+  orderBy?: Array<ProfileOrderByInput>;
+
+  @ApiProperty({
+    required: false,
+    type: Number,
+  })
+  @Field(() => Number, { nullable: true })
+  @Type(() => Number)
+  skip?: number;
+
+  @ApiProperty({
+    required: false,
+    type: Number,
+  })
+  @Field(() => Number, { nullable: true })
+  @Type(() => Number)
+  take?: number;
+}
+
+export { ProfileFindManyArgs };
+",
+  "server/src/profile/base/ProfileFindUniqueArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+@ArgsType()
+class ProfileFindUniqueArgs {
+  @Field(() => ProfileWhereUniqueInput, { nullable: false })
+  where!: ProfileWhereUniqueInput;
+}
+
+export { ProfileFindUniqueArgs };
+",
+  "server/src/profile/base/ProfileListRelationFilter.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { ValidateNested, IsOptional } from \\"class-validator\\";
+import { Type } from \\"class-transformer\\";
+
+@InputType()
+class ProfileListRelationFilter {
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereInput)
+  @IsOptional()
+  @Field(() => ProfileWhereInput, {
+    nullable: true,
+  })
+  every?: ProfileWhereInput;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereInput)
+  @IsOptional()
+  @Field(() => ProfileWhereInput, {
+    nullable: true,
+  })
+  some?: ProfileWhereInput;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereInput)
+  @IsOptional()
+  @Field(() => ProfileWhereInput, {
+    nullable: true,
+  })
+  none?: ProfileWhereInput;
+}
+export { ProfileListRelationFilter };
+",
+  "server/src/profile/base/ProfileOrderByInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { SortOrder } from \\"../../util/SortOrder\\";
+
+@InputType({
+  isAbstract: true,
+  description: undefined,
+})
+class ProfileOrderByInput {
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  id?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  createdAt?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  updatedAt?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  email?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  userId?: SortOrder;
+}
+
+export { ProfileOrderByInput };
+",
+  "server/src/profile/base/ProfileUpdateInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString, IsOptional, ValidateNested } from \\"class-validator\\";
+import { UserWhereUniqueInput } from \\"../../user/base/UserWhereUniqueInput\\";
+import { Type } from \\"class-transformer\\";
+@InputType()
+class ProfileUpdateInput {
+  @ApiProperty({
+    required: false,
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  @Field(() => String, {
+    nullable: true,
+  })
+  email?: string;
+
+  @ApiProperty({
+    required: false,
+    type: () => UserWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => UserWhereUniqueInput)
+  @IsOptional()
+  @Field(() => UserWhereUniqueInput, {
+    nullable: true,
+  })
+  user?: UserWhereUniqueInput | null;
+}
+export { ProfileUpdateInput };
+",
+  "server/src/profile/base/ProfileWhereInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { StringFilter } from \\"../../util/StringFilter\\";
+import { Type } from \\"class-transformer\\";
+import { IsOptional, ValidateNested } from \\"class-validator\\";
+import { DateTimeFilter } from \\"../../util/DateTimeFilter\\";
+import { UserWhereUniqueInput } from \\"../../user/base/UserWhereUniqueInput\\";
+@InputType()
+class ProfileWhereInput {
+  @ApiProperty({
+    required: false,
+    type: StringFilter,
+  })
+  @Type(() => StringFilter)
+  @IsOptional()
+  @Field(() => StringFilter, {
+    nullable: true,
+  })
+  id?: StringFilter;
+
+  @ApiProperty({
+    required: false,
+    type: DateTimeFilter,
+  })
+  @Type(() => DateTimeFilter)
+  @IsOptional()
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+  })
+  createdAt?: DateTimeFilter;
+
+  @ApiProperty({
+    required: false,
+    type: DateTimeFilter,
+  })
+  @Type(() => DateTimeFilter)
+  @IsOptional()
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+  })
+  updatedAt?: DateTimeFilter;
+
+  @ApiProperty({
+    required: false,
+    type: StringFilter,
+  })
+  @Type(() => StringFilter)
+  @IsOptional()
+  @Field(() => StringFilter, {
+    nullable: true,
+  })
+  email?: StringFilter;
+
+  @ApiProperty({
+    required: false,
+    type: () => UserWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => UserWhereUniqueInput)
+  @IsOptional()
+  @Field(() => UserWhereUniqueInput, {
+    nullable: true,
+  })
+  user?: UserWhereUniqueInput;
+}
+export { ProfileWhereInput };
+",
+  "server/src/profile/base/ProfileWhereUniqueInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString } from \\"class-validator\\";
+@InputType()
+class ProfileWhereUniqueInput {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  id!: string;
+}
+export { ProfileWhereUniqueInput };
+",
+  "server/src/profile/base/UpdateProfileArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+import { ProfileUpdateInput } from \\"./ProfileUpdateInput\\";
+
+@ArgsType()
+class UpdateProfileArgs {
+  @Field(() => ProfileWhereUniqueInput, { nullable: false })
+  where!: ProfileWhereUniqueInput;
+  @Field(() => ProfileUpdateInput, { nullable: false })
+  data!: ProfileUpdateInput;
+}
+
+export { UpdateProfileArgs };
+",
+  "server/src/profile/base/profile.controller.base.spec.ts": "import { Test } from \\"@nestjs/testing\\";
+import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
+import request from \\"supertest\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { ACGuard } from \\"nest-access-control\\";
+import { DefaultAuthGuard } from \\"../../auth/defaultAuth.guard\\";
+import { ACLModule } from \\"../../auth/acl.module\\";
+import { ProfileController } from \\"../profile.controller\\";
+import { ProfileService } from \\"../profile.service\\";
+
+const nonExistingId = \\"nonExistingId\\";
+const existingId = \\"existingId\\";
+const CREATE_INPUT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  email: \\"exampleEmail\\",
+};
+const CREATE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  email: \\"exampleEmail\\",
+};
+const FIND_MANY_RESULT = [
+  {
+    id: \\"exampleId\\",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    email: \\"exampleEmail\\",
+  },
+];
+const FIND_ONE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  email: \\"exampleEmail\\",
+};
+
+const service = {
+  create() {
+    return CREATE_RESULT;
+  },
+  findMany: () => FIND_MANY_RESULT,
+  findOne: ({ where }: { where: { id: string } }) => {
+    switch (where.id) {
+      case existingId:
+        return FIND_ONE_RESULT;
+      case nonExistingId:
+        return null;
+    }
+  },
+};
+
+const basicAuthGuard = {
+  canActivate: (context: ExecutionContext) => {
+    const argumentHost = context.switchToHttp();
+    const request = argumentHost.getRequest();
+    request.user = {
+      roles: [\\"user\\"],
+    };
+    return true;
+  },
+};
+
+const acGuard = {
+  canActivate: () => {
+    return true;
+  },
+};
+
+describe(\\"Profile\\", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: ProfileService,
+          useValue: service,
+        },
+      ],
+      controllers: [ProfileController],
+      imports: [MorganModule.forRoot(), ACLModule],
+    })
+      .overrideGuard(DefaultAuthGuard)
+      .useValue(basicAuthGuard)
+      .overrideGuard(ACGuard)
+      .useValue(acGuard)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  test(\\"POST /profiles\\", async () => {
+    await request(app.getHttpServer())
+      .post(\\"/profiles\\")
+      .send(CREATE_INPUT)
+      .expect(HttpStatus.CREATED)
+      .expect({
+        ...CREATE_RESULT,
+        createdAt: CREATE_RESULT.createdAt.toISOString(),
+        updatedAt: CREATE_RESULT.updatedAt.toISOString(),
+      });
+  });
+
+  test(\\"GET /profiles\\", async () => {
+    await request(app.getHttpServer())
+      .get(\\"/profiles\\")
+      .expect(HttpStatus.OK)
+      .expect([
+        {
+          ...FIND_MANY_RESULT[0],
+          createdAt: FIND_MANY_RESULT[0].createdAt.toISOString(),
+          updatedAt: FIND_MANY_RESULT[0].updatedAt.toISOString(),
+        },
+      ]);
+  });
+
+  test(\\"GET /profiles/:id non existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/profiles\\"}/\${nonExistingId}\`)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        statusCode: HttpStatus.NOT_FOUND,
+        message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
+        error: \\"Not Found\\",
+      });
+  });
+
+  test(\\"GET /profiles/:id existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/profiles\\"}/\${existingId}\`)
+      .expect(HttpStatus.OK)
+      .expect({
+        ...FIND_ONE_RESULT,
+        createdAt: FIND_ONE_RESULT.createdAt.toISOString(),
+        updatedAt: FIND_ONE_RESULT.updatedAt.toISOString(),
+      });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});
+",
+  "server/src/profile/base/profile.controller.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import * as common from \\"@nestjs/common\\";
+import * as swagger from \\"@nestjs/swagger\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import * as defaultAuthGuard from \\"../../auth/defaultAuth.guard\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
+import * as errors from \\"../../errors\\";
+import { Request } from \\"express\\";
+import { plainToClass } from \\"class-transformer\\";
+import { ApiNestedQuery } from \\"../../decorators/api-nested-query.decorator\\";
+import { ProfileService } from \\"../profile.service\\";
+import { AclValidateRequestInterceptor } from \\"../../interceptors/aclValidateRequest.interceptor\\";
+import { AclFilterResponseInterceptor } from \\"../../interceptors/aclFilterResponse.interceptor\\";
+import { ProfileCreateInput } from \\"./ProfileCreateInput\\";
+import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+import { ProfileFindManyArgs } from \\"./ProfileFindManyArgs\\";
+import { ProfileUpdateInput } from \\"./ProfileUpdateInput\\";
+import { Profile } from \\"./Profile\\";
+@swagger.ApiBasicAuth()
+@common.UseGuards(defaultAuthGuard.DefaultAuthGuard, nestAccessControl.ACGuard)
+export class ProfileControllerBase {
+  constructor(
+    protected readonly service: ProfileService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {}
+
+  @common.UseInterceptors(AclValidateRequestInterceptor)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"create\\",
+    possession: \\"any\\",
+  })
+  @common.Post()
+  @swagger.ApiCreatedResponse({ type: Profile })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async create(@common.Body() data: ProfileCreateInput): Promise<Profile> {
+    return await this.service.create({
+      data: {
+        ...data,
+
+        user: data.user
+          ? {
+              connect: data.user,
+            }
+          : undefined,
+      },
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        email: true,
+
+        user: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  @common.Get()
+  @swagger.ApiOkResponse({ type: [Profile] })
+  @swagger.ApiForbiddenResponse()
+  @ApiNestedQuery(ProfileFindManyArgs)
+  async findMany(@common.Req() request: Request): Promise<Profile[]> {
+    const args = plainToClass(ProfileFindManyArgs, request.query);
+    return this.service.findMany({
+      ...args,
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        email: true,
+
+        user: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"own\\",
+  })
+  @common.Get(\\"/:id\\")
+  @swagger.ApiOkResponse({ type: Profile })
+  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async findOne(
+    @common.Param() params: ProfileWhereUniqueInput
+  ): Promise<Profile | null> {
+    const result = await this.service.findOne({
+      where: params,
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        email: true,
+
+        user: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+    if (result === null) {
+      throw new errors.NotFoundException(
+        \`No resource was found for \${JSON.stringify(params)}\`
+      );
+    }
+    return result;
+  }
+
+  @common.UseInterceptors(AclValidateRequestInterceptor)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"update\\",
+    possession: \\"any\\",
+  })
+  @common.Patch(\\"/:id\\")
+  @swagger.ApiOkResponse({ type: Profile })
+  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async update(
+    @common.Param() params: ProfileWhereUniqueInput,
+    @common.Body() data: ProfileUpdateInput
+  ): Promise<Profile | null> {
+    try {
+      return await this.service.update({
+        where: params,
+        data: {
+          ...data,
+
+          user: data.user
+            ? {
+                connect: data.user,
+              }
+            : undefined,
+        },
+        select: {
+          id: true,
+          createdAt: true,
+          updatedAt: true,
+          email: true,
+
+          user: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      });
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new errors.NotFoundException(
+          \`No resource was found for \${JSON.stringify(params)}\`
+        );
+      }
+      throw error;
+    }
+  }
+
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"delete\\",
+    possession: \\"any\\",
+  })
+  @common.Delete(\\"/:id\\")
+  @swagger.ApiOkResponse({ type: Profile })
+  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async delete(
+    @common.Param() params: ProfileWhereUniqueInput
+  ): Promise<Profile | null> {
+    try {
+      return await this.service.delete({
+        where: params,
+        select: {
+          id: true,
+          createdAt: true,
+          updatedAt: true,
+          email: true,
+
+          user: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      });
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new errors.NotFoundException(
+          \`No resource was found for \${JSON.stringify(params)}\`
+        );
+      }
+      throw error;
+    }
+  }
+}
+",
+  "server/src/profile/base/profile.module.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../../auth/acl.module\\";
+import { AuthModule } from \\"../../auth/auth.module\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+
+  exports: [ACLModule, AuthModule, MorganModule, PrismaModule],
+})
+export class ProfileModuleBase {}
+",
+  "server/src/profile/base/profile.service.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { PrismaService } from \\"nestjs-prisma\\";
+import { Prisma, Profile, User } from \\"@prisma/client\\";
+
+export class ProfileServiceBase {
+  constructor(protected readonly prisma: PrismaService) {}
+
+  async count<T extends Prisma.ProfileFindManyArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
+  ): Promise<number> {
+    return this.prisma.profile.count(args);
+  }
+
+  async findMany<T extends Prisma.ProfileFindManyArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
+  ): Promise<Profile[]> {
+    return this.prisma.profile.findMany(args);
+  }
+  async findOne<T extends Prisma.ProfileFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
+  ): Promise<Profile | null> {
+    return this.prisma.profile.findUnique(args);
+  }
+  async create<T extends Prisma.ProfileCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileCreateArgs>
+  ): Promise<Profile> {
+    return this.prisma.profile.create<T>(args);
+  }
+  async update<T extends Prisma.ProfileUpdateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileUpdateArgs>
+  ): Promise<Profile> {
+    return this.prisma.profile.update<T>(args);
+  }
+  async delete<T extends Prisma.ProfileDeleteArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileDeleteArgs>
+  ): Promise<Profile> {
+    return this.prisma.profile.delete(args);
+  }
+
+  async getUser(parentId: string): Promise<User | null> {
+    return this.prisma.profile
+      .findUnique({
+        where: { id: parentId },
+      })
+      .user();
+  }
+}
+",
+  "server/src/profile/profile.controller.ts": "import * as common from \\"@nestjs/common\\";
+import * as swagger from \\"@nestjs/swagger\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { ProfileService } from \\"./profile.service\\";
+import { ProfileControllerBase } from \\"./base/profile.controller.base\\";
+
+@swagger.ApiTags(\\"profiles\\")
+@common.Controller(\\"profiles\\")
+export class ProfileController extends ProfileControllerBase {
+  constructor(
+    protected readonly service: ProfileService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/profile/profile.module.ts": "import { Module } from \\"@nestjs/common\\";
+import { ProfileModuleBase } from \\"./base/profile.module.base\\";
+import { ProfileService } from \\"./profile.service\\";
+import { ProfileController } from \\"./profile.controller\\";
+
+@Module({
+  imports: [ProfileModuleBase],
+  controllers: [ProfileController],
+  providers: [ProfileService],
+  exports: [ProfileService],
+})
+export class ProfileModule {}
+",
+  "server/src/profile/profile.service.ts": "import { Injectable } from \\"@nestjs/common\\";
+import { PrismaService } from \\"nestjs-prisma\\";
+import { ProfileServiceBase } from \\"./base/profile.service.base\\";
+
+@Injectable()
+export class ProfileService extends ProfileServiceBase {
+  constructor(protected readonly prisma: PrismaService) {
+    super(prisma);
+  }
+}
+",
   "server/src/providers/secrets/base/secretsManager.service.base.spec.ts": "import { ConfigService } from \\"@nestjs/config\\";
 import { mock } from \\"jest-mock-extended\\";
 import { SecretsManagerServiceBase } from \\"./secretsManager.service.base\\";
@@ -10072,6 +11356,7 @@ import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { GraphQLJSONObject } from \\"graphql-type-json\\";
 import { JsonValue } from \\"type-fest\\";
+import { Profile } from \\"../../profile/base/Profile\\";
 @ObjectType()
 class User {
   @ApiProperty({
@@ -10221,6 +11506,15 @@ class User {
   @IsJSON()
   @Field(() => GraphQLJSONObject)
   extendedProperties!: JsonValue;
+
+  @ApiProperty({
+    required: false,
+    type: () => Profile,
+  })
+  @ValidateNested()
+  @Type(() => Profile)
+  @IsOptional()
+  profile?: Profile | null;
 }
 export { User };
 ",
@@ -10258,6 +11552,7 @@ import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { GraphQLJSONObject } from \\"graphql-type-json\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../../profile/base/ProfileWhereUniqueInput\\";
 @InputType()
 class UserCreateInput {
   @ApiProperty({
@@ -10414,6 +11709,18 @@ class UserCreateInput {
   @IsJSON()
   @Field(() => GraphQLJSONObject)
   extendedProperties!: InputJsonValue;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereUniqueInput)
+  @IsOptional()
+  @Field(() => ProfileWhereUniqueInput, {
+    nullable: true,
+  })
+  profile?: ProfileWhereUniqueInput | null;
 }
 export { UserCreateInput };
 ",
@@ -10740,6 +12047,15 @@ class UserOrderByInput {
     nullable: true,
   })
   extendedProperties?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  profileId?: SortOrder;
 }
 
 export { UserOrderByInput };
@@ -10778,6 +12094,7 @@ import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { GraphQLJSONObject } from \\"graphql-type-json\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../../profile/base/ProfileWhereUniqueInput\\";
 @InputType()
 class UserUpdateInput {
   @ApiProperty({
@@ -10973,6 +12290,18 @@ class UserUpdateInput {
     nullable: true,
   })
   extendedProperties?: InputJsonValue;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereUniqueInput)
+  @IsOptional()
+  @Field(() => ProfileWhereUniqueInput, {
+    nullable: true,
+  })
+  profile?: ProfileWhereUniqueInput | null;
 }
 export { UserUpdateInput };
 ",
@@ -11044,6 +12373,7 @@ import { OrganizationListRelationFilter } from \\"../../organization/base/Organi
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { BooleanFilter } from \\"../../util/BooleanFilter\\";
 import { JsonFilter } from \\"../../util/JsonFilter\\";
+import { ProfileWhereUniqueInput } from \\"../../profile/base/ProfileWhereUniqueInput\\";
 @InputType()
 class UserWhereInput {
   @ApiProperty({
@@ -11168,6 +12498,18 @@ class UserWhereInput {
     nullable: true,
   })
   extendedProperties?: JsonFilter;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereUniqueInput)
+  @IsOptional()
+  @Field(() => ProfileWhereUniqueInput, {
+    nullable: true,
+  })
+  profile?: ProfileWhereUniqueInput;
 }
 export { UserWhereInput };
 ",
@@ -11432,6 +12774,12 @@ export class UserControllerBase {
               connect: data.manager,
             }
           : undefined,
+
+        profile: data.profile
+          ? {
+              connect: data.profile,
+            }
+          : undefined,
       },
       select: {
         username: true,
@@ -11455,6 +12803,12 @@ export class UserControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
   }
@@ -11495,6 +12849,12 @@ export class UserControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
   }
@@ -11536,6 +12896,12 @@ export class UserControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
     if (result === null) {
@@ -11571,6 +12937,12 @@ export class UserControllerBase {
                 connect: data.manager,
               }
             : undefined,
+
+          profile: data.profile
+            ? {
+                connect: data.profile,
+              }
+            : undefined,
         },
         select: {
           username: true,
@@ -11594,6 +12966,12 @@ export class UserControllerBase {
           isCurious: true,
           location: true,
           extendedProperties: true,
+
+          profile: {
+            select: {
+              id: true,
+            },
+          },
         },
       });
     } catch (error) {
@@ -11643,6 +13021,12 @@ export class UserControllerBase {
           isCurious: true,
           location: true,
           extendedProperties: true,
+
+          profile: {
+            select: {
+              id: true,
+            },
+          },
         },
       });
     } catch (error) {
@@ -11692,6 +13076,12 @@ export class UserControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
     if (results === null) {
@@ -11906,7 +13296,7 @@ https://docs.amplication.com/docs/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from \\"nestjs-prisma\\";
-import { Prisma, User, Organization } from \\"@prisma/client\\";
+import { Prisma, User, Organization, Profile } from \\"@prisma/client\\";
 import { PasswordService } from \\"../../auth/password.service\\";
 import { transformStringFieldUpdateInput } from \\"../../prisma.util\\";
 
@@ -11996,6 +13386,14 @@ export class UserServiceBase {
         where: { id: parentId },
       })
       .manager();
+  }
+
+  async getProfile(parentId: string): Promise<Profile | null> {
+    return this.prisma.user
+      .findUnique({
+        where: { id: parentId },
+      })
+      .profile();
   }
 }
 ",

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -15,6 +15,10 @@ import { UserList } from \\"./user/UserList\\";
 import { UserCreate } from \\"./user/UserCreate\\";
 import { UserEdit } from \\"./user/UserEdit\\";
 import { UserShow } from \\"./user/UserShow\\";
+import { ProfileList } from \\"./profile/ProfileList\\";
+import { ProfileCreate } from \\"./profile/ProfileCreate\\";
+import { ProfileEdit } from \\"./profile/ProfileEdit\\";
+import { ProfileShow } from \\"./profile/ProfileShow\\";
 import { OrderList } from \\"./order/OrderList\\";
 import { OrderCreate } from \\"./order/OrderCreate\\";
 import { OrderEdit } from \\"./order/OrderEdit\\";
@@ -63,6 +67,13 @@ const App = (): React.ReactElement => {
           edit={UserEdit}
           create={UserCreate}
           show={UserShow}
+        />
+        <Resource
+          name=\\"Profile\\"
+          list={ProfileList}
+          edit={ProfileEdit}
+          create={ProfileCreate}
+          show={ProfileShow}
         />
         <Resource
           name=\\"Order\\"
@@ -719,6 +730,100 @@ export type UserUpdateManyWithoutOrganizationsInput = {
   set?: Array<UserWhereUniqueInput>;
 };
 ",
+  "admin-ui/src/api/profile/CreateProfileArgs.ts": "import { ProfileCreateInput } from \\"./ProfileCreateInput\\";
+
+export type CreateProfileArgs = {
+  data: ProfileCreateInput;
+};
+",
+  "admin-ui/src/api/profile/DeleteProfileArgs.ts": "import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+export type DeleteProfileArgs = {
+  where: ProfileWhereUniqueInput;
+};
+",
+  "admin-ui/src/api/profile/Profile.ts": "import { User } from \\"../user/User\\";
+
+export type Profile = {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  email: string;
+  user?: User | null;
+};
+",
+  "admin-ui/src/api/profile/ProfileCreateInput.ts": "import { UserWhereUniqueInput } from \\"../user/UserWhereUniqueInput\\";
+
+export type ProfileCreateInput = {
+  email: string;
+  user?: UserWhereUniqueInput | null;
+};
+",
+  "admin-ui/src/api/profile/ProfileFindManyArgs.ts": "import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { ProfileOrderByInput } from \\"./ProfileOrderByInput\\";
+
+export type ProfileFindManyArgs = {
+  where?: ProfileWhereInput;
+  orderBy?: Array<ProfileOrderByInput>;
+  skip?: number;
+  take?: number;
+};
+",
+  "admin-ui/src/api/profile/ProfileFindUniqueArgs.ts": "import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+export type ProfileFindUniqueArgs = {
+  where: ProfileWhereUniqueInput;
+};
+",
+  "admin-ui/src/api/profile/ProfileListRelationFilter.ts": "import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+
+export type ProfileListRelationFilter = {
+  every?: ProfileWhereInput;
+  some?: ProfileWhereInput;
+  none?: ProfileWhereInput;
+};
+",
+  "admin-ui/src/api/profile/ProfileOrderByInput.ts": "import { SortOrder } from \\"../../util/SortOrder\\";
+
+export type ProfileOrderByInput = {
+  id?: SortOrder;
+  createdAt?: SortOrder;
+  updatedAt?: SortOrder;
+  email?: SortOrder;
+  userId?: SortOrder;
+};
+",
+  "admin-ui/src/api/profile/ProfileUpdateInput.ts": "import { UserWhereUniqueInput } from \\"../user/UserWhereUniqueInput\\";
+
+export type ProfileUpdateInput = {
+  email?: string;
+  user?: UserWhereUniqueInput | null;
+};
+",
+  "admin-ui/src/api/profile/ProfileWhereInput.ts": "import { StringFilter } from \\"../../util/StringFilter\\";
+import { DateTimeFilter } from \\"../../util/DateTimeFilter\\";
+import { UserWhereUniqueInput } from \\"../user/UserWhereUniqueInput\\";
+
+export type ProfileWhereInput = {
+  id?: StringFilter;
+  createdAt?: DateTimeFilter;
+  updatedAt?: DateTimeFilter;
+  email?: StringFilter;
+  user?: UserWhereUniqueInput;
+};
+",
+  "admin-ui/src/api/profile/ProfileWhereUniqueInput.ts": "export type ProfileWhereUniqueInput = {
+  id: string;
+};
+",
+  "admin-ui/src/api/profile/UpdateProfileArgs.ts": "import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+import { ProfileUpdateInput } from \\"./ProfileUpdateInput\\";
+
+export type UpdateProfileArgs = {
+  where: ProfileWhereUniqueInput;
+  data: ProfileUpdateInput;
+};
+",
   "admin-ui/src/api/user/CreateUserArgs.ts": "import { UserCreateInput } from \\"./UserCreateInput\\";
 
 export type CreateUserArgs = {
@@ -766,6 +871,7 @@ export type UpdateUserArgs = {
 ",
   "admin-ui/src/api/user/User.ts": "import { Organization } from \\"../organization/Organization\\";
 import { JsonValue } from \\"type-fest\\";
+import { Profile } from \\"../profile/Profile\\";
 
 export type User = {
   username: string;
@@ -785,12 +891,14 @@ export type User = {
   isCurious: boolean;
   location: string;
   extendedProperties: JsonValue;
+  profile?: Profile | null;
 };
 ",
   "admin-ui/src/api/user/UserCreateInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { UserCreateNestedManyWithoutUsersInput } from \\"./UserCreateNestedManyWithoutUsersInput\\";
 import { OrganizationCreateNestedManyWithoutUsersInput } from \\"./OrganizationCreateNestedManyWithoutUsersInput\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../profile/ProfileWhereUniqueInput\\";
 
 export type UserCreateInput = {
   username: string;
@@ -810,6 +918,7 @@ export type UserCreateInput = {
   isCurious: boolean;
   location: string;
   extendedProperties: InputJsonValue;
+  profile?: ProfileWhereUniqueInput | null;
 };
 ",
   "admin-ui/src/api/user/UserCreateNestedManyWithoutUsersInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
@@ -861,12 +970,14 @@ export type UserOrderByInput = {
   isCurious?: SortOrder;
   location?: SortOrder;
   extendedProperties?: SortOrder;
+  profileId?: SortOrder;
 };
 ",
   "admin-ui/src/api/user/UserUpdateInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { UserUpdateManyWithoutUsersInput } from \\"./UserUpdateManyWithoutUsersInput\\";
 import { OrganizationUpdateManyWithoutUsersInput } from \\"./OrganizationUpdateManyWithoutUsersInput\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../profile/ProfileWhereUniqueInput\\";
 
 export type UserUpdateInput = {
   username?: string;
@@ -886,6 +997,7 @@ export type UserUpdateInput = {
   isCurious?: boolean;
   location?: string;
   extendedProperties?: InputJsonValue;
+  profile?: ProfileWhereUniqueInput | null;
 };
 ",
   "admin-ui/src/api/user/UserUpdateManyWithoutUsersInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
@@ -903,6 +1015,7 @@ import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { OrganizationListRelationFilter } from \\"../organization/OrganizationListRelationFilter\\";
 import { BooleanFilter } from \\"../../util/BooleanFilter\\";
 import { JsonFilter } from \\"../../util/JsonFilter\\";
+import { ProfileWhereUniqueInput } from \\"../profile/ProfileWhereUniqueInput\\";
 
 export type UserWhereInput = {
   id?: StringFilter;
@@ -916,6 +1029,7 @@ export type UserWhereInput = {
   isCurious?: BooleanFilter;
   location?: StringFilter;
   extendedProperties?: JsonFilter;
+  profile?: ProfileWhereUniqueInput;
 };
 ",
   "admin-ui/src/api/user/UserWhereUniqueInput.ts": "export type UserWhereUniqueInput = {
@@ -2012,6 +2126,123 @@ const Dashboard = () => (
 
 export default Dashboard;
 ",
+  "admin-ui/src/profile/ProfileCreate.tsx": "import * as React from \\"react\\";
+import {
+  Create,
+  SimpleForm,
+  CreateProps,
+  TextInput,
+  ReferenceInput,
+  SelectInput,
+} from \\"react-admin\\";
+import { UserTitle } from \\"../user/UserTitle\\";
+
+export const ProfileCreate = (props: CreateProps): React.ReactElement => {
+  return (
+    <Create {...props}>
+      <SimpleForm>
+        <TextInput label=\\"Email\\" source=\\"email\\" type=\\"email\\" />
+        <ReferenceInput source=\\"user.id\\" reference=\\"User\\" label=\\"User\\">
+          <SelectInput optionText={UserTitle} />
+        </ReferenceInput>
+      </SimpleForm>
+    </Create>
+  );
+};
+",
+  "admin-ui/src/profile/ProfileEdit.tsx": "import * as React from \\"react\\";
+import {
+  Edit,
+  SimpleForm,
+  EditProps,
+  TextInput,
+  ReferenceInput,
+  SelectInput,
+} from \\"react-admin\\";
+import { UserTitle } from \\"../user/UserTitle\\";
+
+export const ProfileEdit = (props: EditProps): React.ReactElement => {
+  return (
+    <Edit {...props}>
+      <SimpleForm>
+        <TextInput label=\\"Email\\" source=\\"email\\" type=\\"email\\" />
+        <ReferenceInput source=\\"user.id\\" reference=\\"User\\" label=\\"User\\">
+          <SelectInput optionText={UserTitle} />
+        </ReferenceInput>
+      </SimpleForm>
+    </Edit>
+  );
+};
+",
+  "admin-ui/src/profile/ProfileList.tsx": "import * as React from \\"react\\";
+import {
+  List,
+  Datagrid,
+  ListProps,
+  TextField,
+  DateField,
+  ReferenceField,
+} from \\"react-admin\\";
+import Pagination from \\"../Components/Pagination\\";
+import { USER_TITLE_FIELD } from \\"../user/UserTitle\\";
+
+export const ProfileList = (props: ListProps): React.ReactElement => {
+  return (
+    <List
+      {...props}
+      bulkActionButtons={false}
+      title={\\"Profiles\\"}
+      perPage={50}
+      pagination={<Pagination />}
+    >
+      <Datagrid rowClick=\\"show\\">
+        <TextField label=\\"Id\\" source=\\"id\\" />
+        <DateField source=\\"createdAt\\" label=\\"Created At\\" />
+        <DateField source=\\"updatedAt\\" label=\\"Updated At\\" />
+        <TextField label=\\"Email\\" source=\\"email\\" />
+        <ReferenceField label=\\"User\\" source=\\"user.id\\" reference=\\"User\\">
+          <TextField source={USER_TITLE_FIELD} />
+        </ReferenceField>
+      </Datagrid>
+    </List>
+  );
+};
+",
+  "admin-ui/src/profile/ProfileShow.tsx": "import * as React from \\"react\\";
+import {
+  Show,
+  SimpleShowLayout,
+  ShowProps,
+  TextField,
+  DateField,
+  ReferenceField,
+} from \\"react-admin\\";
+import { USER_TITLE_FIELD } from \\"../user/UserTitle\\";
+
+export const ProfileShow = (props: ShowProps): React.ReactElement => {
+  return (
+    <Show {...props}>
+      <SimpleShowLayout>
+        <TextField label=\\"Id\\" source=\\"id\\" />
+        <DateField source=\\"createdAt\\" label=\\"Created At\\" />
+        <DateField source=\\"updatedAt\\" label=\\"Updated At\\" />
+        <TextField label=\\"Email\\" source=\\"email\\" />
+        <ReferenceField label=\\"User\\" source=\\"user.id\\" reference=\\"User\\">
+          <TextField source={USER_TITLE_FIELD} />
+        </ReferenceField>
+      </SimpleShowLayout>
+    </Show>
+  );
+};
+",
+  "admin-ui/src/profile/ProfileTitle.ts": "import { Profile as TProfile } from \\"../api/profile/Profile\\";
+
+export const PROFILE_TITLE_FIELD = \\"id\\";
+
+export const ProfileTitle = (record: TProfile): string => {
+  return record.id || record.id;
+};
+",
   "admin-ui/src/reportWebVitals.ts": "import { ReportHandler } from \\"web-vitals\\";
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
@@ -2120,6 +2351,7 @@ import {
 
 import { UserTitle } from \\"./UserTitle\\";
 import { OrganizationTitle } from \\"../organization/OrganizationTitle\\";
+import { ProfileTitle } from \\"../profile/ProfileTitle\\";
 import { ROLES_OPTIONS } from \\"../user/RolesOptions\\";
 
 export const UserCreate = (props: CreateProps): React.ReactElement => {
@@ -2183,6 +2415,9 @@ export const UserCreate = (props: CreateProps): React.ReactElement => {
         <BooleanInput label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextInput label=\\"Location\\" source=\\"location\\" />
         <div />
+        <ReferenceInput source=\\"profile.id\\" reference=\\"Profile\\" label=\\"Profile\\">
+          <SelectInput optionText={ProfileTitle} />
+        </ReferenceInput>
       </SimpleForm>
     </Create>
   );
@@ -2207,6 +2442,7 @@ import {
 
 import { UserTitle } from \\"./UserTitle\\";
 import { OrganizationTitle } from \\"../organization/OrganizationTitle\\";
+import { ProfileTitle } from \\"../profile/ProfileTitle\\";
 import { ROLES_OPTIONS } from \\"../user/RolesOptions\\";
 
 export const UserEdit = (props: EditProps): React.ReactElement => {
@@ -2270,6 +2506,9 @@ export const UserEdit = (props: EditProps): React.ReactElement => {
         <BooleanInput label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextInput label=\\"Location\\" source=\\"location\\" />
         <div />
+        <ReferenceInput source=\\"profile.id\\" reference=\\"Profile\\" label=\\"Profile\\">
+          <SelectInput optionText={ProfileTitle} />
+        </ReferenceInput>
       </SimpleForm>
     </Edit>
   );
@@ -2286,6 +2525,7 @@ import {
 } from \\"react-admin\\";
 import Pagination from \\"../Components/Pagination\\";
 import { USER_TITLE_FIELD } from \\"./UserTitle\\";
+import { PROFILE_TITLE_FIELD } from \\"../profile/ProfileTitle\\";
 
 export const UserList = (props: ListProps): React.ReactElement => {
   return (
@@ -2314,6 +2554,9 @@ export const UserList = (props: ListProps): React.ReactElement => {
         <BooleanField label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextField label=\\"Location\\" source=\\"location\\" />
         <TextField label=\\"Extended Properties\\" source=\\"extendedProperties\\" />
+        <ReferenceField label=\\"Profile\\" source=\\"profile.id\\" reference=\\"Profile\\">
+          <TextField source={PROFILE_TITLE_FIELD} />
+        </ReferenceField>
       </Datagrid>
     </List>
   );
@@ -2329,6 +2572,7 @@ import {
   BooleanField,
 } from \\"react-admin\\";
 import { USER_TITLE_FIELD } from \\"./UserTitle\\";
+import { PROFILE_TITLE_FIELD } from \\"../profile/ProfileTitle\\";
 
 export const UserShow = (props: ShowProps): React.ReactElement => {
   return (
@@ -2351,6 +2595,9 @@ export const UserShow = (props: ShowProps): React.ReactElement => {
         <BooleanField label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextField label=\\"Location\\" source=\\"location\\" />
         <TextField label=\\"Extended Properties\\" source=\\"extendedProperties\\" />
+        <ReferenceField label=\\"Profile\\" source=\\"profile.id\\" reference=\\"Profile\\">
+          <TextField source={PROFILE_TITLE_FIELD} />
+        </ReferenceField>
       </SimpleShowLayout>
     </Show>
   );
@@ -2620,6 +2867,16 @@ model User {
   isCurious          Boolean
   location           String
   extendedProperties Json
+  profile            Profile?            @relation(fields: [profileId], references: [id])
+  profileId          String?             @unique
+}
+
+model Profile {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  email     String
+  user      User?
 }
 
 model Order {
@@ -2841,6 +3098,7 @@ async function seed(bcryptSalt: Salt) {
 import { APP_INTERCEPTOR } from \\"@nestjs/core\\";
 import { MorganInterceptor, MorganModule } from \\"nest-morgan\\";
 import { UserModule } from \\"./user/user.module\\";
+import { ProfileModule } from \\"./profile/profile.module\\";
 import { OrderModule } from \\"./order/order.module\\";
 import { OrganizationModule } from \\"./organization/organization.module\\";
 import { CustomerModule } from \\"./customer/customer.module\\";
@@ -2858,6 +3116,7 @@ import { GraphQLModule } from \\"@nestjs/graphql\\";
   controllers: [],
   imports: [
     UserModule,
+    ProfileModule,
     OrderModule,
     OrganizationModule,
     CustomerModule,
@@ -8309,6 +8568,837 @@ export async function transformStringFieldUpdateInput<
   return input;
 }
 ",
+  "server/src/profile/base/CreateProfileArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileCreateInput } from \\"./ProfileCreateInput\\";
+
+@ArgsType()
+class CreateProfileArgs {
+  @Field(() => ProfileCreateInput, { nullable: false })
+  data!: ProfileCreateInput;
+}
+
+export { CreateProfileArgs };
+",
+  "server/src/profile/base/DeleteProfileArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+@ArgsType()
+class DeleteProfileArgs {
+  @Field(() => ProfileWhereUniqueInput, { nullable: false })
+  where!: ProfileWhereUniqueInput;
+}
+
+export { DeleteProfileArgs };
+",
+  "server/src/profile/base/Profile.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ObjectType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString, IsDate, ValidateNested, IsOptional } from \\"class-validator\\";
+import { Type } from \\"class-transformer\\";
+import { User } from \\"../../user/base/User\\";
+@ObjectType()
+class Profile {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  id!: string;
+
+  @ApiProperty({
+    required: true,
+  })
+  @IsDate()
+  @Type(() => Date)
+  @Field(() => Date)
+  createdAt!: Date;
+
+  @ApiProperty({
+    required: true,
+  })
+  @IsDate()
+  @Type(() => Date)
+  @Field(() => Date)
+  updatedAt!: Date;
+
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  email!: string;
+
+  @ApiProperty({
+    required: false,
+    type: () => User,
+  })
+  @ValidateNested()
+  @Type(() => User)
+  @IsOptional()
+  user?: User | null;
+}
+export { Profile };
+",
+  "server/src/profile/base/ProfileCreateInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString, ValidateNested, IsOptional } from \\"class-validator\\";
+import { UserWhereUniqueInput } from \\"../../user/base/UserWhereUniqueInput\\";
+import { Type } from \\"class-transformer\\";
+@InputType()
+class ProfileCreateInput {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  email!: string;
+
+  @ApiProperty({
+    required: false,
+    type: () => UserWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => UserWhereUniqueInput)
+  @IsOptional()
+  @Field(() => UserWhereUniqueInput, {
+    nullable: true,
+  })
+  user?: UserWhereUniqueInput | null;
+}
+export { ProfileCreateInput };
+",
+  "server/src/profile/base/ProfileFindManyArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { Type } from \\"class-transformer\\";
+import { ProfileOrderByInput } from \\"./ProfileOrderByInput\\";
+
+@ArgsType()
+class ProfileFindManyArgs {
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @Field(() => ProfileWhereInput, { nullable: true })
+  @Type(() => ProfileWhereInput)
+  where?: ProfileWhereInput;
+
+  @ApiProperty({
+    required: false,
+    type: [ProfileOrderByInput],
+  })
+  @Field(() => [ProfileOrderByInput], { nullable: true })
+  @Type(() => ProfileOrderByInput)
+  orderBy?: Array<ProfileOrderByInput>;
+
+  @ApiProperty({
+    required: false,
+    type: Number,
+  })
+  @Field(() => Number, { nullable: true })
+  @Type(() => Number)
+  skip?: number;
+
+  @ApiProperty({
+    required: false,
+    type: Number,
+  })
+  @Field(() => Number, { nullable: true })
+  @Type(() => Number)
+  take?: number;
+}
+
+export { ProfileFindManyArgs };
+",
+  "server/src/profile/base/ProfileFindUniqueArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+@ArgsType()
+class ProfileFindUniqueArgs {
+  @Field(() => ProfileWhereUniqueInput, { nullable: false })
+  where!: ProfileWhereUniqueInput;
+}
+
+export { ProfileFindUniqueArgs };
+",
+  "server/src/profile/base/ProfileListRelationFilter.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { ValidateNested, IsOptional } from \\"class-validator\\";
+import { Type } from \\"class-transformer\\";
+
+@InputType()
+class ProfileListRelationFilter {
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereInput)
+  @IsOptional()
+  @Field(() => ProfileWhereInput, {
+    nullable: true,
+  })
+  every?: ProfileWhereInput;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereInput)
+  @IsOptional()
+  @Field(() => ProfileWhereInput, {
+    nullable: true,
+  })
+  some?: ProfileWhereInput;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereInput)
+  @IsOptional()
+  @Field(() => ProfileWhereInput, {
+    nullable: true,
+  })
+  none?: ProfileWhereInput;
+}
+export { ProfileListRelationFilter };
+",
+  "server/src/profile/base/ProfileOrderByInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { SortOrder } from \\"../../util/SortOrder\\";
+
+@InputType({
+  isAbstract: true,
+  description: undefined,
+})
+class ProfileOrderByInput {
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  id?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  createdAt?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  updatedAt?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  email?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  userId?: SortOrder;
+}
+
+export { ProfileOrderByInput };
+",
+  "server/src/profile/base/ProfileUpdateInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString, IsOptional, ValidateNested } from \\"class-validator\\";
+import { UserWhereUniqueInput } from \\"../../user/base/UserWhereUniqueInput\\";
+import { Type } from \\"class-transformer\\";
+@InputType()
+class ProfileUpdateInput {
+  @ApiProperty({
+    required: false,
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  @Field(() => String, {
+    nullable: true,
+  })
+  email?: string;
+
+  @ApiProperty({
+    required: false,
+    type: () => UserWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => UserWhereUniqueInput)
+  @IsOptional()
+  @Field(() => UserWhereUniqueInput, {
+    nullable: true,
+  })
+  user?: UserWhereUniqueInput | null;
+}
+export { ProfileUpdateInput };
+",
+  "server/src/profile/base/ProfileWhereInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { StringFilter } from \\"../../util/StringFilter\\";
+import { Type } from \\"class-transformer\\";
+import { IsOptional, ValidateNested } from \\"class-validator\\";
+import { DateTimeFilter } from \\"../../util/DateTimeFilter\\";
+import { UserWhereUniqueInput } from \\"../../user/base/UserWhereUniqueInput\\";
+@InputType()
+class ProfileWhereInput {
+  @ApiProperty({
+    required: false,
+    type: StringFilter,
+  })
+  @Type(() => StringFilter)
+  @IsOptional()
+  @Field(() => StringFilter, {
+    nullable: true,
+  })
+  id?: StringFilter;
+
+  @ApiProperty({
+    required: false,
+    type: DateTimeFilter,
+  })
+  @Type(() => DateTimeFilter)
+  @IsOptional()
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+  })
+  createdAt?: DateTimeFilter;
+
+  @ApiProperty({
+    required: false,
+    type: DateTimeFilter,
+  })
+  @Type(() => DateTimeFilter)
+  @IsOptional()
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+  })
+  updatedAt?: DateTimeFilter;
+
+  @ApiProperty({
+    required: false,
+    type: StringFilter,
+  })
+  @Type(() => StringFilter)
+  @IsOptional()
+  @Field(() => StringFilter, {
+    nullable: true,
+  })
+  email?: StringFilter;
+
+  @ApiProperty({
+    required: false,
+    type: () => UserWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => UserWhereUniqueInput)
+  @IsOptional()
+  @Field(() => UserWhereUniqueInput, {
+    nullable: true,
+  })
+  user?: UserWhereUniqueInput;
+}
+export { ProfileWhereInput };
+",
+  "server/src/profile/base/ProfileWhereUniqueInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString } from \\"class-validator\\";
+@InputType()
+class ProfileWhereUniqueInput {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  id!: string;
+}
+export { ProfileWhereUniqueInput };
+",
+  "server/src/profile/base/UpdateProfileArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+import { ProfileUpdateInput } from \\"./ProfileUpdateInput\\";
+
+@ArgsType()
+class UpdateProfileArgs {
+  @Field(() => ProfileWhereUniqueInput, { nullable: false })
+  where!: ProfileWhereUniqueInput;
+  @Field(() => ProfileUpdateInput, { nullable: false })
+  data!: ProfileUpdateInput;
+}
+
+export { UpdateProfileArgs };
+",
+  "server/src/profile/base/profile.module.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../../auth/acl.module\\";
+import { AuthModule } from \\"../../auth/auth.module\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+
+  exports: [ACLModule, AuthModule, MorganModule, PrismaModule],
+})
+export class ProfileModuleBase {}
+",
+  "server/src/profile/base/profile.resolver.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import * as common from \\"@nestjs/common\\";
+import * as graphql from \\"@nestjs/graphql\\";
+import * as apollo from \\"apollo-server-express\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { GqlDefaultAuthGuard } from \\"../../auth/gqlDefaultAuth.guard\\";
+import * as gqlACGuard from \\"../../auth/gqlAC.guard\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
+import { MetaQueryPayload } from \\"../../util/MetaQueryPayload\\";
+import { AclFilterResponseInterceptor } from \\"../../interceptors/aclFilterResponse.interceptor\\";
+import { AclValidateRequestInterceptor } from \\"../../interceptors/aclValidateRequest.interceptor\\";
+import { CreateProfileArgs } from \\"./CreateProfileArgs\\";
+import { UpdateProfileArgs } from \\"./UpdateProfileArgs\\";
+import { DeleteProfileArgs } from \\"./DeleteProfileArgs\\";
+import { ProfileFindManyArgs } from \\"./ProfileFindManyArgs\\";
+import { ProfileFindUniqueArgs } from \\"./ProfileFindUniqueArgs\\";
+import { Profile } from \\"./Profile\\";
+import { User } from \\"../../user/base/User\\";
+import { ProfileService } from \\"../profile.service\\";
+
+@graphql.Resolver(() => Profile)
+@common.UseGuards(GqlDefaultAuthGuard, gqlACGuard.GqlACGuard)
+export class ProfileResolverBase {
+  constructor(
+    protected readonly service: ProfileService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {}
+
+  @graphql.Query(() => MetaQueryPayload)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  async _profilesMeta(
+    @graphql.Args() args: ProfileFindManyArgs
+  ): Promise<MetaQueryPayload> {
+    const results = await this.service.count({
+      ...args,
+      skip: undefined,
+      take: undefined,
+    });
+    return {
+      count: results,
+    };
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @graphql.Query(() => [Profile])
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  async profiles(
+    @graphql.Args() args: ProfileFindManyArgs
+  ): Promise<Profile[]> {
+    return this.service.findMany(args);
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @graphql.Query(() => Profile, { nullable: true })
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"own\\",
+  })
+  async profile(
+    @graphql.Args() args: ProfileFindUniqueArgs
+  ): Promise<Profile | null> {
+    const result = await this.service.findOne(args);
+    if (result === null) {
+      return null;
+    }
+    return result;
+  }
+
+  @common.UseInterceptors(AclValidateRequestInterceptor)
+  @graphql.Mutation(() => Profile)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"create\\",
+    possession: \\"any\\",
+  })
+  async createProfile(
+    @graphql.Args() args: CreateProfileArgs
+  ): Promise<Profile> {
+    return await this.service.create({
+      ...args,
+      data: {
+        ...args.data,
+
+        user: args.data.user
+          ? {
+              connect: args.data.user,
+            }
+          : undefined,
+      },
+    });
+  }
+
+  @common.UseInterceptors(AclValidateRequestInterceptor)
+  @graphql.Mutation(() => Profile)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"update\\",
+    possession: \\"any\\",
+  })
+  async updateProfile(
+    @graphql.Args() args: UpdateProfileArgs
+  ): Promise<Profile | null> {
+    try {
+      return await this.service.update({
+        ...args,
+        data: {
+          ...args.data,
+
+          user: args.data.user
+            ? {
+                connect: args.data.user,
+              }
+            : undefined,
+        },
+      });
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new apollo.ApolloError(
+          \`No resource was found for \${JSON.stringify(args.where)}\`
+        );
+      }
+      throw error;
+    }
+  }
+
+  @graphql.Mutation(() => Profile)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"delete\\",
+    possession: \\"any\\",
+  })
+  async deleteProfile(
+    @graphql.Args() args: DeleteProfileArgs
+  ): Promise<Profile | null> {
+    try {
+      return await this.service.delete(args);
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new apollo.ApolloError(
+          \`No resource was found for \${JSON.stringify(args.where)}\`
+        );
+      }
+      throw error;
+    }
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @graphql.ResolveField(() => User, { nullable: true })
+  @nestAccessControl.UseRoles({
+    resource: \\"User\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  async user(@graphql.Parent() parent: Profile): Promise<User | null> {
+    const result = await this.service.getUser(parent.id);
+
+    if (!result) {
+      return null;
+    }
+    return result;
+  }
+}
+",
+  "server/src/profile/base/profile.service.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { PrismaService } from \\"nestjs-prisma\\";
+import { Prisma, Profile, User } from \\"@prisma/client\\";
+
+export class ProfileServiceBase {
+  constructor(protected readonly prisma: PrismaService) {}
+
+  async count<T extends Prisma.ProfileFindManyArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
+  ): Promise<number> {
+    return this.prisma.profile.count(args);
+  }
+
+  async findMany<T extends Prisma.ProfileFindManyArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
+  ): Promise<Profile[]> {
+    return this.prisma.profile.findMany(args);
+  }
+  async findOne<T extends Prisma.ProfileFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
+  ): Promise<Profile | null> {
+    return this.prisma.profile.findUnique(args);
+  }
+  async create<T extends Prisma.ProfileCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileCreateArgs>
+  ): Promise<Profile> {
+    return this.prisma.profile.create<T>(args);
+  }
+  async update<T extends Prisma.ProfileUpdateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileUpdateArgs>
+  ): Promise<Profile> {
+    return this.prisma.profile.update<T>(args);
+  }
+  async delete<T extends Prisma.ProfileDeleteArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileDeleteArgs>
+  ): Promise<Profile> {
+    return this.prisma.profile.delete(args);
+  }
+
+  async getUser(parentId: string): Promise<User | null> {
+    return this.prisma.profile
+      .findUnique({
+        where: { id: parentId },
+      })
+      .user();
+  }
+}
+",
+  "server/src/profile/profile.module.ts": "import { Module } from \\"@nestjs/common\\";
+import { ProfileModuleBase } from \\"./base/profile.module.base\\";
+import { ProfileService } from \\"./profile.service\\";
+import { ProfileResolver } from \\"./profile.resolver\\";
+
+@Module({
+  imports: [ProfileModuleBase],
+  providers: [ProfileService, ProfileResolver],
+  exports: [ProfileService],
+})
+export class ProfileModule {}
+",
+  "server/src/profile/profile.resolver.ts": "import * as common from \\"@nestjs/common\\";
+import * as graphql from \\"@nestjs/graphql\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { GqlDefaultAuthGuard } from \\"../auth/gqlDefaultAuth.guard\\";
+import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
+import { ProfileResolverBase } from \\"./base/profile.resolver.base\\";
+import { Profile } from \\"./base/Profile\\";
+import { ProfileService } from \\"./profile.service\\";
+
+@graphql.Resolver(() => Profile)
+@common.UseGuards(GqlDefaultAuthGuard, gqlACGuard.GqlACGuard)
+export class ProfileResolver extends ProfileResolverBase {
+  constructor(
+    protected readonly service: ProfileService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/profile/profile.service.ts": "import { Injectable } from \\"@nestjs/common\\";
+import { PrismaService } from \\"nestjs-prisma\\";
+import { ProfileServiceBase } from \\"./base/profile.service.base\\";
+
+@Injectable()
+export class ProfileService extends ProfileServiceBase {
+  constructor(protected readonly prisma: PrismaService) {
+    super(prisma);
+  }
+}
+",
   "server/src/providers/secrets/base/secretsManager.service.base.spec.ts": "import { ConfigService } from \\"@nestjs/config\\";
 import { mock } from \\"jest-mock-extended\\";
 import { SecretsManagerServiceBase } from \\"./secretsManager.service.base\\";
@@ -8823,6 +9913,7 @@ import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { GraphQLJSONObject } from \\"graphql-type-json\\";
 import { JsonValue } from \\"type-fest\\";
+import { Profile } from \\"../../profile/base/Profile\\";
 @ObjectType()
 class User {
   @ApiProperty({
@@ -8972,6 +10063,15 @@ class User {
   @IsJSON()
   @Field(() => GraphQLJSONObject)
   extendedProperties!: JsonValue;
+
+  @ApiProperty({
+    required: false,
+    type: () => Profile,
+  })
+  @ValidateNested()
+  @Type(() => Profile)
+  @IsOptional()
+  profile?: Profile | null;
 }
 export { User };
 ",
@@ -9009,6 +10109,7 @@ import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { GraphQLJSONObject } from \\"graphql-type-json\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../../profile/base/ProfileWhereUniqueInput\\";
 @InputType()
 class UserCreateInput {
   @ApiProperty({
@@ -9165,6 +10266,18 @@ class UserCreateInput {
   @IsJSON()
   @Field(() => GraphQLJSONObject)
   extendedProperties!: InputJsonValue;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereUniqueInput)
+  @IsOptional()
+  @Field(() => ProfileWhereUniqueInput, {
+    nullable: true,
+  })
+  profile?: ProfileWhereUniqueInput | null;
 }
 export { UserCreateInput };
 ",
@@ -9491,6 +10604,15 @@ class UserOrderByInput {
     nullable: true,
   })
   extendedProperties?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  profileId?: SortOrder;
 }
 
 export { UserOrderByInput };
@@ -9529,6 +10651,7 @@ import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { GraphQLJSONObject } from \\"graphql-type-json\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../../profile/base/ProfileWhereUniqueInput\\";
 @InputType()
 class UserUpdateInput {
   @ApiProperty({
@@ -9724,6 +10847,18 @@ class UserUpdateInput {
     nullable: true,
   })
   extendedProperties?: InputJsonValue;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereUniqueInput)
+  @IsOptional()
+  @Field(() => ProfileWhereUniqueInput, {
+    nullable: true,
+  })
+  profile?: ProfileWhereUniqueInput | null;
 }
 export { UserUpdateInput };
 ",
@@ -9795,6 +10930,7 @@ import { OrganizationListRelationFilter } from \\"../../organization/base/Organi
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { BooleanFilter } from \\"../../util/BooleanFilter\\";
 import { JsonFilter } from \\"../../util/JsonFilter\\";
+import { ProfileWhereUniqueInput } from \\"../../profile/base/ProfileWhereUniqueInput\\";
 @InputType()
 class UserWhereInput {
   @ApiProperty({
@@ -9919,6 +11055,18 @@ class UserWhereInput {
     nullable: true,
   })
   extendedProperties?: JsonFilter;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereUniqueInput)
+  @IsOptional()
+  @Field(() => ProfileWhereUniqueInput, {
+    nullable: true,
+  })
+  profile?: ProfileWhereUniqueInput;
 }
 export { UserWhereInput };
 ",
@@ -10006,6 +11154,7 @@ import { UserFindUniqueArgs } from \\"./UserFindUniqueArgs\\";
 import { User } from \\"./User\\";
 import { OrganizationFindManyArgs } from \\"../../organization/base/OrganizationFindManyArgs\\";
 import { Organization } from \\"../../organization/base/Organization\\";
+import { Profile } from \\"../../profile/base/Profile\\";
 import { UserService } from \\"../user.service\\";
 
 @graphql.Resolver(() => User)
@@ -10079,6 +11228,12 @@ export class UserResolverBase {
               connect: args.data.manager,
             }
           : undefined,
+
+        profile: args.data.profile
+          ? {
+              connect: args.data.profile,
+            }
+          : undefined,
       },
     });
   }
@@ -10100,6 +11255,12 @@ export class UserResolverBase {
           manager: args.data.manager
             ? {
                 connect: args.data.manager,
+              }
+            : undefined,
+
+          profile: args.data.profile
+            ? {
+                connect: args.data.profile,
               }
             : undefined,
         },
@@ -10188,6 +11349,22 @@ export class UserResolverBase {
     }
     return result;
   }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @graphql.ResolveField(() => Profile, { nullable: true })
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  async profile(@graphql.Parent() parent: User): Promise<Profile | null> {
+    const result = await this.service.getProfile(parent.id);
+
+    if (!result) {
+      return null;
+    }
+    return result;
+  }
 }
 ",
   "server/src/user/base/user.service.base.ts": "/*
@@ -10202,7 +11379,7 @@ https://docs.amplication.com/docs/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from \\"nestjs-prisma\\";
-import { Prisma, User, Organization } from \\"@prisma/client\\";
+import { Prisma, User, Organization, Profile } from \\"@prisma/client\\";
 import { PasswordService } from \\"../../auth/password.service\\";
 import { transformStringFieldUpdateInput } from \\"../../prisma.util\\";
 
@@ -10292,6 +11469,14 @@ export class UserServiceBase {
         where: { id: parentId },
       })
       .manager();
+  }
+
+  async getProfile(parentId: string): Promise<Profile | null> {
+    return this.prisma.user
+      .findUnique({
+        where: { id: parentId },
+      })
+      .profile();
   }
 }
 ",

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -15,6 +15,10 @@ import { UserList } from \\"./user/UserList\\";
 import { UserCreate } from \\"./user/UserCreate\\";
 import { UserEdit } from \\"./user/UserEdit\\";
 import { UserShow } from \\"./user/UserShow\\";
+import { ProfileList } from \\"./profile/ProfileList\\";
+import { ProfileCreate } from \\"./profile/ProfileCreate\\";
+import { ProfileEdit } from \\"./profile/ProfileEdit\\";
+import { ProfileShow } from \\"./profile/ProfileShow\\";
 import { OrderList } from \\"./order/OrderList\\";
 import { OrderCreate } from \\"./order/OrderCreate\\";
 import { OrderEdit } from \\"./order/OrderEdit\\";
@@ -63,6 +67,13 @@ const App = (): React.ReactElement => {
           edit={UserEdit}
           create={UserCreate}
           show={UserShow}
+        />
+        <Resource
+          name=\\"Profile\\"
+          list={ProfileList}
+          edit={ProfileEdit}
+          create={ProfileCreate}
+          show={ProfileShow}
         />
         <Resource
           name=\\"Order\\"
@@ -719,6 +730,100 @@ export type UserUpdateManyWithoutOrganizationsInput = {
   set?: Array<UserWhereUniqueInput>;
 };
 ",
+  "admin-ui/src/api/profile/CreateProfileArgs.ts": "import { ProfileCreateInput } from \\"./ProfileCreateInput\\";
+
+export type CreateProfileArgs = {
+  data: ProfileCreateInput;
+};
+",
+  "admin-ui/src/api/profile/DeleteProfileArgs.ts": "import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+export type DeleteProfileArgs = {
+  where: ProfileWhereUniqueInput;
+};
+",
+  "admin-ui/src/api/profile/Profile.ts": "import { User } from \\"../user/User\\";
+
+export type Profile = {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  email: string;
+  user?: User | null;
+};
+",
+  "admin-ui/src/api/profile/ProfileCreateInput.ts": "import { UserWhereUniqueInput } from \\"../user/UserWhereUniqueInput\\";
+
+export type ProfileCreateInput = {
+  email: string;
+  user?: UserWhereUniqueInput | null;
+};
+",
+  "admin-ui/src/api/profile/ProfileFindManyArgs.ts": "import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { ProfileOrderByInput } from \\"./ProfileOrderByInput\\";
+
+export type ProfileFindManyArgs = {
+  where?: ProfileWhereInput;
+  orderBy?: Array<ProfileOrderByInput>;
+  skip?: number;
+  take?: number;
+};
+",
+  "admin-ui/src/api/profile/ProfileFindUniqueArgs.ts": "import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+export type ProfileFindUniqueArgs = {
+  where: ProfileWhereUniqueInput;
+};
+",
+  "admin-ui/src/api/profile/ProfileListRelationFilter.ts": "import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+
+export type ProfileListRelationFilter = {
+  every?: ProfileWhereInput;
+  some?: ProfileWhereInput;
+  none?: ProfileWhereInput;
+};
+",
+  "admin-ui/src/api/profile/ProfileOrderByInput.ts": "import { SortOrder } from \\"../../util/SortOrder\\";
+
+export type ProfileOrderByInput = {
+  id?: SortOrder;
+  createdAt?: SortOrder;
+  updatedAt?: SortOrder;
+  email?: SortOrder;
+  userId?: SortOrder;
+};
+",
+  "admin-ui/src/api/profile/ProfileUpdateInput.ts": "import { UserWhereUniqueInput } from \\"../user/UserWhereUniqueInput\\";
+
+export type ProfileUpdateInput = {
+  email?: string;
+  user?: UserWhereUniqueInput | null;
+};
+",
+  "admin-ui/src/api/profile/ProfileWhereInput.ts": "import { StringFilter } from \\"../../util/StringFilter\\";
+import { DateTimeFilter } from \\"../../util/DateTimeFilter\\";
+import { UserWhereUniqueInput } from \\"../user/UserWhereUniqueInput\\";
+
+export type ProfileWhereInput = {
+  id?: StringFilter;
+  createdAt?: DateTimeFilter;
+  updatedAt?: DateTimeFilter;
+  email?: StringFilter;
+  user?: UserWhereUniqueInput;
+};
+",
+  "admin-ui/src/api/profile/ProfileWhereUniqueInput.ts": "export type ProfileWhereUniqueInput = {
+  id: string;
+};
+",
+  "admin-ui/src/api/profile/UpdateProfileArgs.ts": "import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+import { ProfileUpdateInput } from \\"./ProfileUpdateInput\\";
+
+export type UpdateProfileArgs = {
+  where: ProfileWhereUniqueInput;
+  data: ProfileUpdateInput;
+};
+",
   "admin-ui/src/api/user/CreateUserArgs.ts": "import { UserCreateInput } from \\"./UserCreateInput\\";
 
 export type CreateUserArgs = {
@@ -766,6 +871,7 @@ export type UpdateUserArgs = {
 ",
   "admin-ui/src/api/user/User.ts": "import { Organization } from \\"../organization/Organization\\";
 import { JsonValue } from \\"type-fest\\";
+import { Profile } from \\"../profile/Profile\\";
 
 export type User = {
   username: string;
@@ -785,12 +891,14 @@ export type User = {
   isCurious: boolean;
   location: string;
   extendedProperties: JsonValue;
+  profile?: Profile | null;
 };
 ",
   "admin-ui/src/api/user/UserCreateInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { UserCreateNestedManyWithoutUsersInput } from \\"./UserCreateNestedManyWithoutUsersInput\\";
 import { OrganizationCreateNestedManyWithoutUsersInput } from \\"./OrganizationCreateNestedManyWithoutUsersInput\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../profile/ProfileWhereUniqueInput\\";
 
 export type UserCreateInput = {
   username: string;
@@ -810,6 +918,7 @@ export type UserCreateInput = {
   isCurious: boolean;
   location: string;
   extendedProperties: InputJsonValue;
+  profile?: ProfileWhereUniqueInput | null;
 };
 ",
   "admin-ui/src/api/user/UserCreateNestedManyWithoutUsersInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
@@ -861,12 +970,14 @@ export type UserOrderByInput = {
   isCurious?: SortOrder;
   location?: SortOrder;
   extendedProperties?: SortOrder;
+  profileId?: SortOrder;
 };
 ",
   "admin-ui/src/api/user/UserUpdateInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { UserUpdateManyWithoutUsersInput } from \\"./UserUpdateManyWithoutUsersInput\\";
 import { OrganizationUpdateManyWithoutUsersInput } from \\"./OrganizationUpdateManyWithoutUsersInput\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../profile/ProfileWhereUniqueInput\\";
 
 export type UserUpdateInput = {
   username?: string;
@@ -886,6 +997,7 @@ export type UserUpdateInput = {
   isCurious?: boolean;
   location?: string;
   extendedProperties?: InputJsonValue;
+  profile?: ProfileWhereUniqueInput | null;
 };
 ",
   "admin-ui/src/api/user/UserUpdateManyWithoutUsersInput.ts": "import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
@@ -903,6 +1015,7 @@ import { UserWhereUniqueInput } from \\"./UserWhereUniqueInput\\";
 import { OrganizationListRelationFilter } from \\"../organization/OrganizationListRelationFilter\\";
 import { BooleanFilter } from \\"../../util/BooleanFilter\\";
 import { JsonFilter } from \\"../../util/JsonFilter\\";
+import { ProfileWhereUniqueInput } from \\"../profile/ProfileWhereUniqueInput\\";
 
 export type UserWhereInput = {
   id?: StringFilter;
@@ -916,6 +1029,7 @@ export type UserWhereInput = {
   isCurious?: BooleanFilter;
   location?: StringFilter;
   extendedProperties?: JsonFilter;
+  profile?: ProfileWhereUniqueInput;
 };
 ",
   "admin-ui/src/api/user/UserWhereUniqueInput.ts": "export type UserWhereUniqueInput = {
@@ -2012,6 +2126,123 @@ const Dashboard = () => (
 
 export default Dashboard;
 ",
+  "admin-ui/src/profile/ProfileCreate.tsx": "import * as React from \\"react\\";
+import {
+  Create,
+  SimpleForm,
+  CreateProps,
+  TextInput,
+  ReferenceInput,
+  SelectInput,
+} from \\"react-admin\\";
+import { UserTitle } from \\"../user/UserTitle\\";
+
+export const ProfileCreate = (props: CreateProps): React.ReactElement => {
+  return (
+    <Create {...props}>
+      <SimpleForm>
+        <TextInput label=\\"Email\\" source=\\"email\\" type=\\"email\\" />
+        <ReferenceInput source=\\"user.id\\" reference=\\"User\\" label=\\"User\\">
+          <SelectInput optionText={UserTitle} />
+        </ReferenceInput>
+      </SimpleForm>
+    </Create>
+  );
+};
+",
+  "admin-ui/src/profile/ProfileEdit.tsx": "import * as React from \\"react\\";
+import {
+  Edit,
+  SimpleForm,
+  EditProps,
+  TextInput,
+  ReferenceInput,
+  SelectInput,
+} from \\"react-admin\\";
+import { UserTitle } from \\"../user/UserTitle\\";
+
+export const ProfileEdit = (props: EditProps): React.ReactElement => {
+  return (
+    <Edit {...props}>
+      <SimpleForm>
+        <TextInput label=\\"Email\\" source=\\"email\\" type=\\"email\\" />
+        <ReferenceInput source=\\"user.id\\" reference=\\"User\\" label=\\"User\\">
+          <SelectInput optionText={UserTitle} />
+        </ReferenceInput>
+      </SimpleForm>
+    </Edit>
+  );
+};
+",
+  "admin-ui/src/profile/ProfileList.tsx": "import * as React from \\"react\\";
+import {
+  List,
+  Datagrid,
+  ListProps,
+  TextField,
+  DateField,
+  ReferenceField,
+} from \\"react-admin\\";
+import Pagination from \\"../Components/Pagination\\";
+import { USER_TITLE_FIELD } from \\"../user/UserTitle\\";
+
+export const ProfileList = (props: ListProps): React.ReactElement => {
+  return (
+    <List
+      {...props}
+      bulkActionButtons={false}
+      title={\\"Profiles\\"}
+      perPage={50}
+      pagination={<Pagination />}
+    >
+      <Datagrid rowClick=\\"show\\">
+        <TextField label=\\"Id\\" source=\\"id\\" />
+        <DateField source=\\"createdAt\\" label=\\"Created At\\" />
+        <DateField source=\\"updatedAt\\" label=\\"Updated At\\" />
+        <TextField label=\\"Email\\" source=\\"email\\" />
+        <ReferenceField label=\\"User\\" source=\\"user.id\\" reference=\\"User\\">
+          <TextField source={USER_TITLE_FIELD} />
+        </ReferenceField>
+      </Datagrid>
+    </List>
+  );
+};
+",
+  "admin-ui/src/profile/ProfileShow.tsx": "import * as React from \\"react\\";
+import {
+  Show,
+  SimpleShowLayout,
+  ShowProps,
+  TextField,
+  DateField,
+  ReferenceField,
+} from \\"react-admin\\";
+import { USER_TITLE_FIELD } from \\"../user/UserTitle\\";
+
+export const ProfileShow = (props: ShowProps): React.ReactElement => {
+  return (
+    <Show {...props}>
+      <SimpleShowLayout>
+        <TextField label=\\"Id\\" source=\\"id\\" />
+        <DateField source=\\"createdAt\\" label=\\"Created At\\" />
+        <DateField source=\\"updatedAt\\" label=\\"Updated At\\" />
+        <TextField label=\\"Email\\" source=\\"email\\" />
+        <ReferenceField label=\\"User\\" source=\\"user.id\\" reference=\\"User\\">
+          <TextField source={USER_TITLE_FIELD} />
+        </ReferenceField>
+      </SimpleShowLayout>
+    </Show>
+  );
+};
+",
+  "admin-ui/src/profile/ProfileTitle.ts": "import { Profile as TProfile } from \\"../api/profile/Profile\\";
+
+export const PROFILE_TITLE_FIELD = \\"id\\";
+
+export const ProfileTitle = (record: TProfile): string => {
+  return record.id || record.id;
+};
+",
   "admin-ui/src/reportWebVitals.ts": "import { ReportHandler } from \\"web-vitals\\";
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
@@ -2120,6 +2351,7 @@ import {
 
 import { UserTitle } from \\"./UserTitle\\";
 import { OrganizationTitle } from \\"../organization/OrganizationTitle\\";
+import { ProfileTitle } from \\"../profile/ProfileTitle\\";
 import { ROLES_OPTIONS } from \\"../user/RolesOptions\\";
 
 export const UserCreate = (props: CreateProps): React.ReactElement => {
@@ -2183,6 +2415,9 @@ export const UserCreate = (props: CreateProps): React.ReactElement => {
         <BooleanInput label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextInput label=\\"Location\\" source=\\"location\\" />
         <div />
+        <ReferenceInput source=\\"profile.id\\" reference=\\"Profile\\" label=\\"Profile\\">
+          <SelectInput optionText={ProfileTitle} />
+        </ReferenceInput>
       </SimpleForm>
     </Create>
   );
@@ -2207,6 +2442,7 @@ import {
 
 import { UserTitle } from \\"./UserTitle\\";
 import { OrganizationTitle } from \\"../organization/OrganizationTitle\\";
+import { ProfileTitle } from \\"../profile/ProfileTitle\\";
 import { ROLES_OPTIONS } from \\"../user/RolesOptions\\";
 
 export const UserEdit = (props: EditProps): React.ReactElement => {
@@ -2270,6 +2506,9 @@ export const UserEdit = (props: EditProps): React.ReactElement => {
         <BooleanInput label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextInput label=\\"Location\\" source=\\"location\\" />
         <div />
+        <ReferenceInput source=\\"profile.id\\" reference=\\"Profile\\" label=\\"Profile\\">
+          <SelectInput optionText={ProfileTitle} />
+        </ReferenceInput>
       </SimpleForm>
     </Edit>
   );
@@ -2286,6 +2525,7 @@ import {
 } from \\"react-admin\\";
 import Pagination from \\"../Components/Pagination\\";
 import { USER_TITLE_FIELD } from \\"./UserTitle\\";
+import { PROFILE_TITLE_FIELD } from \\"../profile/ProfileTitle\\";
 
 export const UserList = (props: ListProps): React.ReactElement => {
   return (
@@ -2314,6 +2554,9 @@ export const UserList = (props: ListProps): React.ReactElement => {
         <BooleanField label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextField label=\\"Location\\" source=\\"location\\" />
         <TextField label=\\"Extended Properties\\" source=\\"extendedProperties\\" />
+        <ReferenceField label=\\"Profile\\" source=\\"profile.id\\" reference=\\"Profile\\">
+          <TextField source={PROFILE_TITLE_FIELD} />
+        </ReferenceField>
       </Datagrid>
     </List>
   );
@@ -2329,6 +2572,7 @@ import {
   BooleanField,
 } from \\"react-admin\\";
 import { USER_TITLE_FIELD } from \\"./UserTitle\\";
+import { PROFILE_TITLE_FIELD } from \\"../profile/ProfileTitle\\";
 
 export const UserShow = (props: ShowProps): React.ReactElement => {
   return (
@@ -2351,6 +2595,9 @@ export const UserShow = (props: ShowProps): React.ReactElement => {
         <BooleanField label=\\"Is Curious\\" source=\\"isCurious\\" />
         <TextField label=\\"Location\\" source=\\"location\\" />
         <TextField label=\\"Extended Properties\\" source=\\"extendedProperties\\" />
+        <ReferenceField label=\\"Profile\\" source=\\"profile.id\\" reference=\\"Profile\\">
+          <TextField source={PROFILE_TITLE_FIELD} />
+        </ReferenceField>
       </SimpleShowLayout>
     </Show>
   );
@@ -2620,6 +2867,16 @@ model User {
   isCurious          Boolean
   location           String
   extendedProperties Json
+  profile            Profile?            @relation(fields: [profileId], references: [id])
+  profileId          String?             @unique
+}
+
+model Profile {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  email     String
+  user      User?
 }
 
 model Order {
@@ -2841,6 +3098,7 @@ async function seed(bcryptSalt: Salt) {
 import { APP_INTERCEPTOR } from \\"@nestjs/core\\";
 import { MorganInterceptor, MorganModule } from \\"nest-morgan\\";
 import { UserModule } from \\"./user/user.module\\";
+import { ProfileModule } from \\"./profile/profile.module\\";
 import { OrderModule } from \\"./order/order.module\\";
 import { OrganizationModule } from \\"./organization/organization.module\\";
 import { CustomerModule } from \\"./customer/customer.module\\";
@@ -2858,6 +3116,7 @@ import { GraphQLModule } from \\"@nestjs/graphql\\";
   controllers: [],
   imports: [
     UserModule,
+    ProfileModule,
     OrderModule,
     OrganizationModule,
     CustomerModule,
@@ -9583,6 +9842,12 @@ export class OrganizationControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
     if (results === null) {
@@ -10340,6 +10605,1229 @@ export async function transformStringFieldUpdateInput<
   return input;
 }
 ",
+  "server/src/profile/base/CreateProfileArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileCreateInput } from \\"./ProfileCreateInput\\";
+
+@ArgsType()
+class CreateProfileArgs {
+  @Field(() => ProfileCreateInput, { nullable: false })
+  data!: ProfileCreateInput;
+}
+
+export { CreateProfileArgs };
+",
+  "server/src/profile/base/DeleteProfileArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+@ArgsType()
+class DeleteProfileArgs {
+  @Field(() => ProfileWhereUniqueInput, { nullable: false })
+  where!: ProfileWhereUniqueInput;
+}
+
+export { DeleteProfileArgs };
+",
+  "server/src/profile/base/Profile.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ObjectType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString, IsDate, ValidateNested, IsOptional } from \\"class-validator\\";
+import { Type } from \\"class-transformer\\";
+import { User } from \\"../../user/base/User\\";
+@ObjectType()
+class Profile {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  id!: string;
+
+  @ApiProperty({
+    required: true,
+  })
+  @IsDate()
+  @Type(() => Date)
+  @Field(() => Date)
+  createdAt!: Date;
+
+  @ApiProperty({
+    required: true,
+  })
+  @IsDate()
+  @Type(() => Date)
+  @Field(() => Date)
+  updatedAt!: Date;
+
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  email!: string;
+
+  @ApiProperty({
+    required: false,
+    type: () => User,
+  })
+  @ValidateNested()
+  @Type(() => User)
+  @IsOptional()
+  user?: User | null;
+}
+export { Profile };
+",
+  "server/src/profile/base/ProfileCreateInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString, ValidateNested, IsOptional } from \\"class-validator\\";
+import { UserWhereUniqueInput } from \\"../../user/base/UserWhereUniqueInput\\";
+import { Type } from \\"class-transformer\\";
+@InputType()
+class ProfileCreateInput {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  email!: string;
+
+  @ApiProperty({
+    required: false,
+    type: () => UserWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => UserWhereUniqueInput)
+  @IsOptional()
+  @Field(() => UserWhereUniqueInput, {
+    nullable: true,
+  })
+  user?: UserWhereUniqueInput | null;
+}
+export { ProfileCreateInput };
+",
+  "server/src/profile/base/ProfileFindManyArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { Type } from \\"class-transformer\\";
+import { ProfileOrderByInput } from \\"./ProfileOrderByInput\\";
+
+@ArgsType()
+class ProfileFindManyArgs {
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @Field(() => ProfileWhereInput, { nullable: true })
+  @Type(() => ProfileWhereInput)
+  where?: ProfileWhereInput;
+
+  @ApiProperty({
+    required: false,
+    type: [ProfileOrderByInput],
+  })
+  @Field(() => [ProfileOrderByInput], { nullable: true })
+  @Type(() => ProfileOrderByInput)
+  orderBy?: Array<ProfileOrderByInput>;
+
+  @ApiProperty({
+    required: false,
+    type: Number,
+  })
+  @Field(() => Number, { nullable: true })
+  @Type(() => Number)
+  skip?: number;
+
+  @ApiProperty({
+    required: false,
+    type: Number,
+  })
+  @Field(() => Number, { nullable: true })
+  @Type(() => Number)
+  take?: number;
+}
+
+export { ProfileFindManyArgs };
+",
+  "server/src/profile/base/ProfileFindUniqueArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+
+@ArgsType()
+class ProfileFindUniqueArgs {
+  @Field(() => ProfileWhereUniqueInput, { nullable: false })
+  where!: ProfileWhereUniqueInput;
+}
+
+export { ProfileFindUniqueArgs };
+",
+  "server/src/profile/base/ProfileListRelationFilter.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { ValidateNested, IsOptional } from \\"class-validator\\";
+import { Type } from \\"class-transformer\\";
+
+@InputType()
+class ProfileListRelationFilter {
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereInput)
+  @IsOptional()
+  @Field(() => ProfileWhereInput, {
+    nullable: true,
+  })
+  every?: ProfileWhereInput;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereInput)
+  @IsOptional()
+  @Field(() => ProfileWhereInput, {
+    nullable: true,
+  })
+  some?: ProfileWhereInput;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereInput)
+  @IsOptional()
+  @Field(() => ProfileWhereInput, {
+    nullable: true,
+  })
+  none?: ProfileWhereInput;
+}
+export { ProfileListRelationFilter };
+",
+  "server/src/profile/base/ProfileOrderByInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { SortOrder } from \\"../../util/SortOrder\\";
+
+@InputType({
+  isAbstract: true,
+  description: undefined,
+})
+class ProfileOrderByInput {
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  id?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  createdAt?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  updatedAt?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  email?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  userId?: SortOrder;
+}
+
+export { ProfileOrderByInput };
+",
+  "server/src/profile/base/ProfileUpdateInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString, IsOptional, ValidateNested } from \\"class-validator\\";
+import { UserWhereUniqueInput } from \\"../../user/base/UserWhereUniqueInput\\";
+import { Type } from \\"class-transformer\\";
+@InputType()
+class ProfileUpdateInput {
+  @ApiProperty({
+    required: false,
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  @Field(() => String, {
+    nullable: true,
+  })
+  email?: string;
+
+  @ApiProperty({
+    required: false,
+    type: () => UserWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => UserWhereUniqueInput)
+  @IsOptional()
+  @Field(() => UserWhereUniqueInput, {
+    nullable: true,
+  })
+  user?: UserWhereUniqueInput | null;
+}
+export { ProfileUpdateInput };
+",
+  "server/src/profile/base/ProfileWhereInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { StringFilter } from \\"../../util/StringFilter\\";
+import { Type } from \\"class-transformer\\";
+import { IsOptional, ValidateNested } from \\"class-validator\\";
+import { DateTimeFilter } from \\"../../util/DateTimeFilter\\";
+import { UserWhereUniqueInput } from \\"../../user/base/UserWhereUniqueInput\\";
+@InputType()
+class ProfileWhereInput {
+  @ApiProperty({
+    required: false,
+    type: StringFilter,
+  })
+  @Type(() => StringFilter)
+  @IsOptional()
+  @Field(() => StringFilter, {
+    nullable: true,
+  })
+  id?: StringFilter;
+
+  @ApiProperty({
+    required: false,
+    type: DateTimeFilter,
+  })
+  @Type(() => DateTimeFilter)
+  @IsOptional()
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+  })
+  createdAt?: DateTimeFilter;
+
+  @ApiProperty({
+    required: false,
+    type: DateTimeFilter,
+  })
+  @Type(() => DateTimeFilter)
+  @IsOptional()
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+  })
+  updatedAt?: DateTimeFilter;
+
+  @ApiProperty({
+    required: false,
+    type: StringFilter,
+  })
+  @Type(() => StringFilter)
+  @IsOptional()
+  @Field(() => StringFilter, {
+    nullable: true,
+  })
+  email?: StringFilter;
+
+  @ApiProperty({
+    required: false,
+    type: () => UserWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => UserWhereUniqueInput)
+  @IsOptional()
+  @Field(() => UserWhereUniqueInput, {
+    nullable: true,
+  })
+  user?: UserWhereUniqueInput;
+}
+export { ProfileWhereInput };
+",
+  "server/src/profile/base/ProfileWhereUniqueInput.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { InputType, Field } from \\"@nestjs/graphql\\";
+import { ApiProperty } from \\"@nestjs/swagger\\";
+import { IsString } from \\"class-validator\\";
+@InputType()
+class ProfileWhereUniqueInput {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @Field(() => String)
+  id!: string;
+}
+export { ProfileWhereUniqueInput };
+",
+  "server/src/profile/base/UpdateProfileArgs.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { ArgsType, Field } from \\"@nestjs/graphql\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+import { ProfileUpdateInput } from \\"./ProfileUpdateInput\\";
+
+@ArgsType()
+class UpdateProfileArgs {
+  @Field(() => ProfileWhereUniqueInput, { nullable: false })
+  where!: ProfileWhereUniqueInput;
+  @Field(() => ProfileUpdateInput, { nullable: false })
+  data!: ProfileUpdateInput;
+}
+
+export { UpdateProfileArgs };
+",
+  "server/src/profile/base/profile.controller.base.spec.ts": "import { Test } from \\"@nestjs/testing\\";
+import { INestApplication, HttpStatus, ExecutionContext } from \\"@nestjs/common\\";
+import request from \\"supertest\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { ACGuard } from \\"nest-access-control\\";
+import { DefaultAuthGuard } from \\"../../auth/defaultAuth.guard\\";
+import { ACLModule } from \\"../../auth/acl.module\\";
+import { ProfileController } from \\"../profile.controller\\";
+import { ProfileService } from \\"../profile.service\\";
+
+const nonExistingId = \\"nonExistingId\\";
+const existingId = \\"existingId\\";
+const CREATE_INPUT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  email: \\"exampleEmail\\",
+};
+const CREATE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  email: \\"exampleEmail\\",
+};
+const FIND_MANY_RESULT = [
+  {
+    id: \\"exampleId\\",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    email: \\"exampleEmail\\",
+  },
+];
+const FIND_ONE_RESULT = {
+  id: \\"exampleId\\",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  email: \\"exampleEmail\\",
+};
+
+const service = {
+  create() {
+    return CREATE_RESULT;
+  },
+  findMany: () => FIND_MANY_RESULT,
+  findOne: ({ where }: { where: { id: string } }) => {
+    switch (where.id) {
+      case existingId:
+        return FIND_ONE_RESULT;
+      case nonExistingId:
+        return null;
+    }
+  },
+};
+
+const basicAuthGuard = {
+  canActivate: (context: ExecutionContext) => {
+    const argumentHost = context.switchToHttp();
+    const request = argumentHost.getRequest();
+    request.user = {
+      roles: [\\"user\\"],
+    };
+    return true;
+  },
+};
+
+const acGuard = {
+  canActivate: () => {
+    return true;
+  },
+};
+
+describe(\\"Profile\\", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: ProfileService,
+          useValue: service,
+        },
+      ],
+      controllers: [ProfileController],
+      imports: [MorganModule.forRoot(), ACLModule],
+    })
+      .overrideGuard(DefaultAuthGuard)
+      .useValue(basicAuthGuard)
+      .overrideGuard(ACGuard)
+      .useValue(acGuard)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  test(\\"POST /profiles\\", async () => {
+    await request(app.getHttpServer())
+      .post(\\"/profiles\\")
+      .send(CREATE_INPUT)
+      .expect(HttpStatus.CREATED)
+      .expect({
+        ...CREATE_RESULT,
+        createdAt: CREATE_RESULT.createdAt.toISOString(),
+        updatedAt: CREATE_RESULT.updatedAt.toISOString(),
+      });
+  });
+
+  test(\\"GET /profiles\\", async () => {
+    await request(app.getHttpServer())
+      .get(\\"/profiles\\")
+      .expect(HttpStatus.OK)
+      .expect([
+        {
+          ...FIND_MANY_RESULT[0],
+          createdAt: FIND_MANY_RESULT[0].createdAt.toISOString(),
+          updatedAt: FIND_MANY_RESULT[0].updatedAt.toISOString(),
+        },
+      ]);
+  });
+
+  test(\\"GET /profiles/:id non existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/profiles\\"}/\${nonExistingId}\`)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        statusCode: HttpStatus.NOT_FOUND,
+        message: \`No resource was found for {\\"\${\\"id\\"}\\":\\"\${nonExistingId}\\"}\`,
+        error: \\"Not Found\\",
+      });
+  });
+
+  test(\\"GET /profiles/:id existing\\", async () => {
+    await request(app.getHttpServer())
+      .get(\`\${\\"/profiles\\"}/\${existingId}\`)
+      .expect(HttpStatus.OK)
+      .expect({
+        ...FIND_ONE_RESULT,
+        createdAt: FIND_ONE_RESULT.createdAt.toISOString(),
+        updatedAt: FIND_ONE_RESULT.updatedAt.toISOString(),
+      });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});
+",
+  "server/src/profile/base/profile.controller.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import * as common from \\"@nestjs/common\\";
+import * as swagger from \\"@nestjs/swagger\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import * as defaultAuthGuard from \\"../../auth/defaultAuth.guard\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
+import * as errors from \\"../../errors\\";
+import { Request } from \\"express\\";
+import { plainToClass } from \\"class-transformer\\";
+import { ApiNestedQuery } from \\"../../decorators/api-nested-query.decorator\\";
+import { ProfileService } from \\"../profile.service\\";
+import { AclValidateRequestInterceptor } from \\"../../interceptors/aclValidateRequest.interceptor\\";
+import { AclFilterResponseInterceptor } from \\"../../interceptors/aclFilterResponse.interceptor\\";
+import { ProfileCreateInput } from \\"./ProfileCreateInput\\";
+import { ProfileWhereInput } from \\"./ProfileWhereInput\\";
+import { ProfileWhereUniqueInput } from \\"./ProfileWhereUniqueInput\\";
+import { ProfileFindManyArgs } from \\"./ProfileFindManyArgs\\";
+import { ProfileUpdateInput } from \\"./ProfileUpdateInput\\";
+import { Profile } from \\"./Profile\\";
+@swagger.ApiBasicAuth()
+@common.UseGuards(defaultAuthGuard.DefaultAuthGuard, nestAccessControl.ACGuard)
+export class ProfileControllerBase {
+  constructor(
+    protected readonly service: ProfileService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {}
+
+  @common.UseInterceptors(AclValidateRequestInterceptor)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"create\\",
+    possession: \\"any\\",
+  })
+  @common.Post()
+  @swagger.ApiCreatedResponse({ type: Profile })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async create(@common.Body() data: ProfileCreateInput): Promise<Profile> {
+    return await this.service.create({
+      data: {
+        ...data,
+
+        user: data.user
+          ? {
+              connect: data.user,
+            }
+          : undefined,
+      },
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        email: true,
+
+        user: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  @common.Get()
+  @swagger.ApiOkResponse({ type: [Profile] })
+  @swagger.ApiForbiddenResponse()
+  @ApiNestedQuery(ProfileFindManyArgs)
+  async findMany(@common.Req() request: Request): Promise<Profile[]> {
+    const args = plainToClass(ProfileFindManyArgs, request.query);
+    return this.service.findMany({
+      ...args,
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        email: true,
+
+        user: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"own\\",
+  })
+  @common.Get(\\"/:id\\")
+  @swagger.ApiOkResponse({ type: Profile })
+  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async findOne(
+    @common.Param() params: ProfileWhereUniqueInput
+  ): Promise<Profile | null> {
+    const result = await this.service.findOne({
+      where: params,
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        email: true,
+
+        user: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+    if (result === null) {
+      throw new errors.NotFoundException(
+        \`No resource was found for \${JSON.stringify(params)}\`
+      );
+    }
+    return result;
+  }
+
+  @common.UseInterceptors(AclValidateRequestInterceptor)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"update\\",
+    possession: \\"any\\",
+  })
+  @common.Patch(\\"/:id\\")
+  @swagger.ApiOkResponse({ type: Profile })
+  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async update(
+    @common.Param() params: ProfileWhereUniqueInput,
+    @common.Body() data: ProfileUpdateInput
+  ): Promise<Profile | null> {
+    try {
+      return await this.service.update({
+        where: params,
+        data: {
+          ...data,
+
+          user: data.user
+            ? {
+                connect: data.user,
+              }
+            : undefined,
+        },
+        select: {
+          id: true,
+          createdAt: true,
+          updatedAt: true,
+          email: true,
+
+          user: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      });
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new errors.NotFoundException(
+          \`No resource was found for \${JSON.stringify(params)}\`
+        );
+      }
+      throw error;
+    }
+  }
+
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"delete\\",
+    possession: \\"any\\",
+  })
+  @common.Delete(\\"/:id\\")
+  @swagger.ApiOkResponse({ type: Profile })
+  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
+  @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
+  async delete(
+    @common.Param() params: ProfileWhereUniqueInput
+  ): Promise<Profile | null> {
+    try {
+      return await this.service.delete({
+        where: params,
+        select: {
+          id: true,
+          createdAt: true,
+          updatedAt: true,
+          email: true,
+
+          user: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      });
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new errors.NotFoundException(
+          \`No resource was found for \${JSON.stringify(params)}\`
+        );
+      }
+      throw error;
+    }
+  }
+}
+",
+  "server/src/profile/base/profile.module.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { Module, forwardRef } from \\"@nestjs/common\\";
+import { MorganModule } from \\"nest-morgan\\";
+import { PrismaModule } from \\"nestjs-prisma\\";
+import { ACLModule } from \\"../../auth/acl.module\\";
+import { AuthModule } from \\"../../auth/auth.module\\";
+
+@Module({
+  imports: [
+    ACLModule,
+    forwardRef(() => AuthModule),
+    MorganModule,
+    PrismaModule,
+  ],
+
+  exports: [ACLModule, AuthModule, MorganModule, PrismaModule],
+})
+export class ProfileModuleBase {}
+",
+  "server/src/profile/base/profile.resolver.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import * as common from \\"@nestjs/common\\";
+import * as graphql from \\"@nestjs/graphql\\";
+import * as apollo from \\"apollo-server-express\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { GqlDefaultAuthGuard } from \\"../../auth/gqlDefaultAuth.guard\\";
+import * as gqlACGuard from \\"../../auth/gqlAC.guard\\";
+import { isRecordNotFoundError } from \\"../../prisma.util\\";
+import { MetaQueryPayload } from \\"../../util/MetaQueryPayload\\";
+import { AclFilterResponseInterceptor } from \\"../../interceptors/aclFilterResponse.interceptor\\";
+import { AclValidateRequestInterceptor } from \\"../../interceptors/aclValidateRequest.interceptor\\";
+import { CreateProfileArgs } from \\"./CreateProfileArgs\\";
+import { UpdateProfileArgs } from \\"./UpdateProfileArgs\\";
+import { DeleteProfileArgs } from \\"./DeleteProfileArgs\\";
+import { ProfileFindManyArgs } from \\"./ProfileFindManyArgs\\";
+import { ProfileFindUniqueArgs } from \\"./ProfileFindUniqueArgs\\";
+import { Profile } from \\"./Profile\\";
+import { User } from \\"../../user/base/User\\";
+import { ProfileService } from \\"../profile.service\\";
+
+@graphql.Resolver(() => Profile)
+@common.UseGuards(GqlDefaultAuthGuard, gqlACGuard.GqlACGuard)
+export class ProfileResolverBase {
+  constructor(
+    protected readonly service: ProfileService,
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {}
+
+  @graphql.Query(() => MetaQueryPayload)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  async _profilesMeta(
+    @graphql.Args() args: ProfileFindManyArgs
+  ): Promise<MetaQueryPayload> {
+    const results = await this.service.count({
+      ...args,
+      skip: undefined,
+      take: undefined,
+    });
+    return {
+      count: results,
+    };
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @graphql.Query(() => [Profile])
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  async profiles(
+    @graphql.Args() args: ProfileFindManyArgs
+  ): Promise<Profile[]> {
+    return this.service.findMany(args);
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @graphql.Query(() => Profile, { nullable: true })
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"own\\",
+  })
+  async profile(
+    @graphql.Args() args: ProfileFindUniqueArgs
+  ): Promise<Profile | null> {
+    const result = await this.service.findOne(args);
+    if (result === null) {
+      return null;
+    }
+    return result;
+  }
+
+  @common.UseInterceptors(AclValidateRequestInterceptor)
+  @graphql.Mutation(() => Profile)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"create\\",
+    possession: \\"any\\",
+  })
+  async createProfile(
+    @graphql.Args() args: CreateProfileArgs
+  ): Promise<Profile> {
+    return await this.service.create({
+      ...args,
+      data: {
+        ...args.data,
+
+        user: args.data.user
+          ? {
+              connect: args.data.user,
+            }
+          : undefined,
+      },
+    });
+  }
+
+  @common.UseInterceptors(AclValidateRequestInterceptor)
+  @graphql.Mutation(() => Profile)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"update\\",
+    possession: \\"any\\",
+  })
+  async updateProfile(
+    @graphql.Args() args: UpdateProfileArgs
+  ): Promise<Profile | null> {
+    try {
+      return await this.service.update({
+        ...args,
+        data: {
+          ...args.data,
+
+          user: args.data.user
+            ? {
+                connect: args.data.user,
+              }
+            : undefined,
+        },
+      });
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new apollo.ApolloError(
+          \`No resource was found for \${JSON.stringify(args.where)}\`
+        );
+      }
+      throw error;
+    }
+  }
+
+  @graphql.Mutation(() => Profile)
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"delete\\",
+    possession: \\"any\\",
+  })
+  async deleteProfile(
+    @graphql.Args() args: DeleteProfileArgs
+  ): Promise<Profile | null> {
+    try {
+      return await this.service.delete(args);
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        throw new apollo.ApolloError(
+          \`No resource was found for \${JSON.stringify(args.where)}\`
+        );
+      }
+      throw error;
+    }
+  }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @graphql.ResolveField(() => User, { nullable: true })
+  @nestAccessControl.UseRoles({
+    resource: \\"User\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  async user(@graphql.Parent() parent: Profile): Promise<User | null> {
+    const result = await this.service.getUser(parent.id);
+
+    if (!result) {
+      return null;
+    }
+    return result;
+  }
+}
+",
+  "server/src/profile/base/profile.service.base.ts": "/*
+------------------------------------------------------------------------------ 
+This code was generated by Amplication. 
+ 
+Changes to this file will be lost if the code is regenerated. 
+
+There are other ways to to customize your code, see this doc to learn more
+https://docs.amplication.com/docs/how-to/custom-code
+
+------------------------------------------------------------------------------
+  */
+import { PrismaService } from \\"nestjs-prisma\\";
+import { Prisma, Profile, User } from \\"@prisma/client\\";
+
+export class ProfileServiceBase {
+  constructor(protected readonly prisma: PrismaService) {}
+
+  async count<T extends Prisma.ProfileFindManyArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
+  ): Promise<number> {
+    return this.prisma.profile.count(args);
+  }
+
+  async findMany<T extends Prisma.ProfileFindManyArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
+  ): Promise<Profile[]> {
+    return this.prisma.profile.findMany(args);
+  }
+  async findOne<T extends Prisma.ProfileFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
+  ): Promise<Profile | null> {
+    return this.prisma.profile.findUnique(args);
+  }
+  async create<T extends Prisma.ProfileCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileCreateArgs>
+  ): Promise<Profile> {
+    return this.prisma.profile.create<T>(args);
+  }
+  async update<T extends Prisma.ProfileUpdateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileUpdateArgs>
+  ): Promise<Profile> {
+    return this.prisma.profile.update<T>(args);
+  }
+  async delete<T extends Prisma.ProfileDeleteArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ProfileDeleteArgs>
+  ): Promise<Profile> {
+    return this.prisma.profile.delete(args);
+  }
+
+  async getUser(parentId: string): Promise<User | null> {
+    return this.prisma.profile
+      .findUnique({
+        where: { id: parentId },
+      })
+      .user();
+  }
+}
+",
+  "server/src/profile/profile.controller.ts": "import * as common from \\"@nestjs/common\\";
+import * as swagger from \\"@nestjs/swagger\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { ProfileService } from \\"./profile.service\\";
+import { ProfileControllerBase } from \\"./base/profile.controller.base\\";
+
+@swagger.ApiTags(\\"profiles\\")
+@common.Controller(\\"profiles\\")
+export class ProfileController extends ProfileControllerBase {
+  constructor(
+    protected readonly service: ProfileService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/profile/profile.module.ts": "import { Module } from \\"@nestjs/common\\";
+import { ProfileModuleBase } from \\"./base/profile.module.base\\";
+import { ProfileService } from \\"./profile.service\\";
+import { ProfileController } from \\"./profile.controller\\";
+import { ProfileResolver } from \\"./profile.resolver\\";
+
+@Module({
+  imports: [ProfileModuleBase],
+  controllers: [ProfileController],
+  providers: [ProfileService, ProfileResolver],
+  exports: [ProfileService],
+})
+export class ProfileModule {}
+",
+  "server/src/profile/profile.resolver.ts": "import * as common from \\"@nestjs/common\\";
+import * as graphql from \\"@nestjs/graphql\\";
+import * as nestAccessControl from \\"nest-access-control\\";
+import { GqlDefaultAuthGuard } from \\"../auth/gqlDefaultAuth.guard\\";
+import * as gqlACGuard from \\"../auth/gqlAC.guard\\";
+import { ProfileResolverBase } from \\"./base/profile.resolver.base\\";
+import { Profile } from \\"./base/Profile\\";
+import { ProfileService } from \\"./profile.service\\";
+
+@graphql.Resolver(() => Profile)
+@common.UseGuards(GqlDefaultAuthGuard, gqlACGuard.GqlACGuard)
+export class ProfileResolver extends ProfileResolverBase {
+  constructor(
+    protected readonly service: ProfileService,
+    @nestAccessControl.InjectRolesBuilder()
+    protected readonly rolesBuilder: nestAccessControl.RolesBuilder
+  ) {
+    super(service, rolesBuilder);
+  }
+}
+",
+  "server/src/profile/profile.service.ts": "import { Injectable } from \\"@nestjs/common\\";
+import { PrismaService } from \\"nestjs-prisma\\";
+import { ProfileServiceBase } from \\"./base/profile.service.base\\";
+
+@Injectable()
+export class ProfileService extends ProfileServiceBase {
+  constructor(protected readonly prisma: PrismaService) {
+    super(prisma);
+  }
+}
+",
   "server/src/providers/secrets/base/secretsManager.service.base.spec.ts": "import { ConfigService } from \\"@nestjs/config\\";
 import { mock } from \\"jest-mock-extended\\";
 import { SecretsManagerServiceBase } from \\"./secretsManager.service.base\\";
@@ -10854,6 +12342,7 @@ import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { GraphQLJSONObject } from \\"graphql-type-json\\";
 import { JsonValue } from \\"type-fest\\";
+import { Profile } from \\"../../profile/base/Profile\\";
 @ObjectType()
 class User {
   @ApiProperty({
@@ -11003,6 +12492,15 @@ class User {
   @IsJSON()
   @Field(() => GraphQLJSONObject)
   extendedProperties!: JsonValue;
+
+  @ApiProperty({
+    required: false,
+    type: () => Profile,
+  })
+  @ValidateNested()
+  @Type(() => Profile)
+  @IsOptional()
+  profile?: Profile | null;
 }
 export { User };
 ",
@@ -11040,6 +12538,7 @@ import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { GraphQLJSONObject } from \\"graphql-type-json\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../../profile/base/ProfileWhereUniqueInput\\";
 @InputType()
 class UserCreateInput {
   @ApiProperty({
@@ -11196,6 +12695,18 @@ class UserCreateInput {
   @IsJSON()
   @Field(() => GraphQLJSONObject)
   extendedProperties!: InputJsonValue;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereUniqueInput)
+  @IsOptional()
+  @Field(() => ProfileWhereUniqueInput, {
+    nullable: true,
+  })
+  profile?: ProfileWhereUniqueInput | null;
 }
 export { UserCreateInput };
 ",
@@ -11522,6 +13033,15 @@ class UserOrderByInput {
     nullable: true,
   })
   extendedProperties?: SortOrder;
+
+  @ApiProperty({
+    required: false,
+    enum: [\\"asc\\", \\"desc\\"],
+  })
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
+  profileId?: SortOrder;
 }
 
 export { UserOrderByInput };
@@ -11560,6 +13080,7 @@ import { EnumUserInterests } from \\"./EnumUserInterests\\";
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { GraphQLJSONObject } from \\"graphql-type-json\\";
 import { InputJsonValue } from \\"../../types\\";
+import { ProfileWhereUniqueInput } from \\"../../profile/base/ProfileWhereUniqueInput\\";
 @InputType()
 class UserUpdateInput {
   @ApiProperty({
@@ -11755,6 +13276,18 @@ class UserUpdateInput {
     nullable: true,
   })
   extendedProperties?: InputJsonValue;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereUniqueInput)
+  @IsOptional()
+  @Field(() => ProfileWhereUniqueInput, {
+    nullable: true,
+  })
+  profile?: ProfileWhereUniqueInput | null;
 }
 export { UserUpdateInput };
 ",
@@ -11826,6 +13359,7 @@ import { OrganizationListRelationFilter } from \\"../../organization/base/Organi
 import { EnumUserPriority } from \\"./EnumUserPriority\\";
 import { BooleanFilter } from \\"../../util/BooleanFilter\\";
 import { JsonFilter } from \\"../../util/JsonFilter\\";
+import { ProfileWhereUniqueInput } from \\"../../profile/base/ProfileWhereUniqueInput\\";
 @InputType()
 class UserWhereInput {
   @ApiProperty({
@@ -11950,6 +13484,18 @@ class UserWhereInput {
     nullable: true,
   })
   extendedProperties?: JsonFilter;
+
+  @ApiProperty({
+    required: false,
+    type: () => ProfileWhereUniqueInput,
+  })
+  @ValidateNested()
+  @Type(() => ProfileWhereUniqueInput)
+  @IsOptional()
+  @Field(() => ProfileWhereUniqueInput, {
+    nullable: true,
+  })
+  profile?: ProfileWhereUniqueInput;
 }
 export { UserWhereInput };
 ",
@@ -12214,6 +13760,12 @@ export class UserControllerBase {
               connect: data.manager,
             }
           : undefined,
+
+        profile: data.profile
+          ? {
+              connect: data.profile,
+            }
+          : undefined,
       },
       select: {
         username: true,
@@ -12237,6 +13789,12 @@ export class UserControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
   }
@@ -12277,6 +13835,12 @@ export class UserControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
   }
@@ -12318,6 +13882,12 @@ export class UserControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
     if (result === null) {
@@ -12353,6 +13923,12 @@ export class UserControllerBase {
                 connect: data.manager,
               }
             : undefined,
+
+          profile: data.profile
+            ? {
+                connect: data.profile,
+              }
+            : undefined,
         },
         select: {
           username: true,
@@ -12376,6 +13952,12 @@ export class UserControllerBase {
           isCurious: true,
           location: true,
           extendedProperties: true,
+
+          profile: {
+            select: {
+              id: true,
+            },
+          },
         },
       });
     } catch (error) {
@@ -12425,6 +14007,12 @@ export class UserControllerBase {
           isCurious: true,
           location: true,
           extendedProperties: true,
+
+          profile: {
+            select: {
+              id: true,
+            },
+          },
         },
       });
     } catch (error) {
@@ -12474,6 +14062,12 @@ export class UserControllerBase {
         isCurious: true,
         location: true,
         extendedProperties: true,
+
+        profile: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
     if (results === null) {
@@ -12705,6 +14299,7 @@ import { UserFindUniqueArgs } from \\"./UserFindUniqueArgs\\";
 import { User } from \\"./User\\";
 import { OrganizationFindManyArgs } from \\"../../organization/base/OrganizationFindManyArgs\\";
 import { Organization } from \\"../../organization/base/Organization\\";
+import { Profile } from \\"../../profile/base/Profile\\";
 import { UserService } from \\"../user.service\\";
 
 @graphql.Resolver(() => User)
@@ -12778,6 +14373,12 @@ export class UserResolverBase {
               connect: args.data.manager,
             }
           : undefined,
+
+        profile: args.data.profile
+          ? {
+              connect: args.data.profile,
+            }
+          : undefined,
       },
     });
   }
@@ -12799,6 +14400,12 @@ export class UserResolverBase {
           manager: args.data.manager
             ? {
                 connect: args.data.manager,
+              }
+            : undefined,
+
+          profile: args.data.profile
+            ? {
+                connect: args.data.profile,
               }
             : undefined,
         },
@@ -12887,6 +14494,22 @@ export class UserResolverBase {
     }
     return result;
   }
+
+  @common.UseInterceptors(AclFilterResponseInterceptor)
+  @graphql.ResolveField(() => Profile, { nullable: true })
+  @nestAccessControl.UseRoles({
+    resource: \\"Profile\\",
+    action: \\"read\\",
+    possession: \\"any\\",
+  })
+  async profile(@graphql.Parent() parent: User): Promise<Profile | null> {
+    const result = await this.service.getProfile(parent.id);
+
+    if (!result) {
+      return null;
+    }
+    return result;
+  }
 }
 ",
   "server/src/user/base/user.service.base.ts": "/*
@@ -12901,7 +14524,7 @@ https://docs.amplication.com/docs/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from \\"nestjs-prisma\\";
-import { Prisma, User, Organization } from \\"@prisma/client\\";
+import { Prisma, User, Organization, Profile } from \\"@prisma/client\\";
 import { PasswordService } from \\"../../auth/password.service\\";
 import { transformStringFieldUpdateInput } from \\"../../prisma.util\\";
 
@@ -12991,6 +14614,14 @@ export class UserServiceBase {
         where: { id: parentId },
       })
       .manager();
+  }
+
+  async getProfile(parentId: string): Promise<Profile | null> {
+    return this.prisma.user
+      .findUnique({
+        where: { id: parentId },
+      })
+      .profile();
   }
 }
 ",

--- a/packages/amplication-data-service-generator/src/tests/entities.ts
+++ b/packages/amplication-data-service-generator/src/tests/entities.ts
@@ -6,6 +6,7 @@ import {
 } from "@amplication/code-gen-types";
 
 const CUSTOMER_ENTITY_ID = "b8d49afb-8c12-49fa-9d6e-eb64be0ddded";
+const PROFILE_ENTITY_ID = "f36aa4e3-d275-41d0-843a-876ec66bc2f7";
 const CUSTOMER_ORDERS_FIELD_ID = "a766a160-506c-4212-9e5e-8ecd1d530eb4";
 const CUSTOMER_ORGANIZATION_FIELD_ID = "e4ea7c84-e998-482e-8bd2-34657a3ff23c";
 const CUSTOMER_VIP_ORGANIZATION_FIELD_ID =
@@ -22,6 +23,9 @@ const USER_ORGANIZATION_FIELD_ID = "ae21f2fb-9174-49de-9576-632d859a5dd1";
 
 const USER_MANAGER_FIELD_ID = "9bb55fcc-1c3a-4b99-8bcf-6ea85d052c3d";
 const USER_EMPLOYEES_FIELD_ID = "7bb3d5c1-f5b9-4fa4-8087-87f0c549d5f2";
+
+const USER_PROFILE_FIELD_ID = "118e407b-30f7-48da-af9c-de1393548b4c";
+const PROFILE_USER_FIELD_ID = "42d31012-6164-472a-92d0-a8f5dc0486d4";
 
 const USER: Entity = {
   id: USER_ID,
@@ -210,6 +214,124 @@ const USER: Entity = {
       unique: false,
       searchable: true,
       dataType: EnumDataType.Json,
+    },
+    // check 1:1 relation
+    {
+      id: "b227bd7a-2fe5-47f8-8f3e-29a2c26111b7",
+      permanentId: USER_PROFILE_FIELD_ID,
+      name: "profile",
+      displayName: "Profile",
+      dataType: EnumDataType.Lookup,
+      properties: {
+        relatedEntityId: PROFILE_ENTITY_ID,
+        relatedFieldId: PROFILE_USER_FIELD_ID,
+        allowMultipleSelection: false,
+      },
+      required: false,
+      unique: false,
+      searchable: true,
+    },
+  ],
+  permissions: [
+    {
+      action: EnumEntityAction.Create,
+      permissionFields: [],
+      permissionRoles: [],
+      type: EnumEntityPermissionType.AllRoles,
+    },
+    {
+      action: EnumEntityAction.Delete,
+      permissionFields: [],
+      permissionRoles: [],
+      type: EnumEntityPermissionType.AllRoles,
+    },
+    {
+      action: EnumEntityAction.Search,
+      permissionFields: [],
+      permissionRoles: [],
+      type: EnumEntityPermissionType.AllRoles,
+    },
+    {
+      action: EnumEntityAction.Update,
+      permissionFields: [],
+      permissionRoles: [],
+      type: EnumEntityPermissionType.AllRoles,
+    },
+    {
+      action: EnumEntityAction.View,
+      permissionFields: [],
+      permissionRoles: [],
+      type: EnumEntityPermissionType.AllRoles,
+    },
+  ],
+};
+
+const PROFILE: Entity = {
+  id: PROFILE_ENTITY_ID,
+  name: "Profile",
+  displayName: "Profile",
+  pluralDisplayName: "Profiles",
+  pluralName: "profiles",
+  fields: [
+    {
+      id: "fbf703ef-c844-4ccc-9e0b-519bb5865dd4",
+      permanentId: "34306463-d040-40cf-8027-732256a2f09a",
+      name: "id",
+      displayName: "Id",
+      dataType: EnumDataType.Id,
+      properties: {},
+      required: true,
+      unique: false,
+      searchable: true,
+    },
+    {
+      id: "9fb9d3a7-dbb9-446d-86c6-64288f155376",
+      permanentId: "0f95129d-21bc-4356-b654-06bb6bc716d9",
+      name: "createdAt",
+      displayName: "Created At",
+      dataType: EnumDataType.CreatedAt,
+      properties: {},
+      required: true,
+      unique: false,
+      searchable: true,
+    },
+    {
+      id: "6c373d03-3e01-4b49-9a24-abae9a019acb",
+      permanentId: "540c2056-7b17-4d9f-b880-d151f3d09e36",
+      name: "updatedAt",
+      displayName: "Updated At",
+      dataType: EnumDataType.UpdatedAt,
+      properties: {},
+      required: true,
+      unique: false,
+      searchable: true,
+    },
+    {
+      id: "73ae2f7e-be53-4ad1-9e0a-e67b4813f152",
+      permanentId: "50068313-7da1-406a-a6d0-99600ef0291a",
+      name: "email",
+      displayName: "Email",
+      dataType: EnumDataType.Email,
+      properties: {},
+      required: true,
+      unique: false,
+      searchable: true,
+    },
+    // check 1:1 relation
+    {
+      id: "c98933ba-1fbb-46b3-9460-07328bc3b08b",
+      permanentId: PROFILE_USER_FIELD_ID,
+      name: "user",
+      displayName: "User",
+      dataType: EnumDataType.Lookup,
+      properties: {
+        relatedEntityId: USER_ID,
+        relatedFieldId: USER_PROFILE_FIELD_ID,
+        allowMultipleSelection: false,
+      },
+      required: false,
+      unique: false,
+      searchable: true,
     },
   ],
   permissions: [
@@ -877,6 +999,13 @@ const EMPTY: Entity = {
   ],
 };
 
-const entities: Entity[] = [USER, ORDER, ORGANIZATION, CUSTOMER, EMPTY];
+const entities: Entity[] = [
+  USER,
+  PROFILE,
+  ORDER,
+  ORGANIZATION,
+  CUSTOMER,
+  EMPTY,
+];
 
 export default entities;

--- a/packages/amplication-data-service-generator/src/version.ts
+++ b/packages/amplication-data-service-generator/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.14.1";
+export const version = "0.14.3";


### PR DESCRIPTION
Issue Number: #2578 

## PR Details
When setting 1:1 relation and running the generated app, prisma schema was generated in a wrong way.

According to Prisma: _"In a one-to-one relation, the side of the relation without a relation scalar (the field representing the foreign key in the database) must be optional"_

The code was generated without the "?" meaning: required.

Another issue: the side of the relation **with** the foreign key must be `@unique`
![image](https://user-images.githubusercontent.com/39680385/179850968-d22facf4-befb-4f12-a931-97aa7c50248d.png)

The profile relation field of the User model references the id field of the Profile model.  In this case, you need to mark the field with the @unique attribute, to guarantee that there is only a single Profile connected to each User.

![Screen Shot 2022-07-20 at 0 17 07](https://user-images.githubusercontent.com/39680385/179850435-a3be2275-286d-4090-bafb-4a18d9caa1c3.png)


## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

