### PR TITLE
 🐛 Bug Report: fix React error on client

### DIFF
--- a/packages/amplication-client/src/Components/CreateResourceButtonItem.tsx
+++ b/packages/amplication-client/src/Components/CreateResourceButtonItem.tsx
@@ -39,6 +39,7 @@ const CreateResourceButtonItem = ({ item }: props) => {
     <SelectMenuItem
       closeAfterSelectionChange
       onSelectionChange={handleSelectItem}
+      as="span"
     >
       <Link
         onClick={handleClick}


### PR DESCRIPTION
### Before
<img width="805" alt="Screenshot 2023-01-31 at 13 44 00" src="https://user-images.githubusercontent.com/21334508/215739683-114683c0-1321-4f15-bf69-8d27e9d89888.png">

### After
This error `validateDOMNesting(...): cannot appear as a descendant of...` no longer shows up in the browser console.

Fixes https://github.com/amplication/amplication/issues/5032