### PR TITLE
Fix copy admin UI template package json to `dist`

### DIFF
--- a/packages/amplication-data-service-generator/scripts/copy-files.ts
+++ b/packages/amplication-data-service-generator/scripts/copy-files.ts
@@ -24,7 +24,7 @@ const GLOB_SOURCES: string[] = [
   `${SERVER_SRC_DIRECTORY_GLOB}/**/*.template.(ts|env|json|yml)`,
   `${SERVER_SRC_DIRECTORY_GLOB}/**/*.db.template.(yml)`,
   `${SERVER_SRC_DIRECTORY_GLOB}/static/**`,
-  `${ADMIN_SRC_DIRECTORY_GLOB}/**/*.template.(ts|tsx|html|env)`,
+  `${ADMIN_SRC_DIRECTORY_GLOB}/**/*.template.(ts|tsx|html|env|json)`,
   `${ADMIN_SRC_DIRECTORY_GLOB}/static/**`,
 ];
 


### PR DESCRIPTION
## PR Details

fix generated app failure by adding `json` to the admin UI global directory

![image](https://user-images.githubusercontent.com/39680385/196648383-408cde53-3477-43a6-8871-2486c6bea0b7.png)


## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
