### PR TITLE
feat(code-utils): add append imports function

### DIFF
--- a/libs/util/code-gen-utils/package-lock.json
+++ b/libs/util/code-gen-utils/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amplication/code-gen-utils",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amplication/code-gen-utils",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "recast": "^0.20.5"
       }

--- a/libs/util/code-gen-utils/package.json
+++ b/libs/util/code-gen-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/code-gen-utils",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "dependencies": {
     "recast": "^0.20.5"
   }

--- a/libs/util/code-gen-utils/src/lib/imports/appendImports.spec.ts
+++ b/libs/util/code-gen-utils/src/lib/imports/appendImports.spec.ts
@@ -13,6 +13,7 @@ const {
 } = builders;
 describe("Testing the functionality of append imports", () => {
   it("should append the imports to the end of the imports section of a typescript file", () => {
+    // ARRANGE
     const file: namedTypes.File = builders.file(
       program([
         importDeclaration(
@@ -31,6 +32,8 @@ describe("Testing the functionality of append imports", () => {
         ]),
       ])
     );
+
+    // ACT
     appendImports(file, [
       importDeclaration(
         [importSpecifier(identifier("ofek"))],
@@ -38,6 +41,8 @@ describe("Testing the functionality of append imports", () => {
       ),
     ]);
     const code = print(file).code;
+
+    // ASSERT
     expect(code).toBe(
       `import { first } from "import";
 import { second } from "import";
@@ -46,6 +51,7 @@ const a = 1;`
     );
   });
   it("should put the import in the start of the file if there are no imports", () => {
+    // ARRANGE
     const file: namedTypes.File = builders.file(
       program([
         variableDeclaration("const", [
@@ -56,6 +62,8 @@ const a = 1;`
         ]),
       ])
     );
+
+    // ACT
     appendImports(file, [
       importDeclaration(
         [importSpecifier(identifier("ofek"))],
@@ -63,6 +71,8 @@ const a = 1;`
       ),
     ]);
     const code = print(file).code;
+
+    // ASSERT
     expect(code).toBe(
       `import { ofek } from "test";
 const a = 1;`

--- a/libs/util/code-gen-utils/src/lib/imports/appendImports.spec.ts
+++ b/libs/util/code-gen-utils/src/lib/imports/appendImports.spec.ts
@@ -1,0 +1,71 @@
+import { appendImports } from "./appendImports";
+import { types } from "recast";
+import { namedTypes } from "ast-types/gen/namedTypes";
+import { print } from "../files";
+const { builders } = types;
+const {
+  importDeclaration,
+  program,
+  variableDeclaration,
+  stringLiteral,
+  importSpecifier,
+  identifier,
+} = builders;
+describe("Testing the functionality of append imports", () => {
+  it("should append the imports to the end of the imports section of a typescript file", () => {
+    const file: namedTypes.File = builders.file(
+      program([
+        importDeclaration(
+          [importSpecifier(identifier("first"))],
+          stringLiteral("import")
+        ),
+        importDeclaration(
+          [importSpecifier(identifier("second"))],
+          stringLiteral("import")
+        ),
+        variableDeclaration("const", [
+          builders.variableDeclarator(
+            builders.identifier("a"),
+            builders.literal(1)
+          ),
+        ]),
+      ])
+    );
+    appendImports(file, [
+      importDeclaration(
+        [importSpecifier(identifier("ofek"))],
+        stringLiteral("test")
+      ),
+    ]);
+    const code = print(file).code;
+    expect(code).toBe(
+      `import { first } from "import";
+import { second } from "import";
+import { ofek } from "test";
+const a = 1;`
+    );
+  });
+  it("should put the import in the start of the file if there are no imports", () => {
+    const file: namedTypes.File = builders.file(
+      program([
+        variableDeclaration("const", [
+          builders.variableDeclarator(
+            builders.identifier("a"),
+            builders.literal(1)
+          ),
+        ]),
+      ])
+    );
+    appendImports(file, [
+      importDeclaration(
+        [importSpecifier(identifier("ofek"))],
+        stringLiteral("test")
+      ),
+    ]);
+    const code = print(file).code;
+    expect(code).toBe(
+      `import { ofek } from "test";
+const a = 1;`
+    );
+  });
+});

--- a/libs/util/code-gen-utils/src/lib/imports/appendImports.ts
+++ b/libs/util/code-gen-utils/src/lib/imports/appendImports.ts
@@ -1,0 +1,26 @@
+import { namedTypes } from "ast-types";
+
+/**
+ * This function will append an import to the imports of a AST source file by searching for the last import and inserting the new import after it.
+ * This file mutate the file ast object.
+ */
+export function appendImports(
+  file: namedTypes.File,
+  imports: namedTypes.ImportDeclaration[]
+): namedTypes.File {
+  const {
+    program: { body },
+  } = file;
+
+  let locationOfLastImport = 0;
+  body.forEach((node, i) => {
+    if (node.type === "ImportDeclaration") {
+      locationOfLastImport = i;
+    }
+  });
+
+  const newImportLocation =
+    locationOfLastImport === 0 ? 0 : locationOfLastImport + 1;
+  body.splice(newImportLocation, 0, ...imports);
+  return file;
+}

--- a/libs/util/code-gen-utils/src/lib/imports/index.ts
+++ b/libs/util/code-gen-utils/src/lib/imports/index.ts
@@ -1,0 +1,1 @@
+export * from "./appendImports";

--- a/libs/util/code-gen-utils/src/lib/index.ts
+++ b/libs/util/code-gen-utils/src/lib/index.ts
@@ -1,3 +1,4 @@
 export * from "./enum-builder";
 export * from "./files";
 export * from "./parse";
+export * from "./imports";


### PR DESCRIPTION

Close: #[issue-number]

## PR Details

This pull request add new function that append the imports to the end of the imports section
## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
