### PR TITLE
fix(amplication-server): added return type for function onApplicationShutdown

### DIFF
--- a/packages/amplication-server/src/app.module.ts
+++ b/packages/amplication-server/src/app.module.ts
@@ -59,7 +59,7 @@ import { GoogleSecretsManagerService } from 'src/services/googleSecretsManager.s
   ]
 })
 export class AppModule implements OnApplicationShutdown {
-  onApplicationShutdown(signal: string) {
+  onApplicationShutdown(signal: string): void {
     console.trace(`Application shut down (signal: ${signal})`);
   }
 }


### PR DESCRIPTION
## PR Details

Added return `void` type for the function `onApplicationShutdown` inside `packages/amplication-server/src/app.module.ts`.


## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
