### PR TITLE
Analytics stop work after routes refactor in most of the pages 

### DIFF
--- a/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.scss
+++ b/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.scss
@@ -41,7 +41,7 @@ $max-width: 700px;
 
     .circle-badge i {
       color: var(--black5);
-      font-size: 14px;
+      font-size: 20px;
     }
   }
 

--- a/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.scss
+++ b/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.scss
@@ -41,7 +41,7 @@ $max-width: 700px;
 
     .circle-badge i {
       color: var(--black5);
-      font-size: 20px;
+      font-size: 14px;
     }
   }
 

--- a/packages/amplication-client/src/routes/appRoutes.tsx
+++ b/packages/amplication-client/src/routes/appRoutes.tsx
@@ -11,6 +11,7 @@ export interface RouteDef {
   moduleClass?: string;
   routeTrackType?: string;
   permission?: boolean;
+  isAnalytics?: boolean
 }
 
 export const Routes: RouteDef[] = [
@@ -37,6 +38,7 @@ export const Routes: RouteDef[] = [
             moduleClass: "code-view-page",
             routeTrackType: "",
             exactPath: false,
+            isAnalytics: true,
           },
           {
             path:
@@ -46,6 +48,7 @@ export const Routes: RouteDef[] = [
             moduleClass: "commits-page",
             routeTrackType: "",
             exactPath: false,
+            isAnalytics: true,
           },
           {
             path:
@@ -57,6 +60,7 @@ export const Routes: RouteDef[] = [
             moduleClass: "pending-changes-page",
             routeTrackType: "",
             exactPath: true,
+            isAnalytics: true,
           },
           {
             path:
@@ -68,6 +72,7 @@ export const Routes: RouteDef[] = [
             moduleClass: "create-service-wizard",
             routeTrackType: "",
             exactPath: true,
+            isAnalytics: true,
           },
           {
             path:
@@ -86,6 +91,7 @@ export const Routes: RouteDef[] = [
         moduleName: "",
         exactPath: true,
         routes: [],
+        isAnalytics: true,
       },
       {
         path: "/:workspace([A-Za-z0-9-]{20,})/settings",
@@ -93,6 +99,7 @@ export const Routes: RouteDef[] = [
         moduleName: "",
         exactPath: true,
         routes: [],
+        isAnalytics: true,
       },
     ],
   },
@@ -103,6 +110,7 @@ export const Routes: RouteDef[] = [
     routeTrackType: "login",
     moduleClass: "login-page",
     exactPath: true,
+    isAnalytics: true,
   },
   {
     path: "/github-auth-app/callback",
@@ -113,6 +121,7 @@ export const Routes: RouteDef[] = [
     permission: true,
     routeTrackType: "auth app with git callback",
     exactPath: true,
+    isAnalytics: true,
   },
   {
     path: "/signup",
@@ -121,6 +130,7 @@ export const Routes: RouteDef[] = [
     moduleClass: "signup-page",
     routeTrackType: "signup",
     exactPath: true,
+    isAnalytics: true,
   },
   {
     path: "/user/profile",
@@ -130,5 +140,6 @@ export const Routes: RouteDef[] = [
     routeTrackType: "",
     exactPath: true,
     routes: [],
+    isAnalytics: true,
   },
 ];

--- a/packages/amplication-client/src/routes/resourceEntitiesRoutes.tsx
+++ b/packages/amplication-client/src/routes/resourceEntitiesRoutes.tsx
@@ -8,6 +8,7 @@ const resourceEntitiesRoutes = [
     routeTrackType: "",
     exactPath: false,
     routes: [],
+    isAnalytics: true,
   },
   {
     path:
@@ -17,6 +18,7 @@ const resourceEntitiesRoutes = [
     routeTrackType: "",
     exactPath: true,
     routes: [],
+    isAnalytics: true,
   },
   {
     path: "/:workspace/:project/:resource/entities/fields",
@@ -33,6 +35,7 @@ const resourceEntitiesRoutes = [
         routeTrackType: "",
         exactPath: true,
         routes: [],
+        isAnalytics: true,
       },
     ],
   },

--- a/packages/amplication-client/src/routes/resourceRoutes.tsx
+++ b/packages/amplication-client/src/routes/resourceRoutes.tsx
@@ -19,6 +19,7 @@ const resourceRoutes = [
     moduleName: "",
     routeTrackType: "",
     exactPath: true,
+    isAnalytics: true,
   },
   {
     path:
@@ -28,6 +29,7 @@ const resourceRoutes = [
     moduleClass: "changes-page",
     routeTrackType: "",
     exactPath: true,
+    isAnalytics: true,
   },
   {
     path: "/:workspace/:project/:resource/roles",
@@ -43,6 +45,7 @@ const resourceRoutes = [
         routeTrackType: "",
         exactPath: true,
         routes: [],
+        isAnalytics: true,
       },
     ],
   },
@@ -62,6 +65,7 @@ const resourceRoutes = [
         routeTrackType: "",
         exactPath: true,
         routes: [],
+        isAnalytics: true,
       },
     ],
   },
@@ -72,6 +76,7 @@ const resourceRoutes = [
     routeTrackType: "",
     exactPath: true,
     routes: [],
+    isAnalytics: true,
   },
   {
     path:

--- a/packages/amplication-client/src/routes/resourceSettingsRoutes.tsx
+++ b/packages/amplication-client/src/routes/resourceSettingsRoutes.tsx
@@ -9,6 +9,7 @@ const resourceSettingsRoutes = [
     routeTrackType: "",
     exactPath: true,
     routes: [],
+    isAnalytics: true,
   },
   {
     path:
@@ -20,6 +21,7 @@ const resourceSettingsRoutes = [
     routeTrackType: "",
     exactPath: true,
     routes: [],
+    isAnalytics: true,
   },
   {
     path:
@@ -31,6 +33,7 @@ const resourceSettingsRoutes = [
     routeTrackType: "",
     exactPath: true,
     routes: [],
+    isAnalytics: true,
   },
   {
     path:
@@ -42,6 +45,7 @@ const resourceSettingsRoutes = [
     routeTrackType: "",
     exactPath: true,
     routes: [],
+    isAnalytics: true,
   },
   {
     path:
@@ -51,6 +55,7 @@ const resourceSettingsRoutes = [
     routeTrackType: "",
     exactPath: true,
     routes: [],
+    isAnalytics: true,
   },
   {
     path:
@@ -60,6 +65,7 @@ const resourceSettingsRoutes = [
     routeTrackType: "",
     exactPath: true,
     routes: [],
+    isAnalytics: true,
   },
 ];
 

--- a/packages/amplication-client/src/routes/routesUtil.tsx
+++ b/packages/amplication-client/src/routes/routesUtil.tsx
@@ -94,9 +94,7 @@ export const routesGenerator: (
   );
 };
 
-
 const pageTracking = (path: string, url: string, params: any)=> {
-  console.log({path});
   analytics.page(path.replaceAll("/", "-"), {
     path,
     url,

--- a/packages/amplication-client/src/routes/routesUtil.tsx
+++ b/packages/amplication-client/src/routes/routesUtil.tsx
@@ -2,6 +2,7 @@ import React, { Suspense } from "react";
 import { Redirect, Route, Switch } from "react-router-dom";
 import { RouteDef } from "./appRoutes";
 import useAuthenticated from "../authentication/use-authenticated";
+import * as analytics from "../util/analytics";
 
 export type AppRouteProps = {
   moduleName: string | undefined;
@@ -22,7 +23,9 @@ const LazyRouteWrapper: React.FC<{
         path={route.path}
         exact={route.exactPath}
         render={(props) => {
-          const { location } = props;
+          const { location , match } = props;
+
+          route.isAnalytics &&  pageTracking(match.path, match.url, match.params); 
           const nestedRoutes =
             route.routes && routesGenerator(route.routes, route.path);
 
@@ -90,3 +93,13 @@ export const routesGenerator: (
     </Switch>
   );
 };
+
+
+const pageTracking = (path: string, url: string, params: any)=> {
+  console.log({path});
+  analytics.page(path.replaceAll("/", "-"), {
+    path,
+    url,
+    params: params,
+  });
+}


### PR DESCRIPTION

Issue Number:  #3619 

## PR Details

Fix the new routes, so the relevant  paths will have analytics 

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

