### PR TITLE
fix(server): Add auth-strategy creation to install-plugin migration s…

### DIFF
--- a/packages/amplication-server/migration-scripts/install-auth-core-plugin.ts
+++ b/packages/amplication-server/migration-scripts/install-auth-core-plugin.ts
@@ -531,5 +531,3 @@ main().catch(console.error);
 
 // Execute from bash
 // $ POSTGRESQL_URL=postgres://[user]:[password]@127.0.0.1:5432/app-database npx ts-node install-auth-core-plugin.ts
-
-// $ POSTGRESQL_URL=postgresql://admin:admin@localhost:5432/amplication npx ts-node migration-scripts/install-auth-core-plugin.ts

--- a/packages/amplication-server/migration-scripts/install-auth-core-plugin.ts
+++ b/packages/amplication-server/migration-scripts/install-auth-core-plugin.ts
@@ -88,12 +88,7 @@ async function main() {
     plugins: PluginInstallation[],
     authProvider: string
   ): boolean {
-    const plugin = plugins.find(
-      (plugin) => plugin.pluginId.trim() == authProvider
-    );
-
-    if (plugin) return true;
-    return false;
+    return plugins.some((plugin) => plugin.pluginId.trim() == authProvider);
   }
 
   function isAuthStrategyPluginExist(


### PR DESCRIPTION

Close: #4431 

## PR Details

Add auth-strategy plugin if it does not exist in install-plugin migration script
## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

Test cases: 

Add new services. 
DO NOT install plugins: auth-core / auth-basic/ auth-jwt 
Run the migration script: install-auth-core-plugin with the following command: 
POSTGRESQL_URL=postgres://[user]:[password]@127.0.0.1:5432/app-database npx ts-node install-auth-core-plugin.ts 

Check that every new service you created in the first step has installed plugins: 
auth-core
auth-basic/ auth-jwt  (according to the auth provider type). 


