### PR TITLE
refactor DSG extract `createPrismaSchema` and `createDotEnvModuleInternal` to params and s…

### DIFF
--- a/packages/amplication-code-gen-types/src/plugin-events-params.ts
+++ b/packages/amplication-code-gen-types/src/plugin-events-params.ts
@@ -40,6 +40,6 @@ export type VariableDictionary = {
 export interface CreateServerDotEnvParams extends EventParams {
   before: {
     baseDirectory: string;
-    additionalVariables: VariableDictionary;
+    envVariables: VariableDictionary;
   };
 }

--- a/packages/amplication-data-service-generator/src/server/constants.ts
+++ b/packages/amplication-data-service-generator/src/server/constants.ts
@@ -1,4 +1,21 @@
+import { VariableDictionary } from "@amplication/code-gen-types";
+
 export const BASE_DIRECTORY = "server";
 export const SRC_DIRECTORY = `${BASE_DIRECTORY}/src`;
 export const SCRIPTS_DIRECTORY = `${BASE_DIRECTORY}/scripts`;
 export const AUTH_PATH = `${SRC_DIRECTORY}/auth`;
+
+export const ENV_VARIABLES: VariableDictionary = [
+  { POSTGRESQL_USER: "${dbUser}" },
+  { POSTGRESQL_PASSWORD: "${dbPassword}" },
+  { POSTGRESQL_PORT: "${dbPort}" },
+  {
+    POSTGRESQL_URL:
+      "postgres://${dbUser}:${dbPassword}@${dbHost}:${dbPort}${dbName}",
+  },
+  { BCRYPT_SALT: "10" },
+  { COMPOSE_PROJECT_NAME: "amp_${resourceId}" },
+  { JWT_SECRET_KEY: "Change_ME!!!" },
+  { JWT_EXPIRATION: "2d" },
+  { SERVER_PORT: "3000" },
+];

--- a/packages/amplication-data-service-generator/src/server/create-dotenv.template.env
+++ b/packages/amplication-data-service-generator/src/server/create-dotenv.template.env
@@ -1,9 +1,0 @@
-POSTGRESQL_USER=${dbUser}
-POSTGRESQL_PASSWORD=${dbPassword}
-POSTGRESQL_PORT=${dbPort}
-POSTGRESQL_URL=postgres://${dbUser}:${dbPassword}@${dbHost}:${dbPort}${dbName}
-BCRYPT_SALT=10
-COMPOSE_PROJECT_NAME=amp_${resourceId}
-JWT_SECRET_KEY=Change_ME!!!
-JWT_EXPIRATION=2d
-SERVER_PORT = 3000

--- a/packages/amplication-data-service-generator/src/server/create-dotenv.ts
+++ b/packages/amplication-data-service-generator/src/server/create-dotenv.ts
@@ -29,15 +29,13 @@ export function createDotEnvModule(
  */
 export async function createDotEnvModuleInternal({
   baseDirectory,
-  additionalVariables,
+  envVariables,
 }: CreateServerDotEnvParams["before"]): Promise<Module[]> {
   const context = DsgContext.getInstance;
   const { appInfo } = context;
 
   const code = await readCode(templatePath);
-  const formattedAdditionalVariables = convertToKeyValueSting(
-    additionalVariables
-  );
+  const formattedAdditionalVariables = convertToKeyValueSting(envVariables);
   const codeWithAdditionalVariables = appendAdditionalVariables(
     code,
     formattedAdditionalVariables
@@ -65,12 +63,17 @@ function convertToKeyValueSting(arr: VariableDictionary): string {
   if (!arr.length) return "";
   return arr
     .map((item) =>
-      Object.entries(item).map(([key, value]) => `${key}=${value}`)
+      Object.entries(item).map(([key, value]) => {
+        if (!key.trim() || !value.trim())
+          throw new Error("key or value are missing");
+        return `${key}=${value}`;
+      })
     )
     .join("\n");
 }
 
-function appendAdditionalVariables(file: string, variable: string): string {
-  if (!variable.trim()) return file;
-  return file.concat(`\n${variable}`);
+function appendAdditionalVariables(file: string, variables: string): string {
+  if (!variables.trim()) return file;
+  if (!file.trim()) file.concat(variables);
+  return file.concat(`\n${variables}`);
 }

--- a/packages/amplication-data-service-generator/src/server/create-dotenv.ts
+++ b/packages/amplication-data-service-generator/src/server/create-dotenv.ts
@@ -63,11 +63,7 @@ function convertToKeyValueSting(arr: VariableDictionary): string {
   if (!arr.length) return "";
   return arr
     .map((item) =>
-      Object.entries(item).map(([key, value]) => {
-        if (!key.trim() || !value.trim())
-          throw new Error("key or value are missing");
-        return `${key}=${value}`;
-      })
+      Object.entries(item).map(([key, value]) => `${key}=${value}`)
     )
     .join("\n");
 }

--- a/packages/amplication-data-service-generator/src/server/create-server.ts
+++ b/packages/amplication-data-service-generator/src/server/create-server.ts
@@ -19,7 +19,7 @@ import { createPrismaSchemaModule } from "./prisma/create-prisma-schema-module";
 import { createGrantsModule } from "./create-grants";
 import { createDotEnvModule } from "./create-dotenv";
 import { createSeedModule } from "./seed/create-seed";
-import { BASE_DIRECTORY } from "./constants";
+import { BASE_DIRECTORY, ENV_VARIABLES } from "./constants";
 import { createAuthModules } from "./auth/createAuth";
 
 const STATIC_DIRECTORY = path.resolve(__dirname, "static");
@@ -125,7 +125,7 @@ export async function createServerModules(
   );
   const dotEnvModule = await createDotEnvModule({
     baseDirectory: directoryManager.BASE,
-    additionalVariables: [],
+    envVariables: ENV_VARIABLES,
   });
 
   return [

--- a/packages/amplication-data-service-generator/src/server/prisma/constants.ts
+++ b/packages/amplication-data-service-generator/src/server/prisma/constants.ts
@@ -1,0 +1,18 @@
+import * as PrismaSchemaDSL from "prisma-schema-dsl";
+
+export type PrismaDataSource = {
+  name: string;
+  provider: PrismaSchemaDSL.DataSourceProvider;
+  url: PrismaSchemaDSL.DataSourceURLEnv;
+};
+
+export const CLIENT_GENERATOR: PrismaSchemaDSL.Generator = PrismaSchemaDSL.createGenerator(
+  "client",
+  "prisma-client-js"
+);
+
+export const DATA_SOURCE: PrismaDataSource = {
+  name: "postgres",
+  provider: PrismaSchemaDSL.DataSourceProvider.PostgreSQL,
+  url: new PrismaSchemaDSL.DataSourceURLEnv("POSTGRESQL_URL"),
+};

--- a/packages/amplication-data-service-generator/src/server/prisma/create-prisma-schema-module.ts
+++ b/packages/amplication-data-service-generator/src/server/prisma/create-prisma-schema-module.ts
@@ -1,4 +1,5 @@
 import { Entity, Module } from "@amplication/code-gen-types";
+import { CLIENT_GENERATOR, DATA_SOURCE } from "./constants";
 import { createPrismaSchema } from "./create-prisma-schema";
 
 export async function createPrismaSchemaModule(
@@ -8,6 +9,6 @@ export async function createPrismaSchemaModule(
   const MODULE_PATH = `${baseDirectory}/prisma/schema.prisma`;
   return {
     path: MODULE_PATH,
-    code: await createPrismaSchema(entities),
+    code: await createPrismaSchema(entities, DATA_SOURCE, CLIENT_GENERATOR),
   };
 }

--- a/packages/amplication-data-service-generator/src/server/prisma/create-prisma-schema.spec.ts
+++ b/packages/amplication-data-service-generator/src/server/prisma/create-prisma-schema.spec.ts
@@ -1,14 +1,13 @@
 import * as PrismaSchemaDSL from "prisma-schema-dsl";
 import {
   createPrismaSchema,
-  CLIENT_GENERATOR,
-  DATA_SOURCE,
   createPrismaFields,
   CUID_CALL_EXPRESSION,
   NOW_CALL_EXPRESSION,
   createRelationName,
 } from "./create-prisma-schema";
 import { Entity, EntityField, EnumDataType } from "@amplication/code-gen-types";
+import { CLIENT_GENERATOR, DATA_SOURCE } from "./constants";
 
 const GENERATOR_CODE = `generator ${CLIENT_GENERATOR.name} {
   provider = "${CLIENT_GENERATOR.provider}"
@@ -153,7 +152,11 @@ model ${EXAMPLE_LOOKUP_ENTITY_NAME} {
     ],
   ];
   test.each(cases)("%s", async (name, entities: Entity[], expected: string) => {
-    const schema = await createPrismaSchema(entities);
+    const schema = await createPrismaSchema(
+      entities,
+      DATA_SOURCE,
+      CLIENT_GENERATOR
+    );
     expect(schema).toBe(expected);
   });
 });

--- a/packages/amplication-data-service-generator/src/server/prisma/create-prisma-schema.ts
+++ b/packages/amplication-data-service-generator/src/server/prisma/create-prisma-schema.ts
@@ -11,17 +11,7 @@ import {
 import { countBy } from "lodash";
 
 import { getEnumFields } from "../../util/entity";
-
-export const CLIENT_GENERATOR = PrismaSchemaDSL.createGenerator(
-  "client",
-  "prisma-client-js"
-);
-
-export const DATA_SOURCE = {
-  name: "postgres",
-  provider: PrismaSchemaDSL.DataSourceProvider.PostgreSQL,
-  url: new PrismaSchemaDSL.DataSourceURLEnv("POSTGRESQL_URL"),
-};
+import { PrismaDataSource } from "./constants";
 
 export const CUID_CALL_EXPRESSION = new PrismaSchemaDSL.CallExpression(
   PrismaSchemaDSL.CUID
@@ -31,7 +21,11 @@ export const NOW_CALL_EXPRESSION = new PrismaSchemaDSL.CallExpression(
   PrismaSchemaDSL.NOW
 );
 
-export async function createPrismaSchema(entities: Entity[]): Promise<string> {
+export async function createPrismaSchema(
+  entities: Entity[],
+  dataSource: PrismaDataSource,
+  clientGenerator: PrismaSchemaDSL.Generator
+): Promise<string> {
   const fieldNamesCount = countBy(
     entities.flatMap((entity) => entity.fields),
     "name"
@@ -45,8 +39,8 @@ export async function createPrismaSchema(entities: Entity[]): Promise<string> {
     return enumFields.map((field) => createPrismaEnum(field, entity));
   });
 
-  const schema = PrismaSchemaDSL.createSchema(models, enums, DATA_SOURCE, [
-    CLIENT_GENERATOR,
+  const schema = PrismaSchemaDSL.createSchema(models, enums, dataSource, [
+    clientGenerator,
   ]);
 
   return PrismaSchemaDSL.print(schema);

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -2762,7 +2762,8 @@ export class StringNullableFilter {
   not?: string;
 }
 ",
-  "test/.env": "POSTGRESQL_USER=testUsername
+  "test/.env": "
+POSTGRESQL_USER=testUsername
 POSTGRESQL_PASSWORD=1234
 POSTGRESQL_PORT=5433
 POSTGRESQL_URL=postgres://testUsername:1234@localhost:5433/db-name
@@ -2770,7 +2771,7 @@ BCRYPT_SALT=10
 COMPOSE_PROJECT_NAME=amp_\${resourceId}
 JWT_SECRET_KEY=Change_ME!!!
 JWT_EXPIRATION=2d
-SERVER_PORT = 3000",
+SERVER_PORT=3000",
   "test/docker-compose.db.yml": "version: \\"3\\"
 services:
   db:

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -2762,7 +2762,8 @@ export class StringNullableFilter {
   not?: string;
 }
 ",
-  "server/.env": "POSTGRESQL_USER=testUsername
+  "server/.env": "
+POSTGRESQL_USER=testUsername
 POSTGRESQL_PASSWORD=1234
 POSTGRESQL_PORT=5433
 POSTGRESQL_URL=postgres://testUsername:1234@localhost:5433/db-name
@@ -2770,7 +2771,7 @@ BCRYPT_SALT=10
 COMPOSE_PROJECT_NAME=amp_\${resourceId}
 JWT_SECRET_KEY=Change_ME!!!
 JWT_EXPIRATION=2d
-SERVER_PORT = 3000",
+SERVER_PORT=3000",
   "server/docker-compose.db.yml": "version: \\"3\\"
 services:
   db:

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -2762,7 +2762,8 @@ export class StringNullableFilter {
   not?: string;
 }
 ",
-  "server/.env": "POSTGRESQL_USER=testUsername
+  "server/.env": "
+POSTGRESQL_USER=testUsername
 POSTGRESQL_PASSWORD=1234
 POSTGRESQL_PORT=5433
 POSTGRESQL_URL=postgres://testUsername:1234@localhost:5433/db-name
@@ -2770,7 +2771,7 @@ BCRYPT_SALT=10
 COMPOSE_PROJECT_NAME=amp_\${resourceId}
 JWT_SECRET_KEY=Change_ME!!!
 JWT_EXPIRATION=2d
-SERVER_PORT = 3000",
+SERVER_PORT=3000",
   "server/docker-compose.db.yml": "version: \\"3\\"
 services:
   db:

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -2762,7 +2762,8 @@ export class StringNullableFilter {
   not?: string;
 }
 ",
-  "server/.env": "POSTGRESQL_USER=testUsername
+  "server/.env": "
+POSTGRESQL_USER=testUsername
 POSTGRESQL_PASSWORD=1234
 POSTGRESQL_PORT=5433
 POSTGRESQL_URL=postgres://testUsername:1234@localhost:5433/db-name
@@ -2770,7 +2771,7 @@ BCRYPT_SALT=10
 COMPOSE_PROJECT_NAME=amp_\${resourceId}
 JWT_SECRET_KEY=Change_ME!!!
 JWT_EXPIRATION=2d
-SERVER_PORT = 3000",
+SERVER_PORT=3000",
   "server/docker-compose.db.yml": "version: \\"3\\"
 services:
   db:


### PR DESCRIPTION
Issue Number: a part of #3768 

## PR Details

`createPrismaSchema` 
- added params and used them in the function body instead of constants
- call the function with the constants variables

`createDotEnvModuleInternal`
- changed param name form 'additionalVariables' to `envVariables`
- removed the content of the `.env` file in the server and extracted it to a constant variable (type `VariableDictionary`)
- use this constant when calling to the function (`createDotEnvModuleInternal`)

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
