### PR TITLE
Fix server vulnerabilities

### DIFF
--- a/packages/amplication-data-service-generator/src/server/package-json/package.template.json
+++ b/packages/amplication-data-service-generator/src/server/package-json/package.template.json
@@ -20,13 +20,13 @@
     "compose:down": "docker-compose down --volumes"
   },
   "dependencies": {
-    "@nestjs/common": "8.2.3",
+    "@nestjs/common": "8.4.7",
     "@nestjs/config": "1.1.5",
-    "@nestjs/core": "8.2.3",
+    "@nestjs/core": "8.4.7",
     "@nestjs/graphql": "9.1.2",
     "@nestjs/jwt": "8.0.0",
     "@nestjs/passport": "8.2.2",
-    "@nestjs/platform-express": "8.2.3",
+    "@nestjs/platform-express": "8.4.7",
     "@nestjs/serve-static": "2.2.2",
     "@nestjs/swagger": "5.1.5",
     "@prisma/client": "4.6.1",
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@nestjs/cli": "8.2.5",
-    "@nestjs/testing": "8.2.3",
+    "@nestjs/testing": "8.4.7",
     "@types/bcrypt": "5.0.0",
     "@types/express": "4.17.9",
     "@types/graphql-type-json": "0.3.2",

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -2974,13 +2974,13 @@ volumes:
     \\"compose:down\\": \\"docker-compose down --volumes\\"
   },
   \\"dependencies\\": {
-    \\"@nestjs/common\\": \\"8.2.3\\",
+    \\"@nestjs/common\\": \\"8.4.7\\",
     \\"@nestjs/config\\": \\"1.1.5\\",
-    \\"@nestjs/core\\": \\"8.2.3\\",
+    \\"@nestjs/core\\": \\"8.4.7\\",
     \\"@nestjs/graphql\\": \\"9.1.2\\",
     \\"@nestjs/jwt\\": \\"8.0.0\\",
     \\"@nestjs/passport\\": \\"8.2.2\\",
-    \\"@nestjs/platform-express\\": \\"8.2.3\\",
+    \\"@nestjs/platform-express\\": \\"8.4.7\\",
     \\"@nestjs/serve-static\\": \\"2.2.2\\",
     \\"@nestjs/swagger\\": \\"5.1.5\\",
     \\"@prisma/client\\": \\"4.6.1\\",
@@ -3003,7 +3003,7 @@ volumes:
   },
   \\"devDependencies\\": {
     \\"@nestjs/cli\\": \\"8.2.5\\",
-    \\"@nestjs/testing\\": \\"8.2.3\\",
+    \\"@nestjs/testing\\": \\"8.4.7\\",
     \\"@types/bcrypt\\": \\"5.0.0\\",
     \\"@types/express\\": \\"4.17.9\\",
     \\"@types/graphql-type-json\\": \\"0.3.2\\",

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -2974,13 +2974,13 @@ volumes:
     \\"compose:down\\": \\"docker-compose down --volumes\\"
   },
   \\"dependencies\\": {
-    \\"@nestjs/common\\": \\"8.2.3\\",
+    \\"@nestjs/common\\": \\"8.4.7\\",
     \\"@nestjs/config\\": \\"1.1.5\\",
-    \\"@nestjs/core\\": \\"8.2.3\\",
+    \\"@nestjs/core\\": \\"8.4.7\\",
     \\"@nestjs/graphql\\": \\"9.1.2\\",
     \\"@nestjs/jwt\\": \\"8.0.0\\",
     \\"@nestjs/passport\\": \\"8.2.2\\",
-    \\"@nestjs/platform-express\\": \\"8.2.3\\",
+    \\"@nestjs/platform-express\\": \\"8.4.7\\",
     \\"@nestjs/serve-static\\": \\"2.2.2\\",
     \\"@nestjs/swagger\\": \\"5.1.5\\",
     \\"@prisma/client\\": \\"4.6.1\\",
@@ -3003,7 +3003,7 @@ volumes:
   },
   \\"devDependencies\\": {
     \\"@nestjs/cli\\": \\"8.2.5\\",
-    \\"@nestjs/testing\\": \\"8.2.3\\",
+    \\"@nestjs/testing\\": \\"8.4.7\\",
     \\"@types/bcrypt\\": \\"5.0.0\\",
     \\"@types/express\\": \\"4.17.9\\",
     \\"@types/graphql-type-json\\": \\"0.3.2\\",

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -3009,13 +3009,13 @@ networks:
     \\"compose:down\\": \\"docker-compose down --volumes\\"
   },
   \\"dependencies\\": {
-    \\"@nestjs/common\\": \\"8.2.3\\",
+    \\"@nestjs/common\\": \\"8.4.7\\",
     \\"@nestjs/config\\": \\"1.1.5\\",
-    \\"@nestjs/core\\": \\"8.2.3\\",
+    \\"@nestjs/core\\": \\"8.4.7\\",
     \\"@nestjs/graphql\\": \\"9.1.2\\",
     \\"@nestjs/jwt\\": \\"8.0.0\\",
     \\"@nestjs/passport\\": \\"8.2.2\\",
-    \\"@nestjs/platform-express\\": \\"8.2.3\\",
+    \\"@nestjs/platform-express\\": \\"8.4.7\\",
     \\"@nestjs/serve-static\\": \\"2.2.2\\",
     \\"@nestjs/swagger\\": \\"5.1.5\\",
     \\"@prisma/client\\": \\"4.6.1\\",
@@ -3040,7 +3040,7 @@ networks:
   },
   \\"devDependencies\\": {
     \\"@nestjs/cli\\": \\"8.2.5\\",
-    \\"@nestjs/testing\\": \\"8.2.3\\",
+    \\"@nestjs/testing\\": \\"8.4.7\\",
     \\"@types/bcrypt\\": \\"5.0.0\\",
     \\"@types/express\\": \\"4.17.9\\",
     \\"@types/graphql-type-json\\": \\"0.3.2\\",

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -2974,13 +2974,13 @@ volumes:
     \\"compose:down\\": \\"docker-compose down --volumes\\"
   },
   \\"dependencies\\": {
-    \\"@nestjs/common\\": \\"8.2.3\\",
+    \\"@nestjs/common\\": \\"8.4.7\\",
     \\"@nestjs/config\\": \\"1.1.5\\",
-    \\"@nestjs/core\\": \\"8.2.3\\",
+    \\"@nestjs/core\\": \\"8.4.7\\",
     \\"@nestjs/graphql\\": \\"9.1.2\\",
     \\"@nestjs/jwt\\": \\"8.0.0\\",
     \\"@nestjs/passport\\": \\"8.2.2\\",
-    \\"@nestjs/platform-express\\": \\"8.2.3\\",
+    \\"@nestjs/platform-express\\": \\"8.4.7\\",
     \\"@nestjs/serve-static\\": \\"2.2.2\\",
     \\"@nestjs/swagger\\": \\"5.1.5\\",
     \\"@prisma/client\\": \\"4.6.1\\",
@@ -3003,7 +3003,7 @@ volumes:
   },
   \\"devDependencies\\": {
     \\"@nestjs/cli\\": \\"8.2.5\\",
-    \\"@nestjs/testing\\": \\"8.2.3\\",
+    \\"@nestjs/testing\\": \\"8.4.7\\",
     \\"@types/bcrypt\\": \\"5.0.0\\",
     \\"@types/express\\": \\"4.17.9\\",
     \\"@types/graphql-type-json\\": \\"0.3.2\\",

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -2974,13 +2974,13 @@ volumes:
     \\"compose:down\\": \\"docker-compose down --volumes\\"
   },
   \\"dependencies\\": {
-    \\"@nestjs/common\\": \\"8.2.3\\",
+    \\"@nestjs/common\\": \\"8.4.7\\",
     \\"@nestjs/config\\": \\"1.1.5\\",
-    \\"@nestjs/core\\": \\"8.2.3\\",
+    \\"@nestjs/core\\": \\"8.4.7\\",
     \\"@nestjs/graphql\\": \\"9.1.2\\",
     \\"@nestjs/jwt\\": \\"8.0.0\\",
     \\"@nestjs/passport\\": \\"8.2.2\\",
-    \\"@nestjs/platform-express\\": \\"8.2.3\\",
+    \\"@nestjs/platform-express\\": \\"8.4.7\\",
     \\"@nestjs/serve-static\\": \\"2.2.2\\",
     \\"@nestjs/swagger\\": \\"5.1.5\\",
     \\"@prisma/client\\": \\"4.6.1\\",
@@ -3003,7 +3003,7 @@ volumes:
   },
   \\"devDependencies\\": {
     \\"@nestjs/cli\\": \\"8.2.5\\",
-    \\"@nestjs/testing\\": \\"8.2.3\\",
+    \\"@nestjs/testing\\": \\"8.4.7\\",
     \\"@types/bcrypt\\": \\"5.0.0\\",
     \\"@types/express\\": \\"4.17.9\\",
     \\"@types/graphql-type-json\\": \\"0.3.2\\",

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -2974,13 +2974,13 @@ volumes:
     \\"compose:down\\": \\"docker-compose down --volumes\\"
   },
   \\"dependencies\\": {
-    \\"@nestjs/common\\": \\"8.2.3\\",
+    \\"@nestjs/common\\": \\"8.4.7\\",
     \\"@nestjs/config\\": \\"1.1.5\\",
-    \\"@nestjs/core\\": \\"8.2.3\\",
+    \\"@nestjs/core\\": \\"8.4.7\\",
     \\"@nestjs/graphql\\": \\"9.1.2\\",
     \\"@nestjs/jwt\\": \\"8.0.0\\",
     \\"@nestjs/passport\\": \\"8.2.2\\",
-    \\"@nestjs/platform-express\\": \\"8.2.3\\",
+    \\"@nestjs/platform-express\\": \\"8.4.7\\",
     \\"@nestjs/serve-static\\": \\"2.2.2\\",
     \\"@nestjs/swagger\\": \\"5.1.5\\",
     \\"@prisma/client\\": \\"4.6.1\\",
@@ -3003,7 +3003,7 @@ volumes:
   },
   \\"devDependencies\\": {
     \\"@nestjs/cli\\": \\"8.2.5\\",
-    \\"@nestjs/testing\\": \\"8.2.3\\",
+    \\"@nestjs/testing\\": \\"8.4.7\\",
     \\"@types/bcrypt\\": \\"5.0.0\\",
     \\"@types/express\\": \\"4.17.9\\",
     \\"@types/graphql-type-json\\": \\"0.3.2\\",

--- a/packages/amplication-data-service-generator/src/version.ts
+++ b/packages/amplication-data-service-generator/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.1.0";
+export const version = "1.1.1";


### PR DESCRIPTION
Close: #4531

## PR Details
Update NestJS packages in the `package.json` of the generated server, to the latest 8 versions (`8.4.7`) in order to fix the vulnerabilities.

![image](https://user-images.githubusercontent.com/39680385/205622927-5335150f-0ab0-4a67-916d-36f72e29f2e4.png)


## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error
