### PR TITLE
fix repoName spaces and under-score

### DIFF
--- a/packages/amplication-git-service/src/services/git.service.ts
+++ b/packages/amplication-git-service/src/services/git.service.ts
@@ -28,18 +28,18 @@ export class GitService {
     isPublic: boolean
   ): Promise<RemoteGitRepository> {
     const provider = this.gitServiceFactory.getService(gitProvider);
-    const trimRepoName = repoName.trim().replace(/ /g, '-');
+    //const trimRepoName = repoName.trim().replace(/ /g, '-');
     return await (gitOrganizationType === EnumGitOrganizationType.Organization
       ? provider.createOrganizationRepository(
           installationId,
           gitOrganizationName,
-          trimRepoName,
+          repoName,
           isPublic
         )
       : provider.createUserRepository(
           installationId,
           gitOrganizationName,
-          trimRepoName,
+          repoName,
           isPublic
         ));
   }

--- a/packages/amplication-git-service/src/services/git.service.ts
+++ b/packages/amplication-git-service/src/services/git.service.ts
@@ -28,7 +28,6 @@ export class GitService {
     isPublic: boolean
   ): Promise<RemoteGitRepository> {
     const provider = this.gitServiceFactory.getService(gitProvider);
-    //const trimRepoName = repoName.trim().replace(/ /g, '-');
     return await (gitOrganizationType === EnumGitOrganizationType.Organization
       ? provider.createOrganizationRepository(
           installationId,

--- a/packages/amplication-git-service/src/services/git.service.ts
+++ b/packages/amplication-git-service/src/services/git.service.ts
@@ -28,17 +28,18 @@ export class GitService {
     isPublic: boolean
   ): Promise<RemoteGitRepository> {
     const provider = this.gitServiceFactory.getService(gitProvider);
+    const trimRepoName = repoName.trim().replace(/ /g, '-');
     return await (gitOrganizationType === EnumGitOrganizationType.Organization
       ? provider.createOrganizationRepository(
           installationId,
           gitOrganizationName,
-          repoName,
+          trimRepoName,
           isPublic
         )
       : provider.createUserRepository(
           installationId,
           gitOrganizationName,
-          repoName,
+          trimRepoName,
           isPublic
         ));
   }

--- a/packages/amplication-server/src/core/git/git.provider.service.ts
+++ b/packages/amplication-server/src/core/git/git.provider.service.ts
@@ -72,7 +72,11 @@ export class GitProviderService {
       );
     }
 
-    return await this.connectResourceGitRepository(args);
+    return await this.connectResourceGitRepository({
+      name: remoteRepository.name,
+      gitOrganizationId: args.gitOrganizationId,
+      resourceId: args.resourceId
+    });
   }
 
   async deleteGitRepository(args: DeleteGitRepositoryArgs): Promise<boolean> {


### PR DESCRIPTION
Issue Number: #3566 

## PR Details

trim repo name and replace spaces with "-" so the name will be equal to Github repo name 

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
