### PR TITLE
chore(ci): fix ci deploy trigger secrets

### DIFF
--- a/.github/workflows/ci-nx.yml
+++ b/.github/workflows/ci-nx.yml
@@ -168,4 +168,5 @@ jobs:
     with:
      target-env: ${{ github.head_ref }}
      confirm-env: ${{ github.head_ref }}
+    secrets: inherit
 


### PR DESCRIPTION
Close: https://github.com/amplication/amplication/issues/4340

PR Details
Fix deploy step by passing the secrets to the reusable `Deploy` workflow 
[
To see the change in action, a modified version of the workflow is running here as pull_request triggered https://github.com/overbit/amplication/actions/runs/3647785805
and here manually
https://github.com/overbit/amplication/actions/runs/3647787738](https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow) 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
