### PR TITLE
Fix UI issues on code view selectors

### DIFF
--- a/packages/amplication-client/src/Components/CommitSelector.scss
+++ b/packages/amplication-client/src/Components/CommitSelector.scss
@@ -7,7 +7,7 @@
   }
 
   &__hour {
-    @include regular-10;
+    @include regular-8;
     color: var(--black80);
   }
 
@@ -19,8 +19,5 @@
   }
   .amp-button {
     width: 100%;
-  }
-  .amp-button--secondary {
-    justify-content: left;
   }
 }

--- a/packages/amplication-client/src/Components/CommitSelector.tsx
+++ b/packages/amplication-client/src/Components/CommitSelector.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import { Commit } from "../models";
 import { CommitSelectorItem } from "./CommitSelectorItem";
 import "./CommitSelector.scss";
+import CommitData from "../VersionControl/CommitData";
 
 const CLASS_NAME = "commit-selector";
 
@@ -43,7 +44,7 @@ const CommitSelector = ({ commits, onSelectCommit, selectedCommit }: Props) => {
                     onSelectCommit(commit);
                   }}
                 >
-                  <CommitSelectorItem commit={commit} />
+                  <CommitData commit={commit} />
                 </SelectMenuItem>
               ))}
             </>

--- a/packages/amplication-client/src/Components/CommitSelectorItem.scss
+++ b/packages/amplication-client/src/Components/CommitSelectorItem.scss
@@ -1,4 +1,5 @@
 @import "../style/index.scss";
+$selector-title-max-width: 180px;
 
 .commit-selector-item {
   display: flex;
@@ -7,7 +8,7 @@
   &__title {
     @include regular-12;
     margin: 0 var(--user-badge-spacing);
-    width: 180px;
+    max-width: $selector-title-max-width;
     white-space: nowrap;
     text-align: left;
     overflow: hidden;

--- a/packages/amplication-client/src/Components/CommitSelectorItem.scss
+++ b/packages/amplication-client/src/Components/CommitSelectorItem.scss
@@ -6,6 +6,6 @@
   margin-right: auto;
   &__title {
     @include regular-12;
-    margin: 0 var(--icon-spacing);
+    margin: 0 var(--user-badge-spacing);
   }
 }

--- a/packages/amplication-client/src/Components/CommitSelectorItem.scss
+++ b/packages/amplication-client/src/Components/CommitSelectorItem.scss
@@ -1,17 +1,11 @@
 @import "../style/index.scss";
 
 .commit-selector-item {
-  @include flexFullRowWithSpacing;
-  flex: 1;
+  display: flex;
+  align-items: center;
+  margin-right: auto;
   &__title {
-    display: flex;
-    flex: 1;
-    white-space: nowrap;
-    text-align: left;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-weight: 400;
     @include regular-12;
-    justify-content: space-between;
+    margin: 0 var(--icon-spacing);
   }
 }

--- a/packages/amplication-client/src/Components/CommitSelectorItem.scss
+++ b/packages/amplication-client/src/Components/CommitSelectorItem.scss
@@ -7,5 +7,10 @@
   &__title {
     @include regular-12;
     margin: 0 var(--user-badge-spacing);
+    width: 180px;
+    white-space: nowrap;
+    text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }

--- a/packages/amplication-client/src/Components/CommitSelectorItem.tsx
+++ b/packages/amplication-client/src/Components/CommitSelectorItem.tsx
@@ -1,6 +1,5 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { Commit } from "../models";
-import { truncateWithEllipsis } from "../util/truncatedWithEllipsis";
 import "./CommitSelectorItem.scss";
 import UserBadge from "./UserBadge";
 
@@ -10,18 +9,11 @@ type Props = {
 const CLASS_NAME = "commit-selector-item";
 
 export const CommitSelectorItem = ({ commit }: Props) => {
-  const truncateCommitMessage = useMemo(() => {
-    return truncateWithEllipsis(
-      commit?.message.trim(),
-      15,
-      "No commit message"
-    );
-  }, [commit?.message]);
 
   return (
     <div className={CLASS_NAME}>
       <UserBadge />
-      <div className={`${CLASS_NAME}__title`}>{truncateCommitMessage}</div>
+      <div className={`${CLASS_NAME}__title`}>{commit?.message}</div>
     </div>
   );
 };

--- a/packages/amplication-client/src/Components/CommitSelectorItem.tsx
+++ b/packages/amplication-client/src/Components/CommitSelectorItem.tsx
@@ -2,6 +2,7 @@ import { formatTimeToNow } from "@amplication/design-system";
 import React from "react";
 import { Commit } from "../models";
 import "./CommitSelectorItem.scss";
+import UserBadge from "./UserBadge";
 
 type Props = {
   commit: Commit | null;
@@ -17,12 +18,16 @@ export const CommitSelectorItem = ({ commit }: Props) => {
     <label className={`commit-selector__hour`}>{createdAtHour}</label>
   );
 
+  const truncateCommitMessage = (input: string) =>
+    input.length && input.length < 15 ? input : `${input.substring(0, 15)}...`;
+
   return (
     <div className={CLASS_NAME}>
+      <UserBadge />
       <div className={`${CLASS_NAME}__title`}>
-        {commit?.message ? commit?.message : commit?.createdAt}
-        <div>{createdHourStyle()}</div>
+        {truncateCommitMessage(commit?.message.trim() || "No commit message")}
       </div>
+      <div className={`${CLASS_NAME}__createdAt`}>{createdHourStyle()}</div>
     </div>
   );
 };

--- a/packages/amplication-client/src/Components/CommitSelectorItem.tsx
+++ b/packages/amplication-client/src/Components/CommitSelectorItem.tsx
@@ -1,4 +1,3 @@
-import { formatTimeToNow } from "@amplication/design-system";
 import React, { useMemo } from "react";
 import { Commit } from "../models";
 import { truncateWithEllipsis } from "../util/truncatedWithEllipsis";
@@ -11,14 +10,6 @@ type Props = {
 const CLASS_NAME = "commit-selector-item";
 
 export const CommitSelectorItem = ({ commit }: Props) => {
-  const createdAtHour = commit
-    ? formatTimeToNow(new Date(commit?.createdAt))
-    : null;
-
-  const createdHourStyle = () => (
-    <label className={`commit-selector__hour`}>{createdAtHour}</label>
-  );
-
   const truncateCommitMessage = useMemo(() => {
     return truncateWithEllipsis(
       commit?.message.trim(),
@@ -31,7 +22,6 @@ export const CommitSelectorItem = ({ commit }: Props) => {
     <div className={CLASS_NAME}>
       <UserBadge />
       <div className={`${CLASS_NAME}__title`}>{truncateCommitMessage}</div>
-      <div className={`${CLASS_NAME}__createdAt`}>{createdHourStyle()}</div>
     </div>
   );
 };

--- a/packages/amplication-client/src/Components/CommitSelectorItem.tsx
+++ b/packages/amplication-client/src/Components/CommitSelectorItem.tsx
@@ -9,11 +9,12 @@ type Props = {
 const CLASS_NAME = "commit-selector-item";
 
 export const CommitSelectorItem = ({ commit }: Props) => {
-
   return (
     <div className={CLASS_NAME}>
       <UserBadge />
-      <div className={`${CLASS_NAME}__title`}>{commit?.message}</div>
+      <div className={`${CLASS_NAME}__title`}>
+        {commit?.message || "No commit message"}
+      </div>
     </div>
   );
 };

--- a/packages/amplication-client/src/Components/CommitSelectorItem.tsx
+++ b/packages/amplication-client/src/Components/CommitSelectorItem.tsx
@@ -1,5 +1,5 @@
 import { formatTimeToNow } from "@amplication/design-system";
-import React from "react";
+import React, { useMemo } from "react";
 import { Commit } from "../models";
 import { truncateWithEllipsis } from "../util/truncatedWithEllipsis";
 import "./CommitSelectorItem.scss";
@@ -19,11 +19,13 @@ export const CommitSelectorItem = ({ commit }: Props) => {
     <label className={`commit-selector__hour`}>{createdAtHour}</label>
   );
 
-  const truncateCommitMessage = truncateWithEllipsis(
-    commit?.message.trim(),
-    15,
-    "No commit message"
-  );
+  const truncateCommitMessage = useMemo(() => {
+    return truncateWithEllipsis(
+      commit?.message.trim(),
+      15,
+      "No commit message"
+    );
+  }, [commit?.message]);
 
   return (
     <div className={CLASS_NAME}>

--- a/packages/amplication-client/src/Components/CommitSelectorItem.tsx
+++ b/packages/amplication-client/src/Components/CommitSelectorItem.tsx
@@ -1,6 +1,7 @@
 import { formatTimeToNow } from "@amplication/design-system";
 import React from "react";
 import { Commit } from "../models";
+import { truncateWithEllipsis } from "../util/truncatedWithEllipsis";
 import "./CommitSelectorItem.scss";
 import UserBadge from "./UserBadge";
 
@@ -18,15 +19,16 @@ export const CommitSelectorItem = ({ commit }: Props) => {
     <label className={`commit-selector__hour`}>{createdAtHour}</label>
   );
 
-  const truncateCommitMessage = (input: string) =>
-    input.length && input.length < 15 ? input : `${input.substring(0, 15)}...`;
+  const truncateCommitMessage = truncateWithEllipsis(
+    commit?.message.trim(),
+    15,
+    "No commit message"
+  );
 
   return (
     <div className={CLASS_NAME}>
       <UserBadge />
-      <div className={`${CLASS_NAME}__title`}>
-        {truncateCommitMessage(commit?.message.trim() || "No commit message")}
-      </div>
+      <div className={`${CLASS_NAME}__title`}>{truncateCommitMessage}</div>
       <div className={`${CLASS_NAME}__createdAt`}>{createdHourStyle()}</div>
     </div>
   );

--- a/packages/amplication-client/src/Components/ResourceSelectorItem.tsx
+++ b/packages/amplication-client/src/Components/ResourceSelectorItem.tsx
@@ -1,6 +1,7 @@
 import { formatTimeToNow } from "@amplication/design-system";
 import React from "react";
 import { Resource } from "../models";
+import { truncateWithEllipsis } from "../util/truncatedWithEllipsis";
 import "./CommitSelectorItem.scss";
 import ResourceCircleBadge from "./ResourceCircleBadge";
 
@@ -14,12 +15,18 @@ export const ResourceSelectorItem = ({ resource }: Props) => {
     ? formatTimeToNow(new Date(resource?.createdAt))
     : null;
 
+  const truncateServiceName = truncateWithEllipsis(
+    resource?.name.trim(),
+    15,
+    "Service Name"
+  );
+
   return (
     <div className={CLASS_NAME}>
       {resource && (
         <>
           <ResourceCircleBadge type={resource.resourceType} size={"xsmall"} />
-          <div className={`${CLASS_NAME}__title`}>{resource.name}</div>
+          <div className={`${CLASS_NAME}__title`}>{truncateServiceName}</div>
           <label className={`commit-selector__hour`}>{createdAtHour}</label>
         </>
       )}

--- a/packages/amplication-client/src/Components/ResourceSelectorItem.tsx
+++ b/packages/amplication-client/src/Components/ResourceSelectorItem.tsx
@@ -1,5 +1,5 @@
 import { formatTimeToNow } from "@amplication/design-system";
-import React from "react";
+import React, { useMemo } from "react";
 import { Resource } from "../models";
 import { truncateWithEllipsis } from "../util/truncatedWithEllipsis";
 import "./CommitSelectorItem.scss";
@@ -15,11 +15,9 @@ export const ResourceSelectorItem = ({ resource }: Props) => {
     ? formatTimeToNow(new Date(resource?.createdAt))
     : null;
 
-  const truncateServiceName = truncateWithEllipsis(
-    resource?.name.trim(),
-    15,
-    "Service Name"
-  );
+  const truncateServiceName = useMemo(() => {
+    return truncateWithEllipsis(resource?.name.trim(), 15, "Service Name");
+  }, [resource?.name]);
 
   return (
     <div className={CLASS_NAME}>

--- a/packages/amplication-client/src/Components/ResourceSelectorItem.tsx
+++ b/packages/amplication-client/src/Components/ResourceSelectorItem.tsx
@@ -1,3 +1,4 @@
+import { formatTimeToNow } from "@amplication/design-system";
 import React from "react";
 import { Resource } from "../models";
 import "./CommitSelectorItem.scss";
@@ -9,12 +10,17 @@ type Props = {
 const CLASS_NAME = "commit-selector-item";
 
 export const ResourceSelectorItem = ({ resource }: Props) => {
+  const createdAtHour = resource
+    ? formatTimeToNow(new Date(resource?.createdAt))
+    : null;
+
   return (
     <div className={CLASS_NAME}>
       {resource && (
         <>
           <ResourceCircleBadge type={resource.resourceType} size={"xsmall"} />
           <div className={`${CLASS_NAME}__title`}>{resource.name}</div>
+          <label className={`commit-selector__hour`}>{createdAtHour}</label>
         </>
       )}
     </div>

--- a/packages/amplication-client/src/Components/ResourceSelectorItem.tsx
+++ b/packages/amplication-client/src/Components/ResourceSelectorItem.tsx
@@ -1,6 +1,5 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { Resource } from "../models";
-import { truncateWithEllipsis } from "../util/truncatedWithEllipsis";
 import "./CommitSelectorItem.scss";
 import ResourceCircleBadge from "./ResourceCircleBadge";
 
@@ -10,17 +9,12 @@ type Props = {
 const CLASS_NAME = "commit-selector-item";
 
 export const ResourceSelectorItem = ({ resource }: Props) => {
-
-  const truncateServiceName = useMemo(() => {
-    return truncateWithEllipsis(resource?.name.trim(), 15, "Service Name");
-  }, [resource?.name]);
-
   return (
     <div className={CLASS_NAME}>
       {resource && (
         <>
           <ResourceCircleBadge type={resource.resourceType} size={"xsmall"} />
-          <div className={`${CLASS_NAME}__title`}>{truncateServiceName}</div>
+          <div className={`${CLASS_NAME}__title`}>{resource?.name}</div>
         </>
       )}
     </div>

--- a/packages/amplication-client/src/Components/ResourceSelectorItem.tsx
+++ b/packages/amplication-client/src/Components/ResourceSelectorItem.tsx
@@ -1,4 +1,3 @@
-import { formatTimeToNow } from "@amplication/design-system";
 import React, { useMemo } from "react";
 import { Resource } from "../models";
 import { truncateWithEllipsis } from "../util/truncatedWithEllipsis";
@@ -11,9 +10,6 @@ type Props = {
 const CLASS_NAME = "commit-selector-item";
 
 export const ResourceSelectorItem = ({ resource }: Props) => {
-  const createdAtHour = resource
-    ? formatTimeToNow(new Date(resource?.createdAt))
-    : null;
 
   const truncateServiceName = useMemo(() => {
     return truncateWithEllipsis(resource?.name.trim(), 15, "Service Name");
@@ -25,7 +21,6 @@ export const ResourceSelectorItem = ({ resource }: Props) => {
         <>
           <ResourceCircleBadge type={resource.resourceType} size={"xsmall"} />
           <div className={`${CLASS_NAME}__title`}>{truncateServiceName}</div>
-          <label className={`commit-selector__hour`}>{createdAtHour}</label>
         </>
       )}
     </div>

--- a/packages/amplication-client/src/VersionControl/CommitData.scss
+++ b/packages/amplication-client/src/VersionControl/CommitData.scss
@@ -1,0 +1,25 @@
+@import "../style/index.scss";
+$metadata-width: 150px;
+
+.commit-data {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  &__metadata {
+    display: flex;
+    flex-direction: column;
+    width: $metadata-width;
+    margin: 0 var(--user-badge-spacing);
+
+    &__message {
+      @include regular-12;
+      color: var(--black100);
+    }
+
+    &__created {
+      @include regular-10;
+      color: var(--black80);
+    }
+  }
+}

--- a/packages/amplication-client/src/VersionControl/CommitData.scss
+++ b/packages/amplication-client/src/VersionControl/CommitData.scss
@@ -1,5 +1,5 @@
 @import "../style/index.scss";
-$metadata-width: 150px;
+$metadata-max-width: 150px;
 
 .commit-data {
   display: flex;
@@ -9,7 +9,7 @@ $metadata-width: 150px;
   &__metadata {
     display: flex;
     flex-direction: column;
-    width: $metadata-width;
+    max-width: $metadata-max-width;
     margin: 0 var(--user-badge-spacing);
 
     &__message {

--- a/packages/amplication-client/src/VersionControl/CommitData.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitData.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import UserBadge from "../Components/UserBadge";
+import { Commit } from "../models";
+import "./CommitData.scss";
+
+type Props = {
+  commit: Commit;
+};
+const CLASS_NAME = "commit-data";
+const CommitData: React.FC<Props> = ({ commit }) => {
+  return (
+    <div className={CLASS_NAME}>
+      <UserBadge />
+      <div className={`${CLASS_NAME}__metadata`}>
+        <span className={`${CLASS_NAME}__metadata__message`}>
+          {commit.message || "No commit message"}
+        </span>
+        <span className={`${CLASS_NAME}__metadata__created`}>
+          {new Date(commit.createdAt).toDateString()}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default CommitData;

--- a/packages/amplication-client/src/VersionControl/CommitListItem.scss
+++ b/packages/amplication-client/src/VersionControl/CommitListItem.scss
@@ -2,28 +2,9 @@
 $metadata-width: 150px;
 
 .commit-list-item {
-  &__data {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  &__metadata {
-    display: flex;
-    flex-direction: column;
-    width: $metadata-width;
-    padding: 0 var(--default-spacing-small);
-
-    &__message {
-      @include regular-12;
-      color: var(--black100);
-    }
-
-    &__created {
-      @include regular-10;
-      color: var(--black80);
-    }
-  }
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 
   &__row {
     @include flexFullRowWithSpacing;

--- a/packages/amplication-client/src/VersionControl/CommitListItem.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitListItem.tsx
@@ -4,7 +4,7 @@ import "./CommitListItem.scss";
 import { AppContext } from "../context/appContext";
 import InnerTabLink from "../Layout/InnerTabLink";
 import { BuildStatusIcons } from "./BuildStatusIcons";
-import UserBadge from "../Components/UserBadge";
+import CommitData from "./CommitData";
 
 type Props = {
   projectId: string;
@@ -23,16 +23,8 @@ export const CommitListItem = ({ commit, projectId }: Props) => {
         icon=""
         to={`/${currentWorkspace?.id}/${projectId}/commits/${commit.id}`}
       >
-        <div className={`${CLASS_NAME}__data`}>
-          <UserBadge />
-          <div className={`${CLASS_NAME}__metadata`}>
-            <span className={`${CLASS_NAME}__metadata__message`}>
-              {commit.message || "No commit message"}
-            </span>
-            <span className={`${CLASS_NAME}__metadata__created`}>
-              {new Date(commit.createdAt).toDateString()}
-            </span>
-          </div>
+        <div className={`${CLASS_NAME}`}>
+          <CommitData commit={commit} />
           <BuildStatusIcons build={build} showIcon={false} />
         </div>
       </InnerTabLink>

--- a/packages/amplication-client/src/VersionControl/CommitResourceListItem.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitResourceListItem.tsx
@@ -26,14 +26,14 @@ const CommitResourceListItem = ({ build }: Props) => {
   const resourceChangesCount = useMemo(() => {
     const resourcesChanges = commitChangesByResource(build.commitId);
     return resourcesChanges.find(
-      (resourceChanges) => resourceChanges.resourceId === build.resource.id
+      (resourceChanges) => resourceChanges.resourceId === build.resourceId
     )?.changes.length;
-  }, [build.commitId, build.resource.id, commitChangesByResource]);
+  }, [build.commitId, build.resourceId, commitChangesByResource]);
 
   return (
     <Panel className={CLASS_NAME} panelStyle={EnumPanelStyle.Bordered}>
       <div className={`${CLASS_NAME}__row`}>
-        {build && (
+        {build && build.resource && (
           <>
             <div className={`${CLASS_NAME}__title`}>
               <ResourceCircleBadge type={build.resource.resourceType} />
@@ -60,7 +60,7 @@ const CommitResourceListItem = ({ build }: Props) => {
       <hr className={`${CLASS_NAME}__divider`} />
       <div className={`${CLASS_NAME}__row`}>
         <Link
-          to={`/${currentWorkspace?.id}/${currentProject?.id}/${build.resource.id}/changes/${build.commitId}`}
+          to={`/${currentWorkspace?.id}/${currentProject?.id}/${build.resourceId}/changes/${build.commitId}`}
           className={`${CLASS_NAME}__changes-count`}
         >
           {resourceChangesCount && resourceChangesCount > 0
@@ -70,7 +70,7 @@ const CommitResourceListItem = ({ build }: Props) => {
         </Link>
 
         <Link
-          to={`/${currentWorkspace?.id}/${currentProject?.id}/${build.resource.id}/builds/${build.id}`}
+          to={`/${currentWorkspace?.id}/${currentProject?.id}/${build.resourceId}/builds/${build.id}`}
         >
           view log
         </Link>

--- a/packages/amplication-client/src/VersionControl/hooks/commitQueries.ts
+++ b/packages/amplication-client/src/VersionControl/hooks/commitQueries.ts
@@ -95,6 +95,7 @@ export const GET_COMMITS = gql`
       builds {
         id
         createdAt
+        resourceId
         resource {
           id
           name

--- a/packages/amplication-client/src/style/mixin.scss
+++ b/packages/amplication-client/src/style/mixin.scss
@@ -300,7 +300,6 @@ $bullet-size: 6px;
   }
 }
 
-
 @mixin modalForm {
   display: flex;
   flex-direction: column;
@@ -314,7 +313,7 @@ $bullet-size: 6px;
       margin-bottom: 0;
     }
   }
-  
+
   &__instructions {
     @include body2;
     color: var(--black100);
@@ -466,5 +465,13 @@ $active-indicator-width: 4px;
   font-weight: 400;
   font-size: 10px;
   line-height: 15px;
+  color: #f5f6fa;
+}
+
+@mixin regular-8 {
+  @include font-base();
+  font-weight: 400;
+  font-size: 8px;
+  line-height: 12px;
   color: #f5f6fa;
 }

--- a/packages/amplication-client/src/util/truncatedWithEllipsis.ts
+++ b/packages/amplication-client/src/util/truncatedWithEllipsis.ts
@@ -1,0 +1,8 @@
+export const truncateWithEllipsis = (
+  input: string | undefined,
+  limit: number,
+  defaultValue: string
+) => {
+  if (!input) return defaultValue;
+  return input.length > limit ? `${input.substring(0, limit)}...` : input;
+};

--- a/packages/amplication-client/src/util/truncatedWithEllipsis.ts
+++ b/packages/amplication-client/src/util/truncatedWithEllipsis.ts
@@ -1,8 +1,0 @@
-export const truncateWithEllipsis = (
-  input: string | undefined,
-  limit: number,
-  defaultValue: string
-) => {
-  if (!input) return defaultValue;
-  return input.length > limit ? `${input.substring(0, limit)}...` : input;
-};

--- a/packages/amplication-design-system/src/components/UserAvatar/UserAvatar.scss
+++ b/packages/amplication-design-system/src/components/UserAvatar/UserAvatar.scss
@@ -16,7 +16,7 @@
     text-align: center;
     width: var(--small-menu-item-width);
     color: var(--static-white);
-    font-size: var(--title2-font-size);
+    font-size: var(--text-field-label-font-size);
     text-transform: capitalize;
   }
 }


### PR DESCRIPTION
Issue Number: #3586 

## PR Details

Fix UI issues on code view selectors:
- create a new component, `CommitData`, consisting of the user badge, commit message and commit timestamp. This component is also used on the commits page.
- Truncate String with Ellipsis with css

![image](https://user-images.githubusercontent.com/39680385/187157906-1a2da16b-ca50-4b2e-82a2-3b729a8da809.png)

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
