### PR TITLE
fix #2733: No border radius on the buttons in the permission tab

### DIFF
--- a/packages/amplication-data-service-generator/src/version.ts
+++ b/packages/amplication-data-service-generator/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.14.12";
+export const version = "0.15.2";

--- a/packages/amplication-design-system/src/components/MultiStateToggle/MultiStateToggle.scss
+++ b/packages/amplication-design-system/src/components/MultiStateToggle/MultiStateToggle.scss
@@ -32,13 +32,13 @@
       }
 
       &:first-child {
-        border-radius: var(--form-permission-type-radius) 0 0
+        border-radius: var(--form-permission-type-radius) 0px 0px
           var(--form-permission-type-radius);
       }
 
       &:last-child {
-        border-radius: 0 var(--form-permission-type-radius)
-          var(--form-permission-type-radius) 0;
+        border-radius: 0px var(--form-permission-type-radius)
+          var(--form-permission-type-radius) 0px;
       }
 
       &--selected,

--- a/packages/amplication-design-system/src/style/css-variables.scss
+++ b/packages/amplication-design-system/src/style/css-variables.scss
@@ -120,7 +120,7 @@
   --default-border-radius: 8px;
   --small-border-radius: 4px;
   --form-elements-border-radius: var(--default-border-radius);
-  --form-permission-type-radius: var() var(--small-border-radius);
+  --form-permission-type-radius: var(--small-border-radius);
 
   --default-page-padding: calc(var(--default-spacing-small) * 3);
   --side-bar-width: 440px;


### PR DESCRIPTION
Closes #2733 

This is the new page screenshot:
![Screenshot (114)](https://user-images.githubusercontent.com/101038806/188266005-a8880c1e-d185-4035-846a-1f4120e3a9a4.png)

Not sure if I had to add radius to all sides of the button, let me know if there is any issue with this PR.