### PR TITLE
Add parser option for static and templates

### DIFF
--- a/packages/amplication-data-service-generator/.eslintrc.js
+++ b/packages/amplication-data-service-generator/.eslintrc.js
@@ -1,5 +1,6 @@
 const path = require("path");
 
+/** @type {import('eslint').Linter.Config} */
 module.exports = {
   parser: "@typescript-eslint/parser",
   parserOptions: {
@@ -32,84 +33,8 @@ module.exports = {
     },
   },
   overrides: [
-    {
-      files: ["*.template.ts", "*.template.tsx"],
-      rules: {
-        "@typescript-eslint/no-empty-interface": "off",
-        "import/no-unresolved": "off",
-        "@typescript-eslint/no-unused-vars": "off",
-        "@typescript-eslint/explicit-module-boundary-types": "off",
-        "@typescript-eslint/no-empty-interface": "off",
-        "@typescript-eslint/naming-convention": "off",
-        "@typescript-eslint/naming-convention": [
-          "error",
-          {
-            selector: "default",
-            format: ["camelCase"],
-          },
-          {
-            selector: "variable",
-            modifiers: ["const"],
-            format: ["camelCase", "UPPER_CASE"],
-          },
-          {
-            selector: "property",
-            format: ["camelCase", "UPPER_CASE"],
-          },
-          {
-            selector: "method",
-            format: ["camelCase", "UPPER_CASE"],
-          },
-          {
-            selector: "variable",
-            modifiers: ["const"],
-            types: ["function"],
-            format: ["camelCase", "PascalCase", "UPPER_CASE"],
-          },
-          {
-            selector: "typeLike",
-            format: ["PascalCase", "UPPER_CASE"],
-          },
-          { selector: "enumMember", format: ["PascalCase"] },
-        ],
-      },
-    },
+    require("./lint/eslintrc.template.js"),
+    require("./lint/eslintrc.static.js")
   ],
-  rules: {
-    "@typescript-eslint/ban-ts-comment": "off",
-    "@typescript-eslint/interface-name-prefix": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-explicit-any": "off",
-    "import/no-cycle": "off",
-    "@typescript-eslint/camelcase": "off",
-    "@typescript-eslint/naming-convention": [
-      "error",
-      {
-        selector: "default",
-        format: ["camelCase"],
-      },
-      {
-        selector: "variable",
-        modifiers: ["const"],
-        format: ["camelCase", "UPPER_CASE"],
-      },
-      {
-        selector: "property",
-        format: ["camelCase", "UPPER_CASE"],
-      },
-      {
-        selector: "variable",
-        modifiers: ["const"],
-        types: ["function"],
-        format: ["camelCase", "PascalCase"],
-      },
-      {
-        selector: "typeLike",
-        format: ["PascalCase"],
-      },
-      { selector: "enumMember", format: ["PascalCase"] },
-    ],
-    "@typescript-eslint/no-unused-vars": ["error", { args: "none" }],
-    "@typescript-eslint/no-floating-promises": "error",
-  },
+  rules: require("./lint/common-rules")
 };

--- a/packages/amplication-data-service-generator/lint/common-rules.js
+++ b/packages/amplication-data-service-generator/lint/common-rules.js
@@ -1,0 +1,39 @@
+/** @type {import('eslint').Linter.RulesRecord} */
+module.exports = {
+    "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/interface-name-prefix": "off",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "import/no-cycle": "off",
+    "import/no-unresolved": "error",
+    "@typescript-eslint/camelcase": "off",
+    "@typescript-eslint/naming-convention": [
+        "error",
+        {
+            selector: "default",
+            format: ["camelCase"],
+        },
+        {
+            selector: "variable",
+            modifiers: ["const"],
+            format: ["camelCase", "UPPER_CASE"],
+        },
+        {
+            selector: "property",
+            format: ["camelCase", "UPPER_CASE"],
+        },
+        {
+            selector: "variable",
+            modifiers: ["const"],
+            types: ["function"],
+            format: ["camelCase", "PascalCase"],
+        },
+        {
+            selector: "typeLike",
+            format: ["PascalCase"],
+        },
+        { selector: "enumMember", format: ["PascalCase"] },
+    ],
+    "@typescript-eslint/no-unused-vars": ["error", { args: "none" }],
+    "@typescript-eslint/no-floating-promises": "error",
+}

--- a/packages/amplication-data-service-generator/lint/eslintrc.static.js
+++ b/packages/amplication-data-service-generator/lint/eslintrc.static.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.ConfigOverride} */
+module.exports = {
+    files: ["**/static/**/*.ts"],
+    rules: {
+        ...require("./common-rules"), "import/no-unresolved": "off"
+    },
+    parserOptions: {
+        project: "./tsconfig.only-parse.json"
+    }
+}

--- a/packages/amplication-data-service-generator/lint/eslintrc.template.js
+++ b/packages/amplication-data-service-generator/lint/eslintrc.template.js
@@ -1,0 +1,46 @@
+/** @type {import('eslint').Linter.ConfigOverride} */
+module.exports = {
+    files: ["*.template.ts", "*.template.tsx"],
+    rules: {
+        "@typescript-eslint/no-empty-interface": "off",
+        "import/no-unresolved": "off",
+        "@typescript-eslint/no-unused-vars": "off",
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/no-empty-interface": "off",
+        "@typescript-eslint/naming-convention": "off",
+        "@typescript-eslint/naming-convention": [
+            "error",
+            {
+                selector: "default",
+                format: ["camelCase"],
+            },
+            {
+                selector: "variable",
+                modifiers: ["const"],
+                format: ["camelCase", "UPPER_CASE"],
+            },
+            {
+                selector: "property",
+                format: ["camelCase", "UPPER_CASE"],
+            },
+            {
+                selector: "method",
+                format: ["camelCase", "UPPER_CASE"],
+            },
+            {
+                selector: "variable",
+                modifiers: ["const"],
+                types: ["function"],
+                format: ["camelCase", "PascalCase", "UPPER_CASE"],
+            },
+            {
+                selector: "typeLike",
+                format: ["PascalCase", "UPPER_CASE"],
+            },
+            { selector: "enumMember", format: ["PascalCase"] },
+        ],
+    },
+    parserOptions: {
+        project: "./tsconfig.only-parse.json"
+    }
+}

--- a/packages/amplication-data-service-generator/tsconfig.json
+++ b/packages/amplication-data-service-generator/tsconfig.json
@@ -18,5 +18,5 @@
     "jsx": "react"
   },
   "include": ["src"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/**.template.ts", "**/static/**/**"]
 }

--- a/packages/amplication-data-service-generator/tsconfig.only-parse.json
+++ b/packages/amplication-data-service-generator/tsconfig.only-parse.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR is adding a new set of parser options for the template files and for the statics files.
What was:
regular files - compiled and lint
templates - compiled, lint with @ts-ignore, and copy
static - compiled, lint with @ts-ignore and, copy

Now:
regular files - same
templates - not compiling, lint with **custom** configurations, and copy
static - not compiling, lint with regular configuration, and copy

On the way, we added types to the js files with @type new standard.