### PR TITLE
Remove the `@ts-ignore` from the auth strategy

### DIFF
--- a/packages/amplication-data-service-generator/src/server/auth/token/basicToken.service.spec.template.ts
+++ b/packages/amplication-data-service-generator/src/server/auth/token/basicToken.service.spec.template.ts
@@ -1,12 +1,8 @@
-/* eslint-disable import/no-unresolved */
-//@ts-ignore
 import { TokenServiceBase } from "../../auth/base/token.service.base";
 import {
   INVALID_USERNAME_ERROR,
   INVALID_PASSWORD_ERROR,
-  //@ts-ignore
 } from "../../auth/constants";
-//@ts-ignore
 import { SIGN_TOKEN, VALID_CREDENTIALS, VALID_ID } from "./constants";
 
 describe("Testing the TokenServiceBase", () => {

--- a/packages/amplication-data-service-generator/src/server/auth/token/basicToken.service.template.ts
+++ b/packages/amplication-data-service-generator/src/server/auth/token/basicToken.service.template.ts
@@ -1,8 +1,5 @@
-/* eslint-disable import/no-unresolved */
 import { Injectable } from "@nestjs/common";
-//@ts-ignore
 import { INVALID_PASSWORD_ERROR, INVALID_USERNAME_ERROR } from "../constants";
-//@ts-ignore
 import { ITokenService, ITokenPayload } from "../ITokenService";
 /**
  * TokenServiceBase is a basic http implementation of ITokenService

--- a/packages/amplication-data-service-generator/src/server/auth/token/jwtToken.service.spec.template.ts
+++ b/packages/amplication-data-service-generator/src/server/auth/token/jwtToken.service.spec.template.ts
@@ -1,14 +1,10 @@
-/* eslint-disable import/no-unresolved */
 import { JwtService } from "@nestjs/jwt";
 import { mock } from "jest-mock-extended";
-//@ts-ignore
 import { TokenServiceBase } from "../../auth/base/token.service.base";
 import {
   INVALID_PASSWORD_ERROR,
   INVALID_USERNAME_ERROR,
-  //@ts-ignore
 } from "../../auth/constants";
-//@ts-ignore
 import { SIGN_TOKEN, VALID_CREDENTIALS, VALID_ID } from "./constants";
 
 describe("Testing the TokenServiceBase", () => {

--- a/packages/amplication-data-service-generator/src/server/auth/token/jwtToken.service.template.ts
+++ b/packages/amplication-data-service-generator/src/server/auth/token/jwtToken.service.template.ts
@@ -1,9 +1,6 @@
-/* eslint-disable import/no-unresolved */
 import { Injectable } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
-//@ts-ignore
 import { INVALID_PASSWORD_ERROR, INVALID_USERNAME_ERROR } from "../constants";
-//@ts-ignore
 import { ITokenService, ITokenPayload } from "../ITokenService";
 /**
  * TokenServiceBase is a jwt bearer implementation of ITokenService

--- a/packages/amplication-data-service-generator/src/server/static/src/auth/jwt/base/jwt.strategy.base.ts
+++ b/packages/amplication-data-service-generator/src/server/static/src/auth/jwt/base/jwt.strategy.base.ts
@@ -2,8 +2,6 @@ import { UnauthorizedException } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import { ExtractJwt, Strategy } from "passport-jwt";
 import { IAuthStrategy } from "../../IAuthStrategy";
-// @ts-ignore
-// eslint-disable-next-line
 import { UserService } from "../../user/user.service";
 import { UserInfo } from "../../UserInfo";
 

--- a/packages/amplication-data-service-generator/src/server/static/src/auth/jwt/jwt.strategy.ts
+++ b/packages/amplication-data-service-generator/src/server/static/src/auth/jwt/jwt.strategy.ts
@@ -1,7 +1,5 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { JWT_SECRET_KEY } from "../../constants";
-// @ts-ignore
-// eslint-disable-next-line
 import { UserService } from "../../user/user.service";
 import { JwtStrategyBase } from "./base/jwt.strategy.base";
 @Injectable()

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -3712,8 +3712,7 @@ export class AuthService {
   }
 }
 ",
-  "test/src/auth/base/token.service.base.ts": "/* eslint-disable import/no-unresolved */
-import { Injectable } from \\"@nestjs/common\\";
+  "test/src/auth/base/token.service.base.ts": "import { Injectable } from \\"@nestjs/common\\";
 import { INVALID_PASSWORD_ERROR, INVALID_USERNAME_ERROR } from \\"../constants\\";
 import { ITokenService, ITokenPayload } from \\"../ITokenService\\";
 /**
@@ -12853,15 +12852,11 @@ describe(\\"Testing the jwtStrategyBase.validate()\\", () => {
   });
 });
 ",
-  "test/src/tests/auth/token.service.spec.ts": "/* eslint-disable import/no-unresolved */
-//@ts-ignore
-import { TokenServiceBase } from \\"../../auth/base/token.service.base\\";
+  "test/src/tests/auth/token.service.spec.ts": "import { TokenServiceBase } from \\"../../auth/base/token.service.base\\";
 import {
   INVALID_USERNAME_ERROR,
   INVALID_PASSWORD_ERROR,
-  //@ts-ignore
 } from \\"../../auth/constants\\";
-//@ts-ignore
 import { SIGN_TOKEN, VALID_CREDENTIALS, VALID_ID } from \\"./constants\\";
 
 describe(\\"Testing the TokenServiceBase\\", () => {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -3854,8 +3854,6 @@ export const UserRoles = createParamDecorator(
 import { PassportStrategy } from \\"@nestjs/passport\\";
 import { ExtractJwt, Strategy } from \\"passport-jwt\\";
 import { IAuthStrategy } from \\"../../IAuthStrategy\\";
-// @ts-ignore
-// eslint-disable-next-line
 import { UserService } from \\"../../user/user.service\\";
 import { UserInfo } from \\"../../UserInfo\\";
 
@@ -3887,8 +3885,6 @@ export class JwtStrategyBase
 ",
   "test/src/auth/jwt/jwt.strategy.ts": "import { Inject, Injectable } from \\"@nestjs/common\\";
 import { JWT_SECRET_KEY } from \\"../../constants\\";
-// @ts-ignore
-// eslint-disable-next-line
 import { UserService } from \\"../../user/user.service\\";
 import { JwtStrategyBase } from \\"./base/jwt.strategy.base\\";
 @Injectable()

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -3749,8 +3749,7 @@ export class AuthService {
   }
 }
 ",
-  "server/src/auth/base/token.service.base.ts": "/* eslint-disable import/no-unresolved */
-import { Injectable } from \\"@nestjs/common\\";
+  "server/src/auth/base/token.service.base.ts": "import { Injectable } from \\"@nestjs/common\\";
 import { INVALID_PASSWORD_ERROR, INVALID_USERNAME_ERROR } from \\"../constants\\";
 import { ITokenService, ITokenPayload } from \\"../ITokenService\\";
 /**
@@ -12973,15 +12972,11 @@ describe(\\"Testing the jwtStrategyBase.validate()\\", () => {
   });
 });
 ",
-  "server/src/tests/auth/token.service.spec.ts": "/* eslint-disable import/no-unresolved */
-//@ts-ignore
-import { TokenServiceBase } from \\"../../auth/base/token.service.base\\";
+  "server/src/tests/auth/token.service.spec.ts": "import { TokenServiceBase } from \\"../../auth/base/token.service.base\\";
 import {
   INVALID_USERNAME_ERROR,
   INVALID_PASSWORD_ERROR,
-  //@ts-ignore
 } from \\"../../auth/constants\\";
-//@ts-ignore
 import { SIGN_TOKEN, VALID_CREDENTIALS, VALID_ID } from \\"./constants\\";
 
 describe(\\"Testing the TokenServiceBase\\", () => {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -3891,8 +3891,6 @@ export const UserRoles = createParamDecorator(
 import { PassportStrategy } from \\"@nestjs/passport\\";
 import { ExtractJwt, Strategy } from \\"passport-jwt\\";
 import { IAuthStrategy } from \\"../../IAuthStrategy\\";
-// @ts-ignore
-// eslint-disable-next-line
 import { UserService } from \\"../../user/user.service\\";
 import { UserInfo } from \\"../../UserInfo\\";
 
@@ -3924,8 +3922,6 @@ export class JwtStrategyBase
 ",
   "server/src/auth/jwt/jwt.strategy.ts": "import { Inject, Injectable } from \\"@nestjs/common\\";
 import { JWT_SECRET_KEY } from \\"../../constants\\";
-// @ts-ignore
-// eslint-disable-next-line
 import { UserService } from \\"../../user/user.service\\";
 import { JwtStrategyBase } from \\"./base/jwt.strategy.base\\";
 @Injectable()

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -3854,8 +3854,6 @@ export const UserRoles = createParamDecorator(
 import { PassportStrategy } from \\"@nestjs/passport\\";
 import { ExtractJwt, Strategy } from \\"passport-jwt\\";
 import { IAuthStrategy } from \\"../../IAuthStrategy\\";
-// @ts-ignore
-// eslint-disable-next-line
 import { UserService } from \\"../../user/user.service\\";
 import { UserInfo } from \\"../../UserInfo\\";
 
@@ -3887,8 +3885,6 @@ export class JwtStrategyBase
 ",
   "server/src/auth/jwt/jwt.strategy.ts": "import { Inject, Injectable } from \\"@nestjs/common\\";
 import { JWT_SECRET_KEY } from \\"../../constants\\";
-// @ts-ignore
-// eslint-disable-next-line
 import { UserService } from \\"../../user/user.service\\";
 import { JwtStrategyBase } from \\"./base/jwt.strategy.base\\";
 @Injectable()

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -3712,8 +3712,7 @@ export class AuthService {
   }
 }
 ",
-  "server/src/auth/base/token.service.base.ts": "/* eslint-disable import/no-unresolved */
-import { Injectable } from \\"@nestjs/common\\";
+  "server/src/auth/base/token.service.base.ts": "import { Injectable } from \\"@nestjs/common\\";
 import { INVALID_PASSWORD_ERROR, INVALID_USERNAME_ERROR } from \\"../constants\\";
 import { ITokenService, ITokenPayload } from \\"../ITokenService\\";
 /**
@@ -11867,15 +11866,11 @@ describe(\\"Testing the jwtStrategyBase.validate()\\", () => {
   });
 });
 ",
-  "server/src/tests/auth/token.service.spec.ts": "/* eslint-disable import/no-unresolved */
-//@ts-ignore
-import { TokenServiceBase } from \\"../../auth/base/token.service.base\\";
+  "server/src/tests/auth/token.service.spec.ts": "import { TokenServiceBase } from \\"../../auth/base/token.service.base\\";
 import {
   INVALID_USERNAME_ERROR,
   INVALID_PASSWORD_ERROR,
-  //@ts-ignore
 } from \\"../../auth/constants\\";
-//@ts-ignore
 import { SIGN_TOKEN, VALID_CREDENTIALS, VALID_ID } from \\"./constants\\";
 
 describe(\\"Testing the TokenServiceBase\\", () => {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -3854,8 +3854,6 @@ export const UserRoles = createParamDecorator(
 import { PassportStrategy } from \\"@nestjs/passport\\";
 import { ExtractJwt, Strategy } from \\"passport-jwt\\";
 import { IAuthStrategy } from \\"../../IAuthStrategy\\";
-// @ts-ignore
-// eslint-disable-next-line
 import { UserService } from \\"../../user/user.service\\";
 import { UserInfo } from \\"../../UserInfo\\";
 
@@ -3887,8 +3885,6 @@ export class JwtStrategyBase
 ",
   "server/src/auth/jwt/jwt.strategy.ts": "import { Inject, Injectable } from \\"@nestjs/common\\";
 import { JWT_SECRET_KEY } from \\"../../constants\\";
-// @ts-ignore
-// eslint-disable-next-line
 import { UserService } from \\"../../user/user.service\\";
 import { JwtStrategyBase } from \\"./base/jwt.strategy.base\\";
 @Injectable()

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -3712,8 +3712,7 @@ export class AuthService {
   }
 }
 ",
-  "server/src/auth/base/token.service.base.ts": "/* eslint-disable import/no-unresolved */
-import { Injectable } from \\"@nestjs/common\\";
+  "server/src/auth/base/token.service.base.ts": "import { Injectable } from \\"@nestjs/common\\";
 import { INVALID_PASSWORD_ERROR, INVALID_USERNAME_ERROR } from \\"../constants\\";
 import { ITokenService, ITokenPayload } from \\"../ITokenService\\";
 /**
@@ -10289,15 +10288,11 @@ describe(\\"Testing the jwtStrategyBase.validate()\\", () => {
   });
 });
 ",
-  "server/src/tests/auth/token.service.spec.ts": "/* eslint-disable import/no-unresolved */
-//@ts-ignore
-import { TokenServiceBase } from \\"../../auth/base/token.service.base\\";
+  "server/src/tests/auth/token.service.spec.ts": "import { TokenServiceBase } from \\"../../auth/base/token.service.base\\";
 import {
   INVALID_USERNAME_ERROR,
   INVALID_PASSWORD_ERROR,
-  //@ts-ignore
 } from \\"../../auth/constants\\";
-//@ts-ignore
 import { SIGN_TOKEN, VALID_CREDENTIALS, VALID_ID } from \\"./constants\\";
 
 describe(\\"Testing the TokenServiceBase\\", () => {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -3854,8 +3854,6 @@ export const UserRoles = createParamDecorator(
 import { PassportStrategy } from \\"@nestjs/passport\\";
 import { ExtractJwt, Strategy } from \\"passport-jwt\\";
 import { IAuthStrategy } from \\"../../IAuthStrategy\\";
-// @ts-ignore
-// eslint-disable-next-line
 import { UserService } from \\"../../user/user.service\\";
 import { UserInfo } from \\"../../UserInfo\\";
 
@@ -3887,8 +3885,6 @@ export class JwtStrategyBase
 ",
   "server/src/auth/jwt/jwt.strategy.ts": "import { Inject, Injectable } from \\"@nestjs/common\\";
 import { JWT_SECRET_KEY } from \\"../../constants\\";
-// @ts-ignore
-// eslint-disable-next-line
 import { UserService } from \\"../../user/user.service\\";
 import { JwtStrategyBase } from \\"./base/jwt.strategy.base\\";
 @Injectable()

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -3712,8 +3712,7 @@ export class AuthService {
   }
 }
 ",
-  "server/src/auth/base/token.service.base.ts": "/* eslint-disable import/no-unresolved */
-import { Injectable } from \\"@nestjs/common\\";
+  "server/src/auth/base/token.service.base.ts": "import { Injectable } from \\"@nestjs/common\\";
 import { INVALID_PASSWORD_ERROR, INVALID_USERNAME_ERROR } from \\"../constants\\";
 import { ITokenService, ITokenPayload } from \\"../ITokenService\\";
 /**
@@ -12853,15 +12852,11 @@ describe(\\"Testing the jwtStrategyBase.validate()\\", () => {
   });
 });
 ",
-  "server/src/tests/auth/token.service.spec.ts": "/* eslint-disable import/no-unresolved */
-//@ts-ignore
-import { TokenServiceBase } from \\"../../auth/base/token.service.base\\";
+  "server/src/tests/auth/token.service.spec.ts": "import { TokenServiceBase } from \\"../../auth/base/token.service.base\\";
 import {
   INVALID_USERNAME_ERROR,
   INVALID_PASSWORD_ERROR,
-  //@ts-ignore
 } from \\"../../auth/constants\\";
-//@ts-ignore
 import { SIGN_TOKEN, VALID_CREDENTIALS, VALID_ID } from \\"./constants\\";
 
 describe(\\"Testing the TokenServiceBase\\", () => {


### PR DESCRIPTION
This PR removes the `@ts-ignore` and comment from the auth files to prevent line dropping