### PR TITLE
Install DSG plugins on-demand

### DIFF
--- a/packages/amplication-data-service-generator/.dockerignore
+++ b/packages/amplication-data-service-generator/.dockerignore
@@ -4,3 +4,4 @@
 !src/server/static/package-lock.json
 !src/admin/static/package.json
 !src/admin/static/package-lock.json
+temp

--- a/packages/amplication-data-service-generator/.gitignore
+++ b/packages/amplication-data-service-generator/.gitignore
@@ -7,3 +7,4 @@ generated/
 *.map
 # ESLint
 .eslintcache
+temp

--- a/packages/amplication-data-service-generator/Dockerfile
+++ b/packages/amplication-data-service-generator/Dockerfile
@@ -1,7 +1,7 @@
 ARG ALPINE_VERSION=alpine3.14
-ARG NODE_VERSION=16.13.1
+ARG NODE_VERSION=16.13
 
-FROM node:$NODE_VERSION-$ALPINE_VERSION AS base
+FROM node:$NODE_VERSION AS base
 COPY ./ /app
 
 WORKDIR /app
@@ -12,14 +12,12 @@ RUN npm run bootstrap -- --scope @amplication/data-service-generator --include-d
 
 RUN npm run build -- --scope @amplication/data-service-generator --include-dependencies
 
-
 FROM node:$NODE_VERSION-$ALPINE_VERSION as final
 WORKDIR /app
 
 COPY --from=base /app/packages/amplication-data-service-generator/package.json /app/packages/amplication-data-service-generator/package.json
 COPY --from=base /app/packages/amplication-data-service-generator/node_modules /app/packages/amplication-data-service-generator/node_modules
 COPY --from=base /app/packages/amplication-data-service-generator/dist /app/packages/amplication-data-service-generator/dist
-
 
 COPY --from=base /app/packages/amplication-code-gen-types/package.json /app/packages/amplication-code-gen-types/package.json
 COPY --from=base /app/packages/amplication-code-gen-types/node_modules /app/packages/amplication-code-gen-types/node_modules

--- a/packages/amplication-data-service-generator/package.json
+++ b/packages/amplication-data-service-generator/package.json
@@ -15,17 +15,12 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:e2e": "jest --config ./test/jest-e2e.json --runInBand",
-    "generate-code": "node ./dist/index.js",
+    "generate-code": "node ./dist/install-plugins.js && node ./dist/index.js",
     "generate-test-data-service": "ts-node scripts/generate-test-data-service.ts generated",
     "update-test-data-service-snapshot": "jest -u src/tests/*.spec.ts && jest -u src/tests/server"
   },
   "dependencies": {
     "@amplication/code-gen-types": "^1.0.1",
-    "@amplication/plugin-auth-basic": "^1.0.2",
-    "@amplication/plugin-auth-jwt": "^1.0.2",
-    "@amplication/plugin-broker-kafka": "^0.0.4",
-    "@amplication/plugin-db-mysql": "^0.0.5",
-    "@amplication/plugin-db-postgres": "^1.0.2",
     "@babel/parser": "7.14.7",
     "@extra-set/difference": "2.2.4",
     "camel-case": "4.1.2",

--- a/packages/amplication-data-service-generator/src/index.ts
+++ b/packages/amplication-data-service-generator/src/index.ts
@@ -7,31 +7,33 @@ import { createDataServiceImpl } from "./create-data-service-impl";
 import { defaultLogger } from "./server/logging";
 import axios from "axios";
 
-const [, , source, destination] = process.argv;
-if (!source) {
-  throw new Error("SOURCE is not defined");
+const buildSpecPath = process.env.BUILD_SPEC_PATH;
+const buildOutputPath = process.env.BUILD_OUTPUT_PATH;
+
+if (!buildSpecPath) {
+  throw new Error("BUILD_SPEC_PATH is not defined");
 }
-if (!destination) {
-  throw new Error("DESTINATION is not defined");
+if (!buildOutputPath) {
+  throw new Error("BUILD_OUTPUT_PATH is not defined");
 }
 
-generateCode(source, destination).catch((err) => {
+generateCode(buildSpecPath, buildOutputPath).catch((err) => {
   console.error(err);
   process.exit(1);
 });
 
 export default async function generateCode(
-  source: string,
-  destination: string
+  buildSpecPath: string,
+  buildOutputPath: string
 ): Promise<void> {
   try {
-    const file = await readFile(source, "utf8");
+    const file = await readFile(buildSpecPath, "utf8");
     const buildContext: BuildContext = JSON.parse(file);
     const modules = await createDataServiceImpl(
       buildContext.data,
       defaultLogger
     );
-    await writeModules(modules, destination);
+    await writeModules(modules, buildOutputPath);
     await axios.put(process.env.STATUS_UPDATE_URL || "", {
       buildId: process.env.BUILD_ID,
       status: "Success",

--- a/packages/amplication-data-service-generator/src/install-plugins.ts
+++ b/packages/amplication-data-service-generator/src/install-plugins.ts
@@ -1,0 +1,57 @@
+import { promises as fs } from "fs";
+import { exec } from "child_process";
+
+const buildSpecPath = process.env.BUILD_SPEC_PATH;
+const installationPath = process.env.INSTALLATION_PATH;
+
+if (!buildSpecPath) {
+  throw new Error("BUILD_SPEC_PATH is not defined");
+}
+
+if (!installationPath) {
+  throw new Error("INSTALLATION_PATH is not defined");
+}
+
+interface Plugin {
+  npm: string;
+  version: string;
+}
+
+async function loadPlugins(): Promise<void> {
+  const spec = await loadSpec();
+  const { data } = spec;
+  const { pluginInstallations } = data;
+
+  console.log(`Found ${pluginInstallations.length} plugins to install`);
+  await installPlugins(pluginInstallations);
+}
+
+loadPlugins(); // eslint-disable-line @typescript-eslint/no-floating-promises
+
+async function installPlugins(plugins: Plugin[]) {
+  await fs.mkdir(installationPath as string, { recursive: true });
+
+  const pluginList = plugins
+    .map(({ npm, version }) => `${npm}@${version}`)
+    .join(" ");
+
+  const cmd = `npm install ${pluginList}`;
+  console.log("Installing plugins", { cmd });
+
+  return new Promise((resolve, reject) => {
+    exec(cmd, { cwd: installationPath }, (error, stdout, stderr) => {
+      if (error) {
+        console.error(stderr);
+        reject(error);
+      }
+
+      console.log(stdout);
+      resolve(true);
+    });
+  });
+}
+
+async function loadSpec() {
+  const spec = await fs.readFile(buildSpecPath as string, "utf-8");
+  return JSON.parse(spec);
+}


### PR DESCRIPTION
## PR Details
This PR is the basis for dynamic plugin installations.

1. It uses env variables rather than argument positions for DSG, this is so we can re-use parameters across scripts.
2. Introduces an `install-plugins.ts` script that reads the spec file and dynamically runs `npm install` for plugins in the DSG project, right before running the generation script.
3. Removes all default plugins from `package.json` (we might want to include official plugins to save build times until we have a cache mechanism in place).
4.  Change the `Dockerfile` base image to non-alpine, so it works on M1 and ARM64 computers.

This will most likely break existing tests and functionality. Purely here for visibility for now.

NOTE: Follow-up tickets will be created regarding caching opportunities, as installation times are quite long. However, this, at the bare mininum, will allow us to go live with community plugins loaded on-demand.

https://user-images.githubusercontent.com/4976416/193320668-0943562e-3d80-4d8a-9f0e-226e6c763a66.mov

## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
