### PR TITLE
chore: enable nx distributed cache

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -31,7 +31,8 @@
           "lint",
           "test:e2e",
           "test:cov"
-        ]
+        ],
+        "accessToken": "ZjczM2RhYjEtYzdmOS00MDVhLThkYWEtMDU4MmJkMTQ1ZWZjfHJlYWQ="
       }
     }
   },


### PR DESCRIPTION
Close: #4984 

## PR Details

Add a new Read-Only access token to NxCloud to allow consuming the shared distributed nx cache. On the other pipelines, Nx will use the R/W access token stored as Action Secret

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
