### PR TITLE
chore: fix ci affected to work on next to master PR

### DIFF
--- a/.github/workflows/ci-nx.yml
+++ b/.github/workflows/ci-nx.yml
@@ -77,7 +77,9 @@ jobs:
       - name: Set Affected
         id: set-affected
         run: |
-          echo ::set-output name=affected::"$(npx nx print-affected --type=app | jq -c .projects)"
+          export AFFECTED_PROJECTS=$(npx nx print-affected --type=app | jq -c .projects)
+          echo affected projects: $AFFECTED_PROJECTS
+          echo "affected=$AFFECTED_PROJECTS" >> $GITHUB_OUTPUT
 
   dockerize:
     if: ${{ needs.ci.outputs.affected != '[]' }}

--- a/.github/workflows/ci-nx.yml
+++ b/.github/workflows/ci-nx.yml
@@ -2,13 +2,14 @@ name: Continuous Integration (Nx - Affected)
 
 on:
   workflow_dispatch:
-  push:
-    paths-ignore:
-      - "**/*.md"
-      - ".all-contributorsrc"
+    inputs:
+      nx-base:
+        type: string
+        description: Commit SHA, branch or tag name used by Nx in the affected jobs. 
+        required: true
+        default: next
   pull_request_target:
-    branches: ["next", "master"]
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
     paths-ignore:
       - "**/*.md"
       - ".all-contributorsrc"
@@ -30,7 +31,7 @@ jobs:
 
       - uses: nrwl/nx-set-shas@v3
         with:
-          main-branch-name: ${{ github.base_ref || 'next' }}
+          main-branch-name: ${{ github.base_ref || github.event.inputs.nx-base }}
 
       - name: Cache node modules
         id: cache
@@ -92,7 +93,7 @@ jobs:
           fetch-depth: 0
       - uses: nrwl/nx-set-shas@v3
         with:
-          main-branch-name: next
+          main-branch-name: ${{ github.base_ref || github.event.inputs.nx-base }}
 
       - name: Cache node modules
         id: cache

--- a/.github/workflows/ci-nx.yml
+++ b/.github/workflows/ci-nx.yml
@@ -8,7 +8,7 @@ on:
         description: Commit SHA, branch or tag name used by Nx in the affected jobs. 
         required: true
         default: next
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
     paths-ignore:
       - "**/*.md"


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #4429 

## PR Details

Update ci affected workflow to only be triggered on actions against a pull request. 
This will fix the scenario where CI workflow triggered by push on `next` branch will end not running any build due to Nx not detecting any changes that will affect projects due to the comparison of the HEAD of the `next` branch against itself.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
