### PR TITLE
style: Fixed last commit details getting partially hidden

### DIFF
--- a/packages/amplication-client/src/VersionControl/Commit.scss
+++ b/packages/amplication-client/src/VersionControl/Commit.scss
@@ -15,8 +15,12 @@
     }
 
     textarea {
-      height: var(--textarea-height-small);
+      height: var(--textarea-height);
       background-color: var(--black5);
+
+      @media only screen and (max-width: $breakpoint-desktop) {
+        height: var(--textare-height-small);
+      }
     }
   }
 }

--- a/packages/amplication-client/src/VersionControl/Commit.scss
+++ b/packages/amplication-client/src/VersionControl/Commit.scss
@@ -15,7 +15,7 @@
     }
 
     textarea {
-      height: var(--textarea-height);
+      height: var(--textarea-height-small);
       background-color: var(--black5);
     }
   }

--- a/packages/amplication-client/src/VersionControl/PendingChanges.scss
+++ b/packages/amplication-client/src/VersionControl/PendingChanges.scss
@@ -77,8 +77,9 @@ $resource-name-max-width: 180px;
     justify-content: flex-start;
     align-items: center;
 
-    img {
-      height: $empty-state-image-size;
+    .svg-theme-image {
+      width: 120px;
+      height: 120px;
     }
 
     &__title {

--- a/packages/amplication-client/src/VersionControl/PendingChanges.scss
+++ b/packages/amplication-client/src/VersionControl/PendingChanges.scss
@@ -78,8 +78,8 @@ $resource-name-max-width: 180px;
     align-items: center;
 
     .svg-theme-image {
-      width: 120px;
-      height: 120px;
+      width: $empty-state-image-size;
+      height: $empty-state-image-size;
     }
 
     &__title {


### PR DESCRIPTION
Fixes #4042 

## PR Details

Fixed the styling issue where the last commit details were getting partially hidden

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error