### PR TITLE
fix: added missing return type for the functions in decorators folder

### DIFF
--- a/packages/amplication-server/src/decorators/authorizeContext.decorator.ts
+++ b/packages/amplication-server/src/decorators/authorizeContext.decorator.ts
@@ -2,7 +2,7 @@
  * Decorators for authorizing and injecting resources to a query / mutation
  */
 
-import { SetMetadata } from '@nestjs/common';
+import { CustomDecorator, SetMetadata } from '@nestjs/common';
 import { AuthorizableOriginParameter } from 'src/enums/AuthorizableOriginParameter';
 import {
   AUTHORIZE_CONTEXT,
@@ -21,7 +21,7 @@ import {
 export const AuthorizeContext = (
   parameterType: AuthorizableOriginParameter,
   parameterPath: string
-) =>
+): CustomDecorator<string> =>
   SetMetadata<string, AuthorizeContextParameters>(AUTHORIZE_CONTEXT, {
     parameterType,
     parameterPath

--- a/packages/amplication-server/src/decorators/injectContextValue.decorator.ts
+++ b/packages/amplication-server/src/decorators/injectContextValue.decorator.ts
@@ -1,4 +1,4 @@
-import { SetMetadata } from '@nestjs/common';
+import { CustomDecorator, SetMetadata } from '@nestjs/common';
 import { InjectableOriginParameter } from 'src/enums/InjectableOriginParameter';
 import {
   INJECT_CONTEXT_VALUE,
@@ -14,7 +14,7 @@ import {
 export const InjectContextValue = (
   parameterType: InjectableOriginParameter,
   parameterPath: string
-) =>
+): CustomDecorator<string> =>
   SetMetadata<string, InjectContextValueParameters>(INJECT_CONTEXT_VALUE, {
     parameterType,
     parameterPath

--- a/packages/amplication-server/src/decorators/roles.decorator.ts
+++ b/packages/amplication-server/src/decorators/roles.decorator.ts
@@ -1,6 +1,7 @@
 //Authorization decorator to be used on resolvers and controllers together with the jwt-guard
 
-import { SetMetadata } from '@nestjs/common';
+import { CustomDecorator, SetMetadata } from '@nestjs/common';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const Roles = (...roles: string[]) => SetMetadata('roles', roles);
+export const Roles = (...roles: string[]): CustomDecorator<string> =>
+  SetMetadata('roles', roles);


### PR DESCRIPTION

Issue Number: N/A

## PR Details

Added missing return type `CustomDecorator<string>` for the functions in the decorators folder in amplication-server. 


## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
