### PR TITLE
fix docker compose file

### DIFF
--- a/packages/amplication-data-service-generator/src/server/docker-compose/docker-compose.template.yml
+++ b/packages/amplication-data-service-generator/src/server/docker-compose/docker-compose.template.yml
@@ -29,10 +29,11 @@ services:
         condition: service_healthy
   db:
     image: postgres:12
+    ports:
+      - ${POSTGRESQL_PORT}:5432
     environment:
       POSTGRES_USER: ${POSTGRESQL_USER}
       POSTGRES_PASSWORD: ${POSTGRESQL_PASSWORD}
-      ports: ${POSTGRESQL_PORT}:5432
     volumes:
       - postgres:/var/lib/postgresql/data
     healthcheck:

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -2816,10 +2816,11 @@ services:
         condition: service_healthy
   db:
     image: postgres:12
+    ports:
+      - \${POSTGRESQL_PORT}:5432
     environment:
       POSTGRES_USER: \${POSTGRESQL_USER}
       POSTGRES_PASSWORD: \${POSTGRESQL_PASSWORD}
-      ports: \${POSTGRESQL_PORT}:5432
     volumes:
       - postgres:/var/lib/postgresql/data
     healthcheck:

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -2816,10 +2816,11 @@ services:
         condition: service_healthy
   db:
     image: postgres:12
+    ports:
+      - \${POSTGRESQL_PORT}:5432
     environment:
       POSTGRES_USER: \${POSTGRESQL_USER}
       POSTGRES_PASSWORD: \${POSTGRESQL_PASSWORD}
-      ports: \${POSTGRESQL_PORT}:5432
     volumes:
       - postgres:/var/lib/postgresql/data
     healthcheck:

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -2816,10 +2816,11 @@ services:
         condition: service_healthy
   db:
     image: postgres:12
+    ports:
+      - \${POSTGRESQL_PORT}:5432
     environment:
       POSTGRES_USER: \${POSTGRESQL_USER}
       POSTGRES_PASSWORD: \${POSTGRESQL_PASSWORD}
-      ports: \${POSTGRESQL_PORT}:5432
     volumes:
       - postgres:/var/lib/postgresql/data
     healthcheck:

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -2816,10 +2816,11 @@ services:
         condition: service_healthy
   db:
     image: postgres:12
+    ports:
+      - \${POSTGRESQL_PORT}:5432
     environment:
       POSTGRES_USER: \${POSTGRESQL_USER}
       POSTGRES_PASSWORD: \${POSTGRESQL_PASSWORD}
-      ports: \${POSTGRESQL_PORT}:5432
     volumes:
       - postgres:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## PR Details

fix the `ports` in the docker-compose 

```
environment:
      POSTGRES_USER: ${POSTGRESQL_USER}
      POSTGRES_PASSWORD: ${POSTGRESQL_PASSWORD}
      ports: ${POSTGRESQL_PORT}:5432 <== here is the mistake
    volumes:
      - postgres:/var/lib/postgresql/data
```

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
