### PR TITLE
Change kafka brokers env vars to string

### DIFF
--- a/helm/charts/amplication/values-alex.yaml
+++ b/helm/charts/amplication/values-alex.yaml
@@ -35,7 +35,7 @@ amplication-server:
       CLIENT_HOST: "https://app-alex.amplication-dev.com"
 
       #KAFKA
-      KAFKA_BROKERS: '["amplication-alex-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-alex-cp-kafka-headless:9092"
 
       #GitHub App
       GITHUB_APP_APP_ID: "217654"
@@ -51,7 +51,7 @@ amplication-git-push-webhook-service:
     hostname: webhook-alex.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["amplication-alex-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-alex-cp-kafka-headless:9092"
 
 amplication-git-pull-service:
   config:
@@ -66,7 +66,7 @@ amplication-git-pull-service:
       GIT_DEFAULT_ORIGIN_NAME: origin
       GITHUB_APP_APP_ID: "217654"
       GITHUB_APP_CLIENT_ID: "Iv1.6aca4dc2d00fbedf"
-      KAFKA_BROKERS: '["amplication-alex-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-alex-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-pull-service
       KAFKA_GROUP_ID: git-pull-service-group
 
@@ -75,7 +75,7 @@ amplication-git-pull-service:
 amplication-git-pull-request-service:
   config:
     env:
-      KAFKA_BROKERS: '["amplication-alex-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-alex-cp-kafka-headless:9092"
       GITHUB_APP_APP_ID: "217654"
 
 amplication-storage-gateway:
@@ -83,5 +83,5 @@ amplication-storage-gateway:
     hostname: server-alex.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["amplication-alex-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-alex-cp-kafka-headless:9092"
       GITHUB_APP_APP_ID: "217654"

--- a/helm/charts/amplication/values-amit.yaml
+++ b/helm/charts/amplication/values-amit.yaml
@@ -37,7 +37,7 @@ amplication-server:
 
       #KAFKA
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.0
-      KAFKA_BROKERS: '["amplication-amit-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-amit-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: amplication-server
       KAFKA_GROUP_ID: amplication-server-group
 
@@ -76,7 +76,7 @@ amplication-git-push-webhook-service:
     hostname: webhook-amit.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["amplication-amit-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-amit-cp-kafka-headless:9092"
       KAFKA_REPOSITORY_PUSH_QUEUE: git.external.push.event.0
       KAFKA_CLIENT_ID: git-push-webhook-service
       KAFKA_GROUP_ID: amplication-git-push-webhook-service
@@ -95,7 +95,7 @@ amplication-git-pull-service:
       GITHUB_APP_CLIENT_ID: "Iv1.a8ac08d4d3788314"
       GIT_DEFAULT_ORIGIN_NAME: origin
 
-      KAFKA_BROKERS: '["amplication-amit-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-amit-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-pull-service
       KAFKA_GROUP_ID: git-pull-service-group
 
@@ -104,7 +104,7 @@ amplication-git-pull-service:
 amplication-git-pull-request-service:
   config:
     env:
-      KAFKA_BROKERS: '["amplication-amit-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-amit-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-pull-request-service
       KAFKA_GROUP_ID: git-pull-request-service-group
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.0
@@ -116,6 +116,6 @@ amplication-storage-gateway:
     hostname: server-amit.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["amplication-amit-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-amit-cp-kafka-headless:9092"
       BASE_BUILDS_FOLDER: /amplication-data/build-data
       GITHUB_APP_APP_ID: "215215"

--- a/helm/charts/amplication/values-ariel.yaml
+++ b/helm/charts/amplication/values-ariel.yaml
@@ -25,7 +25,7 @@ amplication-server:
 
       #KAFKA
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.0
-      KAFKA_BROKERS: '["amplication-ariel-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-ariel-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: amplication-server
       KAFKA_GROUP_ID: amplication-server-group
 
@@ -65,7 +65,7 @@ amplication-git-push-webhook-service:
     hostname: webhook-ariel.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["amplication-ariel-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-ariel-cp-kafka-headless:9092"
       KAFKA_REPOSITORY_PUSH_QUEUE: git.external.push.event.0
       KAFKA_CLIENT_ID: git-push-webhook-service
       KAFKA_GROUP_ID: amplication-git-push-webhook-service
@@ -84,7 +84,7 @@ amplication-git-pull-service:
       GITHUB_APP_CLIENT_ID: 'Iv1.500372fe9efa340d'
       GIT_DEFAULT_ORIGIN_NAME: origin
 
-      KAFKA_BROKERS: '["amplication-ariel-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-ariel-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-pull-service
       KAFKA_GROUP_ID: git-pull-service-group
 
@@ -93,7 +93,7 @@ amplication-git-pull-service:
 amplication-git-pull-request-service:
   config:
     env:
-      KAFKA_BROKERS: '["amplication-ariel-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-ariel-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-pull-request-service
       KAFKA_GROUP_ID: git-pull-request-service-group
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.0
@@ -105,6 +105,6 @@ amplication-storage-gateway:
     hostname: server-ariel.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["amplication-ariel-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-ariel-cp-kafka-headless:9092"
       BASE_BUILDS_FOLDER: /amplication-data/build-data
       GITHUB_APP_APP_ID: '219560'

--- a/helm/charts/amplication/values-common.yaml
+++ b/helm/charts/amplication/values-common.yaml
@@ -110,7 +110,7 @@ amplication-server:
       HOST: "https://server.staging.amplication-dev.com"
       CLIENT_HOST: "https://app-dev.staging.amplication-dev.com"
 
-      KAFKA_BROKERS: '["amplication-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: amplication-server
       KAFKA_GROUP_ID: amplication-server
 
@@ -150,7 +150,7 @@ amplication-git-push-webhook-service:
     hostname: webhook.staging.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["amplication-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-push-webhook
       KAFKA_GROUP_ID: amplication-git-push-webhook-service
       PORT: "3000"
@@ -173,7 +173,7 @@ amplication-git-pull-service:
       GIT_DEFAULT_ORIGIN_NAME: origin
       GITHUB_APP_PRIVATE_KEY: ""
 
-      KAFKA_BROKERS: '["amplication-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-pull
       KAFKA_GROUP_ID: amplication-git-pull-service
       KAFKA_REPOSITORY_PUSH_QUEUE: git.external.push.event.0
@@ -183,7 +183,7 @@ amplication-git-pull-request-service:
     repository: 407256539111.dkr.ecr.us-east-1.amazonaws.com/amplication-git-pull-request-service
   config:
     env:
-      KAFKA_BROKERS: '["amplication-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-pull-request
       KAFKA_GROUP_ID: amplication-git-pull-request-service
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.1
@@ -199,7 +199,7 @@ amplication-storage-gateway:
     env:
       PORT: "3002"
       CORS_ENABLE: "1"
-      KAFKA_BROKERS: '["amplication-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: storage-queue-client
       KAFKA_GROUP_ID: storage-server-group
       CHECK_USER_ACCESS_TOPIC: authorization.internal.can-access-build.request.0

--- a/helm/charts/amplication/values-eugene.yaml
+++ b/helm/charts/amplication/values-eugene.yaml
@@ -36,7 +36,7 @@ amplication-server:
 
       #KAFKA
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.0
-      KAFKA_BROKERS: '["amplication-eugene-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-eugene-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: amplication-server
       KAFKA_GROUP_ID: amplication-server-group
 
@@ -75,7 +75,7 @@ amplication-git-push-webhook-service:
     hostname: webhook-eugene.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["amplication-eugene-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-eugene-cp-kafka-headless:9092"
       KAFKA_REPOSITORY_PUSH_QUEUE: git.external.push.event.0
       KAFKA_CLIENT_ID: git-push-webhook-service
       KAFKA_GROUP_ID: amplication-git-push-webhook-service
@@ -94,7 +94,7 @@ amplication-git-pull-service:
       GITHUB_APP_CLIENT_ID: "Iv1.67a34bd44a1938fb"
       GIT_DEFAULT_ORIGIN_NAME: origin
 
-      KAFKA_BROKERS: '["amplication-eugene-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-eugene-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-pull-service
       KAFKA_GROUP_ID: git-pull-service-group
 
@@ -103,7 +103,7 @@ amplication-git-pull-service:
 amplication-git-pull-request-service:
   config:
     env:
-      KAFKA_BROKERS: '["amplication-eugene-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-eugene-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-pull-request-service
       KAFKA_GROUP_ID: git-pull-request-service-group
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.0
@@ -115,6 +115,6 @@ amplication-storage-gateway:
     hostname: server-eugene.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["amplication-eugene-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-eugene-cp-kafka-headless:9092"
       BASE_BUILDS_FOLDER: /amplication-data/build-data
       GITHUB_APP_APP_ID: "227239"

--- a/helm/charts/amplication/values-next.yaml
+++ b/helm/charts/amplication/values-next.yaml
@@ -40,7 +40,7 @@ amplication-server:
 
       #KAFKA
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.0
-      KAFKA_BROKERS: '["amplication-next-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-next-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: amplication-server
       KAFKA_GROUP_ID: amplication-server-group
 
@@ -79,7 +79,7 @@ amplication-git-push-webhook-service:
     hostname: webhook-next.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["amplication-next-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-next-cp-kafka-headless:9092"
       KAFKA_REPOSITORY_PUSH_QUEUE: git.external.push.event.0
       KAFKA_CLIENT_ID: git-push-webhook-service
       KAFKA_GROUP_ID: amplication-git-push-webhook-service
@@ -98,7 +98,7 @@ amplication-git-pull-service:
       GITHUB_APP_CLIENT_ID: "Iv1.ba108fc312eb8265"
       GIT_DEFAULT_ORIGIN_NAME: origin
 
-      KAFKA_BROKERS: '["amplication-next-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-next-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-pull-service
       KAFKA_GROUP_ID: git-pull-service-group
 
@@ -107,7 +107,7 @@ amplication-git-pull-service:
 amplication-git-pull-request-service:
   config:
     env:
-      KAFKA_BROKERS: '["amplication-next-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-next-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-pull-request-service
       KAFKA_GROUP_ID: git-pull-request-service-group
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.0
@@ -119,6 +119,6 @@ amplication-storage-gateway:
     hostname: server-next.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["amplication-next-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-next-cp-kafka-headless:9092"
       BASE_BUILDS_FOLDER: /amplication-data/build-data
       GITHUB_APP_APP_ID: "225471"

--- a/helm/charts/amplication/values-prod.yaml
+++ b/helm/charts/amplication/values-prod.yaml
@@ -52,7 +52,7 @@ amplication-server:
 
       #KAFKA
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.1
-      KAFKA_BROKERS: '["b-2.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092","b-1.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092"]'
+      KAFKA_BROKERS: "b-2.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092,b-1.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092"
       KAFKA_CLIENT_ID: amplication-server
       KAFKA_GROUP_ID: amplication-server-group
 
@@ -95,7 +95,7 @@ amplication-git-push-webhook-service:
   config:
     env:
       #KAFKA
-      KAFKA_BROKERS: '["b-2.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092","b-1.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092"]'
+      KAFKA_BROKERS: "b-2.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092,b-1.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092"
       KAFKA_REPOSITORY_PUSH_QUEUE: git.external.push.event.0
       KAFKA_CLIENT_ID: git-push-webhook-service
       KAFKA_GROUP_ID: amplication-git-push-webhook-service
@@ -116,7 +116,7 @@ amplication-git-pull-service:
       GITHUB_APP_PRIVATE_KEY: ""
 
       #KAFKA
-      KAFKA_BROKERS: '["b-2.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092","b-1.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092"]'
+      KAFKA_BROKERS: "b-2.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092,b-1.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092"
       KAFKA_CLIENT_ID: git-pull-service
       KAFKA_GROUP_ID: git-pull-service-group
 
@@ -132,7 +132,7 @@ amplication-git-pull-request-service:
   config:
     env:
       #KAFKA
-      KAFKA_BROKERS: '["b-2.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092","b-1.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092"]'
+      KAFKA_BROKERS: "b-2.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092,b-1.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092"
       KAFKA_CLIENT_ID: git-pull-request-service
       KAFKA_GROUP_ID: git-pull-request-service-group
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.1
@@ -150,7 +150,7 @@ amplication-storage-gateway:
   config:
     env:
       #KAFKA
-      KAFKA_BROKERS: '["b-2.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092","b-1.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092"]'
+      KAFKA_BROKERS: "b-2.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092,b-1.amplicationuseast1pro.itu8pk.c16.kafka.us-east-1.amazonaws.com:9092"
 
       #EFS
       BASE_BUILDS_FOLDER: /amplication-data/build-data

--- a/helm/charts/amplication/values-shimi.yaml
+++ b/helm/charts/amplication/values-shimi.yaml
@@ -36,7 +36,7 @@ amplication-server:
 
       #KAFKA
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.0
-      KAFKA_BROKERS: '["amplication-shimi-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-shimi-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: amplication-server
       KAFKA_GROUP_ID: amplication-server-group
 
@@ -75,7 +75,7 @@ amplication-git-push-webhook-service:
     hostname: webhook-shimi.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["amplication-shimi-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-shimi-cp-kafka-headless:9092"
       KAFKA_REPOSITORY_PUSH_QUEUE: git.external.push.event.0
       KAFKA_CLIENT_ID: git-push-webhook-service
       KAFKA_GROUP_ID: amplication-git-push-webhook-service
@@ -94,7 +94,7 @@ amplication-git-pull-service:
       GITHUB_APP_CLIENT_ID: "Iv1.88cfcc5cad0fab3e"
       GIT_DEFAULT_ORIGIN_NAME: origin
 
-      KAFKA_BROKERS: '["amplication-shimi-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-shimi-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-pull-service
       KAFKA_GROUP_ID: git-pull-service-group
 
@@ -103,7 +103,7 @@ amplication-git-pull-service:
 amplication-git-pull-request-service:
   config:
     env:
-      KAFKA_BROKERS: '["amplication-shimi-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-shimi-cp-kafka-headless:9092"
       KAFKA_CLIENT_ID: git-pull-request-service
       KAFKA_GROUP_ID: git-pull-request-service-group
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.0
@@ -115,6 +115,6 @@ amplication-storage-gateway:
     hostname: server-shimi.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["amplication-shimi-cp-kafka-headless:9092"]'
+      KAFKA_BROKERS: "amplication-shimi-cp-kafka-headless:9092"
       BASE_BUILDS_FOLDER: /amplication-data/build-data
       GITHUB_APP_APP_ID: "208482"

--- a/helm/charts/amplication/values-staging.yaml
+++ b/helm/charts/amplication/values-staging.yaml
@@ -39,7 +39,7 @@ amplication-server:
 
       #KAFKA
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.0
-      KAFKA_BROKERS: '["b-1.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092","b-2.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092"]'
+      KAFKA_BROKERS: "b-1.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092,b-2.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092"
       KAFKA_CLIENT_ID: amplication-server
       KAFKA_GROUP_ID: amplication-server-group
 
@@ -79,7 +79,7 @@ amplication-git-push-webhook-service:
     hostname: webhook.staging.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["b-1.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092","b-2.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092"]'
+      KAFKA_BROKERS: "b-1.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092,b-2.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092"
       KAFKA_REPOSITORY_PUSH_QUEUE: git.external.push.event.0
       KAFKA_CLIENT_ID: git-push-webhook-service
       KAFKA_GROUP_ID: amplication-git-push-webhook-service
@@ -101,7 +101,7 @@ amplication-git-pull-service:
       GIT_DEFAULT_ORIGIN_NAME: origin
       GITHUB_APP_PRIVATE_KEY: ""
 
-      KAFKA_BROKERS: '["b-1.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092","b-2.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092"]'
+      KAFKA_BROKERS: "b-1.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092,b-2.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092"
       KAFKA_CLIENT_ID: git-pull-service
       KAFKA_GROUP_ID: git-pull-service-group
 
@@ -110,7 +110,7 @@ amplication-git-pull-service:
 amplication-git-pull-request-service:
   config:
     env:
-      KAFKA_BROKERS: '["b-1.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092","b-2.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092"]'
+      KAFKA_BROKERS: "b-1.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092,b-2.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092"
       KAFKA_CLIENT_ID: git-pull-request-service
       KAFKA_GROUP_ID: git-pull-request-service-group
       GENERATE_PULL_REQUEST_TOPIC: git.internal.pull-request.request.0
@@ -122,5 +122,5 @@ amplication-storage-gateway:
     hostname: server.staging.amplication-dev.com
   config:
     env:
-      KAFKA_BROKERS: '["b-1.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092","b-2.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092"]'
+      KAFKA_BROKERS: "b-1.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092,b-2.amplicationuseast1sta.n74l10.c22.kafka.us-east-1.amazonaws.com:9092"
       BASE_BUILDS_FOLDER: /amplication-data/build-data


### PR DESCRIPTION
As part of the helm-charts improvement, the environment variable 'KAFKA_BROKERS' will be changed to string type, so that in the future we can pass the variable as a reference and not manually.