### PR TITLE
chore(ci): fix docker master tag issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,6 @@ jobs:
           images: "439403303254.dkr.ecr.us-east-1.amazonaws.com/${{ matrix.project }}"
           tags: |
             type=sha,prefix=sha-
-            type=ref,event=branch
             type=ref,event=pr,prefix=pr-
             type=ref,event=tag,prefix=tag-
             type=raw,value=${{ github.run_id }},prefix=gh-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+name: Release
 run-name: Release ${{ github.event.workflow_run.head_branch }} by workflow ${{ github.event.workflow_run.id }}
 concurrency: ${{ github.event.workflow_run.head_branch }}
 
@@ -44,13 +45,13 @@ jobs:
             });
             let fs = require('fs');
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/affected-projects.zip`, Buffer.from(download.data));
-      
+
       - name: Configure Nx Affected Projects
         id: configure-nx
-        run: | 
+        run: |
           unzip affected-projects.zip
           cat ./affected-projects >> $GITHUB_OUTPUT
-        
+
       - name: Debug
         run: |
           echo github.event.workflow_run.conclusion ${{ github.event.workflow_run.conclusion }}
@@ -75,10 +76,10 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version-file: 'package.json'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      
+          node-version-file: "package.json"
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
       - name: Cache global node modules
         id: cache-node-modules
         uses: actions/cache@v3
@@ -98,7 +99,7 @@ jobs:
             libs/data-service-generator/node_modules
             libs/util/code-gen-utils/node_modules
             packages/amplication-cli/node_modules
-          key:  ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./**/package-lock.json') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./**/package-lock.json') }}
 
       - name: Install Dependencies
         if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' || steps.cache-other-node-modules.outputs.cache-hit != 'true' }}
@@ -153,8 +154,8 @@ jobs:
           then
             echo environment="staging" >> $GITHUB_OUTPUT
           fi;
-          
-  deploy: 
+
+  deploy:
     name: Deployment
     needs: [nx, dockerize, configure]
     strategy:


### PR DESCRIPTION
Related: #4974
 
## PR Details

Fix the docker tagging logic to not add the default branch name as a tag on `workflow_run` event.
New issue has been added to the docker-metadata repo: https://github.com/docker/metadata-action/issues/259 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
