### PR TITLE
fix(plugin-api): deprecated wrongly stored in db

### DIFF
--- a/packages/amplication-plugin-api/src/pluginVersion/npm-plugin-version.service.ts
+++ b/packages/amplication-plugin-api/src/pluginVersion/npm-plugin-version.service.ts
@@ -26,7 +26,7 @@ export class NpmPluginVersionService {
     for (const [key, value] of Object.entries(npmVersions)) {
       pluginVersions.push({
         createdAt: now,
-        deprecated: `${value.deprecated}`,
+        deprecated: value.deprecated?.toString() || null,
         id: "",
         pluginId: pluginId,
         pluginIdVersion: `${pluginId}_${value.version}`,


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #5163 

## PR Details

Fix the issue where when npm doesn't return deprecated for a package, the undefined string was stored in db. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
