### PR TITLE
Fix signin route

### DIFF
--- a/packages/amplication-client/src/Workspaces/hooks/useCurrentWorkspace.ts
+++ b/packages/amplication-client/src/Workspaces/hooks/useCurrentWorkspace.ts
@@ -31,7 +31,7 @@ const useCurrentWorkspace = (authenticated: boolean) => {
 
     authenticated && getCurrentWorkspace();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authenticated]);
+  }, [authenticated, location.pathname]);
 
   useEffect(() => {
     if (!(data && data.currentWorkspace)) return;


### PR DESCRIPTION
Issue Number: #3255 

## PR Details
Fix singin route - when the user is authenticated and tries to navigate through the URL to `/login`, he/she will be redirected to `currentWorkspace/currentProject`

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
