### PR TITLE
Update Dockerfile for git-pull-service in Nx

### DIFF
--- a/ee/packages/amplication-git-pull-service/Dockerfile
+++ b/ee/packages/amplication-git-pull-service/Dockerfile
@@ -2,10 +2,9 @@ FROM node:16.16-alpine AS base
 
 WORKDIR /app
 
-COPY ./dist/ee/packages/amplication-git-pull-service/package-lock.json .
 COPY ./dist/ee/packages/amplication-git-pull-service/package.json .
 
-RUN npm ci --omit=dev
+RUN npm i --omit=dev
 
 COPY ./dist/ee/packages/amplication-git-pull-service .
 

--- a/ee/packages/amplication-git-pull-service/webpack.config.js
+++ b/ee/packages/amplication-git-pull-service/webpack.config.js
@@ -1,4 +1,3 @@
-const CopyPlugin = require("copy-webpack-plugin");
 const GeneratePackageJsonPlugin = require("generate-package-json-webpack-plugin");
 const path = require("path");
 const packageJson = require("../../../package.json");

--- a/ee/packages/amplication-git-pull-service/webpack.config.js
+++ b/ee/packages/amplication-git-pull-service/webpack.config.js
@@ -33,25 +33,7 @@ module.exports = (config, context) => {
  * @returns {Array} An array of Webpack plugins
  */
 function extractRelevantNodeModules(outputPath) {
-  return [copyPackageLockFile(outputPath), generatePackageJson()];
-}
-
-/**
- * Copy the Yarn lock file to the bundle to make sure that the right dependencies are
- * installed when running `yarn install`.
- *
- * @param {String} outputPath The path to the bundle being built
- * @returns {*} A Webpack plugin
- */
-function copyPackageLockFile(outputPath) {
-  return new CopyPlugin({
-    patterns: [
-      {
-        from: "package-lock.json",
-        to: path.join(outputPath, "package-lock.json"),
-      },
-    ],
-  });
+  return [generatePackageJson()];
 }
 
 /**


### PR DESCRIPTION

## PR Details
This PR is fixing the use of `npm ci` in the docker file instead of `npm I` because we don't use the ci any more; we don't need the package-lock also