### PR TITLE
fix: error on closing the new workspace Dialog without any name

### DIFF
--- a/packages/amplication-client/src/Workspaces/NewWorkspace.tsx
+++ b/packages/amplication-client/src/Workspaces/NewWorkspace.tsx
@@ -22,12 +22,14 @@ const INITIAL_VALUES: CreateWorkspaceType = {
   name: "",
 };
 
+const NAME_MIN_LENGTH = 2;
+
 const FORM_SCHEMA = {
   required: ["name"],
   properties: {
     name: {
       type: "string",
-      minLength: 2,
+      minLength: NAME_MIN_LENGTH,
     },
   },
 };
@@ -109,7 +111,7 @@ const NewWorkspace = ({ onWorkspaceCreated }: Props) => {
           validate(values, FORM_SCHEMA)
         }
         onSubmit={handleSubmit}
-        validateOnMount
+        validateOnBlur={false}
       >
         {(formik) => {
           const handlers = {
@@ -130,7 +132,11 @@ const NewWorkspace = ({ onWorkspaceCreated }: Props) => {
               <Button
                 type="submit"
                 buttonStyle={EnumButtonStyle.Primary}
-                disabled={!formik.isValid || loading}
+                disabled={
+                  !formik.isValid ||
+                  loading ||
+                  formik.values.name.length < NAME_MIN_LENGTH
+                }
               >
                 Create Workspace
               </Button>


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Issue Number: #1868

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

**Required Info.**
- For creating the new workspace, Formik library is used.
- And, a prop validateOnMount was used in order to validate the text input to disable the Create Workspace button.

**What is causing Issue**
- As mentioned in issue, when user click the cross button to close the Dialog, user see the error message, which is not a good UX.
- Its happening because when text field gets blurred, it validates the value, which is wrong in case of empty.
- And, validateOnMount also forcefully cause validation on blur along with its validation on mount.

**Solution**
- Since, after removing the validation on Blur doesn't affect the UX, so in this PR:
1. added validationOnBlur=false
2. removed the validationOnMount
3. And, added a condition to check length of values in button, to make it disable until required condition is not met.

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
