### PR TITLE
fix: Update pending changes not refreshing on new project

### DIFF
--- a/packages/amplication-client/src/Workspaces/hooks/usePendingChanges.ts
+++ b/packages/amplication-client/src/Workspaces/hooks/usePendingChanges.ts
@@ -28,8 +28,7 @@ const usePendingChanges = (currentProject: models.Project | undefined) => {
   });
 
   useEffect(() => {
-    if (!pendingChangesData || !pendingChangesData.pendingChanges.length)
-      return;
+    if (!pendingChangesData) return;
 
     setPendingChanges(pendingChangesData.pendingChanges);
     setPendingChangesMap(


### PR DESCRIPTION
Fixes #4043 

## PR Details
The issue has been fixed where pending changes of older project were retained in a newly started project with no pending changes.
The issues seemed to be the check being done in the `usePendingChanges` hook.

Currently the changes were not updated if the changes length was zero. This was causing the issue.

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
