### PR TITLE
fix/4226-Discord Button in Readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Amplication is currently in its version 1.  This is the first major release of A
 
 Ask your questions and participate in discussions on Amplication-related and web-dev topics at the Amplication Discord channel. 
 
-<a href="https://discord.gg/Z2CG3rUFnu" target="blank_"><img src="https://amplication.com/images/discord_banner_purple.svg" /></a>
+<a href="https://discord.gg/Z2CG3rUFnu" target="_blank"><img src="https://amplication.com/images/discord_banner_purple.svg" /></a>
 
 ## Create a bug report
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Amplication is currently in its version 1.  This is the first major release of A
 Ask your questions and participate in discussions on Amplication-related and web-dev topics at the Amplication Discord channel. 
 
 <a href="https://discord.gg/Z2CG3rUFnu" target="_blank"><img src="https://amplication.com/images/discord_banner_purple.svg" /></a>
-:NOTE: IN markdown it doesn't open in new tab so , For windows press `ctrl` + `left click` and for Mac `cmd` + `left click` .
+>NOTE: IN markdown it doesn't open in new tab so , For windows press `ctrl` + `left click` and for Mac `cmd` + `left click` .
 
 ## Create a bug report
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Amplication is currently in its version 1.  This is the first major release of A
 
 Ask your questions and participate in discussions on Amplication-related and web-dev topics at the Amplication Discord channel. 
 
-[<img src="https://amplication.com/images/discord_banner_purple.svg" />](https://discord.gg/Z2CG3rUFnu){:target="_blank"}
+[<img src="https://amplication.com/images/discord_banner_purple.svg" />](https://discord.gg/Z2CG3rUFnu)`{:target="_blank"}`
 
 ## Create a bug report
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Amplication is currently in its version 1.  This is the first major release of A
 
 Ask your questions and participate in discussions on Amplication-related and web-dev topics at the Amplication Discord channel. 
 
-<a href="https://discord.gg/Z2CG3rUFnu" target="_blank"><img src="https://amplication.com/images/discord_banner_purple.svg" /></a>
+[<img src="https://amplication.com/images/discord_banner_purple.svg" />](https://discord.gg/Z2CG3rUFnu){:target="_blank"}
 
 ## Create a bug report
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Amplication is currently in its version 1.  This is the first major release of A
 
 Ask your questions and participate in discussions on Amplication-related and web-dev topics at the Amplication Discord channel. 
 
-[<img src="https://amplication.com/images/discord_banner_purple.svg" />](https://discord.gg/Z2CG3rUFnu)`{:target="_blank"}`
+<a href="https://discord.gg/Z2CG3rUFnu" target="_blank"><img src="https://amplication.com/images/discord_banner_purple.svg" /></a>{:target="_blank"}
 
 ## Create a bug report
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Amplication is currently in its version 1.  This is the first major release of A
 
 Ask your questions and participate in discussions on Amplication-related and web-dev topics at the Amplication Discord channel. 
 
-<a href="https://discord.gg/Z2CG3rUFnu"><img src="https://amplication.com/images/discord_banner_purple.svg" /></a>
+<a href="https://discord.gg/Z2CG3rUFnu" target="blank"><img src="https://amplication.com/images/discord_banner_purple.svg" /></a>
 
 ## Create a bug report
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Amplication is currently in its version 1.  This is the first major release of A
 Ask your questions and participate in discussions on Amplication-related and web-dev topics at the Amplication Discord channel. 
 
 <a href="https://discord.gg/Z2CG3rUFnu" target="_blank"><img src="https://amplication.com/images/discord_banner_purple.svg" /></a>
->NOTE: IN markdown it doesn't open in new tab so , For windows press `ctrl` + `left click` and for Mac `cmd` + `left click` .
+>NOTE: IN markdown it doesn't open in new tab so , For windows press `ctrl` + `left click` and for Mac `cmd` + `left click`.
 
 ## Create a bug report
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ Amplication is currently in its version 1.  This is the first major release of A
 
 Ask your questions and participate in discussions on Amplication-related and web-dev topics at the Amplication Discord channel. 
 
-<a href="https://discord.gg/Z2CG3rUFnu" target="_blank"><img src="https://amplication.com/images/discord_banner_purple.svg" /></a>{:target="_blank"}
+<a href="https://discord.gg/Z2CG3rUFnu" target="_blank"><img src="https://amplication.com/images/discord_banner_purple.svg" /></a>
+:NOTE: IN markdown it doesn't open in new tab so , For windows press `ctrl` + `left click` and for Mac `cmd` + `left click` .
 
 ## Create a bug report
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Amplication is currently in its version 1.  This is the first major release of A
 
 Ask your questions and participate in discussions on Amplication-related and web-dev topics at the Amplication Discord channel. 
 
-<a href="https://discord.gg/Z2CG3rUFnu" target="blank"><img src="https://amplication.com/images/discord_banner_purple.svg" /></a>
+<a href="https://discord.gg/Z2CG3rUFnu" target="blank_"><img src="https://amplication.com/images/discord_banner_purple.svg" /></a>
 
 ## Create a bug report
 


### PR DESCRIPTION
I have wrote a note to how to open Discord invite link in new tab without closing Github , As markdown doesn't support opening link in new tab with Anchor tag.

