### PR TITLE
Fix/515 validate min/max value for numeric entity fields

### DIFF
--- a/packages/amplication-client/src/util/formikValidateJsonSchema.ts
+++ b/packages/amplication-client/src/util/formikValidateJsonSchema.ts
@@ -38,6 +38,18 @@ export function validate<T>(
 
   const isValid = ajv.validate(validationSchema, values);
 
+  const { minimumValue, maximumValue } = values as unknown as {
+    minimumValue: number;
+    maximumValue: number;
+  };
+  if (minimumValue && minimumValue >= maximumValue) {
+    set(
+      errors,
+      "minimumValue",
+      "Minimum value can not be greater than, or equal to, the Maximum value"
+    );
+  }
+
   if (!isValid && ajv.errors) {
     for (const error of ajv.errors) {
       // remove the first dot from dataPath

--- a/packages/amplication-server/src/core/entity/entity.service.spec.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.spec.ts
@@ -8,6 +8,7 @@ import {
   EntityPendingChange,
   EntityService,
   NAME_VALIDATION_ERROR_MESSAGE,
+  NUMBER_WITH_INVALID_MINIMUM_VALUE,
 } from "./entity.service";
 import {
   Entity,
@@ -222,6 +223,41 @@ const EXAMPLE_ENTITY_FIELD_DATA = {
   },
 };
 
+const EXAMPLE_ENTITY_FIELD_DATA_WITH_INVALID_MINIMUM_VALUE = {
+  name: "exampleEntityFieldNameWithInvalidMinimumValue",
+  displayName: "Example Entity Field Display Name With Invalid Minimum Value",
+  dataType: EnumDataType.WholeNumber,
+  properties: { maximumValue: 10, minimumValue: 10 },
+  required: false,
+  unique: false,
+  searchable: true,
+  description: "",
+};
+const EXAMPLE_ENTITY_FIELD_DATA_WITH_VALID_MINIMUM_VALUE = {
+  name: "exampleEntityFieldNameWithInvalidMinimumValue",
+  displayName: "Example Entity Field Display Name With Invalid Minimum Value",
+  dataType: EnumDataType.WholeNumber,
+  properties: { maximumValue: 10, minimumValue: 1 },
+  required: false,
+  unique: false,
+  searchable: true,
+  description: "",
+};
+const EXAMPLE_ENTITY_FIELD_WHOLE_NUMBER: EntityField = {
+  createdAt: new Date(),
+  dataType: "SingleLineText",
+  description: "example field",
+  displayName: "example field",
+  entityVersionId: "exampleEntityVersion",
+  id: "exampleEntityField",
+  name: "exampleFieldName",
+  permanentId: "exampleEntityFieldPermanentId",
+  properties: null,
+  required: true,
+  searchable: true,
+  unique: false,
+  updatedAt: new Date(),
+};
 const EXAMPLE_USER: User = {
   id: EXAMPLE_USER_ID,
   createdAt: new Date(),
@@ -1038,6 +1074,27 @@ describe("EntityService", () => {
       )
     ).rejects.toThrow(NAME_VALIDATION_ERROR_MESSAGE);
   });
+
+  it("should update Minimum value of a field", async () => {
+    const args = {
+      data: EXAMPLE_ENTITY_FIELD_DATA_WITH_VALID_MINIMUM_VALUE,
+      where: { id: "exampleEntityField" },
+    };
+    expect(await service.updateField(args, EXAMPLE_USER)).toEqual(
+      EXAMPLE_ENTITY_FIELD_WHOLE_NUMBER
+    );
+  });
+
+  it('should throw "Minimum value can not be greater than or equal to, the Maximum value', async () => {
+    const args = {
+      data: EXAMPLE_ENTITY_FIELD_DATA_WITH_INVALID_MINIMUM_VALUE,
+      where: { id: "exampleEntityField" },
+    };
+    await expect(service.updateField(args, EXAMPLE_USER)).rejects.toThrow(
+      NUMBER_WITH_INVALID_MINIMUM_VALUE
+    );
+  });
+
   it("should update entity field", async () => {
     const args = {
       where: { id: EXAMPLE_ENTITY_FIELD.id },

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -5,6 +5,7 @@ import {
   Injectable,
   NotFoundException,
   ConflictException,
+  BadRequestException,
 } from "@nestjs/common";
 import { DataConflictError } from "../../errors/DataConflictError";
 import { Prisma, PrismaService } from "../../prisma";
@@ -124,6 +125,9 @@ export type EntityPendingChange = {
 const NAME_REGEX = /^(?![0-9])[a-zA-Z0-9$_]+$/;
 export const NAME_VALIDATION_ERROR_MESSAGE =
   "Name must only contain letters, numbers, the dollar sign, or the underscore character and must not start with a number";
+
+export const NUMBER_WITH_INVALID_MINIMUM_VALUE =
+  "Minimum value can not be greater than or equal to, the Maximum value";
 
 export const DELETE_ONE_USER_ENTITY_ERROR_MESSAGE = `The 'user' entity is a reserved entity and it cannot be deleted`;
 
@@ -2118,6 +2122,14 @@ export class EntityService {
         "The base properties of the ID field cannot be edited"
       );
     }
+    const { minimumValue, maximumValue } = args?.data
+      ?.properties as unknown as {
+      minimumValue: number;
+      maximumValue: number;
+    };
+    if (minimumValue && minimumValue >= maximumValue) {
+      throw new BadRequestException(NUMBER_WITH_INVALID_MINIMUM_VALUE);
+    }
 
     // Delete related field in case field data type is changed from lookup
     const shouldDeleteRelated =
@@ -2221,7 +2233,9 @@ export class EntityService {
             },
           });
         }
-
+        console.log("====================================");
+        console.log(updatedField);
+        console.log("====================================");
         return updatedField;
       }
     );


### PR DESCRIPTION

Close: #515 
## PR Details

Validate that `minimumValue` is not greater than, or equal to `maximumValue`.
@MichaelSolati has already raised a [PR](https://github.com/amplication/amplication/pull/2800) for this issue but he did not write tests and so the pr was not merged.
I have added 2 tests:
- when `minimumValue` is less than `maximumValue`
- when `minimumValue` is greater than or equal to `maximumValue`


<img width="1171" alt="Screenshot 2023-02-14 at 12 48 15 PM" src="https://user-images.githubusercontent.com/74011196/218666114-cd75d0fb-fc0f-448f-a2fc-3a4ce7a7a52f.png">


<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
