### PR TITLE
fix: #3935 ResourceListItem Wrong Hover Effect

### DIFF
--- a/packages/amplication-design-system/src/components/Panel/Panel.scss
+++ b/packages/amplication-design-system/src/components/Panel/Panel.scss
@@ -35,6 +35,11 @@ $expandable-transition-duration: 0.1s;
     cursor: pointer;
     &:hover {
       background: var(--panel-hover-background);
+      border: $border-black20;
+
+      .amp-horizontal-rule {
+        border-top: $border-black20;
+      }
     }
   }
 


### PR DESCRIPTION
## PR Details
Fixes border and horizontal rule disappearing when the user hovers over a ResourceListItem.

Closes: #3935

## Screenshots

### Before 
![Kapture 2022-10-09 at 18 55 11](https://user-images.githubusercontent.com/8443215/194745422-f92d5b7f-7ad3-4143-9428-565e34ff0324.gif)

### After
![Kapture 2022-10-09 at 18 53 08](https://user-images.githubusercontent.com/8443215/194745567-45deb428-39cd-4cd9-85d8-a9d0f1679ec7.gif)


## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error. <-- Checking this on a different machine. My Macbook Air is not liking these tests.
