### PR TITLE
Set the connect to GitHub button to full width

### DIFF
--- a/packages/amplication-client/src/Resource/git/AppGitStatusPanel.scss
+++ b/packages/amplication-client/src/Resource/git/AppGitStatusPanel.scss
@@ -32,4 +32,9 @@
       padding-right: calc(var(--default-spacing-small) / 2);
     }
   }
+  &__connect {
+    &__button {
+      width: 100%;
+    }
+  }
 }

--- a/packages/amplication-client/src/Resource/git/AppGitStatusPanel.tsx
+++ b/packages/amplication-client/src/Resource/git/AppGitStatusPanel.tsx
@@ -27,7 +27,7 @@ const AppGitStatusPanel = ({ resource, showDisconnectedMessage }: Props) => {
   const repoUrl = `https://github.com/${gitRepositoryFullName}`;
 
   const { currentWorkspace, currentProject } = useContext(AppContext);
-  
+
   const lastSync = new Date(resource.githubLastSync);
 
   return (
@@ -39,11 +39,15 @@ const AppGitStatusPanel = ({ resource, showDisconnectedMessage }: Props) => {
               Connect to GitHub to create a Pull Request with the generated code
             </div>
           )}
-          <Link title={"Connect to GitHub"} to={`/${currentWorkspace?.id}/${currentProject?.id}/${resource.id}/github`}>
+          <Link
+            title={"Connect to GitHub"}
+            to={`/${currentWorkspace?.id}/${currentProject?.id}/${resource.id}/github`}
+          >
             <Button
               buttonStyle={EnumButtonStyle.Secondary}
               icon="github"
               iconPosition={EnumIconPosition.Left}
+              className={`${CLASS_NAME}__connect__button`}
             >
               Connect to GitHub
             </Button>


### PR DESCRIPTION
closes #3066 

## PR Details

Setting the width property of the button to 100%
![Screen Shot 2022-08-16 at 14 54 58](https://user-images.githubusercontent.com/61761153/184873546-f23b7225-7a46-4574-91dd-4e84dff583f3.png)

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/code_of_conduct.md) file for detailed contributing guidelines.
