### PR TITLE
Fix 4892 - Change Page Title when showing Purchase Modal

### DIFF
--- a/packages/amplication-client/src/Purchase/PurchasePage.tsx
+++ b/packages/amplication-client/src/Purchase/PurchasePage.tsx
@@ -2,6 +2,7 @@ import { Paywall, BillingPeriod, Price } from "@stigg/react-sdk";
 import { useTracking } from "../util/analytics";
 import { AnalyticsEventNames } from "../util/analytics-events.types";
 import { useHistory } from "react-router-dom";
+import { Helmet } from "react-helmet";
 import * as models from "../models";
 import {
   Button,
@@ -120,8 +121,13 @@ const PurchasePage = (props) => {
     [upgradeToPro, handleContactUsClick]
   );
 
+  const pageTitle = "Pricing & Plans";
+
   return (
     <Modal open fullScreen>
+      <Helmet>
+        <title>{`Amplication | ${pageTitle} : `}</title>
+      </Helmet>
       <div className={CLASS_NAME}>
         {isLoading && <PurchaseLoader />}
         <div className={`${CLASS_NAME}__layout`}>


### PR DESCRIPTION
Close: #4892 
## PR Details

The issue pertained to the page title not changing when the user clicked purchase and displayed the purchase modal. I used the PageContent existing layout to change the title when the modal was displayed. An alternative solution was to call the Helmet component directly but I thought this way is cleaner.

## PR Checklist

- No tests needed for the change.
- No errors from existing tests.

