### PR TITLE
`setup:dev` script not longer clean by default

### DIFF
--- a/.github/workflows/ci-nx.yml
+++ b/.github/workflows/ci-nx.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - feature/nx
+      - feature/nx-october
   pull_request:
 
 jobs:

--- a/packages/amplication-data-service-generator/src/version.ts
+++ b/packages/amplication-data-service-generator/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.0.2";
+export const version = "1.0.3";

--- a/script/setup.ts
+++ b/script/setup.ts
@@ -1,7 +1,8 @@
 import { exec } from "child_process";
-import { satisfies } from "semver";
-import { createLogger, format, Logger, transports } from "winston";
 import * as ora from "ora";
+import { satisfies } from "semver";
+import { createLogger, format, transports } from "winston";
+import { argv } from "yargs";
 
 const { combine, colorize, simple } = format;
 
@@ -120,7 +121,6 @@ const prismaMigration: Task[] = [
 ];
 
 const tasks: Task[][] = [
-  clean,
   bootstrap,
   buildStep,
   dockerCompose,
@@ -130,6 +130,11 @@ const tasks: Task[][] = [
 ];
 
 if (require.main === module) {
+  const args = argv;
+  if (args.clean) {
+    tasks.unshift(clean);
+  }
+
   (async () => {
     try {
       preValidate();

--- a/script/setup.ts
+++ b/script/setup.ts
@@ -6,8 +6,7 @@ import { argv } from "yargs";
 
 const { combine, colorize, simple } = format;
 
-const spinner = ora();
-spinner.color = "green";
+const spinner = ora({ color: "green" });
 
 const logo = `  
             ...   :..              


### PR DESCRIPTION
## PR Details

This PR changes the default behavior of the `setup:dev` script to not clean by default. This behavior suggested by @yuval-hazaz to shorten the setup time.

To use the clean option just run `npm run setup:dev -- --clean`

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
