### PR TITLE
fix create controller and create controller base event params

### DIFF
--- a/packages/amplication-code-gen-types/src/plugin-events-params.ts
+++ b/packages/amplication-code-gen-types/src/plugin-events-params.ts
@@ -37,7 +37,7 @@ export interface CreateEntityControllerParams extends EventParams {
   serviceId: namedTypes.Identifier;
 }
 export interface CreateEntityControllerBaseParams extends EventParams {
-  baseTemplatePath: string;
+  template: namedTypes.File;
   entity: Entity;
   entityName: string;
   entityType: string;

--- a/packages/amplication-code-gen-types/src/plugin-events-params.ts
+++ b/packages/amplication-code-gen-types/src/plugin-events-params.ts
@@ -29,7 +29,7 @@ export interface CreateEntityServiceParams extends EventParams {
   template: namedTypes.File;
 }
 export interface CreateEntityControllerParams extends EventParams {
-  templatePath: string;
+  template: namedTypes.File;
   entityName: string;
   entityServiceModule: string;
   templateMapping: { [key: string]: any };

--- a/packages/amplication-data-service-generator/src/util/ast.ts
+++ b/packages/amplication-data-service-generator/src/util/ast.ts
@@ -117,7 +117,7 @@ export function extractImportDeclarations(
 ): namedTypes.ImportDeclaration[] {
   const newBody = [];
   const imports = [];
-  for (const statement of file?.program.body) {
+  for (const statement of file.program.body) {
     if (namedTypes.ImportDeclaration.check(statement)) {
       imports.push(statement);
     } else {

--- a/packages/amplication-data-service-generator/src/util/ast.ts
+++ b/packages/amplication-data-service-generator/src/util/ast.ts
@@ -117,7 +117,7 @@ export function extractImportDeclarations(
 ): namedTypes.ImportDeclaration[] {
   const newBody = [];
   const imports = [];
-  for (const statement of file.program.body) {
+  for (const statement of file?.program.body) {
     if (namedTypes.ImportDeclaration.check(statement)) {
       imports.push(statement);
     } else {


### PR DESCRIPTION
Issue Number: #4156 

## PR Details
rename and change the type of the event params:
`CreateEntityControllerParams ` and `CreateEntityControllerBaseParams `:
 `templatePath` (type `string`) => `template` (type `namedTypes.File`)

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

