### PR TITLE
update route sign-up path to go to service wizard

### DIFF
--- a/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
@@ -41,7 +41,6 @@ const CreateServiceWizard: React.FC<Props> = ({ moduleClass, match }) => {
 
   const { trackEvent } = useTracking();
   const history = useHistory();
-  
   const [createResourceWithEntities, { loading, data, error }] = useMutation<
     TData
   >(CREATE_RESOURCE_WITH_ENTITIES, {

--- a/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
@@ -41,7 +41,7 @@ const CreateServiceWizard: React.FC<Props> = ({ moduleClass, match }) => {
 
   const { trackEvent } = useTracking();
   const history = useHistory();
-
+  
   const [createResourceWithEntities, { loading, data, error }] = useMutation<
     TData
   >(CREATE_RESOURCE_WITH_ENTITIES, {

--- a/packages/amplication-client/src/User/Signup.tsx
+++ b/packages/amplication-client/src/User/Signup.tsx
@@ -58,11 +58,10 @@ const Signup = () => {
   useEffect(() => {
     if (data) {
       setToken(data.signup.token);
-      // @ts-ignore
-      const { from } = location.state || {
-        from: { pathname: "/create-resource" },
-      };
-      history.replace(from);
+      history.push({
+        pathname: '/',
+        search: '?route=create-resource'
+      })
     }
   }, [data, history, location]);
 

--- a/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
@@ -28,7 +28,10 @@ type Props = {
   InnerRoutes: JSX.Element | undefined;
 };
 
-const WorkspaceLayout: React.FC<Props> = ({ InnerRoutes, moduleClass }) => {
+const WorkspaceLayout: React.FC<Props> = ({
+  InnerRoutes,
+  moduleClass,
+}) => {
   const authenticated = useAuthenticated();
   const { currentWorkspace, handleSetCurrentWorkspace } = useWorkspaceSelector(
     authenticated

--- a/packages/amplication-client/src/Workspaces/hooks/useCurrentWorkspace.ts
+++ b/packages/amplication-client/src/Workspaces/hooks/useCurrentWorkspace.ts
@@ -35,8 +35,11 @@ const useCurrentWorkspace = (authenticated: boolean) => {
 
   useEffect(() => {
     if (!(data && data.currentWorkspace)) return;
-
-    location.pathname === "/" && history.push(`/${data.currentWorkspace.id}`);
+    location.pathname === "/" &&
+      history.push({
+        pathname: `/${data.currentWorkspace.id}`,
+        search: location.search,
+      });
   }, [data, history, location]);
 
   return {

--- a/packages/amplication-client/src/Workspaces/hooks/useProjectSelector.ts
+++ b/packages/amplication-client/src/Workspaces/hooks/useProjectSelector.ts
@@ -1,6 +1,6 @@
 import { useLazyQuery, useMutation } from "@apollo/client";
 import { useCallback, useEffect, useState } from "react";
-import { useHistory, useParams } from "react-router-dom";
+import { useHistory, useLocation, useParams } from "react-router-dom";
 import * as models from "../../models";
 import { CREATE_PROJECT, GET_PROJECTS } from "../queries/projectQuery";
 
@@ -19,6 +19,7 @@ const useProjectSelector = (
   currentWorkspace: models.Workspace | undefined
 ) => {
   const history = useHistory();
+  const location = useLocation();
   const { project } = useParams<{ project?: string; resource?: string }>();
   const [currentProject, setCurrentProject] = useState<models.Project>();
   const [projectsList, setProjectList] = useState<models.Project[]>([]);
@@ -47,14 +48,16 @@ const useProjectSelector = (
         null
       );
 
+      const isFromSignup = location.search.includes("route=create-resource");
       selectedProject && setCurrentProject(selectedProject);
       currentWorkspace &&
         history.push(
           `/${currentWorkspace.id}/${
             selectedProject ? selectedProject.id : projects[0].id
-          }`
+          }${isFromSignup ? "/create-resource" : ""}`
         );
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [currentWorkspace, history, project]
   );
 

--- a/packages/amplication-client/src/Workspaces/hooks/useWorkspaceSelector.ts
+++ b/packages/amplication-client/src/Workspaces/hooks/useWorkspaceSelector.ts
@@ -54,14 +54,17 @@ const useWorkspaceSelector = (authenticated: boolean) => {
 
   useEffect(() => {
     if (loading && !authenticated) return;
-
     data &&
       data.currentWorkspace.id !== workspace &&
-      history.push(`/${data.currentWorkspace.id}`);
+      history.push({
+        pathname: `/${data.currentWorkspace.id}`,
+        search: location.search,
+      });
 
     data &&
       data.currentWorkspace.id === workspace &&
       setCurrentWorkspace(data.currentWorkspace);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authenticated, data, history, loading, workspace]);
 
   useEffect(() => {

--- a/packages/amplication-client/src/routes/appRoutes.tsx
+++ b/packages/amplication-client/src/routes/appRoutes.tsx
@@ -25,27 +25,26 @@ export const Routes: RouteDef[] = [
       {
         path: "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})",
         // Component: lazy(() => import("../Resource/ResourceHome")),
-        moduleName: "",
-        exactPath: true,
+
+        moduleName: "CreateServiceWizard",
+        moduleClass: "create-service-wizard",
+        permission: true,
+        exactPath: false,
         routes: [
           {
-            path: "/:workspace/:project/",
-            Component: lazy(() => import("../Resource/ResourceHome")),
-            moduleName: "",
+            path:
+              "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})/create-resource",
+            Component: lazy(
+              () => import("../Resource/create-resource/CreateServiceWizard")
+            ),
+            moduleName: "CreateServiceWizard",
+            moduleClass: "create-service-wizard",
             routeTrackType: "",
             exactPath: true,
-            routes: resourceRoutes,
           },
           {
-            path: "/:workspace/:project/create-resource",
-            Component: lazy(() => import("../Resource/ResourceHome")),
-            moduleName: "",
-            routeTrackType: "",
-            exactPath: true,
-            routes: resourceRoutes,
-          },
-          {
-            path: "/:workspace/:project/:resource",
+            path:
+              "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})/:resource",
             Component: lazy(() => import("../Resource/ResourceHome")),
             moduleName: "",
             routeTrackType: "",
@@ -80,8 +79,8 @@ export const Routes: RouteDef[] = [
   },
   {
     path: "/github-auth-app/callback",
-    Component: lazy(() =>
-      import("../Resource/git/AuthResourceWithGitCallback")
+    Component: lazy(
+      () => import("../Resource/git/AuthResourceWithGitCallback")
     ),
     moduleName: "AuthAppWithGitCallback",
     permission: true,
@@ -103,5 +102,5 @@ export const Routes: RouteDef[] = [
     moduleName: "",
     routeTrackType: "",
     exactPath: true,
-  }
+  },
 ];

--- a/packages/amplication-server/src/core/auth/auth.service.spec.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.spec.ts
@@ -4,7 +4,8 @@ import {
   Workspace,
   User,
   UserRole,
-  PrismaService
+  PrismaService,
+  Project
 } from '@amplication/prisma-db';
 import { JwtService } from '@nestjs/jwt';
 import { Role } from 'src/enums/Role';
@@ -26,6 +27,15 @@ const EXAMPLE_ACCOUNT: Account = {
   updatedAt: new Date(),
   currentUserId: null,
   githubId: null
+};
+
+const EXAMPLE_PROJECT: Project = {
+  id: 'exampleId',
+  name: 'Example name',
+  workspaceId: 'ExampleWorkspaceId',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  deletedAt: undefined
 };
 
 const EXAMPLE_HASHED_PASSWORD = 'HASHED PASSWORD';
@@ -142,6 +152,8 @@ const createWorkspaceMock = jest.fn(() => ({
   users: [EXAMPLE_AUTH_USER]
 }));
 
+const prismaCreateProjectMock = jest.fn(() => EXAMPLE_PROJECT);
+
 describe('AuthService', () => {
   let service: AuthService;
 
@@ -155,6 +167,7 @@ describe('AuthService', () => {
     validatePasswordMock.mockClear();
     findUsersMock.mockClear();
     createWorkspaceMock.mockClear();
+    prismaCreateProjectMock.mockClear();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -196,6 +209,9 @@ describe('AuthService', () => {
           useClass: jest.fn(() => ({
             account: {
               findUnique: prismaAccountFindOneMock
+            },
+            project: {
+              create: prismaCreateProjectMock
             }
           }))
         },

--- a/packages/amplication-server/src/core/auth/auth.service.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.ts
@@ -119,6 +119,17 @@ export class AuthService {
         account
       );
 
+      await this.prismaService.project.create({
+        data: {
+          name: 'My project',
+          workspace: {
+            connect: {
+              id: workspace.id
+            }
+          }
+        }
+      });
+
       const [user] = workspace.users;
 
       await this.accountService.setCurrentUser(account.id, user.id);


### PR DESCRIPTION

Issue Number: #3215

## PR Details

After the change in the app routing and build new service wizard, we needed to update the route path, so it will get to the new create service wizard page with the rights values (workspace and project ids). 

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
