### PR TITLE
CLI - fix `AMP_SERVER_URL` value

### DIFF
--- a/packages/amplication-cli/src/properties.ts
+++ b/packages/amplication-cli/src/properties.ts
@@ -3,7 +3,7 @@ export const AMP_CURRENT_ENTITY = 'AMP_CURRENT_ENTITY';
 export const AMP_CURRENT_FIELD = 'AMP_CURRENT_FIELD';
 export const AMP_SERVER_URL = 'AMP_SERVER_URL';
 export const AMP_OUTPUT_FORMAT = 'AMP_OUTPUT_FORMAT';
-export const DEFAULT_SERVER_URL = 'https://app.amplication.com';
+export const DEFAULT_SERVER_URL = 'https://server.amplication.com';
 
 export const allowedProperties = [
   AMP_CURRENT_APP,


### PR DESCRIPTION
fixed issue: #2865 

## PR Details

[CLI docs](https://docs.amplication.com/docs/cli/) says that the server URL's default should be server.amplication.com, but it's still app.amplication.com.

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
