### PR TITLE
chore(dsg): update dependencies

### DIFF
--- a/libs/data-service-generator/package-lock.json
+++ b/libs/data-service-generator/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@amplication/data-service-generator",
-  "version": "1.1.10",
+  "version": "1.1.11-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amplication/data-service-generator",
-      "version": "1.1.10",
+      "version": "1.1.11-beta.3",
       "dependencies": {
         "@amplication/code-gen-utils": "^0.0.3",
-        "@amplication/plugin-db-postgres": "^1.1.7",
+        "@amplication/plugin-db-postgres": "1.1.7",
         "@babel/parser": "7.14.7",
         "@extra-set/difference": "2.2.4",
         "axios": "1.2.1",
@@ -28,7 +28,7 @@
         "yaml": "2.1.1"
       },
       "devDependencies": {
-        "@amplication/code-gen-types": "^1.1.19",
+        "@amplication/code-gen-types": "^1.1.21",
         "@apollo/client": "3.6.9",
         "@babel/types": "^7.19.4",
         "@prisma/client": "4.6.1",
@@ -75,15 +75,15 @@
       }
     },
     "node_modules/@amplication/code-gen-types": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@amplication/code-gen-types/-/code-gen-types-1.1.19.tgz",
-      "integrity": "sha512-HcT7+9kuDA+F9Knp5XxdgTk7WGyr5uK5/ZVJhP+JNCtJtmIGyHvZX7vOlQ30TLhCu/1cm8T6hla2tPogFtNjmA==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@amplication/code-gen-types/-/code-gen-types-1.1.21.tgz",
+      "integrity": "sha512-B+v9RDJhuh0UoE/yxqbBFR5fYdl+YC3hRmXjgtpXqE0+GKOvSQwQI9HgvmVE3w3NjPlfUCfWkY4hO7H/wRVK6w==",
       "dependencies": {
         "@nestjs/core": "^9.0.9",
         "ast-types": "^0.14.2",
         "json-schema": "0.4.0",
         "lodash": "^4.17.21",
-        "prisma-schema-dsl-types": "^1.0.2",
+        "prisma-schema-dsl-types": "^1.0.5",
         "type-fest": "0.11.0",
         "winston": "3.8.2"
       },
@@ -11448,15 +11448,15 @@
   },
   "dependencies": {
     "@amplication/code-gen-types": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@amplication/code-gen-types/-/code-gen-types-1.1.19.tgz",
-      "integrity": "sha512-HcT7+9kuDA+F9Knp5XxdgTk7WGyr5uK5/ZVJhP+JNCtJtmIGyHvZX7vOlQ30TLhCu/1cm8T6hla2tPogFtNjmA==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@amplication/code-gen-types/-/code-gen-types-1.1.21.tgz",
+      "integrity": "sha512-B+v9RDJhuh0UoE/yxqbBFR5fYdl+YC3hRmXjgtpXqE0+GKOvSQwQI9HgvmVE3w3NjPlfUCfWkY4hO7H/wRVK6w==",
       "requires": {
         "@nestjs/core": "^9.0.9",
         "ast-types": "^0.14.2",
         "json-schema": "0.4.0",
         "lodash": "^4.17.21",
-        "prisma-schema-dsl-types": "^1.0.2",
+        "prisma-schema-dsl-types": "^1.0.5",
         "type-fest": "0.11.0",
         "winston": "3.8.2"
       }

--- a/libs/data-service-generator/package.json
+++ b/libs/data-service-generator/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@amplication/data-service-generator",
-  "version": "1.1.11-beta.0",
+  "version": "1.1.11-beta.3",
   "private": false,
   "main": "./src/index.js",
   "dependencies": {
     "@amplication/code-gen-utils": "^0.0.3",
-    "@amplication/plugin-db-postgres": "^1.1.7",
+    "@amplication/plugin-db-postgres": "1.1.7",
     "@babel/parser": "7.14.7",
     "@extra-set/difference": "2.2.4",
     "axios": "1.2.1",
@@ -24,7 +24,7 @@
     "yaml": "2.1.1"
   },
   "devDependencies": {
-    "@amplication/code-gen-types": "^1.1.19",
+    "@amplication/code-gen-types": "^1.1.21",
     "@apollo/client": "3.6.9",
     "@babel/types": "^7.19.4",
     "@prisma/client": "4.6.1",

--- a/libs/data-service-generator/src/version.ts
+++ b/libs/data-service-generator/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.1.11-beta.0";
+export const version = "1.1.11-beta.3";

--- a/packages/amplication-code-gen-types/package.json
+++ b/packages/amplication-code-gen-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/code-gen-types",
-  "version": "1.1.19",
+  "version": "1.1.21",
   "description": "This library supplies all the contracts for Amplication Code Generation. The purpose is to make the contracts available for inclusion in plugins.",
   "main": "src/index.js",
   "author": {
@@ -13,7 +13,7 @@
     "ast-types": "^0.14.2",
     "json-schema": "0.4.0",
     "lodash": "^4.17.21",
-    "prisma-schema-dsl-types": "^1.0.2",
+    "prisma-schema-dsl-types": "^1.0.5",
     "type-fest": "0.11.0",
     "winston": "3.8.2"
   }


### PR DESCRIPTION
part of #4992 - a quick fix, but not a solution 

## PR Details

- Update code-gen-types dependency: `prisma-schema-dsl-type`
- `Update data-service-generator` dependency - lock the Postgres version to `1.1.7`, which is before the change of using webpack.

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
