### PR TITLE
fix/4368-copy-package-lock-in-dockerfile

### DIFF
--- a/packages/amplication-server/Dockerfile
+++ b/packages/amplication-server/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get install -y openssl
 
 WORKDIR /app
 
-COPY ./dist/packages/amplication-server/package.json .
+COPY ./dist/packages/amplication-server/package*.json ./
 
 RUN npm i --omit=dev
 


### PR DESCRIPTION
instead of just adding the package.json also copying the package-lock.json file avoids unexpected errors/ behaviour when deploying your docker container compared to your local environment.

<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close #4368

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

See explanations here:
[Stackoverflow thread 1](https://stackoverflow.com/questions/65234362/should-i-copy-package-lock-json-to-the-container-image-in-dockerfile)

## PR Checklist
- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
