### PR TITLE
fix(client): admin ui base directory form field appears...

### DIFF
--- a/packages/amplication-client/src/Resource/resourceSettings/DirectoriesServiceSettingsForm.tsx
+++ b/packages/amplication-client/src/Resource/resourceSettings/DirectoriesServiceSettingsForm.tsx
@@ -84,23 +84,27 @@ const DirectoriesServiceSettingsForm: React.FC<{}> = () => {
                     labelType="normal"
                   />
                 </Panel>
-                <Panel panelStyle={EnumPanelStyle.Transparent}>
-                  <h2>Admin UI</h2>
-                  <TextField
-                    className={`${CLASS_NAME}__formWrapper_field`}
-                    name="adminUISettings[adminUIPath]"
-                    placeholder="packages/[SERVICE-NAME]"
-                    label="Admin UI base directory"
-                    disabled={
-                      !data?.serviceSettings.serverSettings.generateGraphQL
-                    }
-                    value={
-                      data?.serviceSettings.adminUISettings.adminUIPath || ""
-                    }
-                    helpText={data?.serviceSettings.adminUISettings.adminUIPath}
-                    labelType="normal"
-                  />
-                </Panel>
+                {data.serviceSettings.adminUISettings.generateAdminUI && (
+                  <Panel panelStyle={EnumPanelStyle.Transparent}>
+                    <h2>Admin UI</h2>
+                    <TextField
+                      className={`${CLASS_NAME}__formWrapper_field`}
+                      name="adminUISettings[adminUIPath]"
+                      placeholder="packages/[SERVICE-NAME]"
+                      label="Admin UI base directory"
+                      disabled={
+                        !data?.serviceSettings.serverSettings.generateGraphQL
+                      }
+                      value={
+                        data?.serviceSettings.adminUISettings.adminUIPath || ""
+                      }
+                      helpText={
+                        data?.serviceSettings.adminUISettings.adminUIPath
+                      }
+                      labelType="normal"
+                    />
+                  </Panel>
+                )}
               </Form>
             );
           }}

--- a/packages/amplication-client/src/Resource/useSettingsHook.ts
+++ b/packages/amplication-client/src/Resource/useSettingsHook.ts
@@ -3,7 +3,7 @@ import { useCallback } from "react";
 
 export interface SettingsHookParams {
   trackEvent: (event: { eventName: string; [key: string]: any }) => void;
-  resourceId: string;
+  resourceId: string | undefined;
   updateResourceSettings: any;
 }
 


### PR DESCRIPTION
… even when admin ui settings are toggled off and type issue for resource id.

<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.
-->

Issue Number: #3655 

## PR Details
Resource ID type checking threw an error, as the resource id should either be of type undefined or string from output of optional chaining (use this with caution, as this doesn't throw an error).
Updated the type for our resource id parameter in the useSettings hook, accordingly. If the resource id needs to be a string (even an empty one), we can just do  `const resourceId = currentResource?.id ?? ""` in our directories service settings form.

Demonstration of updated UI below.

https://user-images.githubusercontent.com/20914059/189873999-9e333708-3738-4269-84cb-0a529d0e559f.mov



<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

## PR Checklist
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
