### PR TITLE
Message Broker page - the first topic is not selected

### DIFF
--- a/packages/amplication-client/src/ServiceConnections/ServiceConnectionsPage.tsx
+++ b/packages/amplication-client/src/ServiceConnections/ServiceConnectionsPage.tsx
@@ -19,7 +19,7 @@ const TopicsPage: React.FC<Props> = ({ match, innerRoutes }: Props) => {
     <PageContent
       pageTitle={pageTitle}
       className="topics"
-      sideContent={<ServiceConnectionsList resourceId={resource} />}
+      sideContent={<ServiceConnectionsList resourceId={resource} selectFirst />}
     >
       {innerRoutes}
     </PageContent>

--- a/packages/amplication-client/src/routes/resourceRoutes.tsx
+++ b/packages/amplication-client/src/routes/resourceRoutes.tsx
@@ -72,7 +72,7 @@ const resourceRoutes = [
     Component: lazy(() => import("../MessageBrokerServices/ServicesPage")),
     moduleName: "",
     routeTrackType: "",
-    exactPath: false
+    exactPath: false,
   },
   {
     path: "/:workspace/:project/:resource/service-connections",


### PR DESCRIPTION

Issue Number: #3893

## PR Details

When the service broker page loads, the first service broker from the list will be selected. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
