### PR TITLE
feat(dsg): add warning for DSG builds that are using deprecated plugins

### DIFF
--- a/packages/data-service-generator/src/utils/dynamic-installation/Tarball.ts
+++ b/packages/data-service-generator/src/utils/dynamic-installation/Tarball.ts
@@ -1,5 +1,6 @@
 import downloadHelper from "download";
 import { packument } from "pacote";
+import { createLog } from "../../create-log";
 import { PackageInstallation } from "./DynamicPackageInstallationManager";
 
 export class Tarball {
@@ -34,11 +35,16 @@ export class Tarball {
     }
     const requestedVersion = response.versions[version];
     if (!requestedVersion) {
-      const latestTag = response["dist-tags"].latest;
-      const latestVersion = response.versions[latestTag];
       throw new Error(
         `Could not find version ${version} for ${name}, please try to install another version, or the latest version: ${latestVersion}`
       );
+    }
+
+    if (requestedVersion.deprecated) {
+      await createLog({
+        level: "warn",
+        message: `${name}@${version} is deprecated, update it to avoid issues in the code generation.`,
+      });
     }
 
     return requestedVersion.dist.tarball;


### PR DESCRIPTION

Close: #5163 

## PR Details

Adding warnings in the build log for application generated with deprecated plugins

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
