### PR TITLE
Updated instruction text on the Service Dashboard.

### DIFF
--- a/packages/amplication-client/src/Resource/OverviewTile/OverviewTile.tsx
+++ b/packages/amplication-client/src/Resource/OverviewTile/OverviewTile.tsx
@@ -37,10 +37,9 @@ const OverviewTile: React.FC<Props> = ({ resourceId }: Props) => {
           <h2 className={`${CLASS_NAME}__header__title`}>Overview</h2>
         </div>
         <div className={`${CLASS_NAME}__message`}>
-          Your Amplication-generated resource is ready. We created it using the
-          amazing open-source technologies. Push the auto-generated code to
-          GitHub or download the source-code and take it to the moon with your
-          coding skills.
+          Your Amplication-generated resource is ready.
+          We created it using amazing open-source technologies.
+          Push the auto-generated code to GitHub and take it to the moon with your coding skills.
         </div>
         <div className={`${CLASS_NAME}__content`}>
           <div className={`${CLASS_NAME}__content__item`}>


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close #4231 

## PR Details
Overview/Reason:
Amplication no longer want to support the ability to download the code directly from the Amplication platform. So to improve onboarding it was needed to update the instruction text and remove mentioning "download the code".

 Old text:"Your Amplication-generated resource is ready. We created it using the
          amazing open-source technologies. Push the auto-generated code to
          GitHub or download the source-code and take it to the moon with your
          coding skills."

New text :"Your Amplication-generated resource is ready. 
          We created it using amazing open-source technologies.
          Push the auto-generated code to GitHub and take it to the moon with your coding skills."

Content Reference: @GreenMachine01 


## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.