### PR TITLE
fix(server): remove password fields from user entity

### DIFF
--- a/packages/amplication-server/src/core/entity/constants.ts
+++ b/packages/amplication-server/src/core/entity/constants.ts
@@ -136,42 +136,6 @@ export const DEFAULT_ENTITIES: EntityData[] = [
           maxLength: DEFAULT_SINGLE_LINE_TEXT_MAX_LENGTH,
         },
       },
-      {
-        dataType: EnumDataType.Username,
-        name: "username",
-        displayName: "Username",
-        description:
-          "An automatically created field of the username of the user",
-        unique: false,
-        required: true,
-        searchable: true,
-        properties: {
-          maxLength: DEFAULT_SINGLE_LINE_TEXT_MAX_LENGTH,
-        },
-      },
-      {
-        dataType: EnumDataType.Password,
-        name: "password",
-        displayName: "Password",
-        description:
-          "An automatically created field of the password of the user",
-        unique: false,
-        required: true,
-        searchable: false,
-        properties: {
-          maxLength: DEFAULT_SINGLE_LINE_TEXT_MAX_LENGTH,
-        },
-      },
-      {
-        dataType: EnumDataType.Roles,
-        name: "roles",
-        displayName: "Roles",
-        description: "An automatically created field of the roles of the user",
-        unique: false,
-        required: true,
-        searchable: false,
-        properties: {},
-      },
     ],
   },
 ];


### PR DESCRIPTION
part of: #4431 
related comment: https://github.com/amplication/amplication/issues/4431#issuecomment-1423991692
the first issue that was raised there:
![image](https://user-images.githubusercontent.com/39680385/217852479-203ee802-3a35-49b0-ac09-90fd0161bc3f.png)


## PR Details

Remove password fields from the user entity
## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
