### PR TITLE
Added project resolve field to a resource

### DIFF
--- a/packages/amplication-server/src/core/project/project.resolver.ts
+++ b/packages/amplication-server/src/core/project/project.resolver.ts
@@ -20,12 +20,16 @@ import { GqlAuthGuard } from 'src/guards/gql-auth.guard';
 import { AuthorizeContext } from 'src/decorators/authorizeContext.decorator';
 import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
 import { UserEntity } from 'src/decorators/user.decorator';
+import { ResourceService } from '../resource/resource.service';
 
 @Resolver(() => Project)
 @UseFilters(GqlResolverExceptionsFilter)
 @UseGuards(GqlAuthGuard)
 export class ProjectResolver {
-  constructor(private projectService: ProjectService) {}
+  constructor(
+    private projectService: ProjectService,
+    private resourceService: ResourceService
+  ) {}
 
   @Query(() => [Project], { nullable: false })
   @Roles('ORGANIZATION_ADMIN')
@@ -59,6 +63,8 @@ export class ProjectResolver {
 
   @ResolveField(() => [Resource])
   async resources(@Parent() project: Project): Promise<Resource[]> {
-    return this.projectService.resources(project.id);
+    return this.resourceService.resources({
+      where: { project: { id: project.id } }
+    });
   }
 }

--- a/packages/amplication-server/src/core/project/project.resolver.ts
+++ b/packages/amplication-server/src/core/project/project.resolver.ts
@@ -1,6 +1,13 @@
-import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import {
+  Args,
+  Mutation,
+  Parent,
+  Query,
+  ResolveField,
+  Resolver
+} from '@nestjs/graphql';
 import { FindOneArgs } from 'src/dto';
-import { Project, User } from 'src/models';
+import { Project, Resource, User } from 'src/models';
 import { ProjectCreateArgs } from './dto/ProjectCreateArgs';
 import { ProjectFindManyArgs } from './dto/ProjectFindManyArgs';
 import { ProjectService } from './project.service';
@@ -48,5 +55,10 @@ export class ProjectResolver {
     @UserEntity() user: User
   ): Promise<Project> {
     return this.projectService.createProject(args, user.id);
+  }
+
+  @ResolveField(() => Resource)
+  async resources(@Parent() project: Project): Promise<Resource[]> {
+    return this.projectService.resources(project.id);
   }
 }

--- a/packages/amplication-server/src/core/project/project.resolver.ts
+++ b/packages/amplication-server/src/core/project/project.resolver.ts
@@ -57,7 +57,7 @@ export class ProjectResolver {
     return this.projectService.createProject(args, user.id);
   }
 
-  @ResolveField(() => Resource)
+  @ResolveField(() => [Resource])
   async resources(@Parent() project: Project): Promise<Resource[]> {
     return this.projectService.resources(project.id);
   }

--- a/packages/amplication-server/src/core/project/project.service.ts
+++ b/packages/amplication-server/src/core/project/project.service.ts
@@ -1,7 +1,7 @@
 import { PrismaService } from '@amplication/prisma-db';
 import { Injectable } from '@nestjs/common';
 import { FindOneArgs } from 'src/dto';
-import { Project } from 'src/models';
+import { Project, Resource } from 'src/models';
 import { ResourceService } from '..';
 import { ProjectCreateArgs } from './dto/ProjectCreateArgs';
 import { ProjectFindManyArgs } from './dto/ProjectFindManyArgs';
@@ -37,5 +37,9 @@ export class ProjectService {
     await this.resourceService.createProjectConfiguration(project.id, userId);
 
     return project;
+  }
+
+  async resources(projectId: string): Promise<Resource[]> {
+    return this.prisma.resource.findMany({ where: { projectId: projectId } });
   }
 }

--- a/packages/amplication-server/src/core/project/project.service.ts
+++ b/packages/amplication-server/src/core/project/project.service.ts
@@ -40,6 +40,8 @@ export class ProjectService {
   }
 
   async resources(projectId: string): Promise<Resource[]> {
-    return this.prisma.resource.findMany({ where: { projectId: projectId } });
+    return this.resourceService.resources({
+      where: { project: { id: projectId } }
+    });
   }
 }

--- a/packages/amplication-server/src/core/project/project.service.ts
+++ b/packages/amplication-server/src/core/project/project.service.ts
@@ -1,7 +1,7 @@
 import { PrismaService } from '@amplication/prisma-db';
 import { Injectable } from '@nestjs/common';
 import { FindOneArgs } from 'src/dto';
-import { Project, Resource } from 'src/models';
+import { Project } from 'src/models';
 import { ResourceService } from '..';
 import { ProjectCreateArgs } from './dto/ProjectCreateArgs';
 import { ProjectFindManyArgs } from './dto/ProjectFindManyArgs';
@@ -37,11 +37,5 @@ export class ProjectService {
     await this.resourceService.createProjectConfiguration(project.id, userId);
 
     return project;
-  }
-
-  async resources(projectId: string): Promise<Resource[]> {
-    return this.resourceService.resources({
-      where: { project: { id: projectId } }
-    });
   }
 }


### PR DESCRIPTION
Issue Number: #3288

## PR Details
When querying a project/projects, the resources field returned as null, I added the project resolver, removed the field to resources


## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error
