### PR TITLE
refactor(server) align the value of DSG_LOG_TOPIC with the value we use in the build manager

### DIFF
--- a/packages/amplication-server/.env
+++ b/packages/amplication-server/.env
@@ -36,7 +36,7 @@ CODE_GENERATION_REQUEST_TOPIC="build.internal.code-generation.request.1"
 CODE_GENERATION_SUCCESS_TOPIC="build.internal.code-generation.success.1"
 CODE_GENERATION_FAILURE_TOPIC="build.internal.code-generation.failure.1"
 
-DSG_LOG_TOPIC="internal.dsg-log.0"
+DSG_LOG_TOPIC="build.internal.dsg-log.1"
 
 CHECK_USER_ACCESS_TOPIC="auth.user.access"
 


### PR DESCRIPTION
part of https://github.com/amplication/amplication/issues/4564

## PR Details

align the value of DSG_LOG_TOPIC with the value we use in the build manager in order to see the build logs when we run the local DSG runner

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
