### PR TITLE
Remove build id from path

### DIFF
--- a/packages/amplication-git-pull-request-service/src/core/pull-request/pull-request.service.ts
+++ b/packages/amplication-git-pull-request-service/src/core/pull-request/pull-request.service.ts
@@ -49,7 +49,6 @@ export class PullRequestService {
       title,
       body,
       installationId,
-      newBuildId,
       gitResourceMeta,
       base
     );

--- a/packages/amplication-git-service/src/__tests__/services/git.service.spec.ts
+++ b/packages/amplication-git-service/src/__tests__/services/git.service.spec.ts
@@ -127,7 +127,6 @@ describe('GitService', () => {
         const commitMessage = 'exampleCommitMessage';
         const commitDescription = 'exampleCommitDescription';
         const baseBranchName = 'exampleBaseBranchName';
-        const buildId = 'buildId';
         const basePath = 'packages';
         const remoteGitOrganization = await gitService.createPullRequest(
           gitProvider,
@@ -138,7 +137,6 @@ describe('GitService', () => {
           commitMessage,
           commitDescription,
           installationId,
-          buildId,
           {
             adminUIPath: basePath + 'admin-ui',
             serverPath: basePath + 'server'

--- a/packages/amplication-git-service/src/contracts/IGitClient.ts
+++ b/packages/amplication-git-service/src/contracts/IGitClient.ts
@@ -47,7 +47,6 @@ export interface IGitClient {
     commitDescription: string,
     baseBranchName: string,
     installationId: string,
-    amplicationBuildId: string,
     meta: GitResourceMeta
   ): Promise<string>;
 }

--- a/packages/amplication-git-service/src/providers/github.service.ts
+++ b/packages/amplication-git-service/src/providers/github.service.ts
@@ -172,7 +172,6 @@ export class GithubService implements IGitClient {
     commitDescription: string,
     baseBranchName: string,
     installationId: string,
-    amplicationBuildId: string,
     gitResourceMeta: GitResourceMeta
   ): Promise<string> {
     const myOctokit = Octokit.plugin(createPullRequest);
@@ -229,10 +228,7 @@ export class GithubService implements IGitClient {
     const files = Object.fromEntries(
       modules.map(module => {
         if (amplicationIgnoreManger.isIgnored(module.path)) {
-          return [
-            join(AMPLICATION_IGNORED_FOLDER, amplicationBuildId, module.path),
-            module.code
-          ];
+          return [join(AMPLICATION_IGNORED_FOLDER, module.path), module.code];
         }
         if (
           !module.path.startsWith(authFolder) &&

--- a/packages/amplication-git-service/src/services/git.service.ts
+++ b/packages/amplication-git-service/src/services/git.service.ts
@@ -93,7 +93,6 @@ export class GitService {
     commitMessage: string,
     commitDescription: string,
     installationId: string,
-    amplicationBuildId: string,
     gitResourceMeta: GitResourceMeta,
     baseBranchName?: string
   ): Promise<string> {
@@ -107,7 +106,6 @@ export class GitService {
       commitDescription,
       baseBranchName,
       installationId,
-      amplicationBuildId,
       gitResourceMeta
     );
   }


### PR DESCRIPTION
closes: #3640 

## PR Details

This PR removes the build id directory from the amplication ignore logic

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
