### PR TITLE
(client): fix commits broken URL

### DIFF
--- a/packages/amplication-client/src/VersionControl/PendingChangeWithCompare.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChangeWithCompare.tsx
@@ -27,7 +27,7 @@ const PendingChangeWithCompare = ({
     <PanelCollapsible
       initiallyOpen
       className={CLASS_NAME}
-      headerContent={<PendingChange change={change}  />}
+      headerContent={<PendingChange change={change} />}
     >
       {change.originType === models.EnumPendingChangeOriginType.Entity ? (
         <PendingChangeDiffEntity

--- a/packages/amplication-client/src/VersionControl/hooks/commitQueries.ts
+++ b/packages/amplication-client/src/VersionControl/hooks/commitQueries.ts
@@ -142,20 +142,17 @@ export const GET_COMMITS = gql`
             id
             displayName
             updatedAt
-            resource {
-              id
-              name
-            }
           }
           ... on Block {
             id
             displayName
             updatedAt
-            resource {
-              id
-              name
-            }
           }
+        }
+        resource {
+          id
+          name
+          resourceType
         }
       }
       builds {

--- a/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
+++ b/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
@@ -39,8 +39,8 @@ const useCommits = () => {
       const changesByResource = groupBy(
         commits[commitIdx]?.changes,
         (originChange) => {
-          if (!originChange.origin.resource) return;
-          return originChange.origin.resource.id;
+          if (!originChange.resource) return;
+          return originChange.resource.id;
         }
       );
       return Object.entries(changesByResource).map(([resourceId, changes]) => {


### PR DESCRIPTION
Issue Number: #3773 

## PR Details

Align the GET_COMMITS query to get the resource object from the change, and not from the origin type. 
(like in query: GET_PENDING_CHANGES_STATUS). 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
