### PR TITLE
refactor: add health check on kafka container

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -49,13 +49,20 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       JMX_PORT: 9997
       KAFKA_JMX_OPTS: -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=kafka -Dcom.sun.management.jmxremote.rmi.port=9997
+    healthcheck:
+      test: nc -z localhost 9092 || exit -1
+      start_period: 15s
+      interval: 30s
+      timeout: 10s
+      retries: 10
 
   kafka-init-topics:
     image: confluentinc/cp-kafka:5.3.1
     volumes:
       - ./temp/message.json:/data/message.json
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy
     command: "bash -c 'echo Waiting for Kafka to be ready... && \
       cub kafka-ready -b kafka:29092 1 30 && \
       kafka-topics --create --topic second.users --partitions 3 --replication-factor 1 --if-not-exists --zookeeper zookeeper:2181 && \


### PR DESCRIPTION
## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

Add health check on kafka container to avoid issues where `kafka-init-topics` fails to run when the `kafka` containers takes more then 30s to start.

## PR Checklist
- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
