### PR TITLE
fix docker-compose-dev env variable

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,7 +14,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "pg_isready -d $${POSTGRESQL_DB_NAME} -U $${POSTGRES_USER}",
+          "pg_isready -d $${POSTGRESQL_DB_NAME} -U $${POSTGRESQL_USER}",
         ]
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
Close: #4673 

## PR Details

fix docker-compose-dev env variable

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

