### PR TITLE
Use repo's default base branch for Amplication PRs

### DIFF
--- a/packages/amplication-data-service-generator/src/version.ts
+++ b/packages/amplication-data-service-generator/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.14.1";
+export const version = "0.14.4";

--- a/packages/amplication-git-pull-request-service/src/core/pull-request/dto/GitCommit.ts
+++ b/packages/amplication-git-pull-request-service/src/core/pull-request/dto/GitCommit.ts
@@ -1,8 +1,9 @@
-import { IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class GitCommit {
   @IsString()
-  base!: string;
+  @IsOptional()
+  base?: string | undefined;
   @IsString()
   head!: string;
   @IsString()

--- a/packages/amplication-git-pull-request-service/src/core/pull-request/dto/GitCommit.ts
+++ b/packages/amplication-git-pull-request-service/src/core/pull-request/dto/GitCommit.ts
@@ -3,7 +3,7 @@ import { IsOptional, IsString } from 'class-validator';
 export class GitCommit {
   @IsString()
   @IsOptional()
-  base?: string | undefined;
+  base?: string;
   @IsString()
   head!: string;
   @IsString()

--- a/packages/amplication-git-pull-request-service/src/core/pull-request/pull-request.service.ts
+++ b/packages/amplication-git-pull-request-service/src/core/pull-request/pull-request.service.ts
@@ -44,8 +44,8 @@ export class PullRequestService {
       head,
       title,
       body,
-      base,
-      installationId
+      installationId,
+      base
     );
     this.logger.info('Opened a new pull request', { prUrl });
     return { value: { url: prUrl }, status: StatusEnum.Success, error: null };

--- a/packages/amplication-git-service/src/services/git.service.ts
+++ b/packages/amplication-git-service/src/services/git.service.ts
@@ -88,8 +88,8 @@ export class GitService {
     commitName: string,
     commitMessage: string,
     commitDescription: string,
-    baseBranchName: string,
-    installationId: string
+    installationId: string,
+    baseBranchName?: string | undefined
   ): Promise<string> {
     const service = this.gitServiceFactory.getService(gitProvider);
     return await service.createPullRequest(

--- a/packages/amplication-git-service/src/services/git.service.ts
+++ b/packages/amplication-git-service/src/services/git.service.ts
@@ -89,7 +89,7 @@ export class GitService {
     commitMessage: string,
     commitDescription: string,
     installationId: string,
-    baseBranchName?: string | undefined
+    baseBranchName?: string
   ): Promise<string> {
     const service = this.gitServiceFactory.getService(gitProvider);
     return await service.createPullRequest(

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -467,8 +467,8 @@ export class BuildService {
                 installationId: appRepository.gitOrganization.installationId,
                 newBuildId: build.id,
                 oldBuildId,
+                // the base parameter is missing because that in the future we will implement a custom branches but now we don't send so its the default branch
                 commit: {
-                  base: 'main',
                   head: `amplication-build-${build.id}`,
                   title: commitMessage,
                   body: `Amplication build # ${build.id}.

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -467,7 +467,6 @@ export class BuildService {
                 installationId: appRepository.gitOrganization.installationId,
                 newBuildId: build.id,
                 oldBuildId,
-                // the base parameter is missing because that in the future we will implement a custom branches but now we don't send so its the default branch
                 commit: {
                   head: `amplication-build-${build.id}`,
                   title: commitMessage,

--- a/packages/amplication-server/src/core/build/dto/GitCommit.ts
+++ b/packages/amplication-server/src/core/build/dto/GitCommit.ts
@@ -1,8 +1,9 @@
-import { IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class GitCommit {
   @IsString()
-  base!: string;
+  @IsOptional()
+  base?: string | undefined;
   @IsString()
   head!: string;
   @IsString()

--- a/packages/amplication-server/src/core/build/dto/GitCommit.ts
+++ b/packages/amplication-server/src/core/build/dto/GitCommit.ts
@@ -3,7 +3,7 @@ import { IsOptional, IsString } from 'class-validator';
 export class GitCommit {
   @IsString()
   @IsOptional()
-  base?: string | undefined;
+  base?: string;
   @IsString()
   head!: string;
   @IsString()


### PR DESCRIPTION
closes: #3192 

## PR Details

Currently, we have an issue where the base branch is statically defined as `main`. This does not work for many users who choose to use different names, such as `master`.

This PR makes it so we use the target GitHub repo's base branch instead.

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
