### PR TITLE
feat(local-dsg): add option to auto remove exited local dsg containers

### DIFF
--- a/packages/local-dsg-runner/.env
+++ b/packages/local-dsg-runner/.env
@@ -4,3 +4,4 @@ BUILD_OUTPUT_PATH="/dsg-job/code"
 BUILD_SPEC_PATH="/dsg-job/input.json"
 BUILD_MANAGER_URL="http://host.docker.internal:5010"
 PORT=8900
+AUTOREMOVE_CONTAINER=true

--- a/packages/local-dsg-runner/README.md
+++ b/packages/local-dsg-runner/README.md
@@ -51,3 +51,7 @@ local-dsg-runner
 ```
 npx nx serve local-dsg-runner
 ```
+
+#### Troubleshooting issues in DSG
+
+By default, the `local-dsg-runner` automatically clean up exited continers. If you need to read the logs of a failing job, change the .env `AUTOREMOVE_CONTAINER` environment variable to `false` and the container won't be removed from Docker Desktop (or Podman Desktop) 

--- a/packages/local-dsg-runner/src/code-gen/code-gen.controller.ts
+++ b/packages/local-dsg-runner/src/code-gen/code-gen.controller.ts
@@ -8,13 +8,16 @@ function generateCode(req: Request, res: Response) {
   const imageName = "amplication/data-service-generator-runner";
   const containerName = `dsg-runner-${buildId}`;
 
-  const hostMachineDsgFolder = `${process.cwd()}/${
-    process.env.DSG_JOBS_BASE_FOLDER
-  }/${buildId}`;
-  const dockerDsgFolder = process.env.BUILD_VOLUME_PATH;
-  const buildOutputPath = process.env.BUILD_OUTPUT_PATH;
-  const buildSpecPath = process.env.BUILD_SPEC_PATH;
-  const buildMangerUrl = process.env.BUILD_MANAGER_URL;
+  const {
+    DSG_JOBS_BASE_FOLDER: dsgJogsBaseFolder,
+    BUILD_VOLUME_PATH: dockerDsgFolder,
+    BUILD_OUTPUT_PATH: buildOutputPath,
+    BUILD_SPEC_PATH: buildSpecPath,
+    BUILD_MANAGER_URL: buildMangerUrl,
+    AUTOREMOVE_CONTAINER: autoRemove,
+  } = process.env;
+
+  const hostMachineDsgFolder = `${process.cwd()}/${dsgJogsBaseFolder}/${buildId}`;
 
   const docker = new Docker();
 
@@ -24,6 +27,7 @@ function generateCode(req: Request, res: Response) {
       name: containerName,
       HostConfig: {
         Binds: [`${hostMachineDsgFolder}:${dockerDsgFolder}`],
+        AutoRemove: Boolean(autoRemove),
       },
       Cmd: ["node", "./src/main.js"],
       Env: [


### PR DESCRIPTION

Close: #5084

## PR Details

Add a new env variable to allow auto removal of exited DSG containers locally.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
