### PR TITLE
Add `postbuild` script to NX cache list

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -37,16 +37,10 @@
   },
   "targetDefaults": {
     "test": {
-      "dependsOn": [
-        "db:prisma:generate",
-        "^db:prisma:generate",
-        "^prebuild"
-      ]
+      "dependsOn": ["db:prisma:generate", "^db:prisma:generate", "^prebuild"]
     },
     "prebuild": {
-      "dependsOn": [
-        "^prebuild"
-      ]
+      "dependsOn": ["^prebuild"]
     },
     "build": {
       "dependsOn": [
@@ -57,30 +51,16 @@
       ]
     },
     "postbuild": {
-      "dependsOn": [
-        "build",
-        "^postbuild"
-      ]
+      "dependsOn": ["build", "^postbuild"]
     },
     "serve": {
-      "dependsOn": [
-        "db:prisma:generate",
-        "^db:prisma:generate",
-        "^prebuild"
-      ]
+      "dependsOn": ["db:prisma:generate", "^db:prisma:generate", "^prebuild"]
     },
     "lint": {
-      "inputs": [
-        "default",
-        "{workspaceRoot}/.eslintrc.json"
-      ]
+      "inputs": ["default", "{workspaceRoot}/.eslintrc.json"]
     },
     "docker:build": {
-      "dependsOn": [
-        "prebuild",
-        "build",
-        "postbuild"
-      ]
+      "dependsOn": ["prebuild", "build", "postbuild"]
     }
   },
   "generators": {

--- a/nx.json
+++ b/nx.json
@@ -19,6 +19,7 @@
           "install",
           "prebuild",
           "build",
+          "postbuild",
           "prepare",
           "check-format",
           "format",
@@ -36,10 +37,16 @@
   },
   "targetDefaults": {
     "test": {
-      "dependsOn": ["db:prisma:generate", "^db:prisma:generate", "^prebuild"]
+      "dependsOn": [
+        "db:prisma:generate",
+        "^db:prisma:generate",
+        "^prebuild"
+      ]
     },
     "prebuild": {
-      "dependsOn": ["^prebuild"]
+      "dependsOn": [
+        "^prebuild"
+      ]
     },
     "build": {
       "dependsOn": [
@@ -50,16 +57,30 @@
       ]
     },
     "postbuild": {
-      "dependsOn": ["build", "^postbuild"]
+      "dependsOn": [
+        "build",
+        "^postbuild"
+      ]
     },
     "serve": {
-      "dependsOn": ["db:prisma:generate", "^db:prisma:generate", "^prebuild"]
+      "dependsOn": [
+        "db:prisma:generate",
+        "^db:prisma:generate",
+        "^prebuild"
+      ]
     },
     "lint": {
-      "inputs": ["default", "{workspaceRoot}/.eslintrc.json"]
+      "inputs": [
+        "default",
+        "{workspaceRoot}/.eslintrc.json"
+      ]
     },
     "docker:build": {
-      "dependsOn": ["prebuild", "build", "postbuild"]
+      "dependsOn": [
+        "prebuild",
+        "build",
+        "postbuild"
+      ]
     }
   },
   "generators": {


### PR DESCRIPTION
This PR adds the `postbuild` script to the NX `cacheableOperations` list, this PR will fix https://github.com/amplication/amplication/actions/runs/3558419819/jobs/5977089186
The solution has provided by @arielweinberger 