### PR TITLE
Feat/4234 Change create one to create many route

### DIFF
--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
@@ -66,11 +66,11 @@ export class CONTROLLER_BASE {
   })
   @common.Post()
   @swagger.ApiBody({ type: [CREATE_INPUT] })
-  @swagger.ApiCreatedResponse({ type: ENTITY })
+  @swagger.ApiCreatedResponse({ type: [ENTITY] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   async CREATE_ENTITY_FUNCTION(
     @common.Body() data: [CREATE_INPUT]
-  ): Promise<ENTITY> {
+  ): Promise<ENTITY[]> {
     try {
       return await Promise.all(data.map(async _data => {
         await this.service.create({

--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
@@ -12,20 +12,20 @@ import { plainToClass } from "class-transformer";
 // @ts-ignore
 import { ApiNestedQuery } from "../../decorators/api-nested-query.decorator";
 
-declare interface CREATE_INPUT {}
-declare interface WHERE_INPUT {}
-declare interface WHERE_UNIQUE_INPUT {}
+declare interface CREATE_INPUT { }
+declare interface WHERE_INPUT { }
+declare interface WHERE_UNIQUE_INPUT { }
 declare class FIND_MANY_ARGS {
   where: WHERE_INPUT;
 }
-declare interface UPDATE_INPUT {}
+declare interface UPDATE_INPUT { }
 
 declare const FINE_ONE_PATH: string;
 declare const UPDATE_PATH: string;
 declare const DELETE_PATH: string;
 
-declare class ENTITY {}
-declare interface Select {}
+declare class ENTITY { }
+declare interface Select { }
 
 declare interface SERVICE {
   create(args: { data: CREATE_INPUT; select: Select }): Promise<ENTITY>;
@@ -55,7 +55,7 @@ export class CONTROLLER_BASE {
   constructor(
     protected readonly service: SERVICE,
     protected readonly rolesBuilder: nestAccessControl.RolesBuilder
-  ) {}
+  ) { }
 
   // @ts-ignore
   @common.UseInterceptors(AclValidateRequestInterceptor)
@@ -73,12 +73,12 @@ export class CONTROLLER_BASE {
   ): Promise<ENTITY[]> {
     try {
       return await Promise.all(data.map(async _data => {
-        await this.service.create({
-          data: CREATE_DATA_MAPPING, // TODO: replace one with many
+        return await this.service.create({
+          data: CREATE_DATA_MAPPING,
           select: SELECT,
         });
       }));
-    } catch (error) {      
+    } catch (error) {
       throw error;
     }
   }

--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
@@ -77,7 +77,7 @@ export class CONTROLLER_BASE {
           data: CREATE_DATA_MAPPING, // TODO: replace one with many
           select: SELECT,
         });
-      });
+      }));
     } catch (error) {      
       throw error;
     }

--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
@@ -12,20 +12,20 @@ import { plainToClass } from "class-transformer";
 // @ts-ignore
 import { ApiNestedQuery } from "../../decorators/api-nested-query.decorator";
 
-declare interface CREATE_INPUT { }
-declare interface WHERE_INPUT { }
-declare interface WHERE_UNIQUE_INPUT { }
+declare interface CREATE_INPUT {}
+declare interface WHERE_INPUT {}
+declare interface WHERE_UNIQUE_INPUT {}
 declare class FIND_MANY_ARGS {
   where: WHERE_INPUT;
 }
-declare interface UPDATE_INPUT { }
+declare interface UPDATE_INPUT {}
 
 declare const FINE_ONE_PATH: string;
 declare const UPDATE_PATH: string;
 declare const DELETE_PATH: string;
 
-declare class ENTITY { }
-declare interface Select { }
+declare class ENTITY {}
+declare interface Select {}
 
 declare interface SERVICE {
   create(args: { data: CREATE_INPUT; select: Select }): Promise<ENTITY>;
@@ -55,7 +55,7 @@ export class CONTROLLER_BASE {
   constructor(
     protected readonly service: SERVICE,
     protected readonly rolesBuilder: nestAccessControl.RolesBuilder
-  ) { }
+  ) {}
 
   // @ts-ignore
   @common.UseInterceptors(AclValidateRequestInterceptor)
@@ -72,12 +72,14 @@ export class CONTROLLER_BASE {
     @common.Body() data: [CREATE_INPUT]
   ): Promise<ENTITY[]> {
     try {
-      return await Promise.all(data.map(async _data => {
-        return await this.service.create({
-          data: CREATE_DATA_MAPPING,
-          select: SELECT,
-        });
-      }));
+      return await Promise.all(
+        data.map(async (_data) => {
+          return await this.service.create({
+            data: CREATE_DATA_MAPPING,
+            select: SELECT,
+          });
+        })
+      );
     } catch (error) {
       throw error;
     }

--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
@@ -65,15 +65,22 @@ export class CONTROLLER_BASE {
     possession: "any",
   })
   @common.Post()
+  @swagger.ApiBody({ type: [CREATE_INPUT] })
   @swagger.ApiCreatedResponse({ type: ENTITY })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   async CREATE_ENTITY_FUNCTION(
-    @common.Body() data: CREATE_INPUT
+    @common.Body() data: [CREATE_INPUT]
   ): Promise<ENTITY> {
-    return await this.service.create({
-      data: CREATE_DATA_MAPPING,
-      select: SELECT,
-    });
+    try {
+      return await Promise.all(data.map(async _data => {
+        await this.service.create({
+          data: CREATE_DATA_MAPPING, // TODO: replace one with many
+          select: SELECT,
+        });
+      });
+    } catch (error) {      
+      throw error;
+    }
   }
 
   // @ts-ignore

--- a/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/controller.base.template.ts
@@ -73,7 +73,7 @@ export class CONTROLLER_BASE {
   ): Promise<ENTITY[]> {
     try {
       return await Promise.all(
-        data.map(async (_data) => {
+        data.map(async (dataItem) => {
           return await this.service.create({
             data: CREATE_DATA_MAPPING,
             select: SELECT,

--- a/packages/amplication-data-service-generator/src/server/resource/controller/create-controller.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/create-controller.ts
@@ -50,7 +50,7 @@ export type MethodsIdsActionEntityTriplet = {
 
 const TO_MANY_MIXIN_ID = builders.identifier("Mixin");
 export const DATA_ID = builders.identifier("data");
-export const _DATA_ID = builders.identifier("_data");
+export const DATA_ITEM_ID = builders.identifier("dataItem");
 
 const controllerTemplatePath = require.resolve("./controller.template.ts");
 const controllerBaseTemplatePath = require.resolve(
@@ -97,7 +97,7 @@ export async function createControllerModules(
     CREATE_DATA_MAPPING: createDataMapping(
       entity,
       entityDTOs.createInput,
-      _DATA_ID
+      DATA_ITEM_ID
     ),
     UPDATE_INPUT: entityDTOs.updateInput.id,
     UPDATE_DATA_MAPPING: createDataMapping(

--- a/packages/amplication-data-service-generator/src/server/resource/controller/create-controller.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/controller/create-controller.ts
@@ -50,6 +50,7 @@ export type MethodsIdsActionEntityTriplet = {
 
 const TO_MANY_MIXIN_ID = builders.identifier("Mixin");
 export const DATA_ID = builders.identifier("data");
+export const _DATA_ID = builders.identifier("_data");
 
 const controllerTemplatePath = require.resolve("./controller.template.ts");
 const controllerBaseTemplatePath = require.resolve(
@@ -96,7 +97,7 @@ export async function createControllerModules(
     CREATE_DATA_MAPPING: createDataMapping(
       entity,
       entityDTOs.createInput,
-      DATA_ID
+      _DATA_ID
     ),
     UPDATE_INPUT: entityDTOs.updateInput.id,
     UPDATE_DATA_MAPPING: createDataMapping(

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -5663,54 +5663,65 @@ export class CustomerControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Customer })
+  @swagger.ApiBody({ type: [CustomerCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Customer] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: CustomerCreateInput): Promise<Customer> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(
+    @common.Body() data: [CustomerCreateInput]
+  ): Promise<Customer[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        organization: data.organization
-          ? {
-              connect: data.organization,
-            }
-          : undefined,
+              organization: dataItem.organization
+                ? {
+                    connect: dataItem.organization,
+                  }
+                : undefined,
 
-        vipOrganization: data.vipOrganization
-          ? {
-              connect: data.vipOrganization,
-            }
-          : undefined,
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        email: true,
-        firstName: true,
-        lastName: true,
-        isVip: true,
-        birthData: true,
-        averageSale: true,
-        favoriteNumber: true,
-        geoLocation: true,
-        comments: true,
-        favoriteColors: true,
-        customerType: true,
+              vipOrganization: dataItem.vipOrganization
+                ? {
+                    connect: dataItem.vipOrganization,
+                  }
+                : undefined,
+            },
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+              email: true,
+              firstName: true,
+              lastName: true,
+              isVip: true,
+              birthData: true,
+              averageSale: true,
+              favoriteNumber: true,
+              geoLocation: true,
+              comments: true,
+              favoriteColors: true,
+              customerType: true,
 
-        organization: {
-          select: {
-            id: true,
-          },
-        },
+              organization: {
+                select: {
+                  id: true,
+                },
+              },
 
-        vipOrganization: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
+              vipOrganization: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -7099,17 +7110,26 @@ export class EmptyControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Empty })
+  @swagger.ApiBody({ type: [EmptyCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Empty] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: EmptyCreateInput): Promise<Empty> {
-    return await this.service.create({
-      data: data,
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
+  async create(@common.Body() data: [EmptyCreateInput]): Promise<Empty[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: dataItem,
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -8996,32 +9016,41 @@ export class OrderControllerBase {
 
   @Public()
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Order })
+  @swagger.ApiBody({ type: [OrderCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Order] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: OrderCreateInput): Promise<Order> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(@common.Body() data: [OrderCreateInput]): Promise<Order[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        customer: {
-          connect: data.customer,
-        },
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
+              customer: {
+                connect: dataItem.customer,
+              },
+            },
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
 
-        customer: {
-          select: {
-            id: true,
-          },
-        },
+              customer: {
+                select: {
+                  id: true,
+                },
+              },
 
-        status: true,
-        label: true,
-      },
-    });
+              status: true,
+              label: true,
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @Public()
@@ -10432,20 +10461,29 @@ export class OrganizationControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Organization })
+  @swagger.ApiBody({ type: [OrganizationCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Organization] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   async create(
-    @common.Body() data: OrganizationCreateInput
-  ): Promise<Organization> {
-    return await this.service.create({
-      data: data,
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        name: true,
-      },
-    });
+    @common.Body() data: [OrganizationCreateInput]
+  ): Promise<Organization[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: dataItem,
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+              name: true,
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -12104,32 +12142,41 @@ export class ProfileControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Profile })
+  @swagger.ApiBody({ type: [ProfileCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Profile] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: ProfileCreateInput): Promise<Profile> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(@common.Body() data: [ProfileCreateInput]): Promise<Profile[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        user: data.user
-          ? {
-              connect: data.user,
-            }
-          : undefined,
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        email: true,
+              user: dataItem.user
+                ? {
+                    connect: dataItem.user,
+                  }
+                : undefined,
+            },
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+              email: true,
 
-        user: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
+              user: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -14571,55 +14618,64 @@ export class UserControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: User })
+  @swagger.ApiBody({ type: [UserCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [User] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: UserCreateInput): Promise<User> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(@common.Body() data: [UserCreateInput]): Promise<User[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        manager: data.manager
-          ? {
-              connect: data.manager,
-            }
-          : undefined,
+              manager: dataItem.manager
+                ? {
+                    connect: dataItem.manager,
+                  }
+                : undefined,
 
-        profile: data.profile
-          ? {
-              connect: data.profile,
-            }
-          : undefined,
-      },
-      select: {
-        username: true,
-        roles: true,
-        id: true,
-        name: true,
-        bio: true,
-        email: true,
-        age: true,
-        birthDate: true,
-        score: true,
+              profile: dataItem.profile
+                ? {
+                    connect: dataItem.profile,
+                  }
+                : undefined,
+            },
+            select: {
+              username: true,
+              roles: true,
+              id: true,
+              name: true,
+              bio: true,
+              email: true,
+              age: true,
+              birthDate: true,
+              score: true,
 
-        manager: {
-          select: {
-            id: true,
-          },
-        },
+              manager: {
+                select: {
+                  id: true,
+                },
+              },
 
-        interests: true,
-        priority: true,
-        isCurious: true,
-        location: true,
-        extendedProperties: true,
+              interests: true,
+              priority: true,
+              isCurious: true,
+              location: true,
+              extendedProperties: true,
 
-        profile: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
+              profile: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -5702,54 +5702,65 @@ export class CustomerControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Customer })
+  @swagger.ApiBody({ type: [CustomerCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Customer] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: CustomerCreateInput): Promise<Customer> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(
+    @common.Body() data: [CustomerCreateInput]
+  ): Promise<Customer[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        organization: data.organization
-          ? {
-              connect: data.organization,
-            }
-          : undefined,
+              organization: dataItem.organization
+                ? {
+                    connect: dataItem.organization,
+                  }
+                : undefined,
 
-        vipOrganization: data.vipOrganization
-          ? {
-              connect: data.vipOrganization,
-            }
-          : undefined,
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        email: true,
-        firstName: true,
-        lastName: true,
-        isVip: true,
-        birthData: true,
-        averageSale: true,
-        favoriteNumber: true,
-        geoLocation: true,
-        comments: true,
-        favoriteColors: true,
-        customerType: true,
+              vipOrganization: dataItem.vipOrganization
+                ? {
+                    connect: dataItem.vipOrganization,
+                  }
+                : undefined,
+            },
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+              email: true,
+              firstName: true,
+              lastName: true,
+              isVip: true,
+              birthData: true,
+              averageSale: true,
+              favoriteNumber: true,
+              geoLocation: true,
+              comments: true,
+              favoriteColors: true,
+              customerType: true,
 
-        organization: {
-          select: {
-            id: true,
-          },
-        },
+              organization: {
+                select: {
+                  id: true,
+                },
+              },
 
-        vipOrganization: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
+              vipOrganization: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -7138,17 +7149,26 @@ export class EmptyControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Empty })
+  @swagger.ApiBody({ type: [EmptyCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Empty] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: EmptyCreateInput): Promise<Empty> {
-    return await this.service.create({
-      data: data,
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
+  async create(@common.Body() data: [EmptyCreateInput]): Promise<Empty[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: dataItem,
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -9118,32 +9138,41 @@ export class OrderControllerBase {
 
   @Public()
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Order })
+  @swagger.ApiBody({ type: [OrderCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Order] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: OrderCreateInput): Promise<Order> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(@common.Body() data: [OrderCreateInput]): Promise<Order[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        customer: {
-          connect: data.customer,
-        },
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
+              customer: {
+                connect: dataItem.customer,
+              },
+            },
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
 
-        customer: {
-          select: {
-            id: true,
-          },
-        },
+              customer: {
+                select: {
+                  id: true,
+                },
+              },
 
-        status: true,
-        label: true,
-      },
-    });
+              status: true,
+              label: true,
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @Public()
@@ -10554,20 +10583,29 @@ export class OrganizationControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Organization })
+  @swagger.ApiBody({ type: [OrganizationCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Organization] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   async create(
-    @common.Body() data: OrganizationCreateInput
-  ): Promise<Organization> {
-    return await this.service.create({
-      data: data,
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        name: true,
-      },
-    });
+    @common.Body() data: [OrganizationCreateInput]
+  ): Promise<Organization[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: dataItem,
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+              name: true,
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -12226,32 +12264,41 @@ export class ProfileControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Profile })
+  @swagger.ApiBody({ type: [ProfileCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Profile] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: ProfileCreateInput): Promise<Profile> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(@common.Body() data: [ProfileCreateInput]): Promise<Profile[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        user: data.user
-          ? {
-              connect: data.user,
-            }
-          : undefined,
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        email: true,
+              user: dataItem.user
+                ? {
+                    connect: dataItem.user,
+                  }
+                : undefined,
+            },
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+              email: true,
 
-        user: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
+              user: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -14693,55 +14740,64 @@ export class UserControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: User })
+  @swagger.ApiBody({ type: [UserCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [User] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: UserCreateInput): Promise<User> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(@common.Body() data: [UserCreateInput]): Promise<User[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        manager: data.manager
-          ? {
-              connect: data.manager,
-            }
-          : undefined,
+              manager: dataItem.manager
+                ? {
+                    connect: dataItem.manager,
+                  }
+                : undefined,
 
-        profile: data.profile
-          ? {
-              connect: data.profile,
-            }
-          : undefined,
-      },
-      select: {
-        username: true,
-        roles: true,
-        id: true,
-        name: true,
-        bio: true,
-        email: true,
-        age: true,
-        birthDate: true,
-        score: true,
+              profile: dataItem.profile
+                ? {
+                    connect: dataItem.profile,
+                  }
+                : undefined,
+            },
+            select: {
+              username: true,
+              roles: true,
+              id: true,
+              name: true,
+              bio: true,
+              email: true,
+              age: true,
+              birthDate: true,
+              score: true,
 
-        manager: {
-          select: {
-            id: true,
-          },
-        },
+              manager: {
+                select: {
+                  id: true,
+                },
+              },
 
-        interests: true,
-        priority: true,
-        isCurious: true,
-        location: true,
-        extendedProperties: true,
+              interests: true,
+              priority: true,
+              isCurious: true,
+              location: true,
+              extendedProperties: true,
 
-        profile: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
+              profile: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -5663,54 +5663,65 @@ export class CustomerControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Customer })
+  @swagger.ApiBody({ type: [CustomerCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Customer] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: CustomerCreateInput): Promise<Customer> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(
+    @common.Body() data: [CustomerCreateInput]
+  ): Promise<Customer[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        organization: data.organization
-          ? {
-              connect: data.organization,
-            }
-          : undefined,
+              organization: dataItem.organization
+                ? {
+                    connect: dataItem.organization,
+                  }
+                : undefined,
 
-        vipOrganization: data.vipOrganization
-          ? {
-              connect: data.vipOrganization,
-            }
-          : undefined,
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        email: true,
-        firstName: true,
-        lastName: true,
-        isVip: true,
-        birthData: true,
-        averageSale: true,
-        favoriteNumber: true,
-        geoLocation: true,
-        comments: true,
-        favoriteColors: true,
-        customerType: true,
+              vipOrganization: dataItem.vipOrganization
+                ? {
+                    connect: dataItem.vipOrganization,
+                  }
+                : undefined,
+            },
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+              email: true,
+              firstName: true,
+              lastName: true,
+              isVip: true,
+              birthData: true,
+              averageSale: true,
+              favoriteNumber: true,
+              geoLocation: true,
+              comments: true,
+              favoriteColors: true,
+              customerType: true,
 
-        organization: {
-          select: {
-            id: true,
-          },
-        },
+              organization: {
+                select: {
+                  id: true,
+                },
+              },
 
-        vipOrganization: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
+              vipOrganization: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -6845,17 +6856,26 @@ export class EmptyControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Empty })
+  @swagger.ApiBody({ type: [EmptyCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Empty] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: EmptyCreateInput): Promise<Empty> {
-    return await this.service.create({
-      data: data,
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
+  async create(@common.Body() data: [EmptyCreateInput]): Promise<Empty[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: dataItem,
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -8617,32 +8637,41 @@ export class OrderControllerBase {
 
   @Public()
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Order })
+  @swagger.ApiBody({ type: [OrderCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Order] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: OrderCreateInput): Promise<Order> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(@common.Body() data: [OrderCreateInput]): Promise<Order[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        customer: {
-          connect: data.customer,
-        },
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
+              customer: {
+                connect: dataItem.customer,
+              },
+            },
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
 
-        customer: {
-          select: {
-            id: true,
-          },
-        },
+              customer: {
+                select: {
+                  id: true,
+                },
+              },
 
-        status: true,
-        label: true,
-      },
-    });
+              status: true,
+              label: true,
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @Public()
@@ -9885,20 +9914,29 @@ export class OrganizationControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Organization })
+  @swagger.ApiBody({ type: [OrganizationCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Organization] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   async create(
-    @common.Body() data: OrganizationCreateInput
-  ): Promise<Organization> {
-    return await this.service.create({
-      data: data,
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        name: true,
-      },
-    });
+    @common.Body() data: [OrganizationCreateInput]
+  ): Promise<Organization[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: dataItem,
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+              name: true,
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -11322,32 +11360,41 @@ export class ProfileControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Profile })
+  @swagger.ApiBody({ type: [ProfileCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Profile] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: ProfileCreateInput): Promise<Profile> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(@common.Body() data: [ProfileCreateInput]): Promise<Profile[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        user: data.user
-          ? {
-              connect: data.user,
-            }
-          : undefined,
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        email: true,
+              user: dataItem.user
+                ? {
+                    connect: dataItem.user,
+                  }
+                : undefined,
+            },
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+              email: true,
 
-        user: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
+              user: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -13585,55 +13632,64 @@ export class UserControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: User })
+  @swagger.ApiBody({ type: [UserCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [User] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: UserCreateInput): Promise<User> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(@common.Body() data: [UserCreateInput]): Promise<User[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        manager: data.manager
-          ? {
-              connect: data.manager,
-            }
-          : undefined,
+              manager: dataItem.manager
+                ? {
+                    connect: dataItem.manager,
+                  }
+                : undefined,
 
-        profile: data.profile
-          ? {
-              connect: data.profile,
-            }
-          : undefined,
-      },
-      select: {
-        username: true,
-        roles: true,
-        id: true,
-        name: true,
-        bio: true,
-        email: true,
-        age: true,
-        birthDate: true,
-        score: true,
+              profile: dataItem.profile
+                ? {
+                    connect: dataItem.profile,
+                  }
+                : undefined,
+            },
+            select: {
+              username: true,
+              roles: true,
+              id: true,
+              name: true,
+              bio: true,
+              email: true,
+              age: true,
+              birthDate: true,
+              score: true,
 
-        manager: {
-          select: {
-            id: true,
-          },
-        },
+              manager: {
+                select: {
+                  id: true,
+                },
+              },
 
-        interests: true,
-        priority: true,
-        isCurious: true,
-        location: true,
-        extendedProperties: true,
+              interests: true,
+              priority: true,
+              isCurious: true,
+              location: true,
+              extendedProperties: true,
 
-        profile: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
+              profile: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -5663,54 +5663,65 @@ export class CustomerControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Customer })
+  @swagger.ApiBody({ type: [CustomerCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Customer] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: CustomerCreateInput): Promise<Customer> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(
+    @common.Body() data: [CustomerCreateInput]
+  ): Promise<Customer[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        organization: data.organization
-          ? {
-              connect: data.organization,
-            }
-          : undefined,
+              organization: dataItem.organization
+                ? {
+                    connect: dataItem.organization,
+                  }
+                : undefined,
 
-        vipOrganization: data.vipOrganization
-          ? {
-              connect: data.vipOrganization,
-            }
-          : undefined,
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        email: true,
-        firstName: true,
-        lastName: true,
-        isVip: true,
-        birthData: true,
-        averageSale: true,
-        favoriteNumber: true,
-        geoLocation: true,
-        comments: true,
-        favoriteColors: true,
-        customerType: true,
+              vipOrganization: dataItem.vipOrganization
+                ? {
+                    connect: dataItem.vipOrganization,
+                  }
+                : undefined,
+            },
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+              email: true,
+              firstName: true,
+              lastName: true,
+              isVip: true,
+              birthData: true,
+              averageSale: true,
+              favoriteNumber: true,
+              geoLocation: true,
+              comments: true,
+              favoriteColors: true,
+              customerType: true,
 
-        organization: {
-          select: {
-            id: true,
-          },
-        },
+              organization: {
+                select: {
+                  id: true,
+                },
+              },
 
-        vipOrganization: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
+              vipOrganization: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -7099,17 +7110,26 @@ export class EmptyControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Empty })
+  @swagger.ApiBody({ type: [EmptyCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Empty] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: EmptyCreateInput): Promise<Empty> {
-    return await this.service.create({
-      data: data,
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
+  async create(@common.Body() data: [EmptyCreateInput]): Promise<Empty[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: dataItem,
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -8996,32 +9016,41 @@ export class OrderControllerBase {
 
   @Public()
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Order })
+  @swagger.ApiBody({ type: [OrderCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Order] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: OrderCreateInput): Promise<Order> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(@common.Body() data: [OrderCreateInput]): Promise<Order[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        customer: {
-          connect: data.customer,
-        },
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
+              customer: {
+                connect: dataItem.customer,
+              },
+            },
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
 
-        customer: {
-          select: {
-            id: true,
-          },
-        },
+              customer: {
+                select: {
+                  id: true,
+                },
+              },
 
-        status: true,
-        label: true,
-      },
-    });
+              status: true,
+              label: true,
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @Public()
@@ -10432,20 +10461,29 @@ export class OrganizationControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Organization })
+  @swagger.ApiBody({ type: [OrganizationCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Organization] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
   async create(
-    @common.Body() data: OrganizationCreateInput
-  ): Promise<Organization> {
-    return await this.service.create({
-      data: data,
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        name: true,
-      },
-    });
+    @common.Body() data: [OrganizationCreateInput]
+  ): Promise<Organization[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: dataItem,
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+              name: true,
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -12104,32 +12142,41 @@ export class ProfileControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: Profile })
+  @swagger.ApiBody({ type: [ProfileCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [Profile] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: ProfileCreateInput): Promise<Profile> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(@common.Body() data: [ProfileCreateInput]): Promise<Profile[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        user: data.user
-          ? {
-              connect: data.user,
-            }
-          : undefined,
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        email: true,
+              user: dataItem.user
+                ? {
+                    connect: dataItem.user,
+                  }
+                : undefined,
+            },
+            select: {
+              id: true,
+              createdAt: true,
+              updatedAt: true,
+              email: true,
 
-        user: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
+              user: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)
@@ -14571,55 +14618,64 @@ export class UserControllerBase {
     possession: \\"any\\",
   })
   @common.Post()
-  @swagger.ApiCreatedResponse({ type: User })
+  @swagger.ApiBody({ type: [UserCreateInput] })
+  @swagger.ApiCreatedResponse({ type: [User] })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async create(@common.Body() data: UserCreateInput): Promise<User> {
-    return await this.service.create({
-      data: {
-        ...data,
+  async create(@common.Body() data: [UserCreateInput]): Promise<User[]> {
+    try {
+      return await Promise.all(
+        data.map(async (dataItem) => {
+          return await this.service.create({
+            data: {
+              ...dataItem,
 
-        manager: data.manager
-          ? {
-              connect: data.manager,
-            }
-          : undefined,
+              manager: dataItem.manager
+                ? {
+                    connect: dataItem.manager,
+                  }
+                : undefined,
 
-        profile: data.profile
-          ? {
-              connect: data.profile,
-            }
-          : undefined,
-      },
-      select: {
-        username: true,
-        roles: true,
-        id: true,
-        name: true,
-        bio: true,
-        email: true,
-        age: true,
-        birthDate: true,
-        score: true,
+              profile: dataItem.profile
+                ? {
+                    connect: dataItem.profile,
+                  }
+                : undefined,
+            },
+            select: {
+              username: true,
+              roles: true,
+              id: true,
+              name: true,
+              bio: true,
+              email: true,
+              age: true,
+              birthDate: true,
+              score: true,
 
-        manager: {
-          select: {
-            id: true,
-          },
-        },
+              manager: {
+                select: {
+                  id: true,
+                },
+              },
 
-        interests: true,
-        priority: true,
-        isCurious: true,
-        location: true,
-        extendedProperties: true,
+              interests: true,
+              priority: true,
+              isCurious: true,
+              location: true,
+              extendedProperties: true,
 
-        profile: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
+              profile: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          });
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
   }
 
   @common.UseInterceptors(AclFilterResponseInterceptor)


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close #4234

## PR Details

This PR changes the "Create one" to an "Create many" Route as the standard POST Route in the REST-API.
For this I changed the controller template and the data service generator to expect an array of entity objects instead of just one object.

Unfortunately the [ Prisma "createMany" method](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#nested-writes) cannot handle relations in the way "create" can so i loop through the Array of Input objects in the controller and use the Prisma "create" method.

Problem to solve:
Instead of having to loop on the client side to create many records from an array of items and thus having many http-calls that are slow or even fail with an ERR_INSUFFICIENT_RESOURCES in the browser, the standard POST Route could be a "Create Many" Route. In the Request body an array with only one item can be used for creating only one record.

Test snapshots where updated using `npm test -- -u`

Caveats:
- Does this change apply also for GraphQL automatically? (I could not figure this out on the fly)
- This change would be a breaking change for all existing projects as it changes the expected Input for the POST route (making another PR with adding this behaviour as an optional setting in the Amplication UI could solve this)

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

## PR Checklist
- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
