### PR TITLE
Remove resourceId param from PendingChange component 

### DIFF
--- a/packages/amplication-client/src/VersionControl/PendingChange.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChange.tsx
@@ -12,8 +12,6 @@ const TOOLTIP_DIRECTION = "ne";
 
 type Props = {
   change: models.PendingChange;
-  /**@todo: figure out how to pass this value without too many props drilling down */
-  resourceId?: string; 
   linkToOrigin?: boolean;
 };
 
@@ -25,13 +23,13 @@ const ACTION_TO_LABEL: {
   [models.EnumPendingChangeAction.Update]: "U",
 };
 
-const PendingChange = ({ change, resourceId, linkToOrigin = false }: Props) => {
+const PendingChange = ({ change, linkToOrigin = false }: Props) => {
   const { currentWorkspace, currentProject } = useContext(AppContext);
   /**@todo: update the url for other types of blocks  */
   const url =
     change.originType === models.EnumPendingChangeOriginType.Entity
-      ? `/${currentWorkspace?.id}/${currentProject?.id}/${resourceId}/entities/${change.originId}`
-      : `/${currentWorkspace?.id}/${currentProject?.id}/${resourceId}/update`;
+      ? `/${currentWorkspace?.id}/${currentProject?.id}/${change.resource.id}/entities/${change.originId}`
+      : `/${currentWorkspace?.id}/${currentProject?.id}/${change.resource.id}/update`;
 
   const isDeletedEntity =
     change.action === models.EnumPendingChangeAction.Delete;

--- a/packages/amplication-client/src/VersionControl/PendingChanges.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChanges.tsx
@@ -85,7 +85,6 @@ const PendingChanges = ({ projectId }: Props) => {
                   <PendingChange
                     key={change.originId}
                     change={change}
-                    resourceId={projectId}
                     linkToOrigin
                   />
                 ))}


### PR DESCRIPTION
Issue Number: #3704 

## PR Details

Remove resourceId param from PendingChange component, since it is already included in the `change` object

## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
