### PR TITLE
feat(plugin-api): filter out deprecated npm package versions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
       "rules": {
+        "no-console": "warn",
         "@nrwl/nx/enforce-module-boundaries": [
           "error",
           {

--- a/packages/amplication-plugin-api/src/pluginVersion/npm-plugin-version.service.spec.ts
+++ b/packages/amplication-plugin-api/src/pluginVersion/npm-plugin-version.service.spec.ts
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { NpmPluginVersionService } from "./npm-plugin-version.service";
+import { Plugin } from "../../prisma/generated-prisma-client";
+
+const DEPRECATED_NPM = "@amplication/my-deprecated-plugin";
+const NPM_PACKAGE = "@amplication/my-plugin";
+
+const plugins = [
+  {
+    name: "my-deprecated-plugin",
+    npm: DEPRECATED_NPM,
+    pluginId: "my-deprecated-plugin-id",
+  },
+  {
+    name: "my-plugin",
+    npm: NPM_PACKAGE,
+    pluginId: "my-plugin-id",
+  },
+] as Plugin[];
+
+jest.mock("node-fetch", () =>
+  jest.fn().mockImplementation((url: RequestInfo) => {
+    if (url.toString().indexOf(NPM_PACKAGE) > 0) {
+      return {
+        json: jest.fn().mockResolvedValue({
+          name: "my-plugin",
+          "dist-tags": { latest: "2.0.0" },
+          versions: {
+            "1.0.0": {
+              version: "1.0.0",
+              name: "my-plugin",
+              description: "A test package",
+              dist: {
+                tarball:
+                  "https://registry.npmjs.org/my-plugin/-/my-plugin-1.0.0.tgz",
+              },
+            },
+            "2.0.0": {
+              version: "1.0.0",
+              name: "my-plugin",
+              description: "A test package",
+              dist: {
+                tarball:
+                  "https://registry.npmjs.org/my-plugin/-/my-plugin-2.0.0.tgz",
+              },
+              deprecated: "Some reasons",
+            },
+          },
+        }),
+      };
+    }
+    if (url.toString().indexOf(DEPRECATED_NPM) > 0) {
+      return {
+        json: jest.fn().mockResolvedValue({
+          name: "my-deprecated-plugin",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              version: "1.0.0",
+              name: "my-deprecated-plugin",
+              description: "A test package",
+              dist: {
+                tarball:
+                  "https://registry.npmjs.org/my-deprecated-plugin/-/my-deprecated-plugin-1.0.0.tgz",
+              },
+              deprecated: "Use the latest version",
+            },
+          },
+        }),
+      };
+    }
+    return {
+      json: jest.fn(),
+    };
+  })
+);
+
+describe("NpmPluginVersionService", () => {
+  let service: NpmPluginVersionService;
+
+  beforeEach(() => {
+    service = new NpmPluginVersionService();
+  });
+
+  describe("updatePluginsVersion", () => {
+    it("should return an array of structured plugin versions that are not deprecated", async () => {
+      const expectedPlugin = plugins.find((x) => x.npm === NPM_PACKAGE);
+
+      const result = await service.updatePluginsVersion(plugins);
+
+      expect(result).toEqual([
+        {
+          createdAt: expect.any(Date),
+          id: "",
+          pluginId: expectedPlugin.pluginId,
+          pluginIdVersion: `${expectedPlugin.pluginId}_1.0.0`,
+          settings: "{}",
+          updatedAt: expect.any(Date),
+          version: "1.0.0",
+          tarballUrl:
+            "https://registry.npmjs.org/my-plugin/-/my-plugin-1.0.0.tgz",
+        },
+        // ... other versions
+      ]);
+    });
+  });
+});

--- a/packages/amplication-plugin-api/src/pluginVersion/npm-response.types.ts
+++ b/packages/amplication-plugin-api/src/pluginVersion/npm-response.types.ts
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export interface NpmVersion {
+  [versionNumber: string]: {
+    version: string;
+    name: string;
+    description: string;
+    dist: {
+      tarball: string;
+    };
+    deprecated: string;
+  };
+}
+
+export interface NpmPackage {
+  name: string;
+  "dist-tags": { latest: string };
+  versions: NpmVersion;
+}


### PR DESCRIPTION
Close: #5163 

## PR Details

Add logic to filter out deprecated npm package versions.
If deprecated versions have been cached in the DB they will not be deleted as part of this PR

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
