### PR TITLE
Fix the first empty line in the generated `.env` file

### DIFF
--- a/packages/amplication-data-service-generator/src/server/create-dotenv.ts
+++ b/packages/amplication-data-service-generator/src/server/create-dotenv.ts
@@ -70,6 +70,6 @@ function convertToKeyValueSting(arr: VariableDictionary): string {
 
 function appendAdditionalVariables(file: string, variables: string): string {
   if (!variables.trim()) return file;
-  if (!file.trim()) file.concat(variables);
+  if (!file.trim()) return file.concat(variables);
   return file.concat(`\n${variables}`);
 }

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -2762,8 +2762,7 @@ export class StringNullableFilter {
   not?: string;
 }
 ",
-  "test/.env": "
-POSTGRESQL_USER=testUsername
+  "test/.env": "POSTGRESQL_USER=testUsername
 POSTGRESQL_PASSWORD=1234
 POSTGRESQL_PORT=5433
 POSTGRESQL_URL=postgres://testUsername:1234@localhost:5433/db-name

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -2762,8 +2762,7 @@ export class StringNullableFilter {
   not?: string;
 }
 ",
-  "server/.env": "
-POSTGRESQL_USER=testUsername
+  "server/.env": "POSTGRESQL_USER=testUsername
 POSTGRESQL_PASSWORD=1234
 POSTGRESQL_PORT=5433
 POSTGRESQL_URL=postgres://testUsername:1234@localhost:5433/db-name

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -2762,8 +2762,7 @@ export class StringNullableFilter {
   not?: string;
 }
 ",
-  "server/.env": "
-POSTGRESQL_USER=testUsername
+  "server/.env": "POSTGRESQL_USER=testUsername
 POSTGRESQL_PASSWORD=1234
 POSTGRESQL_PORT=5433
 POSTGRESQL_URL=postgres://testUsername:1234@localhost:5433/db-name

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -2762,8 +2762,7 @@ export class StringNullableFilter {
   not?: string;
 }
 ",
-  "server/.env": "
-POSTGRESQL_USER=testUsername
+  "server/.env": "POSTGRESQL_USER=testUsername
 POSTGRESQL_PASSWORD=1234
 POSTGRESQL_PORT=5433
 POSTGRESQL_URL=postgres://testUsername:1234@localhost:5433/db-name


### PR DESCRIPTION

## PR Details

Added the missing return that caused an empty line in the generated `.env` file

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

