### PR TITLE
Refactor `SyncWithGithubPage`

### DIFF
--- a/packages/amplication-client/src/Resource/git/SyncWithGithubPage.tsx
+++ b/packages/amplication-client/src/Resource/git/SyncWithGithubPage.tsx
@@ -40,8 +40,8 @@ const SyncWithGithubPage: React.FC = () => {
 
   const pageTitle = "GitHub";
   const errorMessage = formatError(error);
-  const isServiceResource =
-    data?.resource.resourceType === EnumResourceType.Service;
+  const isProjectConfiguration =
+    data?.resource.resourceType === EnumResourceType.ProjectConfiguration;
 
   return (
     <PageContent pageTitle={pageTitle}>
@@ -55,10 +55,10 @@ const SyncWithGithubPage: React.FC = () => {
           automatically pushes your generated code and creates a Pull Request in
           your GitHub repository.
         </div>
-        {data?.resource && !isServiceResource && (
+        {data?.resource && isProjectConfiguration && (
           <AuthResourceWithGit resource={data.resource} onDone={handleOnDone} />
         )}
-        {isServiceResource && data?.resource && (
+        {!isProjectConfiguration && data?.resource && (
           <ServiceConfigurationGitSettings
             resource={data.resource}
             onDone={handleOnDone}


### PR DESCRIPTION
Refactor the condition on the SyncWithGitHubPage to use the ProjectConfiguration as the test case, so all other future resource types will work properly 


## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
