### PR TITLE
refactor(dsg) added addtionalVariables param to create dotenv module

### DIFF
--- a/packages/amplication-data-service-generator/src/server/create-dotenv.ts
+++ b/packages/amplication-data-service-generator/src/server/create-dotenv.ts
@@ -5,6 +5,9 @@ import { replacePlaceholdersInCode } from "../util/text-file-parser";
 
 const templatePath = require.resolve("./create-dotenv.template.env");
 
+type AdditionalVariables = {
+  [variable: string]: string;
+}[];
 /**
  * Creates the .env file based on the given template with placeholder.
  * The function replaces any placeholder in a ${name} format based on the key in the appInfo.settings
@@ -12,9 +15,17 @@ const templatePath = require.resolve("./create-dotenv.template.env");
  */
 export async function createDotEnvModule(
   appInfo: AppInfo,
-  baseDirectory: string
+  baseDirectory: string,
+  additionalVariables: AdditionalVariables
 ): Promise<Module> {
   const code = await readCode(templatePath);
+  const formattedAdditionalVariables = convertToKeyValueSting(
+    additionalVariables
+  );
+  const codeWithAdditionalVariables = appendAdditionalVariables(
+    code,
+    formattedAdditionalVariables
+  );
 
   if (
     !isEmpty(appInfo.settings.dbName) &&
@@ -25,6 +36,23 @@ export async function createDotEnvModule(
 
   return {
     path: `${baseDirectory}/.env`,
-    code: replacePlaceholdersInCode(code, appInfo.settings),
+    code: replacePlaceholdersInCode(
+      codeWithAdditionalVariables,
+      appInfo.settings
+    ),
   };
+}
+
+function convertToKeyValueSting(arr: AdditionalVariables): string {
+  if (!arr.length) return "";
+  return arr
+    .map((item) =>
+      Object.entries(item).map(([key, value]) => `${key}=${value}`)
+    )
+    .join("\n");
+}
+
+function appendAdditionalVariables(file: string, variable: string): string {
+  if (!variable.trim()) return file;
+  return file.concat(`\n${variable}`);
 }

--- a/packages/amplication-data-service-generator/src/server/create-server.ts
+++ b/packages/amplication-data-service-generator/src/server/create-server.ts
@@ -123,7 +123,11 @@ export async function createServerModules(
     roles,
     directoryManager.SRC
   );
-  const dotEnvModule = await createDotEnvModule(appInfo, directoryManager.BASE);
+  const dotEnvModule = await createDotEnvModule(
+    appInfo,
+    directoryManager.BASE,
+    []
+  );
 
   return [
     ...staticModules,


### PR DESCRIPTION

Part of issue: #3768 

## PR Details
In this PR I added another parameter to `createDotEnvModule` function. 
This function is responsible for creating the `.env` file of the generated server folder.

Now, when we call this function with an empty array, we will get the same `.env` file, but if we call it with:
```
[
  {KAFKA_BROKERS: "["localhost:9092"]"},
  {KAFKA_CLIENT_ID: "client-queue"},
  {KAFKA_GROUP_ID: "server-group"},
]
```

The following env variables will be appended to the `.env` file
```
KAFKA_BROKERS="["localhost:9092"]"
KAFKA_CLIENT_ID='client-queue'
KAFKA_GROUP_ID='"server-group'
```

@morhag90 I need `createDotenvModule` event

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

