### PR TITLE
chore(ci): stop nx to fail release job if a project doesn't have dock…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
 
       # https://www.npmjs.com/package/@nx-tools/nx-docker
       - name: Dockerize
-        run: npx nx docker:build ${{ matrix.project }}
+        run: npx nx run-many --target=docker:build --projects=${{ matrix.project }}
         env:
           INPUT_TAGS: ${{ steps.meta.outputs.tags }}
           INPUT_PUSH: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Release
-run-name: Release ${{ github.event.workflow_run.head_branch }} by workflow ${{ github.event.workflow_run.id }}
+run-name: Release ${{ github.event.workflow_run.head_branch }} by workflow ${{ github.event.workflow_run.id }} - commit ${{ github.event.workflow_run.head_sha }} 
 concurrency: ${{ github.event.workflow_run.head_branch }}
 
 on:
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Close: #5011 

## PR Details

This PR prevents **Release** workflow to fail in case of changes to projects that are not configured with `docker:build` target. 
It consists of a quick fix, that will just prevent the docker step to fail, and a stronger fix will come later that will prevent the docker step to run completely for projects that are not deployed as docker containers.

### Detailed explaination

Currently we run the following command that exit with `1` if the nx project is not configured with the `docker:build` target
```sh
npx nx docker:build data-service-generator
```
<img width="576" alt="image" src="https://user-images.githubusercontent.com/2861984/213413517-0217c923-c10c-4bc1-b83c-802c2950eec7.png">


The following command instead will exit with `0` printing a quick message

```sh
npx nx run-many --target=docker:build --projects=data-service-generator
```
<img width="495" alt="image" src="https://user-images.githubusercontent.com/2861984/213413570-fe09bc38-aeed-481c-a907-c7e6ceac30c0.png">

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
