### PR TITLE
3831 bug report text is not centered on create workspace button

### DIFF
--- a/packages/amplication-client/src/Project/AddNewProject.tsx
+++ b/packages/amplication-client/src/Project/AddNewProject.tsx
@@ -37,7 +37,7 @@ const AddNewProject = () => {
         buttonStyle={EnumButtonStyle.Text}
         icon="plus"
         iconPosition={EnumIconPosition.Left}
-        iconSize="xsmall"
+        iconSize="small"
       >
         <span className={`${CLASS_NAME}__label`}>Add New Project</span>
       </Button>

--- a/packages/amplication-client/src/Project/ProjectList.scss
+++ b/packages/amplication-client/src/Project/ProjectList.scss
@@ -2,18 +2,30 @@
 
 .project-list {
   display: flex;
-  flex-grow: 1;
-  flex-basis: 0px;
-  @include scrollbars(16px, var(--black60), transparent);
-  overflow: auto;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
   
   &__items {
+    overflow-y: auto;
+    @include scrollbars(16px, var(--black60), transparent);
     flex: 1;
   }
 
   .amp-button {
+    height: 36px;
+    padding: 8px;
+    margin-top: var(--default-spacing-small);
+    justify-content: flex-start;
+    gap: 8px;
+
+    &:hover {
+      color: var(--black100);
+      background-color: var(--black10);
+    }
+
     .amp-button__icon {
-      margin: 0 var(--default-spacing-small);
+      margin: 0;
     }
   }
 }

--- a/packages/amplication-client/src/Project/ProjectList.tsx
+++ b/packages/amplication-client/src/Project/ProjectList.tsx
@@ -25,8 +25,8 @@ export const ProjectList = ({
             workspaceId={workspaceId}
           />
         ))}
-        <AddNewProject />
       </div>
+      <AddNewProject />
     </div>
   );
 };

--- a/packages/amplication-client/src/Project/ProjectSideBar.scss
+++ b/packages/amplication-client/src/Project/ProjectSideBar.scss
@@ -4,16 +4,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
-
-  &__project-wrapper {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    
-    .amp-button {
-      justify-content: flex-start;
-    }
-  }
+  min-height: 0;
 
   &__label {
     @include regular-12;

--- a/packages/amplication-client/src/Project/ProjectSideBar.tsx
+++ b/packages/amplication-client/src/Project/ProjectSideBar.tsx
@@ -12,17 +12,15 @@ const ProjectSideBar = () => {
 
   return (
     <div className={CLASS_NAME}>
-      <div className={`${CLASS_NAME}__project-wrapper`}>
-        <p className={`${CLASS_NAME}__label`}>Workspace</p>
-        <WorkspaceSelector />
-        <hr className={`${CLASS_NAME}__divider`} />
-        <ProjectList
-          projects={projectsList}
-          workspaceId={currentWorkspace?.id}
-        />
-        <hr className={`${CLASS_NAME}__divider`} />
-        <ProjectSideBarFooter />
-      </div>
+      <p className={`${CLASS_NAME}__label`}>Workspace</p>
+      <WorkspaceSelector />
+      <hr className={`${CLASS_NAME}__divider`} />
+      <ProjectList
+        projects={projectsList}
+        workspaceId={currentWorkspace?.id}
+      />
+      <hr className={`${CLASS_NAME}__divider`} />
+      <ProjectSideBarFooter />
     </div>
   );
 };

--- a/packages/amplication-client/src/Workspaces/WorkspaceSelector.scss
+++ b/packages/amplication-client/src/Workspaces/WorkspaceSelector.scss
@@ -72,6 +72,8 @@
         color: var(--positive-default);
       }
 
+      align-items: center;
+
       &:hover {
         background-color: var(--black10);
       }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Issue Number: #3831 

## PR Details

The issue was that styles which were intended for add new project button was applied to create new workspace button due to poor style specification and wrong add new project button placement in DOM.
The solution is to place add new button correctly, apply styles to the button specifically.
There is also icon alignment fix in workspace selector as a part of proper boycotting.  

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
