### PR TITLE
fix(server): issue where first kafka event emitted fails silently

### DIFF
--- a/packages/amplication-server/src/core/queue/queue.service.ts
+++ b/packages/amplication-server/src/core/queue/queue.service.ts
@@ -1,15 +1,20 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, OnModuleInit } from "@nestjs/common";
 import { ClientKafka } from "@nestjs/microservices";
 
 export const QUEUE_SERVICE_NAME = "QUEUE_SERVICE";
 
 @Injectable()
-export class QueueService {
+export class QueueService implements OnModuleInit {
   generatePullRequestTopic: string;
   constructor(
     @Inject(QUEUE_SERVICE_NAME)
     private readonly kafkaClient: ClientKafka
   ) {}
+
+  async onModuleInit() {
+    // Explicitly wait for kafka client to connect. https://github.com/nestjs/nest/issues/10449
+    await this.kafkaClient.connect();
+  }
 
   emitMessage(topic: string, message: string): void {
     this.kafkaClient.emit(topic, message);


### PR DESCRIPTION
Close: #4947 

## PR Details

The current Nestjs implementation seems to have a bug that will prevent the first event emitted to be successfully send.
Bug: https://github.com/nestjs/nest/issues/10449 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
