### PR TITLE
enable to copy build logs

### DIFF
--- a/packages/amplication-client/src/VersionControl/ActionLog.tsx
+++ b/packages/amplication-client/src/VersionControl/ActionLog.tsx
@@ -1,15 +1,11 @@
 import React, { useMemo } from "react";
 import { LazyLog } from "react-lazylog";
 import { isEmpty, last } from "lodash";
-
 import Timer from "../Components/Timer";
-
 import { differenceInSeconds } from "date-fns";
-
 import chalk from "chalk";
 import * as models from "../models";
 import logsImage from "../assets/images/logs.svg";
-
 import "./ActionLog.scss";
 import {
   CircleIcon,
@@ -152,7 +148,8 @@ const ActionLog = ({ action, title, versionNumber }: Props) => {
                   extraLines={0}
                   enableSearch={false}
                   text={stepData.messages}
-                  height={10} //we use a random value in order to disable the auto-sizing, and use "height:auto !important" in CSS
+                  height={10}
+                  selectableLines={true} //we use a random value in order to disable the auto-sizing, and use "height:auto !important" in CSS
                 />
               </div>
             )}


### PR DESCRIPTION
Close #[issue-number]

## PR Details

added `selectableLines` prop on react lazylog in order to enable to copy build logs

## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

