### PR TITLE
refactor: client and server to not use @extra-set/difference dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@codebrew/nestjs-storage": "^0.1.7",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
-        "@extra-set/difference": "^2.2.11",
         "@google-cloud/cloudbuild": "^2.6.0",
         "@google-cloud/secret-manager": "^3.12.0",
         "@google-cloud/storage": "^5.20.5",
@@ -3670,11 +3669,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@extra-set/difference": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/@extra-set/difference/-/difference-2.2.11.tgz",
-      "integrity": "sha512-R7oF/hWUx3s+Tfn98CbP3dkTfbrCoV92wI4p4hUH4bqBT2MX+UH55jA7UIbzfYcFUOyQjeP+0ccz4bCuHXtNNQ=="
     },
     "node_modules/@fastify/ajv-compiler": {
       "version": "1.1.0",
@@ -45359,11 +45353,6 @@
           "dev": true
         }
       }
-    },
-    "@extra-set/difference": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/@extra-set/difference/-/difference-2.2.11.tgz",
-      "integrity": "sha512-R7oF/hWUx3s+Tfn98CbP3dkTfbrCoV92wI4p4hUH4bqBT2MX+UH55jA7UIbzfYcFUOyQjeP+0ccz4bCuHXtNNQ=="
     },
     "@fastify/ajv-compiler": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@codebrew/nestjs-storage": "^0.1.7",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@extra-set/difference": "^2.2.11",
     "@google-cloud/cloudbuild": "^2.6.0",
     "@google-cloud/secret-manager": "^3.12.0",
     "@google-cloud/storage": "^5.20.5",

--- a/packages/amplication-client/src/Permissions/EntityPermissionAction.tsx
+++ b/packages/amplication-client/src/Permissions/EntityPermissionAction.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo, useContext } from "react";
 import { gql, useMutation, useQuery } from "@apollo/client";
 import { isEmpty, cloneDeep } from "lodash";
-import difference from "@extra-set/difference";
 
 import "./EntityPermissionAction.scss";
 import * as models from "../models";
@@ -95,8 +94,12 @@ export const EntityPermissionAction = ({
 
   const handleRoleSelectionChange = useCallback(
     (newSelectedRoleIds: Set<string>) => {
-      const addedRoleIds = difference(newSelectedRoleIds, selectedRoleIds);
-      const removedRoleIds = difference(selectedRoleIds, newSelectedRoleIds);
+      const addedRoleIds = new Set(
+        [...newSelectedRoleIds].filter((x) => !selectedRoleIds.has(x))
+      );
+      const removedRoleIds = new Set(
+        [...selectedRoleIds].filter((x) => !newSelectedRoleIds.has(x))
+      );
 
       const addRoles = Array.from(addedRoleIds, (id) => ({
         id,

--- a/packages/amplication-client/src/Permissions/EntityPermissionField.tsx
+++ b/packages/amplication-client/src/Permissions/EntityPermissionField.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo, useContext } from "react";
 import { gql, useMutation } from "@apollo/client";
-import difference from "@extra-set/difference";
 import { cloneDeep } from "lodash";
 
 import * as models from "../models";
@@ -95,8 +94,12 @@ export const EntityPermissionField = ({
 
   const handleRoleSelectionChange = useCallback(
     (newSelectedRoleIds: Set<string>) => {
-      const addedRoleIds = difference(newSelectedRoleIds, selectedRoleIds);
-      const removedRoleIds = difference(selectedRoleIds, newSelectedRoleIds);
+      const addedRoleIds = new Set(
+        [...newSelectedRoleIds].filter((x) => !selectedRoleIds.has(x))
+      );
+      const removedRoleIds = new Set(
+        [...selectedRoleIds].filter((x) => !newSelectedRoleIds.has(x))
+      );
 
       const addPermissionRoles = Array.from(addedRoleIds, (id) => {
         const permissionRole = permission.permissionRoles?.find(

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -10,7 +10,6 @@ import { DataConflictError } from "../../errors/DataConflictError";
 import { Prisma, PrismaService } from "../../prisma";
 import { AmplicationError } from "../../errors/AmplicationError";
 import { camelCase } from "camel-case";
-import difference from "@extra-set/difference";
 import { isEmpty, pick, last, head, omit, isEqual } from "lodash";
 import {
   Entity,
@@ -1201,7 +1200,7 @@ export class EntityService {
 
     const matchingNames = new Set(matchingFields.map(({ name }) => name));
 
-    return difference(uniqueNames, matchingNames);
+    return new Set([...uniqueNames].filter((x) => !matchingNames.has(x)));
   }
 
   async updateEntityPermission(


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Related to : [#4943](https://github.com/amplication/amplication/issues/4943)

## PR Details

Replace the external dependency that contains an invalid index.d.ts ([line 9](https://www.npmjs.com/package/@extra-set/difference?activeTab=explore)) with the magic of ts! 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
