### PR TITLE
Fix inconsistent event name capital letter

### DIFF
--- a/packages/amplication-code-gen-types/src/plugins-types.ts
+++ b/packages/amplication-code-gen-types/src/plugins-types.ts
@@ -59,8 +59,8 @@ export type PluginMap = {
 export enum EventNames {
   CreateEntityController = "CreateEntityController",
   CreateEntityControllerBase = "CreateEntityControllerBase",
-  CreateAuthModules = "createAuthModules",
-  CreateAdminModules = "createAdminModules",
+  CreateAuthModules = "CreateAuthModules",
+  CreateAdminModules = "CreateAdminModules",
   CreateServer = "CreateServer",
   CreateServerAppModule = "CreateServerAppModule",
   CreateServerDotEnv = "CreateServerDotEnv",


### PR DESCRIPTION
Issue Number: #4147 

## PR Details

fix `CreateAuthModules` and `CreateAdminModules` event name to start with a capital letter

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

