### PR TITLE
added refetch to fetch only the topics of the message broker after creation

### DIFF
--- a/packages/amplication-client/src/ServiceConnections/topics/TopicsList.tsx
+++ b/packages/amplication-client/src/ServiceConnections/topics/TopicsList.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@apollo/client";
 import { FieldArray } from "formik";
 import { keyBy } from "lodash";
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { EmptyState } from "../../Components/EmptyState";
 import { EnumImages } from "../../Components/SvgThemeImage";
 import {
@@ -29,10 +29,14 @@ export default function TopicsList({
   messagePatterns,
 }: Props) {
   const { trackEvent } = useTracking();
-  const { data } = useQuery<TData>(topicsOfBroker, {
+  const { data, refetch } = useQuery<TData>(topicsOfBroker, {
     variables: { messageBrokerId },
     skip: !messageBrokerId,
   });
+
+  useEffect(() => {
+    refetch();
+  }, [refetch, messageBrokerId]);
 
   const messagePatternsByTopicId = useMemo(() => {
     if (!messagePatterns) return {};

--- a/packages/amplication-client/src/ServiceConnections/topics/TopicsList.tsx
+++ b/packages/amplication-client/src/ServiceConnections/topics/TopicsList.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@apollo/client";
 import { FieldArray } from "formik";
 import { keyBy } from "lodash";
-import React, { useEffect, useMemo } from "react";
+import React, { useMemo } from "react";
 import { EmptyState } from "../../Components/EmptyState";
 import { EnumImages } from "../../Components/SvgThemeImage";
 import {
@@ -29,14 +29,11 @@ export default function TopicsList({
   messagePatterns,
 }: Props) {
   const { trackEvent } = useTracking();
-  const { data, refetch } = useQuery<TData>(topicsOfBroker, {
+  const { data } = useQuery<TData>(topicsOfBroker, {
+    fetchPolicy: "no-cache",
     variables: { messageBrokerId },
     skip: !messageBrokerId,
   });
-
-  useEffect(() => {
-    refetch();
-  }, [refetch, messageBrokerId]);
 
   const messagePatternsByTopicId = useMemo(() => {
     if (!messagePatterns) return {};


### PR DESCRIPTION
Close #4283 

## PR Details

added refetch to fetch only the topics of the message broker after creation

## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

