### PR TITLE
Revert "chore(ci): fix duplicated execution of ci workflow on next"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ on:
         default: false
   pull_request:
     types: [opened, reopened, synchronize]
-    branches-ignore:
-      - next # To avoid duplicated executions
     paths-ignore:
       - "**/*.md"
       - ".all-contributorsrc"


### PR DESCRIPTION
Reverts amplication/amplication#4986 since it prevents pull_request events for all branches