### PR TITLE
Adjust Kubernetes resource usage

### DIFF
--- a/helm/charts/services/amplication-client/values.yaml
+++ b/helm/charts/services/amplication-client/values.yaml
@@ -15,19 +15,19 @@ image:
 
 service:
   type: LoadBalancer
-  port: 
+  port:
     target: 8080
   protocol: TCP
-  hostname: app.amplication-dev.com	
+  hostname: app.amplication-dev.com
   certificatearn: arn:aws:acm:us-east-1:407256539111:certificate/bc3442ea-ddcb-4870-b4ba-79144e623d71
 
 podAnnotations:
   cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 
-maxMemory: "2Gi"
-minMemory: "2Gi"
-maxCPU: 1
-minCPU: 1
+maxMemory: "1.6Gi"
+minMemory: "1.6Gi"
+maxCPU: "0.9"
+minCPU: "0.9"
 
 config:
   env:

--- a/helm/charts/services/amplication-git-pull-request-service/values.yaml
+++ b/helm/charts/services/amplication-git-pull-request-service/values.yaml
@@ -1,6 +1,5 @@
 name: amplication-git-pull-request-service
 
-
 replicaCount: 1
 autoscaling:
   enabled: false
@@ -17,10 +16,10 @@ image:
 podAnnotations:
   cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 
-maxMemory: "2Gi"
-minMemory: "2Gi"
-maxCPU: 1
-minCPU: 1
+maxMemory: "1.6Gi"
+minMemory: "1.6Gi"
+maxCPU: "0.9"
+minCPU: "0.9"
 
 volume:
   name: amplication-data

--- a/helm/charts/services/amplication-git-pull-service/values.yaml
+++ b/helm/charts/services/amplication-git-pull-service/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: 407256539111.dkr.ecr.us-east-1.amazonaws.com/amplication-git-pull-service-dev
   tag: 0.0.1
   imagePullSecrets: []
-    
+
 volume:
   name: amplication-data
   path: /amplication-data
@@ -20,7 +20,7 @@ volume:
 podAnnotations:
   cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 
-maxMemory: "2Gi"
-minMemory: "2Gi"
-maxCPU: 2
-minCPU: 2
+maxMemory: "1.6Gi"
+minMemory: "1.6Gi"
+maxCPU: "0.9"
+minCPU: "0.9"

--- a/helm/charts/services/amplication-git-push-webhook-service/values.yaml
+++ b/helm/charts/services/amplication-git-push-webhook-service/values.yaml
@@ -16,10 +16,10 @@ image:
 podAnnotations:
   cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 
-maxMemory: "2Gi"
-minMemory: "2Gi"
-maxCPU: 1
-minCPU: 1
+maxMemory: "1.6Gi"
+minMemory: "1.6Gi"
+maxCPU: "0.9"
+minCPU: "0.9"
 
 service:
   type: ClusterIP

--- a/helm/charts/services/amplication-server/values.yaml
+++ b/helm/charts/services/amplication-server/values.yaml
@@ -33,7 +33,7 @@ secrets:
 podAnnotations:
   cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 
-maxMemory: "2Gi"
-minMemory: "2Gi"
-maxCPU: 2
-minCPU: 2
+maxMemory: "1.6Gi"
+minMemory: "1.6Gi"
+maxCPU: "0.9"
+minCPU: "0.9"

--- a/helm/charts/services/amplication-storage-gateway/values.yaml
+++ b/helm/charts/services/amplication-storage-gateway/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: 407256539111.dkr.ecr.us-east-1.amazonaws.com/amplication-storage-gateway
   tag: 0.0.1
   imagePullSecrets: []
-    
+
 volume:
   name: amplication-data
   path: /amplication-data
@@ -20,10 +20,10 @@ volume:
 podAnnotations:
   cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 
-maxMemory: "2Gi"
-minMemory: "2Gi"
-maxCPU: 1
-minCPU: 1
+maxMemory: "1.6Gi"
+minMemory: "1.6Gi"
+maxCPU: "0.9"
+minCPU: "0.9"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Currently our resource usage is set at `2.0Gi` for memory and `1` for CPU.

In fact, the `t3.medium` EC2 instances we are running on, while they have 4GB and 2CPU on paper, have some reserved amounts. The actual allocatable resources are  and `3.6Gi` memory and `1.9` CPU.

This essentially means that each Node can only run one instance, and that each Node runs at around 45% redundancy.

This PR adjusts the values to be half the allocatable values, which should reduce our cloud resource consumption by (hopefully) dramatically.