### PR TITLE
Fix Prisma one-to-many relation compilation errors

### DIFF
--- a/packages/amplication-data-service-generator/src/server/resource/service/to-many.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/service/to-many.template.ts
@@ -14,7 +14,7 @@ export class Mixin {
     parentId: string,
     args: Prisma.ARGS
   ): Promise<RELATED_ENTITY[]> {
-    return await this.prisma.DELEGATE.findUniqueOrThrow({
+    return this.prisma.DELEGATE.findUniqueOrThrow({
       where: { id: parentId },
     }).PROPERTY(args);
   }

--- a/packages/amplication-data-service-generator/src/server/resource/service/to-many.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/service/to-many.template.ts
@@ -14,10 +14,8 @@ export class Mixin {
     parentId: string,
     args: Prisma.ARGS
   ): Promise<RELATED_ENTITY[]> {
-    return (
-      (await this.prisma.DELEGATE.findUnique({
-        where: { id: parentId },
-      }).PROPERTY(args)) ?? []
-    );
+    return await this.prisma.DELEGATE.findUniqueOrThrow({
+      where: { id: parentId },
+    }).PROPERTY(args);
   }
 }

--- a/packages/amplication-data-service-generator/src/server/resource/service/to-many.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/service/to-many.template.ts
@@ -16,6 +16,6 @@ export class Mixin {
   ): Promise<RELATED_ENTITY[]> {
     return this.prisma.DELEGATE.findUnique({
       where: { id: parentId },
-    }).PROPERTY(args);
+    }).PROPERTY(args) as Promise<RELATED_ENTITY[]>;
   }
 }

--- a/packages/amplication-data-service-generator/src/server/resource/service/to-many.template.ts
+++ b/packages/amplication-data-service-generator/src/server/resource/service/to-many.template.ts
@@ -14,8 +14,10 @@ export class Mixin {
     parentId: string,
     args: Prisma.ARGS
   ): Promise<RELATED_ENTITY[]> {
-    return this.prisma.DELEGATE.findUnique({
-      where: { id: parentId },
-    }).PROPERTY(args) as Promise<RELATED_ENTITY[]>;
+    return (
+      (await this.prisma.DELEGATE.findUnique({
+        where: { id: parentId },
+      }).PROPERTY(args)) ?? []
+    );
   }
 }

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -6382,7 +6382,7 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return await this.prisma.customer
+    return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -11415,7 +11415,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -11426,7 +11426,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -11437,7 +11437,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -15649,7 +15649,7 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return await this.prisma.user
+    return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -15660,7 +15660,7 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return await this.prisma.user
+    return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
       })

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -6382,13 +6382,11 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return (
-      (await this.prisma.customer
-        .findUnique({
-          where: { id: parentId },
-        })
-        .orders(args)) ?? []
-    );
+    return await this.prisma.customer
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .orders(args);
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -11417,39 +11415,33 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .users(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .users(args);
   }
 
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .customers(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .customers(args);
   }
 
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .vipCustomers(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .vipCustomers(args);
   }
 }
 ",
@@ -15657,26 +15649,22 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return (
-      (await this.prisma.user
-        .findUnique({
-          where: { id: parentId },
-        })
-        .employees(args)) ?? []
-    );
+    return await this.prisma.user
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .employees(args);
   }
 
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return (
-      (await this.prisma.user
-        .findUnique({
-          where: { id: parentId },
-        })
-        .organizations(args)) ?? []
-    );
+    return await this.prisma.user
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .organizations(args);
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -6382,11 +6382,13 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return this.prisma.customer
-      .findUnique({
-        where: { id: parentId },
-      })
-      .orders(args) as Promise<Order[]>;
+    return (
+      (await this.prisma.customer
+        .findUnique({
+          where: { id: parentId },
+        })
+        .orders(args)) ?? []
+    );
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -11415,33 +11417,39 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .users(args) as Promise<User[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .users(args)) ?? []
+    );
   }
 
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .customers(args) as Promise<Customer[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .customers(args)) ?? []
+    );
   }
 
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .vipCustomers(args) as Promise<Customer[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .vipCustomers(args)) ?? []
+    );
   }
 }
 ",
@@ -15649,22 +15657,26 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return this.prisma.user
-      .findUnique({
-        where: { id: parentId },
-      })
-      .employees(args) as Promise<User[]>;
+    return (
+      (await this.prisma.user
+        .findUnique({
+          where: { id: parentId },
+        })
+        .employees(args)) ?? []
+    );
   }
 
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return this.prisma.user
-      .findUnique({
-        where: { id: parentId },
-      })
-      .organizations(args) as Promise<Organization[]>;
+    return (
+      (await this.prisma.user
+        .findUnique({
+          where: { id: parentId },
+        })
+        .organizations(args)) ?? []
+    );
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -6386,7 +6386,7 @@ export class CustomerServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .orders(args);
+      .orders(args) as Promise<Order[]>;
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -11419,7 +11419,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .users(args);
+      .users(args) as Promise<User[]>;
   }
 
   async findCustomers(
@@ -11430,7 +11430,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .customers(args);
+      .customers(args) as Promise<Customer[]>;
   }
 
   async findVipCustomers(
@@ -11441,7 +11441,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .vipCustomers(args);
+      .vipCustomers(args) as Promise<Customer[]>;
   }
 }
 ",
@@ -15653,7 +15653,7 @@ export class UserServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .employees(args);
+      .employees(args) as Promise<User[]>;
   }
 
   async findOrganizations(
@@ -15664,7 +15664,7 @@ export class UserServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .organizations(args);
+      .organizations(args) as Promise<Organization[]>;
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -6382,7 +6382,7 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return await this.prisma.customer
+    return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -11415,7 +11415,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -11426,7 +11426,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -11437,7 +11437,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -15649,7 +15649,7 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return await this.prisma.user
+    return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -15660,7 +15660,7 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return await this.prisma.user
+    return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
       })

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -6382,13 +6382,11 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return (
-      (await this.prisma.customer
-        .findUnique({
-          where: { id: parentId },
-        })
-        .orders(args)) ?? []
-    );
+    return await this.prisma.customer
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .orders(args);
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -11417,39 +11415,33 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .users(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .users(args);
   }
 
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .customers(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .customers(args);
   }
 
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .vipCustomers(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .vipCustomers(args);
   }
 }
 ",
@@ -15657,26 +15649,22 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return (
-      (await this.prisma.user
-        .findUnique({
-          where: { id: parentId },
-        })
-        .employees(args)) ?? []
-    );
+    return await this.prisma.user
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .employees(args);
   }
 
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return (
-      (await this.prisma.user
-        .findUnique({
-          where: { id: parentId },
-        })
-        .organizations(args)) ?? []
-    );
+    return await this.prisma.user
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .organizations(args);
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -6382,11 +6382,13 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return this.prisma.customer
-      .findUnique({
-        where: { id: parentId },
-      })
-      .orders(args) as Promise<Order[]>;
+    return (
+      (await this.prisma.customer
+        .findUnique({
+          where: { id: parentId },
+        })
+        .orders(args)) ?? []
+    );
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -11415,33 +11417,39 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .users(args) as Promise<User[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .users(args)) ?? []
+    );
   }
 
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .customers(args) as Promise<Customer[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .customers(args)) ?? []
+    );
   }
 
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .vipCustomers(args) as Promise<Customer[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .vipCustomers(args)) ?? []
+    );
   }
 }
 ",
@@ -15649,22 +15657,26 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return this.prisma.user
-      .findUnique({
-        where: { id: parentId },
-      })
-      .employees(args) as Promise<User[]>;
+    return (
+      (await this.prisma.user
+        .findUnique({
+          where: { id: parentId },
+        })
+        .employees(args)) ?? []
+    );
   }
 
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return this.prisma.user
-      .findUnique({
-        where: { id: parentId },
-      })
-      .organizations(args) as Promise<Organization[]>;
+    return (
+      (await this.prisma.user
+        .findUnique({
+          where: { id: parentId },
+        })
+        .organizations(args)) ?? []
+    );
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -6386,7 +6386,7 @@ export class CustomerServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .orders(args);
+      .orders(args) as Promise<Order[]>;
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -11419,7 +11419,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .users(args);
+      .users(args) as Promise<User[]>;
   }
 
   async findCustomers(
@@ -11430,7 +11430,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .customers(args);
+      .customers(args) as Promise<Customer[]>;
   }
 
   async findVipCustomers(
@@ -11441,7 +11441,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .vipCustomers(args);
+      .vipCustomers(args) as Promise<Customer[]>;
   }
 }
 ",
@@ -15653,7 +15653,7 @@ export class UserServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .employees(args);
+      .employees(args) as Promise<User[]>;
   }
 
   async findOrganizations(
@@ -15664,7 +15664,7 @@ export class UserServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .organizations(args);
+      .organizations(args) as Promise<Organization[]>;
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -6421,11 +6421,13 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return this.prisma.customer
-      .findUnique({
-        where: { id: parentId },
-      })
-      .orders(args) as Promise<Order[]>;
+    return (
+      (await this.prisma.customer
+        .findUnique({
+          where: { id: parentId },
+        })
+        .orders(args)) ?? []
+    );
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -11537,33 +11539,39 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .users(args) as Promise<User[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .users(args)) ?? []
+    );
   }
 
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .customers(args) as Promise<Customer[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .customers(args)) ?? []
+    );
   }
 
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .vipCustomers(args) as Promise<Customer[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .vipCustomers(args)) ?? []
+    );
   }
 }
 ",
@@ -15771,22 +15779,26 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return this.prisma.user
-      .findUnique({
-        where: { id: parentId },
-      })
-      .employees(args) as Promise<User[]>;
+    return (
+      (await this.prisma.user
+        .findUnique({
+          where: { id: parentId },
+        })
+        .employees(args)) ?? []
+    );
   }
 
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return this.prisma.user
-      .findUnique({
-        where: { id: parentId },
-      })
-      .organizations(args) as Promise<Organization[]>;
+    return (
+      (await this.prisma.user
+        .findUnique({
+          where: { id: parentId },
+        })
+        .organizations(args)) ?? []
+    );
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -6421,7 +6421,7 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return await this.prisma.customer
+    return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -11537,7 +11537,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -11548,7 +11548,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -11559,7 +11559,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -15771,7 +15771,7 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return await this.prisma.user
+    return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -15782,7 +15782,7 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return await this.prisma.user
+    return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
       })

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -6425,7 +6425,7 @@ export class CustomerServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .orders(args);
+      .orders(args) as Promise<Order[]>;
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -11541,7 +11541,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .users(args);
+      .users(args) as Promise<User[]>;
   }
 
   async findCustomers(
@@ -11552,7 +11552,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .customers(args);
+      .customers(args) as Promise<Customer[]>;
   }
 
   async findVipCustomers(
@@ -11563,7 +11563,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .vipCustomers(args);
+      .vipCustomers(args) as Promise<Customer[]>;
   }
 }
 ",
@@ -15775,7 +15775,7 @@ export class UserServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .employees(args);
+      .employees(args) as Promise<User[]>;
   }
 
   async findOrganizations(
@@ -15786,7 +15786,7 @@ export class UserServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .organizations(args);
+      .organizations(args) as Promise<Organization[]>;
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -6421,13 +6421,11 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return (
-      (await this.prisma.customer
-        .findUnique({
-          where: { id: parentId },
-        })
-        .orders(args)) ?? []
-    );
+    return await this.prisma.customer
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .orders(args);
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -11539,39 +11537,33 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .users(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .users(args);
   }
 
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .customers(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .customers(args);
   }
 
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .vipCustomers(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .vipCustomers(args);
   }
 }
 ",
@@ -15779,26 +15771,22 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return (
-      (await this.prisma.user
-        .findUnique({
-          where: { id: parentId },
-        })
-        .employees(args)) ?? []
-    );
+    return await this.prisma.user
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .employees(args);
   }
 
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return (
-      (await this.prisma.user
-        .findUnique({
-          where: { id: parentId },
-        })
-        .organizations(args)) ?? []
-    );
+    return await this.prisma.user
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .organizations(args);
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -6154,7 +6154,7 @@ export class CustomerServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .orders(args);
+      .orders(args) as Promise<Order[]>;
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -10659,7 +10659,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .users(args);
+      .users(args) as Promise<User[]>;
   }
 
   async findCustomers(
@@ -10670,7 +10670,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .customers(args);
+      .customers(args) as Promise<Customer[]>;
   }
 
   async findVipCustomers(
@@ -10681,7 +10681,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .vipCustomers(args);
+      .vipCustomers(args) as Promise<Customer[]>;
   }
 }
 ",
@@ -14425,7 +14425,7 @@ export class UserServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .employees(args);
+      .employees(args) as Promise<User[]>;
   }
 
   async findOrganizations(
@@ -14436,7 +14436,7 @@ export class UserServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .organizations(args);
+      .organizations(args) as Promise<Organization[]>;
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -6150,11 +6150,13 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return this.prisma.customer
-      .findUnique({
-        where: { id: parentId },
-      })
-      .orders(args) as Promise<Order[]>;
+    return (
+      (await this.prisma.customer
+        .findUnique({
+          where: { id: parentId },
+        })
+        .orders(args)) ?? []
+    );
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -10655,33 +10657,39 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .users(args) as Promise<User[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .users(args)) ?? []
+    );
   }
 
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .customers(args) as Promise<Customer[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .customers(args)) ?? []
+    );
   }
 
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .vipCustomers(args) as Promise<Customer[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .vipCustomers(args)) ?? []
+    );
   }
 }
 ",
@@ -14421,22 +14429,26 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return this.prisma.user
-      .findUnique({
-        where: { id: parentId },
-      })
-      .employees(args) as Promise<User[]>;
+    return (
+      (await this.prisma.user
+        .findUnique({
+          where: { id: parentId },
+        })
+        .employees(args)) ?? []
+    );
   }
 
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return this.prisma.user
-      .findUnique({
-        where: { id: parentId },
-      })
-      .organizations(args) as Promise<Organization[]>;
+    return (
+      (await this.prisma.user
+        .findUnique({
+          where: { id: parentId },
+        })
+        .organizations(args)) ?? []
+    );
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -6150,7 +6150,7 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return await this.prisma.customer
+    return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -10655,7 +10655,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -10666,7 +10666,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -10677,7 +10677,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -14421,7 +14421,7 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return await this.prisma.user
+    return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -14432,7 +14432,7 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return await this.prisma.user
+    return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
       })

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -6150,13 +6150,11 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return (
-      (await this.prisma.customer
-        .findUnique({
-          where: { id: parentId },
-        })
-        .orders(args)) ?? []
-    );
+    return await this.prisma.customer
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .orders(args);
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -10657,39 +10655,33 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .users(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .users(args);
   }
 
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .customers(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .customers(args);
   }
 
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .vipCustomers(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .vipCustomers(args);
   }
 }
 ",
@@ -14429,26 +14421,22 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return (
-      (await this.prisma.user
-        .findUnique({
-          where: { id: parentId },
-        })
-        .employees(args)) ?? []
-    );
+    return await this.prisma.user
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .employees(args);
   }
 
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return (
-      (await this.prisma.user
-        .findUnique({
-          where: { id: parentId },
-        })
-        .organizations(args)) ?? []
-    );
+    return await this.prisma.user
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .organizations(args);
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -5730,11 +5730,13 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return this.prisma.customer
-      .findUnique({
-        where: { id: parentId },
-      })
-      .orders(args) as Promise<Order[]>;
+    return (
+      (await this.prisma.customer
+        .findUnique({
+          where: { id: parentId },
+        })
+        .orders(args)) ?? []
+    );
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -9201,33 +9203,39 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .users(args) as Promise<User[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .users(args)) ?? []
+    );
   }
 
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .customers(args) as Promise<Customer[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .customers(args)) ?? []
+    );
   }
 
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .vipCustomers(args) as Promise<Customer[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .vipCustomers(args)) ?? []
+    );
   }
 }
 ",
@@ -12214,22 +12222,26 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return this.prisma.user
-      .findUnique({
-        where: { id: parentId },
-      })
-      .employees(args) as Promise<User[]>;
+    return (
+      (await this.prisma.user
+        .findUnique({
+          where: { id: parentId },
+        })
+        .employees(args)) ?? []
+    );
   }
 
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return this.prisma.user
-      .findUnique({
-        where: { id: parentId },
-      })
-      .organizations(args) as Promise<Organization[]>;
+    return (
+      (await this.prisma.user
+        .findUnique({
+          where: { id: parentId },
+        })
+        .organizations(args)) ?? []
+    );
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -5734,7 +5734,7 @@ export class CustomerServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .orders(args);
+      .orders(args) as Promise<Order[]>;
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -9205,7 +9205,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .users(args);
+      .users(args) as Promise<User[]>;
   }
 
   async findCustomers(
@@ -9216,7 +9216,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .customers(args);
+      .customers(args) as Promise<Customer[]>;
   }
 
   async findVipCustomers(
@@ -9227,7 +9227,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .vipCustomers(args);
+      .vipCustomers(args) as Promise<Customer[]>;
   }
 }
 ",
@@ -12218,7 +12218,7 @@ export class UserServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .employees(args);
+      .employees(args) as Promise<User[]>;
   }
 
   async findOrganizations(
@@ -12229,7 +12229,7 @@ export class UserServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .organizations(args);
+      .organizations(args) as Promise<Organization[]>;
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -5730,7 +5730,7 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return await this.prisma.customer
+    return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -9201,7 +9201,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -9212,7 +9212,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -9223,7 +9223,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -12214,7 +12214,7 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return await this.prisma.user
+    return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -12225,7 +12225,7 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return await this.prisma.user
+    return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
       })

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -5730,13 +5730,11 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return (
-      (await this.prisma.customer
-        .findUnique({
-          where: { id: parentId },
-        })
-        .orders(args)) ?? []
-    );
+    return await this.prisma.customer
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .orders(args);
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -9203,39 +9201,33 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .users(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .users(args);
   }
 
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .customers(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .customers(args);
   }
 
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .vipCustomers(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .vipCustomers(args);
   }
 }
 ",
@@ -12222,26 +12214,22 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return (
-      (await this.prisma.user
-        .findUnique({
-          where: { id: parentId },
-        })
-        .employees(args)) ?? []
-    );
+    return await this.prisma.user
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .employees(args);
   }
 
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return (
-      (await this.prisma.user
-        .findUnique({
-          where: { id: parentId },
-        })
-        .organizations(args)) ?? []
-    );
+    return await this.prisma.user
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .organizations(args);
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -6382,7 +6382,7 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return await this.prisma.customer
+    return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -11415,7 +11415,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -11426,7 +11426,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -11437,7 +11437,7 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return await this.prisma.organization
+    return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -15649,7 +15649,7 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return await this.prisma.user
+    return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
       })
@@ -15660,7 +15660,7 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return await this.prisma.user
+    return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
       })

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -6382,13 +6382,11 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return (
-      (await this.prisma.customer
-        .findUnique({
-          where: { id: parentId },
-        })
-        .orders(args)) ?? []
-    );
+    return await this.prisma.customer
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .orders(args);
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -11417,39 +11415,33 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .users(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .users(args);
   }
 
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .customers(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .customers(args);
   }
 
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return (
-      (await this.prisma.organization
-        .findUnique({
-          where: { id: parentId },
-        })
-        .vipCustomers(args)) ?? []
-    );
+    return await this.prisma.organization
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .vipCustomers(args);
   }
 }
 ",
@@ -15657,26 +15649,22 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return (
-      (await this.prisma.user
-        .findUnique({
-          where: { id: parentId },
-        })
-        .employees(args)) ?? []
-    );
+    return await this.prisma.user
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .employees(args);
   }
 
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return (
-      (await this.prisma.user
-        .findUnique({
-          where: { id: parentId },
-        })
-        .organizations(args)) ?? []
-    );
+    return await this.prisma.user
+      .findUniqueOrThrow({
+        where: { id: parentId },
+      })
+      .organizations(args);
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -6382,11 +6382,13 @@ export class CustomerServiceBase {
     parentId: string,
     args: Prisma.OrderFindManyArgs
   ): Promise<Order[]> {
-    return this.prisma.customer
-      .findUnique({
-        where: { id: parentId },
-      })
-      .orders(args) as Promise<Order[]>;
+    return (
+      (await this.prisma.customer
+        .findUnique({
+          where: { id: parentId },
+        })
+        .orders(args)) ?? []
+    );
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -11415,33 +11417,39 @@ export class OrganizationServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .users(args) as Promise<User[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .users(args)) ?? []
+    );
   }
 
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .customers(args) as Promise<Customer[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .customers(args)) ?? []
+    );
   }
 
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
   ): Promise<Customer[]> {
-    return this.prisma.organization
-      .findUnique({
-        where: { id: parentId },
-      })
-      .vipCustomers(args) as Promise<Customer[]>;
+    return (
+      (await this.prisma.organization
+        .findUnique({
+          where: { id: parentId },
+        })
+        .vipCustomers(args)) ?? []
+    );
   }
 }
 ",
@@ -15649,22 +15657,26 @@ export class UserServiceBase {
     parentId: string,
     args: Prisma.UserFindManyArgs
   ): Promise<User[]> {
-    return this.prisma.user
-      .findUnique({
-        where: { id: parentId },
-      })
-      .employees(args) as Promise<User[]>;
+    return (
+      (await this.prisma.user
+        .findUnique({
+          where: { id: parentId },
+        })
+        .employees(args)) ?? []
+    );
   }
 
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
   ): Promise<Organization[]> {
-    return this.prisma.user
-      .findUnique({
-        where: { id: parentId },
-      })
-      .organizations(args) as Promise<Organization[]>;
+    return (
+      (await this.prisma.user
+        .findUnique({
+          where: { id: parentId },
+        })
+        .organizations(args)) ?? []
+    );
   }
 
   async getManager(parentId: string): Promise<User | null> {

--- a/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/amplication-data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -6386,7 +6386,7 @@ export class CustomerServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .orders(args);
+      .orders(args) as Promise<Order[]>;
   }
 
   async getOrganization(parentId: string): Promise<Organization | null> {
@@ -11419,7 +11419,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .users(args);
+      .users(args) as Promise<User[]>;
   }
 
   async findCustomers(
@@ -11430,7 +11430,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .customers(args);
+      .customers(args) as Promise<Customer[]>;
   }
 
   async findVipCustomers(
@@ -11441,7 +11441,7 @@ export class OrganizationServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .vipCustomers(args);
+      .vipCustomers(args) as Promise<Customer[]>;
   }
 }
 ",
@@ -15653,7 +15653,7 @@ export class UserServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .employees(args);
+      .employees(args) as Promise<User[]>;
   }
 
   async findOrganizations(
@@ -15664,7 +15664,7 @@ export class UserServiceBase {
       .findUnique({
         where: { id: parentId },
       })
-      .organizations(args);
+      .organizations(args) as Promise<Organization[]>;
   }
 
   async getManager(parentId: string): Promise<User | null> {


### PR DESCRIPTION
Close: #4582

## PR Details
In the new version of Prisma, the return type in  one-to-many relation has changed to 
`PrismaPromise<Array<OrderGetPayload<T>>| Null>`
In our API, when there are no results, we return an empty array and not null.
We reached out to Prisma on Slack, and they gave us the two options:
- use `findUniqueOrThrow` instead of `findUnique`
- add a `!` before  `.orders()`  => ` await findUnique(...)!.orders(...)`

We decided to go with the first solution.

## PR Checklist

- [x] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

