### PR TITLE
Create project after sign-up didn't create default settings

### DIFF
--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -3,12 +3,10 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];
 };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -372,11 +370,15 @@ export type ConnectorRestApiCreateInput = {
   authenticationType: EnumConnectorRestApiAuthenticationType;
   description?: InputMaybe<Scalars['String']>;
   displayName: Scalars['String'];
-  httpBasicAuthenticationSettings?: InputMaybe<HttpBasicAuthenticationSettingsInput>;
+  httpBasicAuthenticationSettings?: InputMaybe<
+    HttpBasicAuthenticationSettingsInput
+  >;
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
-  privateKeyAuthenticationSettings?: InputMaybe<PrivateKeyAuthenticationSettingsInput>;
+  privateKeyAuthenticationSettings?: InputMaybe<
+    PrivateKeyAuthenticationSettingsInput
+  >;
   resource: WhereParentIdInput;
 };
 

--- a/packages/amplication-server/src/core/auth/auth.service.spec.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.spec.ts
@@ -153,7 +153,7 @@ const createWorkspaceMock = jest.fn(() => ({
   users: [EXAMPLE_AUTH_USER]
 }));
 
-const prismaCreateProjectMock = jest.fn(() => EXAMPLE_PROJECT);
+const createProjectMock = jest.fn(() => EXAMPLE_PROJECT);
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -168,7 +168,7 @@ describe('AuthService', () => {
     validatePasswordMock.mockClear();
     findUsersMock.mockClear();
     createWorkspaceMock.mockClear();
-    prismaCreateProjectMock.mockClear();
+    createProjectMock.mockClear();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -216,10 +216,13 @@ describe('AuthService', () => {
           useClass: jest.fn(() => ({
             account: {
               findUnique: prismaAccountFindOneMock
-            },
-            project: {
-              create: prismaCreateProjectMock
             }
+          }))
+        },
+        {
+          provide: ProjectService,
+          useClass: jest.fn(() => ({
+            createProject: createProjectMock
           }))
         },
         AuthService

--- a/packages/amplication-server/src/core/project/project.resolver.ts
+++ b/packages/amplication-server/src/core/project/project.resolver.ts
@@ -58,7 +58,12 @@ export class ProjectResolver {
     @Args() args: ProjectCreateArgs,
     @UserEntity() user: User
   ): Promise<Project> {
-    return this.projectService.createProject(args, user.id);
+    const { name, workspace } = args.data;
+    return this.projectService.createProject(
+      name,
+      workspace.connect.id,
+      user.id
+    );
   }
 
   @ResolveField(() => [Resource])

--- a/packages/amplication-server/src/core/project/project.service.ts
+++ b/packages/amplication-server/src/core/project/project.service.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@nestjs/common';
 import { FindOneArgs } from 'src/dto';
 import { Project } from 'src/models';
 import { ResourceService } from '..';
-import { ProjectCreateArgs } from './dto/ProjectCreateArgs';
 import { ProjectFindManyArgs } from './dto/ProjectFindManyArgs';
 @Injectable()
 export class ProjectService {
@@ -21,15 +20,16 @@ export class ProjectService {
   }
 
   async createProject(
-    args: ProjectCreateArgs,
+    name: string,
+    workspaceId: string,
     userId: string
   ): Promise<Project> {
     const project = await this.prisma.project.create({
       data: {
-        ...args.data,
+        name: name,
         workspace: {
           connect: {
-            id: args.data.workspace.connect.id
+            id: workspaceId
           }
         }
       }


### PR DESCRIPTION

Issue Number: #3360 

## PR Details

In sign-up method, change the create project to be created from the project service with the default project settings 

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

