### PR TITLE
Updating the client generation target

### DIFF
--- a/packages/amplication-prisma-db/.gitignore
+++ b/packages/amplication-prisma-db/.gitignore
@@ -33,3 +33,5 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+prisma/generated

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client-js"
-  output   = "../../../node_modules/@amplication/prisma-clients/amplication-prisma-db"
+  output   = "./generated/prisma-client"
 }
 
 datasource db {

--- a/packages/amplication-prisma-db/project.json
+++ b/packages/amplication-prisma-db/project.json
@@ -6,14 +6,38 @@
   "targets": {
     "lint": {
       "executor": "@nrwl/linter:eslint",
-      "outputs": ["{options.outputFile}"],
+      "outputs": [
+        "{options.outputFile}"
+      ],
       "options": {
-        "lintFilePatterns": ["packages/amplication-prisma-db/**/*.ts"]
+        "lintFilePatterns": [
+          "packages/amplication-prisma-db/**/*.ts"
+        ]
+      }
+    },
+    "build": {
+      "executor": "@nrwl/node:webpack",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/amplication-prisma-db",
+        "main": "packages/amplication-prisma-db/src/index.ts",
+        "tsConfig": "packages/amplication-prisma-db/tsconfig.lib.json"
+      },
+      "configurations": {
+        "production": {
+          "optimization": true,
+          "extractLicenses": true,
+          "inspect": false
+        }
       }
     },
     "test": {
       "executor": "@nrwl/jest:jest",
-      "outputs": ["coverage/packages/amplication-prisma-db"],
+      "outputs": [
+        "coverage/packages/amplication-prisma-db"
+      ],
       "options": {
         "jestConfig": "packages/amplication-prisma-db/jest.config.ts",
         "passWithNoTests": true

--- a/packages/amplication-prisma-db/src/index.ts
+++ b/packages/amplication-prisma-db/src/index.ts
@@ -1,4 +1,4 @@
-export * from '@amplication/prisma-clients/amplication-prisma-db';
+export * from '../prisma/generated/prisma-client';
 export * from './prisma.service';
 export * from './prisma.module';
 export * from 'prisma';

--- a/packages/amplication-prisma-db/src/prisma.service.ts
+++ b/packages/amplication-prisma-db/src/prisma.service.ts
@@ -1,5 +1,5 @@
 import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
-import { PrismaClient } from '@amplication/prisma-clients/amplication-prisma-db';
+import { PrismaClient } from '../prisma/generated/prisma-client';
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {


### PR DESCRIPTION


## PR Details
 This PR is a sub-fix to the running of the server on the new nx tool set.
We change the generation location to let the webpack build process bundle the Prisma SDK into the package code.