### PR TITLE
fix(data-service-gen): add slash in dockerfile

### DIFF
--- a/packages/amplication-data-service-generator/src/server/static/Dockerfile
+++ b/packages/amplication-data-service-generator/src/server/static/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=base /app/dist ./dist
 COPY --from=base /app/prisma ./prisma
 COPY --from=base /app/scripts ./scripts
 COPY --from=base /app/src ./src
-COPY --from=base /app/tsconfig* .
+COPY --from=base /app/tsconfig* ./
 
 EXPOSE 3000
 


### PR DESCRIPTION
Add slash in Docker file

<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close #4188

## PR Details

Using Cloud build the Docker build process fails with the following error:

Step 17/19 : COPY --from=base /app/tsconfig* .
When using COPY with more than one source file, the destination must be a directory and end with a /
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 1

This issue is related to https://github.com/amplication/amplication/issues/3914

I could find the solution explained [in this Stackoverflow thread](https://stackoverflow.com/questions/53650492/when-using-copy-with-more-than-one-source-file-the-destination-must-be-a-direct)

Adding a slash in the end worked for me to not fail the build.
So the proposed solution is to generate a Dockerfile with
COPY --from=base /app/tsconfig* ./
instead of
COPY --from=base /app/tsconfig* .

## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
