### PR TITLE
feat: one-to-one relation FK

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -47,6 +47,7 @@
     "SENDGRID",
     "Signup",
     "slynova",
+    "Stigg",
     "tablename",
     "teleporter",
     "uncontained",

--- a/packages/amplication-client/src/Entity/EntityField.tsx
+++ b/packages/amplication-client/src/Entity/EntityField.tsx
@@ -63,7 +63,7 @@ const EntityField = () => {
   });
 
   const entityField = data?.entity.fields?.[0];
-  const entityDisplayName = data?.entity.displayName;
+  const entityRecord = data?.entity;
 
   const [updateEntityField, { error: updateError }] = useMutation<UpdateData>(
     UPDATE_ENTITY_FIELD,
@@ -194,7 +194,7 @@ const EntityField = () => {
             onSubmit={handleSubmit}
             defaultValues={defaultValues}
             resourceId={resource}
-            entityDisplayName={entityDisplayName || ""}
+            entity={entityRecord}
           />
         </>
       )}
@@ -236,6 +236,7 @@ const GET_ENTITY_FIELD = gql`
         unique
         searchable
         description
+        permanentId
       }
     }
   }

--- a/packages/amplication-client/src/Entity/EntityFieldForm.tsx
+++ b/packages/amplication-client/src/Entity/EntityFieldForm.tsx
@@ -34,7 +34,7 @@ type Props = {
   onSubmit: (values: Values) => void;
   defaultValues?: Partial<models.EntityField>;
   resourceId: string;
-  entityDisplayName: string;
+  entity: models.Entity;
   isSystemDataType?: boolean;
 };
 
@@ -52,7 +52,12 @@ const FORM_SCHEMA = {
   },
 };
 
-const NON_INPUT_GRAPHQL_PROPERTIES = ["createdAt", "updatedAt", "__typename"];
+const NON_INPUT_GRAPHQL_PROPERTIES = [
+  "createdAt",
+  "updatedAt",
+  "__typename",
+  "permanentId",
+];
 
 export const INITIAL_VALUES: Values = {
   id: "",
@@ -70,7 +75,7 @@ const EntityFieldForm = ({
   onSubmit,
   defaultValues = {},
   resourceId,
-  entityDisplayName,
+  entity,
   isSystemDataType,
 }: Props) => {
   const initialValues = useMemo(() => {
@@ -170,7 +175,7 @@ const EntityFieldForm = ({
             <SchemaFields
               schema={schema}
               resourceId={resourceId}
-              entityDisplayName={entityDisplayName}
+              entity={entity}
             />
           </Form>
         );

--- a/packages/amplication-client/src/Entity/RelatedEntityFieldField.tsx
+++ b/packages/amplication-client/src/Entity/RelatedEntityFieldField.tsx
@@ -1,3 +1,4 @@
+import { HorizontalRule } from "@amplication/design-system";
 import { gql, useQuery } from "@apollo/client";
 import { useFormikContext } from "formik";
 import React from "react";
@@ -34,17 +35,20 @@ const RelatedEntityFieldField = ({ entityDisplayName }: Props) => {
   return (
     <div className={CLASS_NAME}>
       {data && relatedField && (
-        <EntityRelationFieldsChart
-          fixInPlace={false}
-          resourceId={data.entity.resourceId}
-          entityId={data.entity.id}
-          field={formik.values}
-          entityName={entityDisplayName}
-          relatedField={relatedField}
-          relatedEntityName={data.entity.displayName}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          onSubmit={() => {}}
-        />
+        <>
+          <HorizontalRule />
+          <EntityRelationFieldsChart
+            fixInPlace={false}
+            resourceId={data.entity.resourceId}
+            entityId={data.entity.id}
+            field={formik.values}
+            entityName={entityDisplayName}
+            relatedField={relatedField}
+            relatedEntityName={data.entity.displayName}
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            onSubmit={() => {}}
+          />
+        </>
       )}
     </div>
   );

--- a/packages/amplication-client/src/Entity/RelationFkHolderField.tsx
+++ b/packages/amplication-client/src/Entity/RelationFkHolderField.tsx
@@ -1,0 +1,63 @@
+import { SelectField, SelectFieldProps } from "@amplication/design-system";
+import { useQuery } from "@apollo/client";
+import { useFormikContext } from "formik";
+import { useMemo } from "react";
+import * as models from "../models";
+import { GET_ENTITY_FIELD_BY_PERMANENT_ID } from "./RelatedEntityFieldField";
+
+type Props = Omit<SelectFieldProps, "options"> & {
+  entity: models.Entity;
+};
+
+const RelationFkHolderField = ({ entity, ...props }: Props) => {
+  const formik = useFormikContext<models.EntityField>();
+
+  const { data } = useQuery<{ entity: models.Entity }>(
+    GET_ENTITY_FIELD_BY_PERMANENT_ID,
+    {
+      variables: {
+        entityId: formik.values.properties.relatedEntityId,
+        fieldPermanentId: formik.values.properties.relatedFieldId,
+      },
+    }
+  );
+
+  const relatedField =
+    data &&
+    data.entity &&
+    data.entity.fields &&
+    data.entity.fields.length &&
+    data.entity.fields[0];
+
+  const isOneToOne = useMemo(() => {
+    return (
+      entity &&
+      data &&
+      !formik.values?.properties.allowMultipleSelection &&
+      !relatedField.properties.allowMultipleSelection
+    );
+  }, [data, formik.values]);
+
+  const entityListOptions = useMemo(() => {
+    return (
+      (entity &&
+        data && [
+          {
+            value: formik.values.permanentId,
+            label: `${entity.displayName} (this side)`,
+          },
+          {
+            value: relatedField.permanentId,
+            label: `${data.entity.displayName} (Other side)`,
+          },
+        ]) ||
+      []
+    );
+  }, [data]);
+
+  if (!isOneToOne) return null;
+
+  return <SelectField {...props} options={entityListOptions} />;
+};
+
+export default RelationFkHolderField;

--- a/packages/amplication-client/src/Entity/SchemaField.tsx
+++ b/packages/amplication-client/src/Entity/SchemaField.tsx
@@ -7,13 +7,15 @@ import RelationAllowMultipleField from "../Components/RelationAllowMultipleField
 import { Schema } from "@amplication/code-gen-types";
 import OptionSet from "../Entity/OptionSet";
 import { JSONSchema7 } from "json-schema";
+import RelationFkHolderField from "./RelationFkHolderField";
+import * as models from "../models";
 
 type Props = {
   propertyName: string;
   propertySchema: Schema;
   isDisabled?: boolean;
   resourceId: string;
-  entityDisplayName: string;
+  entity: models.Entity;
   isSystemData?: boolean;
 };
 
@@ -21,7 +23,7 @@ export const SchemaField = ({
   propertyName,
   propertySchema,
   resourceId,
-  entityDisplayName,
+  entity,
 }: Props) => {
   const fieldName = `properties.${propertyName}`;
   const label = propertySchema.title || capitalCase(propertyName);
@@ -82,14 +84,23 @@ export const SchemaField = ({
         }
         case "#/definitions/EntityFieldId": {
           return (
-            <RelatedEntityFieldField entityDisplayName={entityDisplayName} />
+            <RelatedEntityFieldField entityDisplayName={entity.displayName} />
           );
         }
         case "#/definitions/RelationAllowMultiple": {
           return (
             <RelationAllowMultipleField
               fieldName={fieldName}
-              entityDisplayName={entityDisplayName}
+              entityDisplayName={entity.displayName}
+            />
+          );
+        }
+        case "#/definitions/RelationFkHolder": {
+          return (
+            <RelationFkHolderField
+              entity={entity}
+              label={label}
+              name={fieldName}
             />
           );
         }

--- a/packages/amplication-client/src/Entity/SchemaFields.tsx
+++ b/packages/amplication-client/src/Entity/SchemaFields.tsx
@@ -1,18 +1,15 @@
 import { SchemaField } from "./SchemaField";
 import { Schema } from "@amplication/code-gen-types";
+import * as models from "../models";
 
 type Props = {
   schema: Schema;
-  entityDisplayName: string;
+  entity: models.Entity;
   resourceId: string;
   isDisabled?: boolean;
 };
 
-export const SchemaFields = ({
-  schema,
-  resourceId,
-  entityDisplayName,
-}: Props) => {
+export const SchemaFields = ({ schema, resourceId, entity }: Props) => {
   if (schema === null) {
     return null;
   }
@@ -33,7 +30,7 @@ export const SchemaFields = ({
               propertyName={name}
               propertySchema={property as Schema}
               resourceId={resourceId}
-              entityDisplayName={entityDisplayName}
+              entity={entity}
             />
           </div>
         );

--- a/packages/amplication-code-gen-types/src/schemas/lookup.json
+++ b/packages/amplication-code-gen-types/src/schemas/lookup.json
@@ -15,6 +15,11 @@
       "$ref": "#/definitions/RelationAllowMultiple",
       "default": false
     },
+    "FkHolder": {
+      "title": "Foreign Key Holder",
+      "$ref": "#/definitions/RelationFkHolder",
+      "default": false
+    },
     "relatedFieldId": {
       "title": "Related Field",
       "$ref": "#/definitions/EntityFieldId",
@@ -30,6 +35,9 @@
     },
     "RelationAllowMultiple": {
       "type": "boolean"
+    },
+    "RelationFkHolder": {
+      "type": "string"
     }
   }
 }

--- a/packages/amplication-server/.env
+++ b/packages/amplication-server/.env
@@ -56,5 +56,5 @@ KAFKA_CLIENT_ID='server-queue-client'
 KAFKA_GROUP_ID='main-server-group'
 KAFKA_REPOSITORY_PUSH_QUEUE='git.external.push.event.0'
 
-BILLING_ENABLED=true
+BILLING_ENABLED=false
 BILLING_API_KEY="123456"

--- a/packages/amplication-server/src/core/billing/billing.service.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.ts
@@ -35,9 +35,16 @@ export class BillingService {
     private readonly analytics: SegmentAnalyticsService,
     configService: ConfigService
   ) {
-    const stiggApiKey = configService.get(Env.BILLING_API_KEY);
-    this.stiggClient = Stigg.initialize({ apiKey: stiggApiKey });
-    this.clientHost = configService.get(Env.CLIENT_HOST);
+    const isBillingEnabled = Boolean(
+      configService.get<string>(Env.BILLING_ENABLED) === "true"
+    );
+
+    if (isBillingEnabled) {
+      const stiggApiKey = configService.get(Env.BILLING_API_KEY);
+
+      this.stiggClient = Stigg.initialize({ apiKey: stiggApiKey });
+      this.clientHost = configService.get(Env.CLIENT_HOST);
+    }
   }
 
   async getStiggClient() {

--- a/packages/amplication-server/src/core/billing/billing.service.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.ts
@@ -23,11 +23,18 @@ import {
   EnumEventType,
   SegmentAnalyticsService,
 } from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { ValidationError } from "../../errors/ValidationError";
+import { FeatureUsageReport } from "../project/FeatureUsageReport";
 
 @Injectable()
 export class BillingService {
   private readonly stiggClient: Stigg;
   private readonly clientHost: string;
+  private billingEnabled: boolean;
+
+  get isBillingEnabled(): boolean {
+    return this.billingEnabled;
+  }
 
   constructor(
     @Inject(AMPLICATION_LOGGER_PROVIDER)
@@ -35,25 +42,49 @@ export class BillingService {
     private readonly analytics: SegmentAnalyticsService,
     configService: ConfigService
   ) {
-    const isBillingEnabled = Boolean(
-      configService.get<string>(Env.BILLING_ENABLED) === "true"
-    );
+    try {
+      this.logger.info("starting billing service");
 
-    if (isBillingEnabled) {
-      const stiggApiKey = configService.get(Env.BILLING_API_KEY);
+      this.billingEnabled = Boolean(
+        configService.get<string>(Env.BILLING_ENABLED) === "true"
+      );
 
-      this.stiggClient = Stigg.initialize({ apiKey: stiggApiKey });
-      this.clientHost = configService.get(Env.CLIENT_HOST);
+      if (this.isBillingEnabled) {
+        const stiggApiKey = configService.get(Env.BILLING_API_KEY);
+
+        this.stiggClient = Stigg.initialize({ apiKey: stiggApiKey });
+        this.clientHost = configService.get(Env.CLIENT_HOST);
+        this.stiggClient
+          .waitForInitialization()
+          .then(() => {
+            this.logger.info("Successfully initialized Stigg provider");
+          })
+          .catch((reason) => {
+            this.logger.error("failed to initialize Stigg", { reason });
+            this.logger.error("Disabling billing module");
+            this.stiggClient.close();
+            this.billingEnabled = false;
+          });
+      } else {
+        this.logger.info(
+          "Billing is disabled. Skipping initialization for Stigg Provider."
+        );
+      }
+    } catch (error) {
+      this.logger.error("failed to initialize Stigg", { error });
+      this.logger.error("Disabling billing module");
+      this.billingEnabled = false;
     }
   }
 
-  async getStiggClient() {
+  async getStiggClient(): Promise<Stigg | null> {
     try {
-      await this.stiggClient.waitForInitialization();
-      return this.stiggClient;
+      if (this.isBillingEnabled) {
+        return this.stiggClient;
+      }
+      return null;
     } catch (err) {
       this.logger.error(err);
-      throw err;
     }
   }
 
@@ -62,12 +93,18 @@ export class BillingService {
     feature: BillingFeature,
     value = 1
   ): Promise<ReportUsageAck> {
-    const stiggClient = await this.getStiggClient();
-    return await stiggClient.reportUsage({
-      customerId: workspaceId,
-      featureId: feature,
-      value: value,
-    });
+    try {
+      if (this.isBillingEnabled) {
+        const stiggClient = await this.getStiggClient();
+        return await stiggClient.reportUsage({
+          customerId: workspaceId,
+          featureId: feature,
+          value: value,
+        });
+      }
+    } catch (error) {
+      this.logger.error(error);
+    }
   }
 
   async setUsage(
@@ -75,53 +112,77 @@ export class BillingService {
     feature: BillingFeature,
     value: number
   ): Promise<ReportUsageAck> {
-    const stiggClient = await this.getStiggClient();
+    try {
+      if (this.isBillingEnabled) {
+        const stiggClient = await this.getStiggClient();
 
-    const entitlement = await stiggClient.getMeteredEntitlement({
-      customerId: workspaceId,
-      featureId: feature,
-    });
+        const entitlement = await stiggClient.getMeteredEntitlement({
+          customerId: workspaceId,
+          featureId: feature,
+        });
 
-    const result = value - entitlement.currentUsage;
+        const result = value - entitlement.currentUsage;
 
-    return await stiggClient.reportUsage({
-      customerId: workspaceId,
-      featureId: feature,
-      value: result,
-    });
+        return await stiggClient.reportUsage({
+          customerId: workspaceId,
+          featureId: feature,
+          value: result,
+        });
+      }
+    } catch (error) {
+      this.logger.error(error);
+    }
   }
 
   async getMeteredEntitlement(
     workspaceId: string,
     feature: BillingFeature
   ): Promise<MeteredEntitlement> {
-    const stiggClient = await this.getStiggClient();
-    return await stiggClient.getMeteredEntitlement({
-      customerId: workspaceId,
-      featureId: feature,
-    });
+    try {
+      if (this.isBillingEnabled) {
+        const stiggClient = await this.getStiggClient();
+        return await stiggClient.getMeteredEntitlement({
+          customerId: workspaceId,
+          featureId: feature,
+        });
+      }
+    } catch (error) {
+      this.logger.error(error);
+    }
   }
 
   async getNumericEntitlement(
     workspaceId: string,
     feature: BillingFeature
   ): Promise<NumericEntitlement> {
-    const stiggClient = await this.getStiggClient();
-    return await stiggClient.getNumericEntitlement({
-      customerId: workspaceId,
-      featureId: feature,
-    });
+    try {
+      if (this.isBillingEnabled) {
+        const stiggClient = await this.getStiggClient();
+        return await stiggClient.getNumericEntitlement({
+          customerId: workspaceId,
+          featureId: feature,
+        });
+      }
+    } catch (error) {
+      this.logger.error(error);
+    }
   }
 
   async getBooleanEntitlement(
     workspaceId: string,
     feature: BillingFeature
   ): Promise<BooleanEntitlement> {
-    const stiggClient = await this.getStiggClient();
-    return await stiggClient.getBooleanEntitlement({
-      customerId: workspaceId,
-      featureId: feature,
-    });
+    try {
+      if (this.isBillingEnabled) {
+        const stiggClient = await this.getStiggClient();
+        return await stiggClient.getBooleanEntitlement({
+          customerId: workspaceId,
+          featureId: feature,
+        });
+      }
+    } catch (error) {
+      this.logger.error(error);
+    }
   }
 
   async provisionSubscription(
@@ -157,32 +218,115 @@ export class BillingService {
 
   async getSubscription(workspaceId: string): Promise<Subscription | null> {
     try {
-      const stiggClient = await this.getStiggClient();
-      const workspace = await stiggClient.getCustomer(workspaceId);
+      if (this.billingEnabled) {
+        const stiggClient = await this.getStiggClient();
+        const workspace = await stiggClient.getCustomer(workspaceId);
 
-      const activeSub = await workspace.subscriptions.find((subscription) => {
-        return subscription.status === SubscriptionStatus.Active;
-      });
+        const activeSub = await workspace.subscriptions.find((subscription) => {
+          return subscription.status === SubscriptionStatus.Active;
+        });
 
-      if (activeSub.plan.id === BillingPlan.Free) {
+        if (activeSub.plan.id === BillingPlan.Free) {
+          return null;
+        }
+
+        const amplicationSub = {
+          id: activeSub.id,
+          status: this.mapSubscriptionStatus(activeSub.status),
+          workspaceId: workspaceId,
+          subscriptionPlan: this.mapSubscriptionPlan(
+            activeSub.plan.id as BillingPlan
+          ),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          subscriptionData: new SubscriptionData(),
+        };
+
+        return amplicationSub;
+      } else {
         return null;
       }
-
-      const amplicationSub = {
-        id: activeSub.id,
-        status: this.mapSubscriptionStatus(activeSub.status),
-        workspaceId: workspaceId,
-        subscriptionPlan: this.mapSubscriptionPlan(
-          activeSub.plan.id as BillingPlan
-        ),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        subscriptionData: new SubscriptionData(),
-      };
-
-      return amplicationSub;
     } catch (error) {
+      this.logger.error(error);
       return null; //on any exception, use free plan
+    }
+  }
+
+  async provisionCustomer(
+    workspaceId: string,
+    plan: BillingPlan
+  ): Promise<null> {
+    if (this.isBillingEnabled) {
+      const stiggClient = await this.getStiggClient();
+      await stiggClient.provisionCustomer({
+        customerId: workspaceId,
+        subscriptionParams: {
+          planId: plan,
+        },
+      });
+    }
+    return;
+  }
+
+  //todo: wrap with a try catch and return an object with the details about the limitations
+  async validateSubscriptionPlanLimitationsForWorkspace(
+    workspaceId: string
+  ): Promise<void> {
+    if (this.isBillingEnabled) {
+      const isIgnoreValidationCodeGeneration = await this.getBooleanEntitlement(
+        workspaceId,
+        BillingFeature.IgnoreValidationCodeGeneration
+      );
+
+      //check whether the workspace has entitlement to bypass code generation limitation
+      if (!isIgnoreValidationCodeGeneration.hasAccess) {
+        const servicesEntitlement = await this.getMeteredEntitlement(
+          workspaceId,
+          BillingFeature.Services
+        );
+
+        if (!servicesEntitlement.hasAccess) {
+          throw new ValidationError(
+            `LimitationError: Allowed services per workspace: ${servicesEntitlement.usageLimit}`
+          );
+        }
+
+        const servicesAboveEntitiesPerServiceLimitEntitlement =
+          await this.getMeteredEntitlement(
+            workspaceId,
+            BillingFeature.ServicesAboveEntitiesPerServiceLimit
+          );
+
+        if (!servicesAboveEntitiesPerServiceLimitEntitlement.hasAccess) {
+          const entitiesPerServiceEntitlement =
+            await this.getNumericEntitlement(
+              workspaceId,
+              BillingFeature.EntitiesPerService
+            );
+
+          const entitiesPerServiceLimit = entitiesPerServiceEntitlement.value;
+
+          throw new ValidationError(
+            `LimitationError: Allowed entities per service: ${entitiesPerServiceLimit}`
+          );
+        }
+      }
+    }
+  }
+
+  async resetUsage(workspaceId: string, currentUsage: FeatureUsageReport) {
+    if (this.isBillingEnabled) {
+      await this.setUsage(
+        workspaceId,
+        BillingFeature.Services,
+        currentUsage.services
+      );
+
+      await this.setUsage(
+        workspaceId,
+        BillingFeature.ServicesAboveEntitiesPerServiceLimit,
+        currentUsage.servicesAboveEntityPerServiceLimit
+      );
     }
   }
 

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -143,8 +143,6 @@ export function createInitialStepData(
 }
 @Injectable()
 export class BuildService {
-  private readonly isBillingEnabled: boolean;
-
   constructor(
     private readonly configService: ConfigService,
     private readonly prisma: PrismaService,
@@ -169,10 +167,6 @@ export class BuildService {
     if (!this.host) {
       throw new Error("Missing HOST_VAR in env");
     }
-
-    this.isBillingEnabled = this.configService.get<boolean>(
-      Env.BILLING_ENABLED
-    );
   }
   host: string;
 
@@ -384,15 +378,13 @@ export class BuildService {
       await this.actionService.logInfo(step, PUSH_TO_GITHUB_STEP_FINISH_LOG);
       await this.actionService.complete(step, EnumActionStepStatus.Success);
 
-      if (this.isBillingEnabled) {
-        const workspace = await this.resourceService.getResourceWorkspace(
-          build.resourceId
-        );
-        await this.billingService.reportUsage(
-          workspace.id,
-          BillingFeature.CodePushToGit
-        );
-      }
+      const workspace = await this.resourceService.getResourceWorkspace(
+        build.resourceId
+      );
+      await this.billingService.reportUsage(
+        workspace.id,
+        BillingFeature.CodePushToGit
+      );
     } catch (error) {
       await this.actionService.logInfo(step, PUSH_TO_GITHUB_STEP_FAILED_LOG);
       await this.actionService.logInfo(step, error);

--- a/packages/amplication-server/src/core/project/project.service.spec.ts
+++ b/packages/amplication-server/src/core/project/project.service.spec.ts
@@ -232,6 +232,9 @@ describe("ProjectService", () => {
             getNumericEntitlement: jest.fn(() => {
               return {};
             }),
+            reportUsage: jest.fn(() => {
+              return {};
+            }),
           },
         },
         {
@@ -250,6 +253,9 @@ describe("ProjectService", () => {
             project: {
               findMany: jest.fn(() => {
                 return [EXAMPLE_PROJECT];
+              }),
+              findFirst: jest.fn(() => {
+                return EXAMPLE_PROJECT;
               }),
             },
           })),

--- a/packages/amplication-server/src/core/project/project.service.ts
+++ b/packages/amplication-server/src/core/project/project.service.ts
@@ -197,8 +197,9 @@ export class ProjectService {
     );
   }
 
-  async validateSubscriptionPlanLimitationsForProject(
-    workspaceId: string
+  async validateSubscriptionPlanLimitationsForWorkspace(
+    workspaceId: string,
+    entitiesPerServiceLimit: number
   ): Promise<void> {
     const servicesEntitlement = await this.billingService.getMeteredEntitlement(
       workspaceId,
@@ -219,7 +220,7 @@ export class ProjectService {
 
     if (!servicesAboveEntitiesPerServiceLimitEntitlement.hasAccess) {
       throw new ValidationError(
-        `LimitationError: Allowed entities per service: ${servicesAboveEntitiesPerServiceLimitEntitlement.usageLimit}`
+        `LimitationError: Allowed entities per service: ${entitiesPerServiceLimit}`
       );
     }
   }
@@ -268,8 +269,9 @@ export class ProjectService {
         );
 
       if (!isIgnoreValidationCodeGeneration.hasAccess) {
-        await this.validateSubscriptionPlanLimitationsForProject(
-          project.workspaceId
+        await this.validateSubscriptionPlanLimitationsForWorkspace(
+          project.workspaceId,
+          entitiesPerServiceEntitlement.value
         );
       }
     }

--- a/packages/amplication-server/src/core/project/project.service.ts
+++ b/packages/amplication-server/src/core/project/project.service.ts
@@ -16,30 +16,20 @@ import { ProjectFindFirstArgs } from "./dto/ProjectFindFirstArgs";
 import { ProjectFindManyArgs } from "./dto/ProjectFindManyArgs";
 import { isEmpty } from "lodash";
 import { UpdateProjectArgs } from "./dto/UpdateProjectArgs";
-import { Env } from "../../env";
-import { ConfigService } from "@nestjs/config";
 import { BillingService } from "../billing/billing.service";
 import { BillingFeature } from "../billing/BillingFeature";
-import { ValidationError } from "../../errors/ValidationError";
 import { FeatureUsageReport } from "./FeatureUsageReport";
 
 @Injectable()
 export class ProjectService {
-  private readonly isBillingEnabled: boolean;
-
   constructor(
     private readonly prisma: PrismaService,
     private readonly resourceService: ResourceService,
     private readonly blockService: BlockService,
     private readonly buildService: BuildService,
     private readonly entityService: EntityService,
-    private readonly configService: ConfigService,
     private readonly billingService: BillingService
-  ) {
-    this.isBillingEnabled = this.configService.get<boolean>(
-      Env.BILLING_ENABLED
-    );
-  }
+  ) {}
 
   async findProjects(args: ProjectFindManyArgs): Promise<Project[]> {
     return this.prisma.project.findMany({
@@ -128,10 +118,17 @@ export class ProjectService {
     return [...changedEntities, ...changedBlocks];
   }
 
-  async calculateUsage(
-    workspaceId: string,
-    entitiesPerService: number
+  async calculateMeteredUsage(
+    workspaceId: string
   ): Promise<FeatureUsageReport> {
+    const entitiesPerServiceEntitlement =
+      await this.billingService.getNumericEntitlement(
+        workspaceId,
+        BillingFeature.EntitiesPerService
+      );
+
+    const entitiesPerService = entitiesPerServiceEntitlement.value;
+
     const workspace = await this.prisma.workspace.findUnique({
       where: {
         id: workspaceId,
@@ -178,53 +175,6 @@ export class ProjectService {
     };
   }
 
-  async resetUsage(workspaceId: string, entitiesPerServiceLimit: number) {
-    const usageReport = await this.calculateUsage(
-      workspaceId,
-      entitiesPerServiceLimit
-    );
-
-    await this.billingService.setUsage(
-      workspaceId,
-      BillingFeature.Services,
-      usageReport.services
-    );
-
-    await this.billingService.setUsage(
-      workspaceId,
-      BillingFeature.ServicesAboveEntitiesPerServiceLimit,
-      usageReport.servicesAboveEntityPerServiceLimit
-    );
-  }
-
-  async validateSubscriptionPlanLimitationsForWorkspace(
-    workspaceId: string,
-    entitiesPerServiceLimit: number
-  ): Promise<void> {
-    const servicesEntitlement = await this.billingService.getMeteredEntitlement(
-      workspaceId,
-      BillingFeature.Services
-    );
-
-    if (!servicesEntitlement.hasAccess) {
-      throw new ValidationError(
-        `LimitationError: Allowed services per workspace: ${servicesEntitlement.usageLimit}`
-      );
-    }
-
-    const servicesAboveEntitiesPerServiceLimitEntitlement =
-      await this.billingService.getMeteredEntitlement(
-        workspaceId,
-        BillingFeature.ServicesAboveEntitiesPerServiceLimit
-      );
-
-    if (!servicesAboveEntitiesPerServiceLimitEntitlement.hasAccess) {
-      throw new ValidationError(
-        `LimitationError: Allowed entities per service: ${entitiesPerServiceLimit}`
-      );
-    }
-  }
-
   async commit(
     args: CreateCommitArgs,
     skipPublish?: boolean
@@ -247,33 +197,16 @@ export class ProjectService {
         },
       },
     });
+    const project = await this.findFirst({ where: { id: projectId } });
 
-    if (this.isBillingEnabled) {
-      const project = await this.findFirst({ where: { id: projectId } });
+    //check if billing enabled first to skip calculation
+    if (this.billingService.isBillingEnabled) {
+      const usageReport = await this.calculateMeteredUsage(project.workspaceId);
+      await this.billingService.resetUsage(project.workspaceId, usageReport);
 
-      const entitiesPerServiceEntitlement =
-        await this.billingService.getNumericEntitlement(
-          project.workspaceId,
-          BillingFeature.EntitiesPerService
-        );
-
-      await this.resetUsage(
-        project.workspaceId,
-        entitiesPerServiceEntitlement.value
+      await this.billingService.validateSubscriptionPlanLimitationsForWorkspace(
+        project.workspaceId
       );
-
-      const isIgnoreValidationCodeGeneration =
-        await this.billingService.getBooleanEntitlement(
-          project.workspaceId,
-          BillingFeature.IgnoreValidationCodeGeneration
-        );
-
-      if (!isIgnoreValidationCodeGeneration.hasAccess) {
-        await this.validateSubscriptionPlanLimitationsForWorkspace(
-          project.workspaceId,
-          entitiesPerServiceEntitlement.value
-        );
-      }
     }
 
     if (isEmpty(resources)) {
@@ -289,13 +222,10 @@ export class ProjectService {
 
     const commit = await this.prisma.commit.create(args);
 
-    if (this.isBillingEnabled) {
-      const project = await this.findUnique({ where: { id: projectId } });
-      await this.billingService.reportUsage(
-        project.workspaceId,
-        BillingFeature.CodeGenerationBuilds
-      );
-    }
+    await this.billingService.reportUsage(
+      project.workspaceId,
+      BillingFeature.CodeGenerationBuilds
+    );
 
     await Promise.all(
       changedEntities.flatMap((change) => {

--- a/packages/amplication-server/src/core/resource/resource.service.spec.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.spec.ts
@@ -16,7 +16,7 @@ import {
 import { EnumBlockType } from "../../enums/EnumBlockType";
 import { EnumDataType } from "../../enums/EnumDataType";
 import { QueryMode } from "../../enums/QueryMode";
-import { BlockVersion, Commit, EntityVersion } from "../../models";
+import { BlockVersion, Commit, EntityVersion, Project } from "../../models";
 import { Block } from "../../models/Block";
 import { Entity } from "../../models/Entity";
 import { EntityField } from "../../models/EntityField";
@@ -57,6 +57,7 @@ const EXAMPLE_RESOURCE_ID = "exampleResourceId";
 const EXAMPLE_PROJECT_CONFIGURATION_RESOURCE_ID =
   "exampleProjectConfigurationResourceId";
 const EXAMPLE_PROJECT_ID = "exampleProjectId";
+const EXAMPLE_PROJECT_NAME = "exampleProjectName";
 const EXAMPLE_RESOURCE_NAME = "exampleResourceName";
 const EXAMPLE_RESOURCE_DESCRIPTION = "exampleResourceName";
 
@@ -100,6 +101,14 @@ const EXAMPLE_PROJECT_CONFIGURATION_RESOURCE: Resource = {
   description: EXAMPLE_RESOURCE_DESCRIPTION,
   deletedAt: null,
   gitRepositoryOverride: false,
+};
+
+const EXAMPLE_PROJECT: Project = {
+  id: EXAMPLE_PROJECT_ID,
+  name: EXAMPLE_PROJECT_NAME,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  workspaceId: EXAMPLE_WORKSPACE_ID,
 };
 
 const EXAMPLE_USER_ID = "exampleUserId";
@@ -346,6 +355,8 @@ const entityServiceBulkCreateFields = jest.fn();
 
 const buildServiceCreateMock = jest.fn(() => EXAMPLE_BUILD);
 
+const projectServiceFindUniqueMock = jest.fn(() => EXAMPLE_PROJECT);
+
 const environmentServiceCreateDefaultEnvironmentMock = jest.fn(() => {
   return EXAMPLE_ENVIRONMENT;
 });
@@ -374,6 +385,9 @@ describe("ResourceService", () => {
               return {};
             }),
             getNumericEntitlement: jest.fn(() => {
+              return {};
+            }),
+            reportUsage: jest.fn(() => {
               return {};
             }),
           },
@@ -466,7 +480,9 @@ describe("ResourceService", () => {
         },
         {
           provide: ProjectService,
-          useClass: jest.fn(() => ({})),
+          useClass: jest.fn(() => ({
+            findUnique: projectServiceFindUniqueMock,
+          })),
         },
       ],
     }).compile();

--- a/packages/amplication-server/src/core/workspace/workspace.resolver.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.resolver.ts
@@ -29,26 +29,17 @@ import { AuthorizeContext } from "../../decorators/authorizeContext.decorator";
 import { GitOrganization } from "../../models/GitOrganization";
 import { Subscription } from "../subscription/dto/Subscription";
 import { ProjectService } from "../project/project.service";
-import { Env } from "../../env";
-import { ConfigService } from "@nestjs/config";
 import { BillingService } from "../billing/billing.service";
 
 @Resolver(() => Workspace)
 @UseFilters(GqlResolverExceptionsFilter)
 @UseGuards(GqlAuthGuard)
 export class WorkspaceResolver {
-  private readonly isBillingEnabled: boolean;
-
   constructor(
-    private readonly configService: ConfigService,
     private readonly workspaceService: WorkspaceService,
     private readonly projectService: ProjectService,
     private readonly billingService: BillingService
-  ) {
-    this.isBillingEnabled = this.configService.get<boolean>(
-      Env.BILLING_ENABLED
-    );
-  }
+  ) {}
 
   @Query(() => Workspace, {
     nullable: true,
@@ -155,15 +146,7 @@ export class WorkspaceResolver {
 
   @ResolveField(() => Subscription, { nullable: true })
   async subscription(@Parent() workspace: Workspace): Promise<Subscription> {
-    if (this.isBillingEnabled) {
-      const subscription = await this.billingService.getSubscription(
-        workspace.id
-      );
-      return subscription;
-    }
-
-    const s = await this.workspaceService.getSubscription(workspace.id);
-    return s;
+    return this.billingService.getSubscription(workspace.id);
   }
 
   @ResolveField(() => [GitOrganization])

--- a/packages/amplication-server/src/core/workspace/workspace.service.spec.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.service.spec.ts
@@ -136,8 +136,8 @@ describe("WorkspaceService", () => {
             getNumericEntitlement: jest.fn(() => {
               return {};
             }),
-            getStiggClient: jest.fn(() => {
-              return { provisionCustomer: () => undefined };
+            provisionCustomer: jest.fn(() => {
+              return {};
             }),
           },
         },

--- a/packages/amplication-server/src/core/workspace/workspace.service.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.service.ts
@@ -26,29 +26,20 @@ import { Subscription } from "../subscription/dto/Subscription";
 import { GitOrganization } from "../../models/GitOrganization";
 import { ProjectService } from "../project/project.service";
 import { BillingService } from "../billing/billing.service";
-import { ConfigService } from "@nestjs/config";
-import { Env } from "../../env";
 import { BillingPlan } from "../billing/BillingPlan";
 
 const INVITATION_EXPIRATION_DAYS = 7;
 
 @Injectable()
 export class WorkspaceService {
-  private readonly isBillingEnabled: boolean;
-
   constructor(
     private readonly prisma: PrismaService,
     private readonly userService: UserService,
     private readonly mailService: MailService,
     private readonly subscriptionService: SubscriptionService,
     private readonly projectService: ProjectService,
-    private readonly configService: ConfigService,
     private readonly billingService: BillingService
-  ) {
-    this.isBillingEnabled = this.configService.get<boolean>(
-      Env.BILLING_ENABLED
-    );
-  }
+  ) {}
 
   async getWorkspace(args: FindOneArgs): Promise<Workspace | null> {
     return this.prisma.workspace.findUnique(args);
@@ -104,15 +95,7 @@ export class WorkspaceService {
       },
     });
 
-    const stiggClient = await this.billingService.getStiggClient();
-    if (this.isBillingEnabled) {
-      await stiggClient.provisionCustomer({
-        customerId: workspace.id,
-        subscriptionParams: {
-          planId: BillingPlan.Free,
-        },
-      });
-    }
+    await this.billingService.provisionCustomer(workspace.id, BillingPlan.Free);
 
     const [user] = workspace.users;
 


### PR DESCRIPTION


Close: #1215 

## PR Details

- [x] Add a new property in the "lookup" schema field to hold the side of the FK in a one-to-one relation
- [ ] Add logic on the server side to update the relation field on the related entity together with the current field (both field will always have the same values)
- [ ] Update the logic on the DSG to set the FK based on the new property. When the value of the property is null or undefined, we should keep the current behavior 

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
