### PR TITLE
Add configmap variables for sendgrid to next and staging

### DIFF
--- a/helm/charts/amplication/values-next.yaml
+++ b/helm/charts/amplication/values-next.yaml
@@ -67,6 +67,9 @@ amplication-server:
       GITHUB_APP_CLIENT_ID: "Iv1.ba108fc312eb8265"
       GITHUB_APP_INSTALLATION_URL: "https://github.com/apps/next-environment/installations/new?state={state}"
 
+      SENDGRID_FROM_ADDRESS: next.team@amplication.com
+      SENDGRID_INVITATION_TEMPLATE_ID: d-aaae46e4127c4d2399d242610e6c496a
+
       #GitHub OAuth App
       GITHUB_CLIENT_ID: "4a58ad31c388c892639d"
       GITHUB_REDIRECT_URI: "https://server-next.amplication-dev.com/github/callback"

--- a/helm/charts/amplication/values-staging.yaml
+++ b/helm/charts/amplication/values-staging.yaml
@@ -68,6 +68,9 @@ amplication-server:
       GITHUB_APP_CLIENT_ID: "Iv1.e0d76b0ce191a528"
       GITHUB_APP_INSTALLATION_URL: "https://github.com/apps/amplication-staging/installations/new?state={state}"
 
+      SENDGRID_FROM_ADDRESS: staging.team@amplication.com
+      SENDGRID_INVITATION_TEMPLATE_ID: d-aaae46e4127c4d2399d242610e6c496a
+
       #GitHub OAuth App
       GITHUB_CLIENT_ID: "4f5b9a88cf46d4c5ec32"
       GITHUB_SECRET_SECRET_NAME: "projects/948093699220/secrets/github-secret-amplication-aws/versions/1"


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #4535 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

Added variables for the `next` and `staging` environment to be able to send emails via sendgrid on those environments aswell. The API key is currently specified via the AWS Secrets Manager.

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
