### PR TITLE
fix: updated incorrect last sync date

### DIFF
--- a/packages/amplication-client/src/Resource/git/AppGitStatusPanel.tsx
+++ b/packages/amplication-client/src/Resource/git/AppGitStatusPanel.tsx
@@ -27,7 +27,11 @@ const AppGitStatusPanel = ({ resource, showDisconnectedMessage }: Props) => {
     AppContext
   );
 
-  const lastSync = new Date(resource?.githubLastSync);
+  const lastSync = resource?.githubLastSync
+    ? new Date(resource.githubLastSync)
+    : null;
+
+  const lastSyncDate = lastSync ? format(lastSync, DATE_FORMAT) : "Never";
 
   return (
     <div className={CLASS_NAME}>
@@ -71,17 +75,13 @@ const AppGitStatusPanel = ({ resource, showDisconnectedMessage }: Props) => {
               />
             </a>
           </div>
-          {lastSync && (
-            <div className={`${CLASS_NAME}__last-sync`}>
-              <Icon icon="clock" />
-              <Tooltip
-                aria-label={`Last sync: ${format(lastSync, DATE_FORMAT)}`}
-              >
-                <span>Last sync </span>
-                {format(lastSync, DATE_FORMAT)}
-              </Tooltip>
-            </div>
-          )}
+          <div className={`${CLASS_NAME}__last-sync`}>
+            <Icon icon="clock" />
+            <Tooltip aria-label={`Last sync: ${lastSyncDate}`}>
+              <span>Last sync </span>
+              {lastSyncDate}
+            </Tooltip>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
Fixes #3585 

## PR Details
Fixed the last sync date showing up incorrect value.
This was especially in the case when syncing was never done in the first place.

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
