### PR TITLE
chore(nx): add support for auto detected dependencies in nx workspace

### DIFF
--- a/ee/packages/amplication-git-pull-service/project.json
+++ b/ee/packages/amplication-git-pull-service/project.json
@@ -3,10 +3,6 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "ee/packages/amplication-git-pull-service/src",
   "projectType": "application",
-  "implicitDependencies": [
-    "amplication-kafka",
-    "amplication-nest-logger-module"
-  ],
   "targets": {
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/ee/packages/amplication-git-push-webhook-service/project.json
+++ b/ee/packages/amplication-git-push-webhook-service/project.json
@@ -3,11 +3,6 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "ee/packages/amplication-git-push-webhook-service/src",
   "projectType": "application",
-  "implicitDependencies": [
-    "amplication-prisma-db",
-    "amplication-nest-logger-module",
-    "amplication-kafka"
-  ],
   "targets": {
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,10 @@
 {
   "extends": "nx/presets/npm.json",
+  "pluginsConfig": {
+    "@nrwl/js": {
+      "analyzeSourceFiles": true
+    }
+  },
   "npmScope": "amplication",
   "affected": {
     "defaultBase": "master"

--- a/packages/amplication-build-manager/project.json
+++ b/packages/amplication-build-manager/project.json
@@ -3,11 +3,6 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/amplication-build-manager/src",
   "projectType": "application",
-  "implicitDependencies": [
-    "amplication-kafka",
-    "amplication-nest-logger-module",
-    "amplication-code-gen-types"
-  ],
   "targets": {
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/packages/amplication-client/project.json
+++ b/packages/amplication-client/project.json
@@ -3,10 +3,6 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/amplication-client/src",
   "projectType": "application",
-  "implicitDependencies": [
-    "amplication-design-system",
-    "amplication-code-gen-types"
-  ],
   "targets": {
     "prebuild": {
       "executor": "nx:run-commands",

--- a/packages/amplication-data-service-generator/project.json
+++ b/packages/amplication-data-service-generator/project.json
@@ -3,7 +3,6 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/amplication-data-service-generator/src",
   "projectType": "application",
-  "implicitDependencies": ["amplication-code-gen-types"],
   "targets": {
     "install": {
       "executor": "nx:run-commands",

--- a/packages/amplication-git-pull-request-service/project.json
+++ b/packages/amplication-git-pull-request-service/project.json
@@ -3,11 +3,6 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/amplication-git-pull-request-service/src",
   "projectType": "application",
-  "implicitDependencies": [
-    "amplication-nest-logger-module",
-    "amplication-git-utils",
-    "amplication-kafka"
-  ],
   "targets": {
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/packages/amplication-server/project.json
+++ b/packages/amplication-server/project.json
@@ -3,12 +3,6 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/amplication-server/src",
   "projectType": "application",
-  "implicitDependencies": [
-    "amplication-prisma-db",
-    "amplication-code-gen-types",
-    "amplication-git-utils",
-    "amplication-kafka"
-  ],
   "targets": {
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/packages/amplication-storage-gateway/project.json
+++ b/packages/amplication-storage-gateway/project.json
@@ -3,7 +3,6 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/amplication-storage-gateway/src",
   "projectType": "application",
-  "implicitDependencies": ["amplication-nest-logger-module"],
   "targets": {
     "lint": {
       "executor": "@nrwl/linter:eslint",


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #4344 

## PR Details

Manually telling Nx about the dependencies between your projects is helpful, but as your repo grows it becomes difficult for a person to keep track of all the dependencies that are introduced. If you miss a dependency, the guarantees of the affected command are voided. 
This PR leverage nx plugins capabilities to automatically detect project dependencies without us manually implicitly defining them.

As a result of this change, we can clearly see that we manually added a dependency that did not really exist.

![graph](https://user-images.githubusercontent.com/2861984/205072686-65ceb41a-dda5-43d9-9131-4e988cf99b11.png)

Use `npx nx graph` to visualize the current graph and `npx nx affected:graph --base=next` for visualizing the affected projects.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
