### PR TITLE
Refactor: Pending Changes (Entity/Block) rename resource to origin

### DIFF
--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -1057,7 +1057,7 @@ export enum EnumPendingChangeAction {
   Update = 'Update',
 }
 
-export enum EnumPendingChangeResourceType {
+export enum EnumPendingChangeOriginType {
   Block = 'Block',
   Entity = 'Entity',
 }
@@ -1472,9 +1472,9 @@ export type MutationUpdateWorkspaceArgs = {
 export type PendingChange = {
   __typename?: 'PendingChange';
   action: EnumPendingChangeAction;
-  resource: PendingChangeResource;
-  resourceId: Scalars['String'];
-  resourceType: EnumPendingChangeResourceType;
+  origin: PendingChangeResource;
+  originId: Scalars['String'];
+  originType: EnumPendingChangeOriginType;
   versionNumber: Scalars['Int'];
 };
 

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -1472,13 +1472,13 @@ export type MutationUpdateWorkspaceArgs = {
 export type PendingChange = {
   __typename?: 'PendingChange';
   action: EnumPendingChangeAction;
-  origin: PendingChangeResource;
+  origin: PendingChangeOrigin;
   originId: Scalars['String'];
   originType: EnumPendingChangeOriginType;
   versionNumber: Scalars['Int'];
 };
 
-export type PendingChangeResource = Block | Entity;
+export type PendingChangeOrigin = Block | Entity;
 
 export type PendingChangesDiscardInput = {
   app: WhereParentIdInput;

--- a/packages/amplication-client/src/Application/ApplicationLayout.tsx
+++ b/packages/amplication-client/src/Application/ApplicationLayout.tsx
@@ -78,13 +78,13 @@ function ApplicationLayout({ match }: Props) {
 
   const addChange = useCallback(
     (
-      resourceId: string,
-      resourceType: models.EnumPendingChangeResourceType
+      originId: string,
+      originType: models.EnumPendingChangeOriginType
     ) => {
       const existingChange = pendingChanges.find(
         (changeItem) =>
-          changeItem.resourceId === resourceId &&
-          changeItem.resourceType === resourceType
+          changeItem.originId === originId &&
+          changeItem.originType === originType
       );
       if (existingChange) {
         //reassign pending changes to trigger refresh
@@ -93,8 +93,8 @@ function ApplicationLayout({ match }: Props) {
         setPendingChanges(
           pendingChanges.concat([
             {
-              resourceId,
-              resourceType,
+              originId,
+              originType,
             },
           ])
         );
@@ -105,14 +105,14 @@ function ApplicationLayout({ match }: Props) {
 
   const addEntity = useCallback(
     (entityId: string) => {
-      addChange(entityId, models.EnumPendingChangeResourceType.Entity);
+      addChange(entityId, models.EnumPendingChangeOriginType.Entity);
     },
     [addChange]
   );
 
   const addBlock = useCallback(
     (blockId: string) => {
-      addChange(blockId, models.EnumPendingChangeResourceType.Block);
+      addChange(blockId, models.EnumPendingChangeOriginType.Block);
     },
     [addChange]
   );
@@ -273,8 +273,8 @@ export default enhance(ApplicationLayout);
 export const GET_PENDING_CHANGES_STATUS = gql`
   query pendingChangesStatus($applicationId: String!) {
     pendingChanges(where: { app: { id: $applicationId } }) {
-      resourceId
-      resourceType
+      originId
+      originType
     }
   }
 `;

--- a/packages/amplication-client/src/VersionControl/CommitPage.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitPage.tsx
@@ -120,7 +120,7 @@ const CommitPage = ({ match }: Props) => {
             </div>
             {data.commit.changes.map((change) => (
               <PendingChangeWithCompare
-                key={change.resourceId}
+                key={change.originId}
                 change={change}
                 compareType={EnumCompareType.Previous}
                 splitView={splitView}
@@ -150,11 +150,11 @@ export const GET_COMMIT = gql`
         }
       }
       changes {
-        resourceId
+        originId
         action
-        resourceType
+        originType
         versionNumber
-        resource {
+        origin {
           __typename
           ... on Entity {
             id

--- a/packages/amplication-client/src/VersionControl/DiscardChanges.tsx
+++ b/packages/amplication-client/src/VersionControl/DiscardChanges.tsx
@@ -27,11 +27,11 @@ const DiscardChanges = ({ applicationId, onComplete, onCancel }: Props) => {
       //remove entities from cache to reflect discarded changes
       for (var change of pendingChangesContext.pendingChanges) {
         if (
-          change.resourceType === models.EnumPendingChangeResourceType.Entity
+          change.originType === models.EnumPendingChangeOriginType.Entity
         ) {
           cache.evict({
             id: cache.identify({
-              id: change.resourceId,
+              id: change.originId,
               __typename: "Entity",
             }),
           });
@@ -39,7 +39,7 @@ const DiscardChanges = ({ applicationId, onComplete, onCancel }: Props) => {
           /**@todo: handle other types of blocks */
           cache.evict({
             id: cache.identify({
-              id: change.resourceId,
+              id: change.originId,
               __typename: "AppSettings",
             }),
           });

--- a/packages/amplication-client/src/VersionControl/LastCommit.tsx
+++ b/packages/amplication-client/src/VersionControl/LastCommit.tsx
@@ -143,11 +143,11 @@ export const GET_LAST_COMMIT = gql`
         }
       }
       changes {
-        resourceId
+        originId
         action
-        resourceType
+        originType
         versionNumber
-        resource {
+        origin {
           __typename
           ... on Entity {
             id

--- a/packages/amplication-client/src/VersionControl/PendingChange.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChange.tsx
@@ -12,7 +12,7 @@ const TOOLTIP_DIRECTION = "ne";
 type Props = {
   change: models.PendingChange;
   applicationId: string;
-  linkToResource?: boolean;
+  linkToOrigin?: boolean;
 };
 
 const ACTION_TO_LABEL: {
@@ -26,12 +26,12 @@ const ACTION_TO_LABEL: {
 const PendingChange = ({
   change,
   applicationId,
-  linkToResource = false,
+  linkToOrigin = false,
 }: Props) => {
   /**@todo: update the url for other types of blocks  */
   const url =
-    change.resourceType === models.EnumPendingChangeResourceType.Entity
-      ? `/${applicationId}/entities/${change.resourceId}`
+    change.originType === models.EnumPendingChangeOriginType.Entity
+      ? `/${applicationId}/entities/${change.originId}`
       : `/${applicationId}/update`;
 
   const isDeletedEntity =
@@ -47,15 +47,15 @@ const PendingChange = ({
           className={`${CLASS_NAME}__tooltip_deleted`}
         >
           <div className={classNames(`${CLASS_NAME}__deleted`)}>
-            {change.resource.displayName}
+            {change.origin.displayName}
           </div>
         </Tooltip>
       );
     }
-    if (linkToResource) {
-      return <Link to={url}>{change.resource.displayName}</Link>;
+    if (linkToOrigin) {
+      return <Link to={url}>{change.origin.displayName}</Link>;
     }
-    return change.resource.displayName;
+    return change.origin.displayName;
   };
 
   return (

--- a/packages/amplication-client/src/VersionControl/PendingChangeDiffBlock.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChangeDiffBlock.tsx
@@ -35,7 +35,7 @@ const PendingChangeDiffBlock = ({
     TData
   >(GET_BLOCK_VERSION, {
     variables: {
-      id: change.resourceId,
+      id: change.originId,
       whereVersion:
         compareType === EnumCompareType.Pending
           ? {
@@ -52,7 +52,7 @@ const PendingChangeDiffBlock = ({
     TData
   >(GET_BLOCK_VERSION, {
     variables: {
-      id: change.resourceId,
+      id: change.originId,
       whereVersion:
         compareType === EnumCompareType.Pending
           ? {

--- a/packages/amplication-client/src/VersionControl/PendingChangeDiffEntity.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChangeDiffEntity.tsx
@@ -70,7 +70,7 @@ const PendingChangeDiffEntity = ({
     TData
   >(GET_ENTITY_VERSION, {
     variables: {
-      id: change.resourceId,
+      id: change.originId,
       whereVersion:
         compareType === EnumCompareType.Pending
           ? {
@@ -87,7 +87,7 @@ const PendingChangeDiffEntity = ({
     TData
   >(GET_ENTITY_VERSION, {
     variables: {
-      id: change.resourceId,
+      id: change.originId,
       whereVersion:
         compareType === EnumCompareType.Pending
           ? {

--- a/packages/amplication-client/src/VersionControl/PendingChangeWithCompare.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChangeWithCompare.tsx
@@ -29,16 +29,16 @@ const PendingChangeWithCompare = ({
       className={CLASS_NAME}
       headerContent={<PendingChange change={change} />}
     >
-      {change.resourceType === models.EnumPendingChangeResourceType.Entity ? (
+      {change.originType === models.EnumPendingChangeOriginType.Entity ? (
         <PendingChangeDiffEntity
-          key={change.resourceId}
+          key={change.originId}
           change={change}
           compareType={compareType}
           splitView={splitView}
         />
       ) : (
         <PendingChangeDiffBlock
-          key={change.resourceId}
+          key={change.originId}
           change={change}
           compareType={compareType}
           splitView={splitView}

--- a/packages/amplication-client/src/VersionControl/PendingChanges.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChanges.tsx
@@ -116,10 +116,10 @@ const PendingChanges = ({ applicationId }: Props) => {
             <div className={`${CLASS_NAME}__changes`}>
               {data?.pendingChanges.map((change) => (
                 <PendingChange
-                  key={change.resourceId}
+                  key={change.originId}
                   change={change}
                   applicationId={applicationId}
-                  linkToResource
+                  linkToOrigin
                 />
               ))}
             </div>
@@ -136,11 +136,11 @@ export default PendingChanges;
 export const GET_PENDING_CHANGES = gql`
   query pendingChanges($applicationId: String!) {
     pendingChanges(where: { app: { id: $applicationId } }) {
-      resourceId
+      originId
       action
-      resourceType
+      originType
       versionNumber
-      resource {
+      origin {
         __typename
         ... on Entity {
           id

--- a/packages/amplication-client/src/VersionControl/PendingChangesContext.ts
+++ b/packages/amplication-client/src/VersionControl/PendingChangesContext.ts
@@ -3,7 +3,7 @@ import * as models from "../models";
 
 export type PendingChangeItem = Pick<
   models.PendingChange,
-  "resourceId" | "resourceType"
+  "originId" | "originType"
 >;
 
 export type ContextDataType = {
@@ -15,8 +15,8 @@ export type ContextDataType = {
   addEntity: (entityId: string) => void;
   addBlock: (blockId: string) => void;
   addChange: (
-    resourceId: string,
-    resourceType: models.EnumPendingChangeResourceType
+    originId: string,
+    originType: models.EnumPendingChangeOriginType
   ) => void;
   reset: () => void;
 };
@@ -38,8 +38,8 @@ const PendingChangesContext = createContext<ContextDataType>({
     throw new Error();
   },
   addChange: (
-    resourceId: string,
-    resourceType: models.EnumPendingChangeResourceType
+    originId: string,
+    originType: models.EnumPendingChangeOriginType
   ) => {
     throw new Error();
   },

--- a/packages/amplication-client/src/VersionControl/PendingChangesPage.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChangesPage.tsx
@@ -72,7 +72,7 @@ const PendingChangesPage = ({ match }: Props) => {
         <div className={`${CLASS_NAME}__changes`}>
           {data?.pendingChanges.map((change) => (
             <PendingChangeWithCompare
-              key={change.resourceId}
+              key={change.originId}
               change={change}
               compareType={EnumCompareType.Pending}
               splitView={splitView}
@@ -101,11 +101,11 @@ export const GET_COMMIT = gql`
         }
       }
       changes {
-        resourceId
+        originId
         action
-        resourceType
+        originType
         versionNumber
-        resource {
+        origin {
           __typename
           ... on Entity {
             id

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -1057,7 +1057,7 @@ export enum EnumPendingChangeAction {
   Update = "Update",
 }
 
-export enum EnumPendingChangeResourceType {
+export enum EnumPendingChangeOriginType {
   Block = "Block",
   Entity = "Entity",
 }
@@ -1472,9 +1472,9 @@ export type MutationUpdateWorkspaceArgs = {
 export type PendingChange = {
   __typename?: "PendingChange";
   action: EnumPendingChangeAction;
-  resource: PendingChangeResource;
-  resourceId: Scalars["String"];
-  resourceType: EnumPendingChangeResourceType;
+  origin: PendingChangeResource;
+  originId: Scalars["String"];
+  originType: EnumPendingChangeOriginType;
   versionNumber: Scalars["Int"];
 };
 

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -1472,13 +1472,13 @@ export type MutationUpdateWorkspaceArgs = {
 export type PendingChange = {
   __typename?: "PendingChange";
   action: EnumPendingChangeAction;
-  origin: PendingChangeResource;
+  origin: PendingChangeOrigin;
   originId: Scalars["String"];
   originType: EnumPendingChangeOriginType;
   versionNumber: Scalars["Int"];
 };
 
-export type PendingChangeResource = Block | Entity;
+export type PendingChangeOrigin = Block | Entity;
 
 export type PendingChangesDiscardInput = {
   app: WhereParentIdInput;

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -1057,7 +1057,7 @@ export enum EnumPendingChangeAction {
   Update = "Update",
 }
 
-export enum EnumPendingChangeResourceType {
+export enum EnumPendingChangeOriginType {
   Block = "Block",
   Entity = "Entity",
 }
@@ -1472,9 +1472,9 @@ export type MutationUpdateWorkspaceArgs = {
 export type PendingChange = {
   __typename?: "PendingChange";
   action: EnumPendingChangeAction;
-  resource: PendingChangeResource;
-  resourceId: Scalars["String"];
-  resourceType: EnumPendingChangeResourceType;
+  origin: PendingChangeResource;
+  originId: Scalars["String"];
+  originType: EnumPendingChangeOriginType;
   versionNumber: Scalars["Int"];
 };
 

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -1472,13 +1472,13 @@ export type MutationUpdateWorkspaceArgs = {
 export type PendingChange = {
   __typename?: "PendingChange";
   action: EnumPendingChangeAction;
-  origin: PendingChangeResource;
+  origin: PendingChangeOrigin;
   originId: Scalars["String"];
   originType: EnumPendingChangeOriginType;
   versionNumber: Scalars["Int"];
 };
 
-export type PendingChangeResource = Block | Entity;
+export type PendingChangeOrigin = Block | Entity;
 
 export type PendingChangesDiscardInput = {
   app: WhereParentIdInput;

--- a/packages/amplication-data-service-generator/src/models.ts
+++ b/packages/amplication-data-service-generator/src/models.ts
@@ -1057,7 +1057,7 @@ export enum EnumPendingChangeAction {
   Update = "Update",
 }
 
-export enum EnumPendingChangeResourceType {
+export enum EnumPendingChangeOriginType {
   Block = "Block",
   Entity = "Entity",
 }
@@ -1472,9 +1472,9 @@ export type MutationUpdateWorkspaceArgs = {
 export type PendingChange = {
   __typename?: "PendingChange";
   action: EnumPendingChangeAction;
-  resource: PendingChangeResource;
-  resourceId: Scalars["String"];
-  resourceType: EnumPendingChangeResourceType;
+  origin: PendingChangeResource;
+  originId: Scalars["String"];
+  originType: EnumPendingChangeOriginType;
   versionNumber: Scalars["Int"];
 };
 

--- a/packages/amplication-data-service-generator/src/models.ts
+++ b/packages/amplication-data-service-generator/src/models.ts
@@ -1472,13 +1472,13 @@ export type MutationUpdateWorkspaceArgs = {
 export type PendingChange = {
   __typename?: "PendingChange";
   action: EnumPendingChangeAction;
-  origin: PendingChangeResource;
+  origin: PendingChangeOrigin;
   originId: Scalars["String"];
   originType: EnumPendingChangeOriginType;
   versionNumber: Scalars["Int"];
 };
 
-export type PendingChangeResource = Block | Entity;
+export type PendingChangeOrigin = Block | Entity;
 
 export type PendingChangesDiscardInput = {
   app: WhereParentIdInput;

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -1470,13 +1470,13 @@ export type MutationUpdateWorkspaceArgs = {
 export type PendingChange = {
   __typename?: 'PendingChange';
   action: EnumPendingChangeAction;
-  origin: PendingChangeResource;
+  origin: PendingChangeOrigin;
   originId: Scalars['String'];
   originType: EnumPendingChangeOriginType;
   versionNumber: Scalars['Int'];
 };
 
-export type PendingChangeResource = Block | Entity;
+export type PendingChangeOrigin = Block | Entity;
 
 export type PendingChangesDiscardInput = {
   app: WhereParentIdInput;

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -1055,7 +1055,7 @@ export enum EnumPendingChangeAction {
   Update = 'Update',
 }
 
-export enum EnumPendingChangeResourceType {
+export enum EnumPendingChangeOriginType {
   Block = 'Block',
   Entity = 'Entity',
 }
@@ -1470,9 +1470,9 @@ export type MutationUpdateWorkspaceArgs = {
 export type PendingChange = {
   __typename?: 'PendingChange';
   action: EnumPendingChangeAction;
-  resource: PendingChangeResource;
-  resourceId: Scalars['String'];
-  resourceType: EnumPendingChangeResourceType;
+  origin: PendingChangeResource;
+  originId: Scalars['String'];
+  originType: EnumPendingChangeOriginType;
   versionNumber: Scalars['Int'];
 };
 

--- a/packages/amplication-server/src/core/action/action.resolver.ts
+++ b/packages/amplication-server/src/core/action/action.resolver.ts
@@ -7,7 +7,7 @@ import { ActionStep } from './dto/ActionStep';
 import { FindOneActionArgs } from './dto/FindOneActionArgs';
 import { ActionService } from './action.service';
 import { AuthorizeContext } from 'src/decorators/authorizeContext.decorator';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 
 @Resolver(() => Action)
 @UseFilters(GqlResolverExceptionsFilter)
@@ -16,7 +16,7 @@ export class ActionResolver {
   constructor(private readonly service: ActionService) {}
 
   @Query(() => Action)
-  @AuthorizeContext(AuthorizableResourceParameter.ActionId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.ActionId, 'where.id')
   async action(@Args() args: FindOneActionArgs): Promise<Action> {
     return this.service.findOne(args);
   }

--- a/packages/amplication-server/src/core/app/app.resolver.spec.ts
+++ b/packages/amplication-server/src/core/app/app.resolver.spec.ts
@@ -48,7 +48,7 @@ const EXAMPLE_MESSAGE = 'exampleMessage';
 
 const EXAMPLE_ENTITY_ID = 'exampleEntityId';
 
-const EXAMPLE_RESOURCE_ID = 'exampleOriginId';
+const EXAMPLE_ORIGIN_ID = 'exampleOriginId';
 const EXAMPLE_VERSION_NUMBER = 1;
 
 const EXAMPLE_COMMIT: Commit = {
@@ -101,7 +101,7 @@ const EXAMPLE_APP: App = {
 const EXAMPLE_PENDING_CHANGE: PendingChange = {
   action: EnumPendingChangeAction.Create,
   originType: EnumPendingChangeOriginType.Entity,
-  originId: EXAMPLE_RESOURCE_ID,
+  originId: EXAMPLE_ORIGIN_ID,
   origin: EXAMPLE_ENTITY,
   versionNumber: EXAMPLE_VERSION_NUMBER
 };
@@ -741,7 +741,7 @@ describe('AppResolver', () => {
       pendingChanges: [
         {
           ...EXAMPLE_PENDING_CHANGE,
-          resource: {
+          origin: {
             ...EXAMPLE_ENTITY,
             createdAt: EXAMPLE_ENTITY.createdAt.toISOString(),
             updatedAt: EXAMPLE_ENTITY.updatedAt.toISOString()

--- a/packages/amplication-server/src/core/app/app.resolver.spec.ts
+++ b/packages/amplication-server/src/core/app/app.resolver.spec.ts
@@ -24,7 +24,7 @@ import { Commit } from 'src/models/Commit';
 import { PendingChange } from './dto/PendingChange';
 import {
   EnumPendingChangeAction,
-  EnumPendingChangeResourceType
+  EnumPendingChangeOriginType
 } from '@amplication/code-gen-types/dist/models';
 import { mockGqlAuthGuardCanActivate } from '../../../test/gql-auth-mock';
 import { UserService } from '../user/user.service';
@@ -48,7 +48,7 @@ const EXAMPLE_MESSAGE = 'exampleMessage';
 
 const EXAMPLE_ENTITY_ID = 'exampleEntityId';
 
-const EXAMPLE_RESOURCE_ID = 'exampleResourceId';
+const EXAMPLE_RESOURCE_ID = 'exampleOriginId';
 const EXAMPLE_VERSION_NUMBER = 1;
 
 const EXAMPLE_COMMIT: Commit = {
@@ -100,9 +100,9 @@ const EXAMPLE_APP: App = {
 
 const EXAMPLE_PENDING_CHANGE: PendingChange = {
   action: EnumPendingChangeAction.Create,
-  resourceType: EnumPendingChangeResourceType.Entity,
-  resourceId: EXAMPLE_RESOURCE_ID,
-  resource: EXAMPLE_ENTITY,
+  originType: EnumPendingChangeOriginType.Entity,
+  originId: EXAMPLE_RESOURCE_ID,
+  origin: EXAMPLE_ENTITY,
   versionNumber: EXAMPLE_VERSION_NUMBER
 };
 
@@ -331,10 +331,10 @@ const PENDING_CHANGE_QUERY = gql`
   query($appId: String!) {
     pendingChanges(where: { app: { id: $appId } }) {
       action
-      resourceType
-      resourceId
+      originType
+      originId
       versionNumber
-      resource {
+      origin {
         ... on Entity {
           id
           createdAt

--- a/packages/amplication-server/src/core/app/app.resolver.ts
+++ b/packages/amplication-server/src/core/app/app.resolver.ts
@@ -12,8 +12,8 @@ import { InjectContextValue } from 'src/decorators/injectContextValue.decorator'
 import { Roles } from 'src/decorators/roles.decorator';
 import { UserEntity } from 'src/decorators/user.decorator';
 import { FindOneArgs } from 'src/dto';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
-import { InjectableResourceParameter } from 'src/enums/InjectableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
+import { InjectableOriginParameter } from 'src/enums/InjectableOriginParameter';
 import { GqlResolverExceptionsFilter } from 'src/filters/GqlResolverExceptions.filter';
 import { GqlAuthGuard } from 'src/guards/gql-auth.guard';
 import { App, Commit, Entity, User, Workspace } from 'src/models';
@@ -49,7 +49,7 @@ export class AppResolver {
 
   @Query(() => App, { nullable: true })
   @Roles('ORGANIZATION_ADMIN')
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'where.id')
   async app(@Args() args: FindOneArgs): Promise<App | null> {
     return this.appService.app(args);
   }
@@ -60,7 +60,7 @@ export class AppResolver {
   })
   @Roles('ORGANIZATION_ADMIN')
   @InjectContextValue(
-    InjectableResourceParameter.WorkspaceId,
+    InjectableOriginParameter.WorkspaceId,
     'where.workspace.id'
   )
   async apps(@Args() args: FindManyAppArgs): Promise<App[]> {
@@ -99,7 +99,7 @@ export class AppResolver {
   @Mutation(() => App, { nullable: false })
   @Roles('ORGANIZATION_ADMIN')
   @InjectContextValue(
-    InjectableResourceParameter.WorkspaceId,
+    InjectableOriginParameter.WorkspaceId,
     'data.workspace.connect.id'
   )
   async createApp(
@@ -112,7 +112,7 @@ export class AppResolver {
   @Mutation(() => App, { nullable: false })
   @Roles('ORGANIZATION_ADMIN')
   @InjectContextValue(
-    InjectableResourceParameter.WorkspaceId,
+    InjectableOriginParameter.WorkspaceId,
     'data.app.workspace.connect.id'
   )
   async createAppWithEntities(
@@ -126,7 +126,7 @@ export class AppResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'where.id')
   async deleteApp(@Args() args: FindOneArgs): Promise<App | null> {
     return this.appService.deleteApp(args);
   }
@@ -135,7 +135,7 @@ export class AppResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'where.id')
   async updateApp(@Args() args: UpdateOneAppArgs): Promise<App | null> {
     return this.appService.updateApp(args);
   }
@@ -144,11 +144,8 @@ export class AppResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'data.app.connect.id')
-  @InjectContextValue(
-    InjectableResourceParameter.UserId,
-    'data.user.connect.id'
-  )
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'data.app.connect.id')
+  @InjectContextValue(InjectableOriginParameter.UserId, 'data.user.connect.id')
   async commit(@Args() args: CreateCommitArgs): Promise<Commit | null> {
     return this.appService.commit(args);
   }
@@ -157,11 +154,8 @@ export class AppResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'data.app.connect.id')
-  @InjectContextValue(
-    InjectableResourceParameter.UserId,
-    'data.user.connect.id'
-  )
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'data.app.connect.id')
+  @InjectContextValue(InjectableOriginParameter.UserId, 'data.user.connect.id')
   async discardPendingChanges(
     @Args() args: DiscardPendingChangesArgs
   ): Promise<boolean | null> {
@@ -171,7 +165,7 @@ export class AppResolver {
   @Query(() => [PendingChange], {
     nullable: false
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.app.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'where.app.id')
   async pendingChanges(
     @Args() args: FindPendingChangesArgs,
     @UserEntity() user: User

--- a/packages/amplication-server/src/core/app/app.service.spec.ts
+++ b/packages/amplication-server/src/core/app/app.service.spec.ts
@@ -22,7 +22,7 @@ import { Block } from 'src/models/Block';
 import { EntityField } from 'src/models/EntityField';
 import { PendingChange } from './dto/PendingChange';
 import { EntityVersion, Commit, BlockVersion } from 'src/models';
-import { EnumPendingChangeAction, EnumPendingChangeResourceType } from './dto';
+import { EnumPendingChangeAction, EnumPendingChangeOriginType } from './dto';
 import {
   createSampleAppEntities,
   CREATE_SAMPLE_ENTITIES_COMMIT_MESSAGE,
@@ -142,19 +142,19 @@ const EXAMPLE_ENTITY_FIELD: EntityField = {
 };
 
 const EXAMPLE_CHANGED_ENTITY: PendingChange = {
-  resourceId: EXAMPLE_ENTITY_ID,
+  originId: EXAMPLE_ENTITY_ID,
   action: EnumPendingChangeAction.Create,
-  resourceType: EnumPendingChangeResourceType.Entity,
+  originType: EnumPendingChangeOriginType.Entity,
   versionNumber: 1,
-  resource: EXAMPLE_ENTITY
+  origin: EXAMPLE_ENTITY
 };
 
 const EXAMPLE_CHANGED_BLOCK: PendingChange = {
-  resourceId: EXAMPLE_BLOCK_ID,
+  originId: EXAMPLE_BLOCK_ID,
   action: EnumPendingChangeAction.Create,
-  resourceType: EnumPendingChangeResourceType.Block,
+  originType: EnumPendingChangeOriginType.Block,
   versionNumber: 1,
-  resource: EXAMPLE_BLOCK
+  origin: EXAMPLE_BLOCK
 };
 
 const EXAMPLE_ENTITY_VERSION_ID = 'exampleEntityVersionId';

--- a/packages/amplication-server/src/core/app/app.service.ts
+++ b/packages/amplication-server/src/core/app/app.service.ts
@@ -410,7 +410,7 @@ export class AppService {
   }
 
   /**
-   * Gets all the resources changed since the last commit in the app
+   * Gets all the origins changed since the last commit in the app
    */
   async getPendingChanges(
     args: FindPendingChangesArgs,

--- a/packages/amplication-server/src/core/app/app.service.ts
+++ b/packages/amplication-server/src/core/app/app.service.ts
@@ -495,9 +495,7 @@ export class AppService {
           }
         });
 
-        const releasePromise = this.entityService.releaseLock(
-          change.originId
-        );
+        const releasePromise = this.entityService.releaseLock(change.originId);
 
         return [
           versionPromise.then(() => null),
@@ -598,10 +596,7 @@ export class AppService {
     }
 
     const entityPromises = changedEntities.map(change => {
-      return this.entityService.discardPendingChanges(
-        change.originId,
-        userId
-      );
+      return this.entityService.discardPendingChanges(change.originId, userId);
     });
     const blockPromises = changedBlocks.map(change => {
       return this.blockService.discardPendingChanges(change.originId, userId);

--- a/packages/amplication-server/src/core/app/app.service.ts
+++ b/packages/amplication-server/src/core/app/app.service.ts
@@ -489,14 +489,14 @@ export class AppService {
             },
             entity: {
               connect: {
-                id: change.resourceId
+                id: change.originId
               }
             }
           }
         });
 
         const releasePromise = this.entityService.releaseLock(
-          change.resourceId
+          change.originId
         );
 
         return [
@@ -517,13 +517,13 @@ export class AppService {
             },
             block: {
               connect: {
-                id: change.resourceId
+                id: change.originId
               }
             }
           }
         });
 
-        const releasePromise = this.blockService.releaseLock(change.resourceId);
+        const releasePromise = this.blockService.releaseLock(change.originId);
 
         return [
           versionPromise.then(() => null),
@@ -599,12 +599,12 @@ export class AppService {
 
     const entityPromises = changedEntities.map(change => {
       return this.entityService.discardPendingChanges(
-        change.resourceId,
+        change.originId,
         userId
       );
     });
     const blockPromises = changedBlocks.map(change => {
-      return this.blockService.discardPendingChanges(change.resourceId, userId);
+      return this.blockService.discardPendingChanges(change.originId, userId);
     });
 
     await Promise.all(blockPromises);

--- a/packages/amplication-server/src/core/app/dto/EnumPendingChangeOriginType.ts
+++ b/packages/amplication-server/src/core/app/dto/EnumPendingChangeOriginType.ts
@@ -1,10 +1,10 @@
 import { registerEnumType } from '@nestjs/graphql';
 
-export enum EnumPendingChangeResourceType {
+export enum EnumPendingChangeOriginType {
   Entity = 'Entity',
   Block = 'Block'
 }
 
-registerEnumType(EnumPendingChangeResourceType, {
+registerEnumType(EnumPendingChangeOriginType, {
   name: 'EnumPendingChangeResourceType'
 });

--- a/packages/amplication-server/src/core/app/dto/EnumPendingChangeOriginType.ts
+++ b/packages/amplication-server/src/core/app/dto/EnumPendingChangeOriginType.ts
@@ -6,5 +6,5 @@ export enum EnumPendingChangeOriginType {
 }
 
 registerEnumType(EnumPendingChangeOriginType, {
-  name: 'EnumPendingChangeResourceType'
+  name: 'EnumPendingChangeOriginType'
 });

--- a/packages/amplication-server/src/core/app/dto/PendingChange.ts
+++ b/packages/amplication-server/src/core/app/dto/PendingChange.ts
@@ -3,7 +3,7 @@ import { EnumPendingChangeAction } from './EnumPendingChangeAction';
 import { Entity } from 'src/models/Entity'; // eslint-disable-line import/no-cycle
 import { Block } from 'src/models/Block'; // eslint-disable-line import/no-cycle
 import { EnumPendingChangeOriginType } from './EnumPendingChangeOriginType';
-import { PendingChangeResource } from './PendingChangeResource'; // eslint-disable-line import/no-cycle
+import { PendingChangeOrigin } from './PendingChangeOrigin'; // eslint-disable-line import/no-cycle
 
 @ObjectType({
   isAbstract: true,
@@ -28,7 +28,7 @@ export class PendingChange {
   })
   originId!: string;
 
-  @Field(() => PendingChangeResource, {
+  @Field(() => PendingChangeOrigin, {
     nullable: false,
     description: undefined
   })

--- a/packages/amplication-server/src/core/app/dto/PendingChange.ts
+++ b/packages/amplication-server/src/core/app/dto/PendingChange.ts
@@ -2,7 +2,7 @@ import { Field, Int, ObjectType } from '@nestjs/graphql';
 import { EnumPendingChangeAction } from './EnumPendingChangeAction';
 import { Entity } from 'src/models/Entity'; // eslint-disable-line import/no-cycle
 import { Block } from 'src/models/Block'; // eslint-disable-line import/no-cycle
-import { EnumPendingChangeResourceType } from './EnumPendingChangeResourceType';
+import { EnumPendingChangeOriginType } from './EnumPendingChangeOriginType';
 import { PendingChangeResource } from './PendingChangeResource'; // eslint-disable-line import/no-cycle
 
 @ObjectType({
@@ -16,23 +16,23 @@ export class PendingChange {
   })
   action: EnumPendingChangeAction;
 
-  @Field(() => EnumPendingChangeResourceType, {
+  @Field(() => EnumPendingChangeOriginType, {
     nullable: false,
     description: undefined
   })
-  resourceType: EnumPendingChangeResourceType;
+  originType: EnumPendingChangeOriginType;
 
   @Field(() => String, {
     nullable: false,
     description: undefined
   })
-  resourceId!: string;
+  originId!: string;
 
   @Field(() => PendingChangeResource, {
     nullable: false,
     description: undefined
   })
-  resource: Entity | Block;
+  origin: Entity | Block;
 
   @Field(() => Int, {
     nullable: false,

--- a/packages/amplication-server/src/core/app/dto/PendingChangeOrigin.ts
+++ b/packages/amplication-server/src/core/app/dto/PendingChangeOrigin.ts
@@ -3,8 +3,8 @@ import { Entity } from 'src/models/Entity'; // eslint-disable-line import/no-cyc
 import { Block } from 'src/models/Block'; // eslint-disable-line import/no-cycle
 
 // eslint-disable-next-line  @typescript-eslint/naming-convention
-export const PendingChangeResource = createUnionType({
-  name: 'PendingChangeResource',
+export const PendingChangeOrigin = createUnionType({
+  name: 'PendingChangeOrigin',
   types: () => [Entity, Block],
   resolveType(value) {
     if (value.blockType) {

--- a/packages/amplication-server/src/core/app/dto/index.ts
+++ b/packages/amplication-server/src/core/app/dto/index.ts
@@ -12,7 +12,7 @@ export { DiscardPendingChangesArgs } from './DiscardPendingChangesArgs';
 export { CommitCreateInput } from './CommitCreateInput';
 export { FindPendingChangesArgs } from './FindPendingChangesArgs';
 export { PendingChange } from './PendingChange';
-export { EnumPendingChangeResourceType } from './EnumPendingChangeResourceType';
+export { EnumPendingChangeOriginType } from './EnumPendingChangeOriginType';
 export { EnumPendingChangeAction } from './EnumPendingChangeAction';
 export { FindManyCommitsArgs } from './FindManyCommitsArgs';
 export { AppCreateWithEntitiesInput } from './AppCreateWithEntitiesInput';

--- a/packages/amplication-server/src/core/appRole/appRole.resolver.ts
+++ b/packages/amplication-server/src/core/appRole/appRole.resolver.ts
@@ -1,7 +1,7 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { UseFilters } from '@nestjs/common';
 import { AuthorizeContext } from 'src/decorators/authorizeContext.decorator';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 import {
   CreateAppRoleArgs,
   FindManyAppRoleArgs,
@@ -21,7 +21,7 @@ export class AppRoleResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.BlockId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.BlockId, 'where.id')
   async appRole(@Args() args: FindOneAppRoleArgs): Promise<AppRole | null> {
     return this.appRoleService.getAppRole(args);
   }
@@ -30,7 +30,7 @@ export class AppRoleResolver {
     nullable: false,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.app.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'where.app.id')
   async appRoles(@Args() args: FindManyAppRoleArgs): Promise<AppRole[]> {
     return this.appRoleService.getAppRoles(args);
   }
@@ -39,7 +39,7 @@ export class AppRoleResolver {
     nullable: false,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'data.app.connect.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'data.app.connect.id')
   async createAppRole(@Args() args: CreateAppRoleArgs): Promise<AppRole> {
     return this.appRoleService.createAppRole(args);
   }
@@ -48,7 +48,7 @@ export class AppRoleResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppRoleId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppRoleId, 'where.id')
   async deleteAppRole(
     @Args() args: DeleteAppRoleArgs
   ): Promise<AppRole | null> {
@@ -59,7 +59,7 @@ export class AppRoleResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppRoleId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppRoleId, 'where.id')
   async updateAppRole(
     @Args() args: UpdateOneAppRoleArgs
   ): Promise<AppRole | null> {

--- a/packages/amplication-server/src/core/appSettings/appSettings.resolver.ts
+++ b/packages/amplication-server/src/core/appSettings/appSettings.resolver.ts
@@ -2,7 +2,7 @@ import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { AppSettingsService } from './appSettings.service';
 import { AppSettings, UpdateAppSettingsArgs } from './dto';
 import { AuthorizeContext } from 'src/decorators/authorizeContext.decorator';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 import { FindOneArgs } from 'src/dto';
 import { UserEntity } from 'src/decorators/user.decorator';
 import { User } from 'src/models';
@@ -18,7 +18,7 @@ export class AppSettingsResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'where.id')
   async updateAppSettings(
     @Args() args: UpdateAppSettingsArgs,
     @UserEntity() user: User
@@ -29,7 +29,7 @@ export class AppSettingsResolver {
   @Query(() => AppSettings, {
     nullable: false
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'where.id')
   async appSettings(
     @Args() args: FindOneArgs,
     @UserEntity() user: User

--- a/packages/amplication-server/src/core/auth/auth.resolver.ts
+++ b/packages/amplication-server/src/core/auth/auth.resolver.ts
@@ -18,7 +18,7 @@ import { UserEntity } from 'src/decorators/user.decorator';
 import { GqlAuthGuard } from 'src/guards/gql-auth.guard';
 import { FindOneArgs } from 'src/dto';
 import { AuthorizeContext } from 'src/decorators/authorizeContext.decorator';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 @Resolver(() => Auth)
 @UseFilters(GqlResolverExceptionsFilter)
 export class AuthResolver {
@@ -80,7 +80,7 @@ export class AuthResolver {
 
   @Mutation(() => ApiToken)
   @UseGuards(GqlAuthGuard)
-  @AuthorizeContext(AuthorizableResourceParameter.ApiTokenId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.ApiTokenId, 'where.id')
   async deleteApiToken(
     @UserEntity() user: User,
     @Args() args: FindOneArgs

--- a/packages/amplication-server/src/core/block/block.resolver.ts
+++ b/packages/amplication-server/src/core/block/block.resolver.ts
@@ -2,7 +2,7 @@ import { UseFilters, UseGuards } from '@nestjs/common';
 import { Args, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { AuthorizeContext } from 'src/decorators/authorizeContext.decorator';
 import { FindOneArgs } from 'src/dto';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 import { GqlResolverExceptionsFilter } from 'src/filters/GqlResolverExceptions.filter';
 import { GqlAuthGuard } from 'src/guards/gql-auth.guard';
 import { Block, BlockVersion, User } from 'src/models';
@@ -25,7 +25,7 @@ export class BlockResolver {
     nullable: false,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.app.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'where.app.id')
   async blocks(@Args() args: FindManyBlockArgs): Promise<Block[]> {
     return this.blockService.findMany(args);
   }
@@ -34,7 +34,7 @@ export class BlockResolver {
     nullable: false,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.BlockId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.BlockId, 'where.id')
   async block(@Args() args: FindOneArgs): Promise<Block> {
     return this.blockService.block(args);
   }

--- a/packages/amplication-server/src/core/block/block.service.ts
+++ b/packages/amplication-server/src/core/block/block.service.ts
@@ -32,7 +32,7 @@ import {
 import { FindOneArgs } from 'src/dto';
 import { EnumBlockType } from 'src/enums/EnumBlockType';
 import {
-  EnumPendingChangeResourceType,
+  EnumPendingChangeOriginType,
   EnumPendingChangeAction,
   PendingChange
 } from '../app/dto';
@@ -49,14 +49,14 @@ const NON_COMPARABLE_PROPERTIES = [
 
 export type BlockPendingChange = {
   /** The id of the changed block */
-  resourceId: string;
+  originId: string;
   /** The type of change */
   action: EnumPendingChangeAction;
-  resourceType: EnumPendingChangeResourceType.Block;
+  originType: EnumPendingChangeOriginType.Block;
   /** The block version number */
   versionNumber: number;
   /** The block */
-  resource: Block;
+  origin: Block;
 };
 
 @Injectable()
@@ -615,11 +615,11 @@ export class BlockService {
       }
 
       return {
-        resourceId: block.id,
+        originId: block.id,
         action: action,
-        resourceType: EnumPendingChangeResourceType.Block,
+        originType: EnumPendingChangeOriginType.Block,
         versionNumber: lastVersion.versionNumber + 1,
-        resource: block
+        origin: block
       };
     });
   }
@@ -657,11 +657,11 @@ export class BlockService {
       }
 
       return {
-        resourceId: block.id,
+        originId: block.id,
         action: action,
-        resourceType: EnumPendingChangeResourceType.Block,
+        originType: EnumPendingChangeOriginType.Block,
         versionNumber: changedVersion.versionNumber,
-        resource: block
+        origin: block
       };
     });
   }

--- a/packages/amplication-server/src/core/block/blockType.resolver.ts
+++ b/packages/amplication-server/src/core/block/blockType.resolver.ts
@@ -2,7 +2,7 @@ import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { IBlock, User } from 'src/models';
 import { FindOneArgs } from 'src/dto';
 import { AuthorizeContext } from 'src/decorators/authorizeContext.decorator';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 import { BlockTypeService } from './blockType.service';
 import {
   FindManyBlockArgs,
@@ -39,7 +39,7 @@ export function BlockTypeResolver<
       nullable: true,
       description: undefined
     })
-    @AuthorizeContext(AuthorizableResourceParameter.BlockId, 'where.id')
+    @AuthorizeContext(AuthorizableOriginParameter.BlockId, 'where.id')
     async findOne(@Args() args: FindOneArgs): Promise<T | null> {
       return this.service.findOne(args);
     }
@@ -49,7 +49,7 @@ export function BlockTypeResolver<
       nullable: false,
       description: undefined
     })
-    @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.app.id')
+    @AuthorizeContext(AuthorizableOriginParameter.AppId, 'where.app.id')
     async findMany(
       @Args({ type: () => findManyArgsRef }) args: FindManyArgs
     ): Promise<T[]> {
@@ -61,10 +61,7 @@ export function BlockTypeResolver<
       nullable: false,
       description: undefined
     })
-    @AuthorizeContext(
-      AuthorizableResourceParameter.AppId,
-      'data.app.connect.id'
-    )
+    @AuthorizeContext(AuthorizableOriginParameter.AppId, 'data.app.connect.id')
     async [createName](
       @Args({ type: () => createArgsRef }) args: CreateArgs,
       @UserEntity() user: User
@@ -77,7 +74,7 @@ export function BlockTypeResolver<
       nullable: false,
       description: undefined
     })
-    @AuthorizeContext(AuthorizableResourceParameter.BlockId, 'where.id')
+    @AuthorizeContext(AuthorizableOriginParameter.BlockId, 'where.id')
     async [updateName](
       @Args({ type: () => updateArgsRef }) args: UpdateArgs,
       @UserEntity() user: User

--- a/packages/amplication-server/src/core/build/build.resolver.ts
+++ b/packages/amplication-server/src/core/build/build.resolver.ts
@@ -15,9 +15,9 @@ import { FindOneBuildArgs } from './dto/FindOneBuildArgs';
 import { FindManyBuildArgs } from './dto/FindManyBuildArgs';
 import { BuildService } from './build.service';
 import { AuthorizeContext } from 'src/decorators/authorizeContext.decorator';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 import { InjectContextValue } from 'src/decorators/injectContextValue.decorator';
-import { InjectableResourceParameter } from 'src/enums/InjectableResourceParameter';
+import { InjectableOriginParameter } from 'src/enums/InjectableOriginParameter';
 import { Commit, User } from 'src/models';
 import { UserService } from '../user/user.service';
 import { Action } from '../action/dto';
@@ -37,13 +37,13 @@ export class BuildResolver {
   ) {}
 
   @Query(() => [Build])
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.app.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'where.app.id')
   async builds(@Args() args: FindManyBuildArgs): Promise<Build[]> {
     return this.service.findMany(args);
   }
 
   @Query(() => Build)
-  @AuthorizeContext(AuthorizableResourceParameter.BuildId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.BuildId, 'where.id')
   async build(@Args() args: FindOneBuildArgs): Promise<Build> {
     return this.service.findOne(args);
   }
@@ -75,10 +75,10 @@ export class BuildResolver {
 
   @Mutation(() => Build)
   @InjectContextValue(
-    InjectableResourceParameter.UserId,
+    InjectableOriginParameter.UserId,
     'data.createdBy.connect.id'
   )
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'data.app.connect.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'data.app.connect.id')
   async createBuild(@Args() args: CreateBuildArgs): Promise<Build> {
     return this.service.create(args);
   }

--- a/packages/amplication-server/src/core/commit/commit.resolver.ts
+++ b/packages/amplication-server/src/core/commit/commit.resolver.ts
@@ -3,7 +3,7 @@ import { Args, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { FindManyCommitArgs } from './dto/FindManyCommitArgs';
 import { FindOneCommitArgs } from './dto/FindOneCommitArgs';
 import { AuthorizeContext } from 'src/decorators/authorizeContext.decorator';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 import { GqlResolverExceptionsFilter } from 'src/filters/GqlResolverExceptions.filter';
 import { GqlAuthGuard } from 'src/guards/gql-auth.guard';
 import { Commit, User } from 'src/models';
@@ -37,7 +37,7 @@ export class CommitResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.CommitId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.CommitId, 'where.id')
   async commit(@Args() args: FindOneCommitArgs): Promise<Commit> {
     return this.commitService.findOne(args);
   }
@@ -46,7 +46,7 @@ export class CommitResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.app.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'where.app.id')
   async commits(@Args() args: FindManyCommitArgs): Promise<Commit[]> {
     return this.commitService.findMany(args);
   }

--- a/packages/amplication-server/src/core/entity/entity.resolver.ts
+++ b/packages/amplication-server/src/core/entity/entity.resolver.ts
@@ -19,8 +19,8 @@ import { FindOneArgs } from 'src/dto';
 import { AuthorizeContext } from 'src/decorators/authorizeContext.decorator';
 import { InjectContextValue } from 'src/decorators/injectContextValue.decorator';
 import { UserEntity } from 'src/decorators/user.decorator';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
-import { InjectableResourceParameter } from 'src/enums/InjectableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
+import { InjectableOriginParameter } from 'src/enums/InjectableOriginParameter';
 import { GqlAuthGuard } from 'src/guards/gql-auth.guard';
 import { GqlResolverExceptionsFilter } from 'src/filters/GqlResolverExceptions.filter';
 import { UserService } from '../user/user.service';
@@ -57,7 +57,7 @@ export class EntityResolver {
   @Query(() => Entity, {
     nullable: true
   })
-  @AuthorizeContext(AuthorizableResourceParameter.EntityId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.EntityId, 'where.id')
   async entity(@Args() args: FindOneEntityArgs): Promise<Entity | null> {
     return this.entityService.entity(args);
   }
@@ -65,7 +65,7 @@ export class EntityResolver {
   @Query(() => [Entity], {
     nullable: false
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'where.app.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'where.app.id')
   async entities(@Args() args: FindManyEntityArgs): Promise<Entity[]> {
     return this.entityService.entities(args);
   }
@@ -73,7 +73,7 @@ export class EntityResolver {
   @Mutation(() => Entity, {
     nullable: false
   })
-  @AuthorizeContext(AuthorizableResourceParameter.AppId, 'data.app.connect.id')
+  @AuthorizeContext(AuthorizableOriginParameter.AppId, 'data.app.connect.id')
   async createOneEntity(
     @UserEntity() user: User,
     @Args() args: CreateOneEntityArgs
@@ -84,7 +84,7 @@ export class EntityResolver {
   @Mutation(() => Entity, {
     nullable: true
   })
-  @AuthorizeContext(AuthorizableResourceParameter.EntityId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.EntityId, 'where.id')
   async deleteEntity(
     @UserEntity() user: User,
     @Args() args: DeleteOneEntityArgs
@@ -95,7 +95,7 @@ export class EntityResolver {
   @Mutation(() => Entity, {
     nullable: true
   })
-  @AuthorizeContext(AuthorizableResourceParameter.EntityId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.EntityId, 'where.id')
   async updateEntity(
     @UserEntity() user: User,
     @Args() args: UpdateOneEntityArgs
@@ -106,8 +106,8 @@ export class EntityResolver {
   @Mutation(() => Entity, {
     nullable: true
   })
-  @AuthorizeContext(AuthorizableResourceParameter.EntityId, 'where.id')
-  @InjectContextValue(InjectableResourceParameter.UserId, 'userId')
+  @AuthorizeContext(AuthorizableOriginParameter.EntityId, 'where.id')
+  @InjectContextValue(InjectableOriginParameter.UserId, 'userId')
   async lockEntity(
     @UserEntity() user: User,
     @Args() args: LockEntityArgs
@@ -158,7 +158,7 @@ export class EntityResolver {
   }
 
   @Mutation(() => EntityPermission, { nullable: false })
-  @AuthorizeContext(AuthorizableResourceParameter.EntityId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.EntityId, 'where.id')
   async updateEntityPermission(
     @UserEntity() user: User,
     @Args() args: UpdateEntityPermissionArgs
@@ -168,7 +168,7 @@ export class EntityResolver {
 
   @Mutation(() => EntityPermission, { nullable: false })
   @AuthorizeContext(
-    AuthorizableResourceParameter.EntityId,
+    AuthorizableOriginParameter.EntityId,
     'data.entity.connect.id'
   )
   async updateEntityPermissionRoles(
@@ -180,7 +180,7 @@ export class EntityResolver {
 
   @Mutation(() => EntityPermissionField, { nullable: false })
   @AuthorizeContext(
-    AuthorizableResourceParameter.EntityId,
+    AuthorizableOriginParameter.EntityId,
     'data.entity.connect.id'
   )
   async addEntityPermissionField(
@@ -191,7 +191,7 @@ export class EntityResolver {
   }
 
   @Mutation(() => EntityPermissionField, { nullable: false })
-  @AuthorizeContext(AuthorizableResourceParameter.EntityId, 'where.entityId')
+  @AuthorizeContext(AuthorizableOriginParameter.EntityId, 'where.entityId')
   async deleteEntityPermissionField(
     @UserEntity() user: User,
     @Args() args: DeleteEntityPermissionFieldArgs
@@ -201,7 +201,7 @@ export class EntityResolver {
 
   @Mutation(() => EntityPermissionField, { nullable: false })
   @AuthorizeContext(
-    AuthorizableResourceParameter.EntityPermissionFieldId,
+    AuthorizableOriginParameter.EntityPermissionFieldId,
     'data.permissionField.connect.id'
   )
   async updateEntityPermissionFieldRoles(
@@ -213,7 +213,7 @@ export class EntityResolver {
 
   @Mutation(() => EntityField, { nullable: false })
   @AuthorizeContext(
-    AuthorizableResourceParameter.EntityId,
+    AuthorizableOriginParameter.EntityId,
     'data.entity.connect.id'
   )
   async createEntityField(
@@ -225,7 +225,7 @@ export class EntityResolver {
 
   @Mutation(() => EntityField, { nullable: false })
   @AuthorizeContext(
-    AuthorizableResourceParameter.EntityId,
+    AuthorizableOriginParameter.EntityId,
     'data.entity.connect.id'
   )
   async createEntityFieldByDisplayName(
@@ -236,7 +236,7 @@ export class EntityResolver {
   }
 
   @Mutation(() => EntityField, { nullable: false })
-  @AuthorizeContext(AuthorizableResourceParameter.EntityFieldId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.EntityFieldId, 'where.id')
   async deleteEntityField(
     @UserEntity() user: User,
     @Args() args: FindOneArgs
@@ -245,7 +245,7 @@ export class EntityResolver {
   }
 
   @Mutation(() => EntityField, { nullable: false })
-  @AuthorizeContext(AuthorizableResourceParameter.EntityFieldId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.EntityFieldId, 'where.id')
   async updateEntityField(
     @UserEntity() user: User,
     @Args() args: UpdateOneEntityFieldArgs
@@ -254,7 +254,7 @@ export class EntityResolver {
   }
 
   @Mutation(() => EntityField, { nullable: false })
-  @AuthorizeContext(AuthorizableResourceParameter.EntityFieldId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.EntityFieldId, 'where.id')
   async createDefaultRelatedField(
     @UserEntity() user: User,
     @Args() args: CreateDefaultRelatedFieldArgs

--- a/packages/amplication-server/src/core/entity/entity.service.spec.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.spec.ts
@@ -26,7 +26,7 @@ import { DiffModule } from 'src/services/diff.module';
 import { prepareDeletedItemName } from 'src/util/softDelete';
 import {
   EnumPendingChangeAction,
-  EnumPendingChangeResourceType
+  EnumPendingChangeOriginType
 } from '../app/dto';
 import { DiffService } from 'src/services/diff.service';
 import { isReservedName } from './reservedNames';
@@ -107,11 +107,11 @@ const EXAMPLE_CURRENT_ENTITY_VERSION: EntityVersion = {
 };
 
 const EXAMPLE_ENTITY_PENDING_CHANGE_CREATE: EntityPendingChange = {
-  resourceId: EXAMPLE_ENTITY.id,
+  originId: EXAMPLE_ENTITY.id,
   action: EnumPendingChangeAction.Create,
-  resourceType: EnumPendingChangeResourceType.Entity,
+  originType: EnumPendingChangeOriginType.Entity,
   versionNumber: 1,
-  resource: EXAMPLE_ENTITY
+  origin: EXAMPLE_ENTITY
 };
 const EXAMPLE_DELETED_ENTITY = {
   ...EXAMPLE_ENTITY,
@@ -119,18 +119,18 @@ const EXAMPLE_DELETED_ENTITY = {
   deletedAt: new Date()
 };
 const EXAMPLE_ENTITY_PENDING_CHANGE_DELETE: EntityPendingChange = {
-  resourceId: EXAMPLE_ENTITY.id,
+  originId: EXAMPLE_ENTITY.id,
   action: EnumPendingChangeAction.Delete,
-  resourceType: EnumPendingChangeResourceType.Entity,
+  originType: EnumPendingChangeOriginType.Entity,
   versionNumber: 1,
-  resource: EXAMPLE_DELETED_ENTITY
+  origin: EXAMPLE_DELETED_ENTITY
 };
 const EXAMPLE_ENTITY_PENDING_CHANGE_UPDATE: EntityPendingChange = {
-  resourceId: EXAMPLE_ENTITY.id,
+  originId: EXAMPLE_ENTITY.id,
   action: EnumPendingChangeAction.Update,
-  resourceType: EnumPendingChangeResourceType.Entity,
+  originType: EnumPendingChangeOriginType.Entity,
   versionNumber: 1,
-  resource: EXAMPLE_ENTITY
+  origin: EXAMPLE_ENTITY
 };
 
 const EXAMPLE_LAST_ENTITY_VERSION: EntityVersion = {

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -45,7 +45,7 @@ import {
 } from 'src/util/softDelete';
 
 import {
-  EnumPendingChangeResourceType,
+  EnumPendingChangeOriginType,
   EnumPendingChangeAction,
   PendingChange
 } from '../app/dto';
@@ -104,14 +104,14 @@ export type BulkEntityData = Omit<
 
 export type EntityPendingChange = {
   /** The id of the changed entity */
-  resourceId: string;
+  originId: string;
   /** The type of change */
   action: EnumPendingChangeAction;
-  resourceType: EnumPendingChangeResourceType.Entity;
+  originType: EnumPendingChangeOriginType.Entity;
   /** The entity version number */
   versionNumber: number;
   /** The entity */
-  resource: Entity;
+  origin: Entity;
 };
 
 /**
@@ -495,11 +495,11 @@ export class EntityService {
       }
 
       return {
-        resourceId: entity.id,
+        originId: entity.id,
         action: action,
-        resourceType: EnumPendingChangeResourceType.Entity,
+        originType: EnumPendingChangeOriginType.Entity,
         versionNumber: lastVersion.versionNumber + 1,
-        resource: entity
+        origin: entity
       };
     });
   }
@@ -539,11 +539,11 @@ export class EntityService {
       }
 
       return {
-        resourceId: entity.id,
+        originId: entity.id,
         action: action,
-        resourceType: EnumPendingChangeResourceType.Entity,
+        originType: EnumPendingChangeOriginType.Entity,
         versionNumber: changedVersion.versionNumber,
-        resource: entity
+        origin: entity
       };
     });
   }

--- a/packages/amplication-server/src/core/git/git.resolver.ts
+++ b/packages/amplication-server/src/core/git/git.resolver.ts
@@ -3,8 +3,8 @@ import { Args, Mutation, Query } from '@nestjs/graphql';
 import { AuthorizeContext } from 'src/decorators/authorizeContext.decorator';
 import { InjectContextValue } from 'src/decorators/injectContextValue.decorator';
 import { FindOneArgs } from 'src/dto';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
-import { InjectableResourceParameter } from 'src/enums/InjectableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
+import { InjectableOriginParameter } from 'src/enums/InjectableOriginParameter';
 import { App } from 'src/models/App';
 import { GitOrganization } from 'src/models/GitOrganization';
 import { GqlResolverExceptionsFilter } from '../../filters/GqlResolverExceptions.filter';
@@ -27,7 +27,7 @@ export class GitResolver {
   constructor(private readonly gitService: GitProviderService) {}
   @Mutation(() => App)
   @AuthorizeContext(
-    AuthorizableResourceParameter.GitOrganizationId,
+    AuthorizableOriginParameter.GitOrganizationId,
     'data.gitOrganizationId'
   )
   async createGitRepository(
@@ -37,14 +37,14 @@ export class GitResolver {
   }
 
   @Query(() => GitOrganization)
-  @AuthorizeContext(AuthorizableResourceParameter.GitOrganizationId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.GitOrganizationId, 'where.id')
   async gitOrganization(@Args() args: FindOneArgs): Promise<GitOrganization> {
     return this.gitService.getGitOrganization(args);
   }
 
   @Mutation(() => App)
   @AuthorizeContext(
-    AuthorizableResourceParameter.GitOrganizationId,
+    AuthorizableOriginParameter.GitOrganizationId,
     'data.gitOrganizationId'
   )
   async connectAppGitRepository(
@@ -54,10 +54,7 @@ export class GitResolver {
   }
 
   @Mutation(() => GitOrganization)
-  @InjectContextValue(
-    InjectableResourceParameter.WorkspaceId,
-    'data.workspaceId'
-  )
+  @InjectContextValue(InjectableOriginParameter.WorkspaceId, 'data.workspaceId')
   async createOrganization(
     @Args() args: CreateGitOrganizationArgs
   ): Promise<GitOrganization> {
@@ -66,7 +63,7 @@ export class GitResolver {
 
   @Mutation(() => App)
   @AuthorizeContext(
-    AuthorizableResourceParameter.GitRepositoryId,
+    AuthorizableOriginParameter.GitRepositoryId,
     'gitRepositoryId'
   )
   async deleteGitRepository(
@@ -77,7 +74,7 @@ export class GitResolver {
 
   @Mutation(() => Boolean)
   @AuthorizeContext(
-    AuthorizableResourceParameter.GitOrganizationId,
+    AuthorizableOriginParameter.GitOrganizationId,
     'gitOrganizationId'
   )
   async deleteGitOrganization(
@@ -87,10 +84,7 @@ export class GitResolver {
   }
 
   @Mutation(() => AuthorizeAppWithGitResult)
-  @InjectContextValue(
-    InjectableResourceParameter.WorkspaceId,
-    'data.workspaceId'
-  )
+  @InjectContextValue(InjectableOriginParameter.WorkspaceId, 'data.workspaceId')
   async getGitAppInstallationUrl(
     @Args() args: GetGitInstallationUrlArgs
   ): Promise<AuthorizeAppWithGitResult> {
@@ -101,7 +95,7 @@ export class GitResolver {
 
   @Query(() => [RemoteGitRepository])
   @AuthorizeContext(
-    AuthorizableResourceParameter.GitOrganizationId,
+    AuthorizableOriginParameter.GitOrganizationId,
     'where.gitOrganizationId'
   )
   async remoteGitRepositories(
@@ -112,7 +106,7 @@ export class GitResolver {
 
   @Query(() => [GitOrganization])
   @InjectContextValue(
-    InjectableResourceParameter.WorkspaceId,
+    InjectableOriginParameter.WorkspaceId,
     'where.workspaceId'
   )
   async gitOrganizations(

--- a/packages/amplication-server/src/core/permissions/permissions.service.spec.ts
+++ b/packages/amplication-server/src/core/permissions/permissions.service.spec.ts
@@ -2,10 +2,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PermissionsService } from './permissions.service';
 import { PrismaService } from '@amplication/prisma-db';
 import { User, Workspace } from 'src/models';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 
-const UNEXPECTED_RESOURCE_TYPE = -1;
-const UNEXPECTED_RESOURCE_ID = 'unexpectedResourceId';
+const UNEXPECTED_ORIGIN_TYPE = -1;
+const UNEXPECTED_ORIGIN_ID = 'unexpectedOriginId';
 
 const EXAMPLE_WORKSPACE_ID = 'exampleWorkspaceId';
 const EXAMPLE_WORKSPACE_NAME = 'exampleWorkspaceName';
@@ -70,56 +70,48 @@ describe('PermissionsService', () => {
     expect(service).toBeDefined();
   });
 
-  it('should return true when resourceType is an authorized workspace id', async () => {
+  it('should return true when originType is an authorized workspace id', async () => {
     const args = {
       user: EXAMPLE_USER,
-      resourceType: AuthorizableResourceParameter.WorkspaceId,
-      resourceId: EXAMPLE_WORKSPACE_ID
+      originType: AuthorizableOriginParameter.WorkspaceId,
+      originId: EXAMPLE_WORKSPACE_ID
     };
     expect(
-      await service.validateAccess(
-        args.user,
-        args.resourceType,
-        args.resourceId
-      )
+      await service.validateAccess(args.user, args.originType, args.originId)
     ).toEqual(true);
   });
 
-  it('should return true when resourceType is an authorized app id', async () => {
+  it('should return true when originType is an authorized app id', async () => {
     const args = {
       user: EXAMPLE_USER,
-      resourceType: AuthorizableResourceParameter.AppId,
-      resourceId: EXAMPLE_APP_ID
+      originType: AuthorizableOriginParameter.AppId,
+      originId: EXAMPLE_APP_ID
     };
     const countArgs = {
       where: {
         deletedAt: null,
-        id: args.resourceId,
+        id: args.originId,
         workspace: {
           id: EXAMPLE_WORKSPACE_ID
         }
       }
     };
     expect(
-      await service.validateAccess(
-        args.user,
-        args.resourceType,
-        args.resourceId
-      )
+      await service.validateAccess(args.user, args.originType, args.originId)
     ).toEqual(true);
     expect(prismaAppCountMock).toBeCalledTimes(1);
     expect(prismaAppCountMock).toBeCalledWith(countArgs);
   });
 
-  it('should return true if resourceType is an authorized instance of AuthorizableResourceParameter', async () => {
+  it('should return true if originType is an authorized instance of AuthorizableOriginParameter', async () => {
     const args = {
       user: EXAMPLE_USER,
-      resourceType: AuthorizableResourceParameter.AppRoleId,
-      resourceId: EXAMPLE_APP_ROLE_ID
+      originType: AuthorizableOriginParameter.AppRoleId,
+      originId: EXAMPLE_APP_ROLE_ID
     };
     const countArgs = {
       where: {
-        id: args.resourceId,
+        id: args.originId,
         app: {
           deletedAt: null,
           workspace: {
@@ -129,11 +121,7 @@ describe('PermissionsService', () => {
       }
     };
     expect(
-      await service.validateAccess(
-        args.user,
-        args.resourceType,
-        args.resourceId
-      )
+      await service.validateAccess(args.user, args.originType, args.originId)
     ).toEqual(true);
     expect(prismaAppRoleCountMock).toBeCalledTimes(1);
     expect(prismaAppRoleCountMock).toBeCalledWith(countArgs);
@@ -142,11 +130,11 @@ describe('PermissionsService', () => {
   it('should throw an error', async () => {
     const args = {
       user: EXAMPLE_USER,
-      resourceType: UNEXPECTED_RESOURCE_TYPE,
-      resourceId: UNEXPECTED_RESOURCE_ID
+      originType: UNEXPECTED_ORIGIN_TYPE,
+      originId: UNEXPECTED_ORIGIN_ID
     };
     await expect(
-      service.validateAccess(args.user, args.resourceType, args.resourceId)
-    ).rejects.toThrow(`Unexpected resource type ${args.resourceType}`);
+      service.validateAccess(args.user, args.originType, args.originId)
+    ).rejects.toThrow(`Unexpected origin type ${args.originType}`);
   });
 });

--- a/packages/amplication-server/src/core/permissions/permissions.service.ts
+++ b/packages/amplication-server/src/core/permissions/permissions.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@amplication/prisma-db';
 import { User } from 'src/models';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 
 @Injectable()
 export class PermissionsService {
@@ -9,14 +9,14 @@ export class PermissionsService {
 
   async validateAccess(
     user: User,
-    resourceType: AuthorizableResourceParameter,
-    resourceId: string
+    originType: AuthorizableOriginParameter,
+    originId: string
   ): Promise<boolean> {
     const { workspace } = user;
 
     const checkByAppParameters = {
       where: {
-        id: resourceId,
+        id: originId,
         app: {
           deletedAt: null,
           workspace: {
@@ -26,14 +26,14 @@ export class PermissionsService {
       }
     };
 
-    if (resourceType === AuthorizableResourceParameter.WorkspaceId) {
-      return resourceId === workspace.id;
+    if (originType === AuthorizableOriginParameter.WorkspaceId) {
+      return originId === workspace.id;
     }
 
-    if (resourceType === AuthorizableResourceParameter.GitOrganizationId) {
+    if (originType === AuthorizableOriginParameter.GitOrganizationId) {
       const matching = await this.prisma.gitOrganization.count({
         where: {
-          id: resourceId,
+          id: originId,
           workspace: {
             id: workspace.id
           }
@@ -42,20 +42,20 @@ export class PermissionsService {
       return matching === 1;
     }
 
-    if (resourceType === AuthorizableResourceParameter.GitRepositoryId) {
+    if (originType === AuthorizableOriginParameter.GitRepositoryId) {
       const matching = await this.prisma.gitRepository.count({
         where: {
-          id: resourceId
+          id: originId
         }
       });
       return matching === 1;
     }
 
-    if (resourceType === AuthorizableResourceParameter.AppId) {
+    if (originType === AuthorizableOriginParameter.AppId) {
       const matching = await this.prisma.app.count({
         where: {
           deletedAt: null,
-          id: resourceId,
+          id: originId,
           workspace: {
             id: workspace.id
           }
@@ -63,10 +63,10 @@ export class PermissionsService {
       });
       return matching === 1;
     }
-    if (resourceType === AuthorizableResourceParameter.InvitationId) {
+    if (originType === AuthorizableOriginParameter.InvitationId) {
       const matching = await this.prisma.invitation.count({
         where: {
-          id: resourceId,
+          id: originId,
           workspace: {
             id: workspace.id
           }
@@ -74,22 +74,22 @@ export class PermissionsService {
       });
       return matching === 1;
     }
-    if (resourceType === AuthorizableResourceParameter.ApiTokenId) {
+    if (originType === AuthorizableOriginParameter.ApiTokenId) {
       const matching = await this.prisma.apiToken.count({
         where: {
-          id: resourceId,
+          id: originId,
           userId: user.id
         }
       });
       return matching === 1;
     }
-    if (resourceType === AuthorizableResourceParameter.ActionId) {
+    if (originType === AuthorizableOriginParameter.ActionId) {
       const matching = await this.prisma.action.count({
         where: {
           // eslint-disable-next-line  @typescript-eslint/naming-convention
           OR: [
             {
-              id: resourceId,
+              id: originId,
               deployments: {
                 some: {
                   build: {
@@ -102,7 +102,7 @@ export class PermissionsService {
               }
             },
             {
-              id: resourceId,
+              id: originId,
               builds: {
                 some: {
                   app: {
@@ -117,10 +117,10 @@ export class PermissionsService {
       });
       return matching === 1;
     }
-    if (resourceType === AuthorizableResourceParameter.DeploymentId) {
+    if (originType === AuthorizableOriginParameter.DeploymentId) {
       const matching = await this.prisma.deployment.count({
         where: {
-          id: resourceId,
+          id: originId,
           environment: {
             app: {
               deletedAt: null,
@@ -131,10 +131,10 @@ export class PermissionsService {
       });
       return matching === 1;
     }
-    if (resourceType === AuthorizableResourceParameter.EntityFieldId) {
+    if (originType === AuthorizableOriginParameter.EntityFieldId) {
       const matching = await this.prisma.entityField.count({
         where: {
-          id: resourceId,
+          id: originId,
           entityVersion: {
             entity: {
               app: {
@@ -147,12 +147,10 @@ export class PermissionsService {
       });
       return matching === 1;
     }
-    if (
-      resourceType === AuthorizableResourceParameter.EntityPermissionFieldId
-    ) {
+    if (originType === AuthorizableOriginParameter.EntityPermissionFieldId) {
       const matching = await this.prisma.entityPermissionField.count({
         where: {
-          id: resourceId,
+          id: originId,
           field: {
             entityVersion: {
               entity: {
@@ -167,33 +165,33 @@ export class PermissionsService {
       });
       return matching === 1;
     }
-    if (resourceType === AuthorizableResourceParameter.EntityId) {
+    if (originType === AuthorizableOriginParameter.EntityId) {
       const matching = await this.prisma.entity.count(checkByAppParameters);
       return matching === 1;
     }
-    if (resourceType === AuthorizableResourceParameter.BlockId) {
+    if (originType === AuthorizableOriginParameter.BlockId) {
       const matching = await this.prisma.block.count(checkByAppParameters);
       return matching === 1;
     }
-    if (resourceType === AuthorizableResourceParameter.BuildId) {
+    if (originType === AuthorizableOriginParameter.BuildId) {
       const matching = await this.prisma.build.count(checkByAppParameters);
       return matching === 1;
     }
-    if (resourceType === AuthorizableResourceParameter.AppRoleId) {
+    if (originType === AuthorizableOriginParameter.AppRoleId) {
       const matching = await this.prisma.appRole.count(checkByAppParameters);
       return matching === 1;
     }
-    if (resourceType === AuthorizableResourceParameter.EnvironmentId) {
+    if (originType === AuthorizableOriginParameter.EnvironmentId) {
       const matching = await this.prisma.environment.count(
         checkByAppParameters
       );
       return matching === 1;
     }
-    if (resourceType === AuthorizableResourceParameter.CommitId) {
+    if (originType === AuthorizableOriginParameter.CommitId) {
       const matching = await this.prisma.commit.count(checkByAppParameters);
       return matching === 1;
     }
 
-    throw new Error(`Unexpected resource type ${resourceType}`);
+    throw new Error(`Unexpected origin type ${originType}`);
   }
 }

--- a/packages/amplication-server/src/core/workspace/workspace.resolver.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.resolver.ts
@@ -25,7 +25,7 @@ import { UseFilters, UseGuards } from '@nestjs/common';
 import { UserEntity } from 'src/decorators/user.decorator';
 import { GqlAuthGuard } from 'src/guards/gql-auth.guard';
 import { WorkspaceService } from './workspace.service';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 import { AuthorizeContext } from 'src/decorators/authorizeContext.decorator';
 import { GitOrganization } from 'src/models/GitOrganization';
 import { Subscription } from '../subscription/dto/Subscription';
@@ -42,7 +42,7 @@ export class WorkspaceResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.WorkspaceId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.WorkspaceId, 'where.id')
   async workspace(@Args() args: FindOneArgs): Promise<Workspace | null> {
     return this.workspaceService.getWorkspace(args);
   }
@@ -68,7 +68,7 @@ export class WorkspaceResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.WorkspaceId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.WorkspaceId, 'where.id')
   async deleteWorkspace(@Args() args: FindOneArgs): Promise<Workspace | null> {
     return this.workspaceService.deleteWorkspace(args);
   }
@@ -77,7 +77,7 @@ export class WorkspaceResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.WorkspaceId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.WorkspaceId, 'where.id')
   async updateWorkspace(
     @Args() args: UpdateOneWorkspaceArgs
   ): Promise<Workspace | null> {
@@ -110,7 +110,7 @@ export class WorkspaceResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.InvitationId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.InvitationId, 'where.id')
   async revokeInvitation(
     @Args() args: RevokeInvitationArgs
   ): Promise<Invitation> {
@@ -121,7 +121,7 @@ export class WorkspaceResolver {
     nullable: true,
     description: undefined
   })
-  @AuthorizeContext(AuthorizableResourceParameter.InvitationId, 'where.id')
+  @AuthorizeContext(AuthorizableOriginParameter.InvitationId, 'where.id')
   async resendInvitation(
     @Args() args: ResendInvitationArgs
   ): Promise<Invitation> {

--- a/packages/amplication-server/src/decorators/authorizeContext.decorator.ts
+++ b/packages/amplication-server/src/decorators/authorizeContext.decorator.ts
@@ -3,7 +3,7 @@
  */
 
 import { SetMetadata } from '@nestjs/common';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 import {
   AUTHORIZE_CONTEXT,
   AuthorizeContextParameters
@@ -19,7 +19,7 @@ import {
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const AuthorizeContext = (
-  parameterType: AuthorizableResourceParameter,
+  parameterType: AuthorizableOriginParameter,
   parameterPath: string
 ) =>
   SetMetadata<string, AuthorizeContextParameters>(AUTHORIZE_CONTEXT, {

--- a/packages/amplication-server/src/decorators/injectContextValue.decorator.ts
+++ b/packages/amplication-server/src/decorators/injectContextValue.decorator.ts
@@ -1,5 +1,5 @@
 import { SetMetadata } from '@nestjs/common';
-import { InjectableResourceParameter } from 'src/enums/InjectableResourceParameter';
+import { InjectableOriginParameter } from 'src/enums/InjectableOriginParameter';
 import {
   INJECT_CONTEXT_VALUE,
   InjectContextValueParameters
@@ -12,7 +12,7 @@ import {
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const InjectContextValue = (
-  parameterType: InjectableResourceParameter,
+  parameterType: InjectableOriginParameter,
   parameterPath: string
 ) =>
   SetMetadata<string, InjectContextValueParameters>(INJECT_CONTEXT_VALUE, {

--- a/packages/amplication-server/src/enums/AuthorizableOriginParameter.ts
+++ b/packages/amplication-server/src/enums/AuthorizableOriginParameter.ts
@@ -4,7 +4,7 @@
  * Each parameter defined in the enum needs a definition of how to authorize it
  * in the { @link PermissionService }
  */
-export enum AuthorizableResourceParameter {
+export enum AuthorizableOriginParameter {
   WorkspaceId,
   AppId,
   EntityId,

--- a/packages/amplication-server/src/enums/InjectableOriginParameter.ts
+++ b/packages/amplication-server/src/enums/InjectableOriginParameter.ts
@@ -1,0 +1,4 @@
+export enum InjectableOriginParameter {
+  UserId,
+  WorkspaceId
+}

--- a/packages/amplication-server/src/enums/InjectableResourceParameter.ts
+++ b/packages/amplication-server/src/enums/InjectableResourceParameter.ts
@@ -1,4 +1,0 @@
-export enum InjectableResourceParameter {
-  UserId,
-  WorkspaceId
-}

--- a/packages/amplication-server/src/guards/gql-auth.guard.spec.ts
+++ b/packages/amplication-server/src/guards/gql-auth.guard.spec.ts
@@ -6,7 +6,7 @@ import {
   AUTHORIZE_CONTEXT,
   AuthorizeContextParameters
 } from './gql-auth.guard';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 import { User } from 'src/models/User';
 import { UserRole } from 'src/models/UserRole';
 import { Workspace } from 'src/models/Workspace';
@@ -16,7 +16,7 @@ const EXAMPLE_ROLE = 'Example Role';
 const EXAMPLE_ROLES: string[] = [EXAMPLE_ROLE];
 const EXAMPLE_AUTHORIZE_CONTEXT_PARAMETERS: AuthorizeContextParameters = {
   parameterPath: 'where.workspace.id',
-  parameterType: AuthorizableResourceParameter.WorkspaceId
+  parameterType: AuthorizableOriginParameter.WorkspaceId
 };
 const EXAMPLE_HANDLER = () => null;
 
@@ -36,10 +36,10 @@ const EXAMPLE_FIND_REQUEST_ARGS = {
   }
 };
 
-const validateAccessMock = jest.fn((user, resourceType, resourceId) => {
+const validateAccessMock = jest.fn((user, originType, originId) => {
   return (
-    resourceType === AuthorizableResourceParameter.WorkspaceId &&
-    resourceId === EXAMPLE_WORKSPACE_ID
+    originType === AuthorizableOriginParameter.WorkspaceId &&
+    originId === EXAMPLE_WORKSPACE_ID
   );
 });
 

--- a/packages/amplication-server/src/guards/gql-auth.guard.ts
+++ b/packages/amplication-server/src/guards/gql-auth.guard.ts
@@ -5,12 +5,12 @@ import { GqlExecutionContext } from '@nestjs/graphql';
 import { get } from 'lodash';
 import { User } from 'src/models';
 import { PermissionsService } from 'src/core/permissions/permissions.service';
-import { AuthorizableResourceParameter } from 'src/enums/AuthorizableResourceParameter';
+import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 
 export const AUTHORIZE_CONTEXT = 'authorizeContext';
 
 export type AuthorizeContextParameters = {
-  parameterType: AuthorizableResourceParameter;
+  parameterType: AuthorizableOriginParameter;
   parameterPath: string;
 };
 

--- a/packages/amplication-server/src/interceptors/inject-context.interceptor.spec.ts
+++ b/packages/amplication-server/src/interceptors/inject-context.interceptor.spec.ts
@@ -6,12 +6,12 @@ import {
   INJECT_CONTEXT_VALUE
 } from './inject-context.interceptor';
 import { Reflector } from '@nestjs/core';
-import { InjectableResourceParameter } from 'src/enums/InjectableResourceParameter';
+import { InjectableOriginParameter } from 'src/enums/InjectableOriginParameter';
 
 const EXAMPLE_HANDLER = () => null;
 const EXAMPLE_INJECT_CONTEXT_VALUE_PARAMETERS: InjectContextValueParameters = {
   parameterPath: 'data.workspace.connect.id',
-  parameterType: InjectableResourceParameter.WorkspaceId
+  parameterType: InjectableOriginParameter.WorkspaceId
 };
 const EXAMPLE_WORKSPACE_ID = 'ExampleWorkspaceId';
 

--- a/packages/amplication-server/src/interceptors/inject-context.interceptor.ts
+++ b/packages/amplication-server/src/interceptors/inject-context.interceptor.ts
@@ -5,7 +5,7 @@ import {
   NestInterceptor
 } from '@nestjs/common';
 import { set } from 'lodash';
-import { InjectableResourceParameter } from 'src/enums/InjectableResourceParameter';
+import { InjectableOriginParameter } from 'src/enums/InjectableOriginParameter';
 import { User } from 'src/models';
 import { Reflector } from '@nestjs/core';
 import { GqlExecutionContext } from '@nestjs/graphql';
@@ -13,7 +13,7 @@ import { GqlExecutionContext } from '@nestjs/graphql';
 export const INJECT_CONTEXT_VALUE = 'injectContextValue';
 
 export type InjectContextValueParameters = {
-  parameterType: InjectableResourceParameter;
+  parameterType: InjectableOriginParameter;
   parameterPath: string;
 };
 
@@ -54,13 +54,13 @@ export class InjectContextInterceptor implements NestInterceptor {
 
   private getInjectableContextValue(
     user: User,
-    parameterType: InjectableResourceParameter
+    parameterType: InjectableOriginParameter
   ): string | undefined {
     switch (parameterType) {
-      case InjectableResourceParameter.UserId: {
+      case InjectableOriginParameter.UserId: {
         return user.id;
       }
-      case InjectableResourceParameter.WorkspaceId: {
+      case InjectableOriginParameter.WorkspaceId: {
         return user.workspace?.id;
       }
       default: {


### PR DESCRIPTION
Issue Number: #3305 

## PR Details

rename:
- `resource` => `origin`
- `resourceId` => `originId`
- `resourceType` => `originType`
- `EnumPendingChangeResourceType` => `EnumPendingChangeOriginType`
- `InjectableResourceParameter` => `InjectableOriginParameter`

## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

