### PR TITLE
Fix/4158 remove the word module from plugin events

### DIFF
--- a/packages/amplication-code-gen-types/src/plugin-events-params.ts
+++ b/packages/amplication-code-gen-types/src/plugin-events-params.ts
@@ -46,11 +46,11 @@ export interface CreateEntityControllerBaseParams extends EventParams {
   controllerBaseId: namedTypes.Identifier;
   serviceId: namedTypes.Identifier;
 }
-export interface CreateAuthModulesParams extends EventParams {
+export interface CreateServerAuthParams extends EventParams {
   srcDir: string;
 }
 
-export interface CreateAdminModulesParams extends EventParams {}
+export interface CreateAdminUIParams extends EventParams {}
 export interface CreateServerParams extends EventParams {}
 
 export type VariableDictionary = {

--- a/packages/amplication-code-gen-types/src/plugin-events.ts
+++ b/packages/amplication-code-gen-types/src/plugin-events.ts
@@ -1,6 +1,6 @@
 import {
-  CreateAdminModulesParams,
-  CreateAuthModulesParams,
+  CreateAdminUIParams,
+  CreateServerAuthParams,
   CreateEntityControllerBaseParams,
   CreateEntityControllerParams,
   CreateEntityServiceBaseParams,
@@ -24,8 +24,8 @@ import {
 import { EventNames, PluginEventType } from "./plugins-types";
 
 export type Events = {
-  [EventNames.CreateAuthModules]?: PluginEventType<CreateAuthModulesParams>;
-  [EventNames.CreateAdminModules]?: PluginEventType<CreateAdminModulesParams>;
+  [EventNames.CreateServerAuth]?: PluginEventType<CreateServerAuthParams>;
+  [EventNames.CreateAdminUI]?: PluginEventType<CreateAdminUIParams>;
   [EventNames.CreateServer]?: PluginEventType<CreateServerParams>;
   [EventNames.CreateServerDotEnv]?: PluginEventType<CreateServerDotEnvParams>;
   [EventNames.CreateEntityService]?: PluginEventType<CreateEntityServiceParams>;

--- a/packages/amplication-code-gen-types/src/plugins-types.ts
+++ b/packages/amplication-code-gen-types/src/plugins-types.ts
@@ -59,8 +59,8 @@ export type PluginMap = {
 export enum EventNames {
   CreateEntityController = "CreateEntityController",
   CreateEntityControllerBase = "CreateEntityControllerBase",
-  CreateAuthModules = "CreateAuthModules",
-  CreateAdminModules = "CreateAdminModules",
+  CreateServerAuth = "CreateServerAuth",
+  CreateAdminUI = "CreateAdminUI",
   CreateServer = "CreateServer",
   CreateServerAppModule = "CreateServerAppModule",
   CreateServerDotEnv = "CreateServerDotEnv",

--- a/packages/amplication-data-service-generator/src/admin/create-admin.ts
+++ b/packages/amplication-data-service-generator/src/admin/create-admin.ts
@@ -30,7 +30,7 @@ const API_PATHNAME = "/api";
 export function createAdminModules(): Promise<Module[]> {
   return pluginWrapper(
     createAdminModulesInternal,
-    EventNames.CreateAdminModules,
+    EventNames.CreateAdminUI,
     {}
   );
 }

--- a/packages/amplication-data-service-generator/src/server/auth/createAuth.ts
+++ b/packages/amplication-data-service-generator/src/server/auth/createAuth.ts
@@ -1,5 +1,5 @@
 import {
-  CreateAuthModulesParams,
+  CreateServerAuthParams,
   EventNames,
   Module,
 } from "@amplication/code-gen-types";
@@ -12,13 +12,13 @@ import { createTokenService } from "./token/createTokenService";
 export function createAuthModules(): Module[] {
   return pluginWrapper(
     createAuthModulesInternal,
-    EventNames.CreateAuthModules,
+    EventNames.CreateServerAuth,
     {}
   );
 }
 
 async function createAuthModulesInternal(
-  eventParams: CreateAuthModulesParams
+  eventParams: CreateServerAuthParams
 ): Promise<Module[]> {
   const { appInfo, serverDirectories } = DsgContext.getInstance;
   const authDir = `${serverDirectories.srcDirectory}/auth`;


### PR DESCRIPTION
Close #4158 

## PR Details
remove the word `Module` from the plugin event name and event params 
```diff
- CreateAuthModules = "createAuthModules",
+ CreateServerAuth = "CreateServerAuth",
```

```diff
- CreateAdminModules = "createAdminModules",
+ CreateAdminUI = "CreateAdminUI",
```

```diff
-export interface CreateAdminModulesParams extends EventParams {}
+export interface CreateAdminUIParams extends EventParams {}
```

```diff
-export interface CreateAuthModulesParams extends EventParams {
-  srcDir: string;
-}
+export interface CreateServerAuthParams extends EventParams {
+ srcDir: string;
+}
```

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
