### PR TITLE
chore(server): fix codegen configuration

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,20 +1,22 @@
 schema: "packages/amplication-server/src/schema.graphql"
+config:
+  skipTypename: true
 generates:
   packages/amplication-client/src/models.ts:
     plugins:
-      - "typescript"
-  libs/data-service-generator/src/models.ts:
+      - typescript
+  packages/data-service-generator/src/models.ts:
     plugins:
-      - "typescript"
+      - typescript
   packages/amplication-code-gen-types/src/models.ts:
     plugins:
-      - "typescript"
+      - typescript
   packages/amplication-cli/src/models.ts:
     plugins:
-      - "typescript"
+      - typescript
   packages/amplication-git-pull-request-service/src/models.ts:
     plugins:
-      - "typescript"
+      - typescript
 hooks:
   afterAllFileWrite:
     - prettier --write

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "build": "nx run-many --target=build",
     "setup:dev": "ts-node ./scripts/setup.ts",
     "clean": "nx clear-cache",
-    "graphql-codegen": "graphql-codegen",
     "docker:dev": "docker-compose -f docker-compose.dev.yml --env-file .env.docker-compose up",
     "docker:dev:cleanup": "docker-compose -f docker-compose.dev.yml --env-file .env.docker-compose down",
     "db:migrate:deploy": "nx run-many --target=db:migrate:deploy",

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -17,7 +17,6 @@ export type Scalars = {
 };
 
 export type Account = {
-  __typename?: 'Account';
   createdAt: Scalars['DateTime'];
   email: Scalars['String'];
   firstName: Scalars['String'];
@@ -29,14 +28,12 @@ export type Account = {
 };
 
 export type Action = {
-  __typename?: 'Action';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   steps?: Maybe<Array<ActionStep>>;
 };
 
 export type ActionLog = {
-  __typename?: 'ActionLog';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   level: EnumActionLogLevel;
@@ -45,7 +42,6 @@ export type ActionLog = {
 };
 
 export type ActionStep = {
-  __typename?: 'ActionStep';
   completedAt?: Maybe<Scalars['DateTime']>;
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
@@ -56,7 +52,6 @@ export type ActionStep = {
 };
 
 export type AdminUiSettings = {
-  __typename?: 'AdminUISettings';
   adminUIPath: Scalars['String'];
   generateAdminUI: Scalars['Boolean'];
 };
@@ -67,7 +62,6 @@ export type AdminUiSettingsUpdateInput = {
 };
 
 export type ApiToken = {
-  __typename?: 'ApiToken';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   lastAccessAt: Scalars['DateTime'];
@@ -83,18 +77,15 @@ export type ApiTokenCreateInput = {
 };
 
 export type Auth = {
-  __typename?: 'Auth';
   /** JWT Bearer token */
   token: Scalars['String'];
 };
 
 export type AuthorizeResourceWithGitResult = {
-  __typename?: 'AuthorizeResourceWithGitResult';
   url: Scalars['String'];
 };
 
 export type Block = {
-  __typename?: 'Block';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -119,7 +110,6 @@ export type BlockVersionsArgs = {
 };
 
 export type BlockInputOutput = {
-  __typename?: 'BlockInputOutput';
   dataType?: Maybe<EnumDataType>;
   dataTypeEntityName?: Maybe<Scalars['String']>;
   description: Scalars['String'];
@@ -149,7 +139,6 @@ export type BlockOrderByInput = {
 };
 
 export type BlockVersion = {
-  __typename?: 'BlockVersion';
   block: Block;
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
@@ -195,7 +184,6 @@ export type BooleanFilter = {
 };
 
 export type Build = {
-  __typename?: 'Build';
   action?: Maybe<Action>;
   actionId: Scalars['String'];
   archiveURI: Scalars['String'];
@@ -243,7 +231,6 @@ export type ChangePasswordInput = {
 };
 
 export type Commit = {
-  __typename?: 'Commit';
   builds?: Maybe<Array<Build>>;
   changes?: Maybe<Array<PendingChange>>;
   createdAt: Scalars['DateTime'];
@@ -315,7 +302,6 @@ export type DateTimeFilter = {
 };
 
 export type Entity = {
-  __typename?: 'Entity';
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -364,7 +350,6 @@ export type EntityCreateInput = {
 };
 
 export type EntityField = {
-  __typename?: 'EntityField';
   createdAt: Scalars['DateTime'];
   dataType: EnumDataType;
   description?: Maybe<Scalars['String']>;
@@ -457,7 +442,6 @@ export type EntityOrderByInput = {
 };
 
 export type EntityPermission = {
-  __typename?: 'EntityPermission';
   action: EnumEntityAction;
   entityVersion?: Maybe<EntityVersion>;
   entityVersionId: Scalars['String'];
@@ -468,7 +452,6 @@ export type EntityPermission = {
 };
 
 export type EntityPermissionField = {
-  __typename?: 'EntityPermissionField';
   entityVersionId: Scalars['String'];
   field: EntityField;
   fieldPermanentId: Scalars['String'];
@@ -485,7 +468,6 @@ export type EntityPermissionFieldWhereUniqueInput = {
 };
 
 export type EntityPermissionRole = {
-  __typename?: 'EntityPermissionRole';
   action: EnumEntityAction;
   entityPermission?: Maybe<EntityPermission>;
   entityVersionId: Scalars['String'];
@@ -520,7 +502,6 @@ export type EntityUpdatePermissionRolesInput = {
 };
 
 export type EntityVersion = {
-  __typename?: 'EntityVersion';
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -706,8 +687,8 @@ export type EnumResourceTypeFilter = {
 };
 
 export enum EnumSubscriptionPlan {
-  Business = 'Business',
   Enterprise = 'Enterprise',
+  Free = 'Free',
   Pro = 'Pro'
 }
 
@@ -725,7 +706,6 @@ export enum EnumWorkspaceMemberType {
 }
 
 export type Environment = {
-  __typename?: 'Environment';
   address: Scalars['String'];
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -741,7 +721,6 @@ export type GitGetInstallationUrlInput = {
 };
 
 export type GitOrganization = {
-  __typename?: 'GitOrganization';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   installationId: Scalars['String'];
@@ -761,7 +740,6 @@ export type GitOrganizationWhereInput = {
 };
 
 export type GitRepository = {
-  __typename?: 'GitRepository';
   createdAt?: Maybe<Scalars['DateTime']>;
   gitOrganization: GitOrganization;
   gitOrganizationId: Scalars['String'];
@@ -798,7 +776,6 @@ export type IntFilter = {
 };
 
 export type Invitation = {
-  __typename?: 'Invitation';
   createdAt: Scalars['DateTime'];
   email: Scalars['String'];
   id: Scalars['String'];
@@ -817,7 +794,6 @@ export type LoginInput = {
 };
 
 export type MessagePattern = {
-  __typename?: 'MessagePattern';
   topicId: Scalars['String'];
   type: EnumMessagePatternConnectionOptions;
 };
@@ -828,7 +804,6 @@ export type MessagePatternCreateInput = {
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
   addEntityPermissionField: EntityPermissionField;
   changePassword: Account;
   commit?: Maybe<Commit>;
@@ -1237,7 +1212,6 @@ export type MutationUpdateWorkspaceArgs = {
 };
 
 export type PendingChange = {
-  __typename?: 'PendingChange';
   action: EnumPendingChangeAction;
   origin: PendingChangeOrigin;
   originId: Scalars['String'];
@@ -1257,7 +1231,6 @@ export type PendingChangesFindInput = {
 };
 
 export type PluginInstallation = IBlock & {
-  __typename?: 'PluginInstallation';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1324,7 +1297,6 @@ export type PluginInstallationsCreateInput = {
 };
 
 export type PluginOrder = IBlock & {
-  __typename?: 'PluginOrder';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1342,7 +1314,6 @@ export type PluginOrder = IBlock & {
 };
 
 export type PluginOrderItem = {
-  __typename?: 'PluginOrderItem';
   order: Scalars['Int'];
   pluginId: Scalars['String'];
 };
@@ -1352,7 +1323,6 @@ export type PluginSetOrderInput = {
 };
 
 export type Project = {
-  __typename?: 'Project';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   name: Scalars['String'];
@@ -1361,7 +1331,6 @@ export type Project = {
 };
 
 export type ProjectConfigurationSettings = IBlock & {
-  __typename?: 'ProjectConfigurationSettings';
   baseDirectory: Scalars['String'];
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
@@ -1406,7 +1375,6 @@ export type ProjectWhereInput = {
 };
 
 export type PropertySelector = {
-  __typename?: 'PropertySelector';
   include: Scalars['Boolean'];
   propertyName: Scalars['String'];
 };
@@ -1426,13 +1394,11 @@ export type ProvisionSubscriptionInput = {
 };
 
 export type ProvisionSubscriptionResult = {
-  __typename?: 'ProvisionSubscriptionResult';
   checkoutUrl?: Maybe<Scalars['String']>;
   provisionStatus: Scalars['String'];
 };
 
 export type Query = {
-  __typename?: 'Query';
   PluginInstallation?: Maybe<PluginInstallation>;
   PluginInstallations: Array<PluginInstallation>;
   ServiceTopics?: Maybe<ServiceTopics>;
@@ -1661,7 +1627,6 @@ export enum QueryMode {
 }
 
 export type RemoteGitRepos = {
-  __typename?: 'RemoteGitRepos';
   currentPage: Scalars['Float'];
   pageSize: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
@@ -1676,7 +1641,6 @@ export type RemoteGitRepositoriesWhereUniqueInput = {
 };
 
 export type RemoteGitRepository = {
-  __typename?: 'RemoteGitRepository';
   admin: Scalars['Boolean'];
   defaultBranch: Scalars['String'];
   fullName: Scalars['String'];
@@ -1686,7 +1650,6 @@ export type RemoteGitRepository = {
 };
 
 export type Resource = {
-  __typename?: 'Resource';
   builds: Array<Build>;
   createdAt: Scalars['DateTime'];
   description: Scalars['String'];
@@ -1768,7 +1731,6 @@ export type ResourceOrderByInput = {
 };
 
 export type ResourceRole = {
-  __typename?: 'ResourceRole';
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -1834,7 +1796,6 @@ export enum Role {
 }
 
 export type ServerSettings = {
-  __typename?: 'ServerSettings';
   generateGraphQL: Scalars['Boolean'];
   generateRestApi: Scalars['Boolean'];
   serverPath: Scalars['String'];
@@ -1847,7 +1808,6 @@ export type ServerSettingsUpdateInput = {
 };
 
 export type ServiceSettings = IBlock & {
-  __typename?: 'ServiceSettings';
   adminUISettings: AdminUiSettings;
   authProvider: EnumAuthProviderType;
   blockType: EnumBlockType;
@@ -1885,7 +1845,6 @@ export type ServiceSettingsUpdateInput = {
 };
 
 export type ServiceTopics = IBlock & {
-  __typename?: 'ServiceTopics';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1972,7 +1931,6 @@ export type StringFilter = {
 };
 
 export type Subscription = {
-  __typename?: 'Subscription';
   cancelUrl?: Maybe<Scalars['String']>;
   cancellationEffectiveDate?: Maybe<Scalars['DateTime']>;
   createdAt: Scalars['DateTime'];
@@ -1988,7 +1946,6 @@ export type Subscription = {
 };
 
 export type Topic = IBlock & {
-  __typename?: 'Topic';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -2046,7 +2003,6 @@ export type UpdateAccountInput = {
 };
 
 export type User = {
-  __typename?: 'User';
   account?: Maybe<Account>;
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
@@ -2057,7 +2013,6 @@ export type User = {
 };
 
 export type UserRole = {
-  __typename?: 'UserRole';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   role: Role;
@@ -2073,7 +2028,6 @@ export type WhereUniqueInput = {
 };
 
 export type Workspace = {
-  __typename?: 'Workspace';
   createdAt: Scalars['DateTime'];
   gitOrganizations?: Maybe<Array<GitOrganization>>;
   id: Scalars['String'];
@@ -2089,7 +2043,6 @@ export type WorkspaceCreateInput = {
 };
 
 export type WorkspaceMember = {
-  __typename?: 'WorkspaceMember';
   member: WorkspaceMemberType;
   type: EnumWorkspaceMemberType;
 };

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -17,7 +17,6 @@ export type Scalars = {
 };
 
 export type Account = {
-  __typename?: 'Account';
   createdAt: Scalars['DateTime'];
   email: Scalars['String'];
   firstName: Scalars['String'];
@@ -29,14 +28,12 @@ export type Account = {
 };
 
 export type Action = {
-  __typename?: 'Action';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   steps?: Maybe<Array<ActionStep>>;
 };
 
 export type ActionLog = {
-  __typename?: 'ActionLog';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   level: EnumActionLogLevel;
@@ -45,7 +42,6 @@ export type ActionLog = {
 };
 
 export type ActionStep = {
-  __typename?: 'ActionStep';
   completedAt?: Maybe<Scalars['DateTime']>;
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
@@ -56,7 +52,6 @@ export type ActionStep = {
 };
 
 export type AdminUiSettings = {
-  __typename?: 'AdminUISettings';
   adminUIPath: Scalars['String'];
   generateAdminUI: Scalars['Boolean'];
 };
@@ -67,7 +62,6 @@ export type AdminUiSettingsUpdateInput = {
 };
 
 export type ApiToken = {
-  __typename?: 'ApiToken';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   lastAccessAt: Scalars['DateTime'];
@@ -83,18 +77,15 @@ export type ApiTokenCreateInput = {
 };
 
 export type Auth = {
-  __typename?: 'Auth';
   /** JWT Bearer token */
   token: Scalars['String'];
 };
 
 export type AuthorizeResourceWithGitResult = {
-  __typename?: 'AuthorizeResourceWithGitResult';
   url: Scalars['String'];
 };
 
 export type Block = {
-  __typename?: 'Block';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -119,7 +110,6 @@ export type BlockVersionsArgs = {
 };
 
 export type BlockInputOutput = {
-  __typename?: 'BlockInputOutput';
   dataType?: Maybe<EnumDataType>;
   dataTypeEntityName?: Maybe<Scalars['String']>;
   description: Scalars['String'];
@@ -149,7 +139,6 @@ export type BlockOrderByInput = {
 };
 
 export type BlockVersion = {
-  __typename?: 'BlockVersion';
   block: Block;
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
@@ -195,7 +184,6 @@ export type BooleanFilter = {
 };
 
 export type Build = {
-  __typename?: 'Build';
   action?: Maybe<Action>;
   actionId: Scalars['String'];
   archiveURI: Scalars['String'];
@@ -243,7 +231,6 @@ export type ChangePasswordInput = {
 };
 
 export type Commit = {
-  __typename?: 'Commit';
   builds?: Maybe<Array<Build>>;
   changes?: Maybe<Array<PendingChange>>;
   createdAt: Scalars['DateTime'];
@@ -315,7 +302,6 @@ export type DateTimeFilter = {
 };
 
 export type Entity = {
-  __typename?: 'Entity';
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -364,7 +350,6 @@ export type EntityCreateInput = {
 };
 
 export type EntityField = {
-  __typename?: 'EntityField';
   createdAt: Scalars['DateTime'];
   dataType: EnumDataType;
   description?: Maybe<Scalars['String']>;
@@ -457,7 +442,6 @@ export type EntityOrderByInput = {
 };
 
 export type EntityPermission = {
-  __typename?: 'EntityPermission';
   action: EnumEntityAction;
   entityVersion?: Maybe<EntityVersion>;
   entityVersionId: Scalars['String'];
@@ -468,7 +452,6 @@ export type EntityPermission = {
 };
 
 export type EntityPermissionField = {
-  __typename?: 'EntityPermissionField';
   entityVersionId: Scalars['String'];
   field: EntityField;
   fieldPermanentId: Scalars['String'];
@@ -485,7 +468,6 @@ export type EntityPermissionFieldWhereUniqueInput = {
 };
 
 export type EntityPermissionRole = {
-  __typename?: 'EntityPermissionRole';
   action: EnumEntityAction;
   entityPermission?: Maybe<EntityPermission>;
   entityVersionId: Scalars['String'];
@@ -520,7 +502,6 @@ export type EntityUpdatePermissionRolesInput = {
 };
 
 export type EntityVersion = {
-  __typename?: 'EntityVersion';
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -706,8 +687,8 @@ export type EnumResourceTypeFilter = {
 };
 
 export enum EnumSubscriptionPlan {
-  Business = 'Business',
   Enterprise = 'Enterprise',
+  Free = 'Free',
   Pro = 'Pro'
 }
 
@@ -725,7 +706,6 @@ export enum EnumWorkspaceMemberType {
 }
 
 export type Environment = {
-  __typename?: 'Environment';
   address: Scalars['String'];
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -741,7 +721,6 @@ export type GitGetInstallationUrlInput = {
 };
 
 export type GitOrganization = {
-  __typename?: 'GitOrganization';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   installationId: Scalars['String'];
@@ -761,7 +740,6 @@ export type GitOrganizationWhereInput = {
 };
 
 export type GitRepository = {
-  __typename?: 'GitRepository';
   createdAt?: Maybe<Scalars['DateTime']>;
   gitOrganization: GitOrganization;
   gitOrganizationId: Scalars['String'];
@@ -798,7 +776,6 @@ export type IntFilter = {
 };
 
 export type Invitation = {
-  __typename?: 'Invitation';
   createdAt: Scalars['DateTime'];
   email: Scalars['String'];
   id: Scalars['String'];
@@ -817,7 +794,6 @@ export type LoginInput = {
 };
 
 export type MessagePattern = {
-  __typename?: 'MessagePattern';
   topicId: Scalars['String'];
   type: EnumMessagePatternConnectionOptions;
 };
@@ -828,7 +804,6 @@ export type MessagePatternCreateInput = {
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
   addEntityPermissionField: EntityPermissionField;
   changePassword: Account;
   commit?: Maybe<Commit>;
@@ -1237,7 +1212,6 @@ export type MutationUpdateWorkspaceArgs = {
 };
 
 export type PendingChange = {
-  __typename?: 'PendingChange';
   action: EnumPendingChangeAction;
   origin: PendingChangeOrigin;
   originId: Scalars['String'];
@@ -1257,7 +1231,6 @@ export type PendingChangesFindInput = {
 };
 
 export type PluginInstallation = IBlock & {
-  __typename?: 'PluginInstallation';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1324,7 +1297,6 @@ export type PluginInstallationsCreateInput = {
 };
 
 export type PluginOrder = IBlock & {
-  __typename?: 'PluginOrder';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1342,7 +1314,6 @@ export type PluginOrder = IBlock & {
 };
 
 export type PluginOrderItem = {
-  __typename?: 'PluginOrderItem';
   order: Scalars['Int'];
   pluginId: Scalars['String'];
 };
@@ -1352,7 +1323,6 @@ export type PluginSetOrderInput = {
 };
 
 export type Project = {
-  __typename?: 'Project';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   name: Scalars['String'];
@@ -1361,7 +1331,6 @@ export type Project = {
 };
 
 export type ProjectConfigurationSettings = IBlock & {
-  __typename?: 'ProjectConfigurationSettings';
   baseDirectory: Scalars['String'];
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
@@ -1406,7 +1375,6 @@ export type ProjectWhereInput = {
 };
 
 export type PropertySelector = {
-  __typename?: 'PropertySelector';
   include: Scalars['Boolean'];
   propertyName: Scalars['String'];
 };
@@ -1426,13 +1394,11 @@ export type ProvisionSubscriptionInput = {
 };
 
 export type ProvisionSubscriptionResult = {
-  __typename?: 'ProvisionSubscriptionResult';
   checkoutUrl?: Maybe<Scalars['String']>;
   provisionStatus: Scalars['String'];
 };
 
 export type Query = {
-  __typename?: 'Query';
   PluginInstallation?: Maybe<PluginInstallation>;
   PluginInstallations: Array<PluginInstallation>;
   ServiceTopics?: Maybe<ServiceTopics>;
@@ -1661,7 +1627,6 @@ export enum QueryMode {
 }
 
 export type RemoteGitRepos = {
-  __typename?: 'RemoteGitRepos';
   currentPage: Scalars['Float'];
   pageSize: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
@@ -1676,7 +1641,6 @@ export type RemoteGitRepositoriesWhereUniqueInput = {
 };
 
 export type RemoteGitRepository = {
-  __typename?: 'RemoteGitRepository';
   admin: Scalars['Boolean'];
   defaultBranch: Scalars['String'];
   fullName: Scalars['String'];
@@ -1686,7 +1650,6 @@ export type RemoteGitRepository = {
 };
 
 export type Resource = {
-  __typename?: 'Resource';
   builds: Array<Build>;
   createdAt: Scalars['DateTime'];
   description: Scalars['String'];
@@ -1768,7 +1731,6 @@ export type ResourceOrderByInput = {
 };
 
 export type ResourceRole = {
-  __typename?: 'ResourceRole';
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -1834,7 +1796,6 @@ export enum Role {
 }
 
 export type ServerSettings = {
-  __typename?: 'ServerSettings';
   generateGraphQL: Scalars['Boolean'];
   generateRestApi: Scalars['Boolean'];
   serverPath: Scalars['String'];
@@ -1847,7 +1808,6 @@ export type ServerSettingsUpdateInput = {
 };
 
 export type ServiceSettings = IBlock & {
-  __typename?: 'ServiceSettings';
   adminUISettings: AdminUiSettings;
   authProvider: EnumAuthProviderType;
   blockType: EnumBlockType;
@@ -1885,7 +1845,6 @@ export type ServiceSettingsUpdateInput = {
 };
 
 export type ServiceTopics = IBlock & {
-  __typename?: 'ServiceTopics';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1972,7 +1931,6 @@ export type StringFilter = {
 };
 
 export type Subscription = {
-  __typename?: 'Subscription';
   cancelUrl?: Maybe<Scalars['String']>;
   cancellationEffectiveDate?: Maybe<Scalars['DateTime']>;
   createdAt: Scalars['DateTime'];
@@ -1988,7 +1946,6 @@ export type Subscription = {
 };
 
 export type Topic = IBlock & {
-  __typename?: 'Topic';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -2046,7 +2003,6 @@ export type UpdateAccountInput = {
 };
 
 export type User = {
-  __typename?: 'User';
   account?: Maybe<Account>;
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
@@ -2057,7 +2013,6 @@ export type User = {
 };
 
 export type UserRole = {
-  __typename?: 'UserRole';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   role: Role;
@@ -2073,7 +2028,6 @@ export type WhereUniqueInput = {
 };
 
 export type Workspace = {
-  __typename?: 'Workspace';
   createdAt: Scalars['DateTime'];
   gitOrganizations?: Maybe<Array<GitOrganization>>;
   id: Scalars['String'];
@@ -2089,7 +2043,6 @@ export type WorkspaceCreateInput = {
 };
 
 export type WorkspaceMember = {
-  __typename?: 'WorkspaceMember';
   member: WorkspaceMemberType;
   type: EnumWorkspaceMemberType;
 };

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -17,7 +17,6 @@ export type Scalars = {
 };
 
 export type Account = {
-  __typename?: 'Account';
   createdAt: Scalars['DateTime'];
   email: Scalars['String'];
   firstName: Scalars['String'];
@@ -29,14 +28,12 @@ export type Account = {
 };
 
 export type Action = {
-  __typename?: 'Action';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   steps?: Maybe<Array<ActionStep>>;
 };
 
 export type ActionLog = {
-  __typename?: 'ActionLog';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   level: EnumActionLogLevel;
@@ -45,7 +42,6 @@ export type ActionLog = {
 };
 
 export type ActionStep = {
-  __typename?: 'ActionStep';
   completedAt?: Maybe<Scalars['DateTime']>;
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
@@ -56,7 +52,6 @@ export type ActionStep = {
 };
 
 export type AdminUiSettings = {
-  __typename?: 'AdminUISettings';
   adminUIPath: Scalars['String'];
   generateAdminUI: Scalars['Boolean'];
 };
@@ -67,7 +62,6 @@ export type AdminUiSettingsUpdateInput = {
 };
 
 export type ApiToken = {
-  __typename?: 'ApiToken';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   lastAccessAt: Scalars['DateTime'];
@@ -83,18 +77,15 @@ export type ApiTokenCreateInput = {
 };
 
 export type Auth = {
-  __typename?: 'Auth';
   /** JWT Bearer token */
   token: Scalars['String'];
 };
 
 export type AuthorizeResourceWithGitResult = {
-  __typename?: 'AuthorizeResourceWithGitResult';
   url: Scalars['String'];
 };
 
 export type Block = {
-  __typename?: 'Block';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -119,7 +110,6 @@ export type BlockVersionsArgs = {
 };
 
 export type BlockInputOutput = {
-  __typename?: 'BlockInputOutput';
   dataType?: Maybe<EnumDataType>;
   dataTypeEntityName?: Maybe<Scalars['String']>;
   description: Scalars['String'];
@@ -149,7 +139,6 @@ export type BlockOrderByInput = {
 };
 
 export type BlockVersion = {
-  __typename?: 'BlockVersion';
   block: Block;
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
@@ -195,7 +184,6 @@ export type BooleanFilter = {
 };
 
 export type Build = {
-  __typename?: 'Build';
   action?: Maybe<Action>;
   actionId: Scalars['String'];
   archiveURI: Scalars['String'];
@@ -243,7 +231,6 @@ export type ChangePasswordInput = {
 };
 
 export type Commit = {
-  __typename?: 'Commit';
   builds?: Maybe<Array<Build>>;
   changes?: Maybe<Array<PendingChange>>;
   createdAt: Scalars['DateTime'];
@@ -315,7 +302,6 @@ export type DateTimeFilter = {
 };
 
 export type Entity = {
-  __typename?: 'Entity';
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -364,7 +350,6 @@ export type EntityCreateInput = {
 };
 
 export type EntityField = {
-  __typename?: 'EntityField';
   createdAt: Scalars['DateTime'];
   dataType: EnumDataType;
   description?: Maybe<Scalars['String']>;
@@ -457,7 +442,6 @@ export type EntityOrderByInput = {
 };
 
 export type EntityPermission = {
-  __typename?: 'EntityPermission';
   action: EnumEntityAction;
   entityVersion?: Maybe<EntityVersion>;
   entityVersionId: Scalars['String'];
@@ -468,7 +452,6 @@ export type EntityPermission = {
 };
 
 export type EntityPermissionField = {
-  __typename?: 'EntityPermissionField';
   entityVersionId: Scalars['String'];
   field: EntityField;
   fieldPermanentId: Scalars['String'];
@@ -485,7 +468,6 @@ export type EntityPermissionFieldWhereUniqueInput = {
 };
 
 export type EntityPermissionRole = {
-  __typename?: 'EntityPermissionRole';
   action: EnumEntityAction;
   entityPermission?: Maybe<EntityPermission>;
   entityVersionId: Scalars['String'];
@@ -520,7 +502,6 @@ export type EntityUpdatePermissionRolesInput = {
 };
 
 export type EntityVersion = {
-  __typename?: 'EntityVersion';
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -706,8 +687,8 @@ export type EnumResourceTypeFilter = {
 };
 
 export enum EnumSubscriptionPlan {
-  Business = 'Business',
   Enterprise = 'Enterprise',
+  Free = 'Free',
   Pro = 'Pro'
 }
 
@@ -725,7 +706,6 @@ export enum EnumWorkspaceMemberType {
 }
 
 export type Environment = {
-  __typename?: 'Environment';
   address: Scalars['String'];
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -741,7 +721,6 @@ export type GitGetInstallationUrlInput = {
 };
 
 export type GitOrganization = {
-  __typename?: 'GitOrganization';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   installationId: Scalars['String'];
@@ -761,7 +740,6 @@ export type GitOrganizationWhereInput = {
 };
 
 export type GitRepository = {
-  __typename?: 'GitRepository';
   createdAt?: Maybe<Scalars['DateTime']>;
   gitOrganization: GitOrganization;
   gitOrganizationId: Scalars['String'];
@@ -798,7 +776,6 @@ export type IntFilter = {
 };
 
 export type Invitation = {
-  __typename?: 'Invitation';
   createdAt: Scalars['DateTime'];
   email: Scalars['String'];
   id: Scalars['String'];
@@ -817,7 +794,6 @@ export type LoginInput = {
 };
 
 export type MessagePattern = {
-  __typename?: 'MessagePattern';
   topicId: Scalars['String'];
   type: EnumMessagePatternConnectionOptions;
 };
@@ -828,7 +804,6 @@ export type MessagePatternCreateInput = {
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
   addEntityPermissionField: EntityPermissionField;
   changePassword: Account;
   commit?: Maybe<Commit>;
@@ -1237,7 +1212,6 @@ export type MutationUpdateWorkspaceArgs = {
 };
 
 export type PendingChange = {
-  __typename?: 'PendingChange';
   action: EnumPendingChangeAction;
   origin: PendingChangeOrigin;
   originId: Scalars['String'];
@@ -1257,7 +1231,6 @@ export type PendingChangesFindInput = {
 };
 
 export type PluginInstallation = IBlock & {
-  __typename?: 'PluginInstallation';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1324,7 +1297,6 @@ export type PluginInstallationsCreateInput = {
 };
 
 export type PluginOrder = IBlock & {
-  __typename?: 'PluginOrder';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1342,7 +1314,6 @@ export type PluginOrder = IBlock & {
 };
 
 export type PluginOrderItem = {
-  __typename?: 'PluginOrderItem';
   order: Scalars['Int'];
   pluginId: Scalars['String'];
 };
@@ -1352,7 +1323,6 @@ export type PluginSetOrderInput = {
 };
 
 export type Project = {
-  __typename?: 'Project';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   name: Scalars['String'];
@@ -1361,7 +1331,6 @@ export type Project = {
 };
 
 export type ProjectConfigurationSettings = IBlock & {
-  __typename?: 'ProjectConfigurationSettings';
   baseDirectory: Scalars['String'];
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
@@ -1406,7 +1375,6 @@ export type ProjectWhereInput = {
 };
 
 export type PropertySelector = {
-  __typename?: 'PropertySelector';
   include: Scalars['Boolean'];
   propertyName: Scalars['String'];
 };
@@ -1426,13 +1394,11 @@ export type ProvisionSubscriptionInput = {
 };
 
 export type ProvisionSubscriptionResult = {
-  __typename?: 'ProvisionSubscriptionResult';
   checkoutUrl?: Maybe<Scalars['String']>;
   provisionStatus: Scalars['String'];
 };
 
 export type Query = {
-  __typename?: 'Query';
   PluginInstallation?: Maybe<PluginInstallation>;
   PluginInstallations: Array<PluginInstallation>;
   ServiceTopics?: Maybe<ServiceTopics>;
@@ -1661,7 +1627,6 @@ export enum QueryMode {
 }
 
 export type RemoteGitRepos = {
-  __typename?: 'RemoteGitRepos';
   currentPage: Scalars['Float'];
   pageSize: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
@@ -1676,7 +1641,6 @@ export type RemoteGitRepositoriesWhereUniqueInput = {
 };
 
 export type RemoteGitRepository = {
-  __typename?: 'RemoteGitRepository';
   admin: Scalars['Boolean'];
   defaultBranch: Scalars['String'];
   fullName: Scalars['String'];
@@ -1686,7 +1650,6 @@ export type RemoteGitRepository = {
 };
 
 export type Resource = {
-  __typename?: 'Resource';
   builds: Array<Build>;
   createdAt: Scalars['DateTime'];
   description: Scalars['String'];
@@ -1768,7 +1731,6 @@ export type ResourceOrderByInput = {
 };
 
 export type ResourceRole = {
-  __typename?: 'ResourceRole';
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -1834,7 +1796,6 @@ export enum Role {
 }
 
 export type ServerSettings = {
-  __typename?: 'ServerSettings';
   generateGraphQL: Scalars['Boolean'];
   generateRestApi: Scalars['Boolean'];
   serverPath: Scalars['String'];
@@ -1847,7 +1808,6 @@ export type ServerSettingsUpdateInput = {
 };
 
 export type ServiceSettings = IBlock & {
-  __typename?: 'ServiceSettings';
   adminUISettings: AdminUiSettings;
   authProvider: EnumAuthProviderType;
   blockType: EnumBlockType;
@@ -1885,7 +1845,6 @@ export type ServiceSettingsUpdateInput = {
 };
 
 export type ServiceTopics = IBlock & {
-  __typename?: 'ServiceTopics';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1972,7 +1931,6 @@ export type StringFilter = {
 };
 
 export type Subscription = {
-  __typename?: 'Subscription';
   cancelUrl?: Maybe<Scalars['String']>;
   cancellationEffectiveDate?: Maybe<Scalars['DateTime']>;
   createdAt: Scalars['DateTime'];
@@ -1988,7 +1946,6 @@ export type Subscription = {
 };
 
 export type Topic = IBlock & {
-  __typename?: 'Topic';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -2046,7 +2003,6 @@ export type UpdateAccountInput = {
 };
 
 export type User = {
-  __typename?: 'User';
   account?: Maybe<Account>;
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
@@ -2057,7 +2013,6 @@ export type User = {
 };
 
 export type UserRole = {
-  __typename?: 'UserRole';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   role: Role;
@@ -2073,7 +2028,6 @@ export type WhereUniqueInput = {
 };
 
 export type Workspace = {
-  __typename?: 'Workspace';
   createdAt: Scalars['DateTime'];
   gitOrganizations?: Maybe<Array<GitOrganization>>;
   id: Scalars['String'];
@@ -2089,7 +2043,6 @@ export type WorkspaceCreateInput = {
 };
 
 export type WorkspaceMember = {
-  __typename?: 'WorkspaceMember';
   member: WorkspaceMemberType;
   type: EnumWorkspaceMemberType;
 };

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -17,7 +17,6 @@ export type Scalars = {
 };
 
 export type Account = {
-  __typename?: 'Account';
   createdAt: Scalars['DateTime'];
   email: Scalars['String'];
   firstName: Scalars['String'];
@@ -29,14 +28,12 @@ export type Account = {
 };
 
 export type Action = {
-  __typename?: 'Action';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   steps?: Maybe<Array<ActionStep>>;
 };
 
 export type ActionLog = {
-  __typename?: 'ActionLog';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   level: EnumActionLogLevel;
@@ -45,7 +42,6 @@ export type ActionLog = {
 };
 
 export type ActionStep = {
-  __typename?: 'ActionStep';
   completedAt?: Maybe<Scalars['DateTime']>;
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
@@ -56,7 +52,6 @@ export type ActionStep = {
 };
 
 export type AdminUiSettings = {
-  __typename?: 'AdminUISettings';
   adminUIPath: Scalars['String'];
   generateAdminUI: Scalars['Boolean'];
 };
@@ -67,7 +62,6 @@ export type AdminUiSettingsUpdateInput = {
 };
 
 export type ApiToken = {
-  __typename?: 'ApiToken';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   lastAccessAt: Scalars['DateTime'];
@@ -83,18 +77,15 @@ export type ApiTokenCreateInput = {
 };
 
 export type Auth = {
-  __typename?: 'Auth';
   /** JWT Bearer token */
   token: Scalars['String'];
 };
 
 export type AuthorizeResourceWithGitResult = {
-  __typename?: 'AuthorizeResourceWithGitResult';
   url: Scalars['String'];
 };
 
 export type Block = {
-  __typename?: 'Block';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -119,7 +110,6 @@ export type BlockVersionsArgs = {
 };
 
 export type BlockInputOutput = {
-  __typename?: 'BlockInputOutput';
   dataType?: Maybe<EnumDataType>;
   dataTypeEntityName?: Maybe<Scalars['String']>;
   description: Scalars['String'];
@@ -149,7 +139,6 @@ export type BlockOrderByInput = {
 };
 
 export type BlockVersion = {
-  __typename?: 'BlockVersion';
   block: Block;
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
@@ -195,7 +184,6 @@ export type BooleanFilter = {
 };
 
 export type Build = {
-  __typename?: 'Build';
   action?: Maybe<Action>;
   actionId: Scalars['String'];
   archiveURI: Scalars['String'];
@@ -243,7 +231,6 @@ export type ChangePasswordInput = {
 };
 
 export type Commit = {
-  __typename?: 'Commit';
   builds?: Maybe<Array<Build>>;
   changes?: Maybe<Array<PendingChange>>;
   createdAt: Scalars['DateTime'];
@@ -315,7 +302,6 @@ export type DateTimeFilter = {
 };
 
 export type Entity = {
-  __typename?: 'Entity';
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -364,7 +350,6 @@ export type EntityCreateInput = {
 };
 
 export type EntityField = {
-  __typename?: 'EntityField';
   createdAt: Scalars['DateTime'];
   dataType: EnumDataType;
   description?: Maybe<Scalars['String']>;
@@ -457,7 +442,6 @@ export type EntityOrderByInput = {
 };
 
 export type EntityPermission = {
-  __typename?: 'EntityPermission';
   action: EnumEntityAction;
   entityVersion?: Maybe<EntityVersion>;
   entityVersionId: Scalars['String'];
@@ -468,7 +452,6 @@ export type EntityPermission = {
 };
 
 export type EntityPermissionField = {
-  __typename?: 'EntityPermissionField';
   entityVersionId: Scalars['String'];
   field: EntityField;
   fieldPermanentId: Scalars['String'];
@@ -485,7 +468,6 @@ export type EntityPermissionFieldWhereUniqueInput = {
 };
 
 export type EntityPermissionRole = {
-  __typename?: 'EntityPermissionRole';
   action: EnumEntityAction;
   entityPermission?: Maybe<EntityPermission>;
   entityVersionId: Scalars['String'];
@@ -520,7 +502,6 @@ export type EntityUpdatePermissionRolesInput = {
 };
 
 export type EntityVersion = {
-  __typename?: 'EntityVersion';
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -706,8 +687,8 @@ export type EnumResourceTypeFilter = {
 };
 
 export enum EnumSubscriptionPlan {
-  Business = 'Business',
   Enterprise = 'Enterprise',
+  Free = 'Free',
   Pro = 'Pro'
 }
 
@@ -725,7 +706,6 @@ export enum EnumWorkspaceMemberType {
 }
 
 export type Environment = {
-  __typename?: 'Environment';
   address: Scalars['String'];
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -741,7 +721,6 @@ export type GitGetInstallationUrlInput = {
 };
 
 export type GitOrganization = {
-  __typename?: 'GitOrganization';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   installationId: Scalars['String'];
@@ -761,7 +740,6 @@ export type GitOrganizationWhereInput = {
 };
 
 export type GitRepository = {
-  __typename?: 'GitRepository';
   createdAt?: Maybe<Scalars['DateTime']>;
   gitOrganization: GitOrganization;
   gitOrganizationId: Scalars['String'];
@@ -798,7 +776,6 @@ export type IntFilter = {
 };
 
 export type Invitation = {
-  __typename?: 'Invitation';
   createdAt: Scalars['DateTime'];
   email: Scalars['String'];
   id: Scalars['String'];
@@ -817,7 +794,6 @@ export type LoginInput = {
 };
 
 export type MessagePattern = {
-  __typename?: 'MessagePattern';
   topicId: Scalars['String'];
   type: EnumMessagePatternConnectionOptions;
 };
@@ -828,7 +804,6 @@ export type MessagePatternCreateInput = {
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
   addEntityPermissionField: EntityPermissionField;
   changePassword: Account;
   commit?: Maybe<Commit>;
@@ -1237,7 +1212,6 @@ export type MutationUpdateWorkspaceArgs = {
 };
 
 export type PendingChange = {
-  __typename?: 'PendingChange';
   action: EnumPendingChangeAction;
   origin: PendingChangeOrigin;
   originId: Scalars['String'];
@@ -1257,7 +1231,6 @@ export type PendingChangesFindInput = {
 };
 
 export type PluginInstallation = IBlock & {
-  __typename?: 'PluginInstallation';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1324,7 +1297,6 @@ export type PluginInstallationsCreateInput = {
 };
 
 export type PluginOrder = IBlock & {
-  __typename?: 'PluginOrder';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1342,7 +1314,6 @@ export type PluginOrder = IBlock & {
 };
 
 export type PluginOrderItem = {
-  __typename?: 'PluginOrderItem';
   order: Scalars['Int'];
   pluginId: Scalars['String'];
 };
@@ -1352,7 +1323,6 @@ export type PluginSetOrderInput = {
 };
 
 export type Project = {
-  __typename?: 'Project';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   name: Scalars['String'];
@@ -1361,7 +1331,6 @@ export type Project = {
 };
 
 export type ProjectConfigurationSettings = IBlock & {
-  __typename?: 'ProjectConfigurationSettings';
   baseDirectory: Scalars['String'];
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
@@ -1406,7 +1375,6 @@ export type ProjectWhereInput = {
 };
 
 export type PropertySelector = {
-  __typename?: 'PropertySelector';
   include: Scalars['Boolean'];
   propertyName: Scalars['String'];
 };
@@ -1426,13 +1394,11 @@ export type ProvisionSubscriptionInput = {
 };
 
 export type ProvisionSubscriptionResult = {
-  __typename?: 'ProvisionSubscriptionResult';
   checkoutUrl?: Maybe<Scalars['String']>;
   provisionStatus: Scalars['String'];
 };
 
 export type Query = {
-  __typename?: 'Query';
   PluginInstallation?: Maybe<PluginInstallation>;
   PluginInstallations: Array<PluginInstallation>;
   ServiceTopics?: Maybe<ServiceTopics>;
@@ -1661,7 +1627,6 @@ export enum QueryMode {
 }
 
 export type RemoteGitRepos = {
-  __typename?: 'RemoteGitRepos';
   currentPage: Scalars['Float'];
   pageSize: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
@@ -1676,7 +1641,6 @@ export type RemoteGitRepositoriesWhereUniqueInput = {
 };
 
 export type RemoteGitRepository = {
-  __typename?: 'RemoteGitRepository';
   admin: Scalars['Boolean'];
   defaultBranch: Scalars['String'];
   fullName: Scalars['String'];
@@ -1686,7 +1650,6 @@ export type RemoteGitRepository = {
 };
 
 export type Resource = {
-  __typename?: 'Resource';
   builds: Array<Build>;
   createdAt: Scalars['DateTime'];
   description: Scalars['String'];
@@ -1768,7 +1731,6 @@ export type ResourceOrderByInput = {
 };
 
 export type ResourceRole = {
-  __typename?: 'ResourceRole';
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -1834,7 +1796,6 @@ export enum Role {
 }
 
 export type ServerSettings = {
-  __typename?: 'ServerSettings';
   generateGraphQL: Scalars['Boolean'];
   generateRestApi: Scalars['Boolean'];
   serverPath: Scalars['String'];
@@ -1847,7 +1808,6 @@ export type ServerSettingsUpdateInput = {
 };
 
 export type ServiceSettings = IBlock & {
-  __typename?: 'ServiceSettings';
   adminUISettings: AdminUiSettings;
   authProvider: EnumAuthProviderType;
   blockType: EnumBlockType;
@@ -1885,7 +1845,6 @@ export type ServiceSettingsUpdateInput = {
 };
 
 export type ServiceTopics = IBlock & {
-  __typename?: 'ServiceTopics';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1972,7 +1931,6 @@ export type StringFilter = {
 };
 
 export type Subscription = {
-  __typename?: 'Subscription';
   cancelUrl?: Maybe<Scalars['String']>;
   cancellationEffectiveDate?: Maybe<Scalars['DateTime']>;
   createdAt: Scalars['DateTime'];
@@ -1988,7 +1946,6 @@ export type Subscription = {
 };
 
 export type Topic = IBlock & {
-  __typename?: 'Topic';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -2046,7 +2003,6 @@ export type UpdateAccountInput = {
 };
 
 export type User = {
-  __typename?: 'User';
   account?: Maybe<Account>;
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
@@ -2057,7 +2013,6 @@ export type User = {
 };
 
 export type UserRole = {
-  __typename?: 'UserRole';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   role: Role;
@@ -2073,7 +2028,6 @@ export type WhereUniqueInput = {
 };
 
 export type Workspace = {
-  __typename?: 'Workspace';
   createdAt: Scalars['DateTime'];
   gitOrganizations?: Maybe<Array<GitOrganization>>;
   id: Scalars['String'];
@@ -2089,7 +2043,6 @@ export type WorkspaceCreateInput = {
 };
 
 export type WorkspaceMember = {
-  __typename?: 'WorkspaceMember';
   member: WorkspaceMemberType;
   type: EnumWorkspaceMemberType;
 };

--- a/packages/amplication-server/project.json
+++ b/packages/amplication-server/project.json
@@ -4,6 +4,10 @@
   "sourceRoot": "packages/amplication-server/src",
   "projectType": "application",
   "implicitDependencies": ["amplication-prisma-db"],
+  "namedInputs": {
+    "codegen-config": ["{workspaceRoot}/codegen.yml"],
+    "default": ["{projectRoot}/**/*", "codegen-config"]
+  },
   "targets": {
     "lint": {
       "executor": "@nrwl/linter:eslint",
@@ -15,6 +19,7 @@
     "test": {
       "executor": "@nrwl/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/packages/amplication-server"],
+      "dependsOn": ["graphql:schema:check"],
       "options": {
         "jestConfig": "packages/amplication-server/jest.config.ts",
         "passWithNoTests": true
@@ -32,7 +37,7 @@
     "build": {
       "executor": "@nrwl/node:webpack",
       "outputs": ["{options.outputPath}"],
-      "dependsOn": ["graphql:schema:generate", "graphql:schema:check"],
+      "dependsOn": ["graphql:schema:generate", "graphql:models:generate"],
       "options": {
         "webpackConfig": "packages/amplication-server/webpack.config.js",
         "outputPath": "dist/packages/amplication-server",
@@ -83,6 +88,14 @@
       "options": {
         "command": "ts-node -P tsconfig.app.json -r tsconfig-paths/register scripts/generate-graphql-schema.ts",
         "cwd": "packages/amplication-server"
+      }
+    },
+    "graphql:models:generate": {
+      "executor": "nx:run-commands",
+      "inputs": ["{projectRoot}/src/schema.graphql"],
+      "dependsOn": ["graphql:schema:generate"],
+      "options": {
+        "command": "graphql-codegen"
       }
     },
     "graphql:schema:check": {

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -17,7 +17,6 @@ export type Scalars = {
 };
 
 export type Account = {
-  __typename?: 'Account';
   createdAt: Scalars['DateTime'];
   email: Scalars['String'];
   firstName: Scalars['String'];
@@ -29,14 +28,12 @@ export type Account = {
 };
 
 export type Action = {
-  __typename?: 'Action';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   steps?: Maybe<Array<ActionStep>>;
 };
 
 export type ActionLog = {
-  __typename?: 'ActionLog';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   level: EnumActionLogLevel;
@@ -45,7 +42,6 @@ export type ActionLog = {
 };
 
 export type ActionStep = {
-  __typename?: 'ActionStep';
   completedAt?: Maybe<Scalars['DateTime']>;
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
@@ -56,7 +52,6 @@ export type ActionStep = {
 };
 
 export type AdminUiSettings = {
-  __typename?: 'AdminUISettings';
   adminUIPath: Scalars['String'];
   generateAdminUI: Scalars['Boolean'];
 };
@@ -67,7 +62,6 @@ export type AdminUiSettingsUpdateInput = {
 };
 
 export type ApiToken = {
-  __typename?: 'ApiToken';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   lastAccessAt: Scalars['DateTime'];
@@ -83,18 +77,15 @@ export type ApiTokenCreateInput = {
 };
 
 export type Auth = {
-  __typename?: 'Auth';
   /** JWT Bearer token */
   token: Scalars['String'];
 };
 
 export type AuthorizeResourceWithGitResult = {
-  __typename?: 'AuthorizeResourceWithGitResult';
   url: Scalars['String'];
 };
 
 export type Block = {
-  __typename?: 'Block';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -119,7 +110,6 @@ export type BlockVersionsArgs = {
 };
 
 export type BlockInputOutput = {
-  __typename?: 'BlockInputOutput';
   dataType?: Maybe<EnumDataType>;
   dataTypeEntityName?: Maybe<Scalars['String']>;
   description: Scalars['String'];
@@ -149,7 +139,6 @@ export type BlockOrderByInput = {
 };
 
 export type BlockVersion = {
-  __typename?: 'BlockVersion';
   block: Block;
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
@@ -195,7 +184,6 @@ export type BooleanFilter = {
 };
 
 export type Build = {
-  __typename?: 'Build';
   action?: Maybe<Action>;
   actionId: Scalars['String'];
   archiveURI: Scalars['String'];
@@ -243,7 +231,6 @@ export type ChangePasswordInput = {
 };
 
 export type Commit = {
-  __typename?: 'Commit';
   builds?: Maybe<Array<Build>>;
   changes?: Maybe<Array<PendingChange>>;
   createdAt: Scalars['DateTime'];
@@ -315,7 +302,6 @@ export type DateTimeFilter = {
 };
 
 export type Entity = {
-  __typename?: 'Entity';
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -364,7 +350,6 @@ export type EntityCreateInput = {
 };
 
 export type EntityField = {
-  __typename?: 'EntityField';
   createdAt: Scalars['DateTime'];
   dataType: EnumDataType;
   description?: Maybe<Scalars['String']>;
@@ -457,7 +442,6 @@ export type EntityOrderByInput = {
 };
 
 export type EntityPermission = {
-  __typename?: 'EntityPermission';
   action: EnumEntityAction;
   entityVersion?: Maybe<EntityVersion>;
   entityVersionId: Scalars['String'];
@@ -468,7 +452,6 @@ export type EntityPermission = {
 };
 
 export type EntityPermissionField = {
-  __typename?: 'EntityPermissionField';
   entityVersionId: Scalars['String'];
   field: EntityField;
   fieldPermanentId: Scalars['String'];
@@ -485,7 +468,6 @@ export type EntityPermissionFieldWhereUniqueInput = {
 };
 
 export type EntityPermissionRole = {
-  __typename?: 'EntityPermissionRole';
   action: EnumEntityAction;
   entityPermission?: Maybe<EntityPermission>;
   entityVersionId: Scalars['String'];
@@ -520,7 +502,6 @@ export type EntityUpdatePermissionRolesInput = {
 };
 
 export type EntityVersion = {
-  __typename?: 'EntityVersion';
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -706,8 +687,8 @@ export type EnumResourceTypeFilter = {
 };
 
 export enum EnumSubscriptionPlan {
-  Business = 'Business',
   Enterprise = 'Enterprise',
+  Free = 'Free',
   Pro = 'Pro'
 }
 
@@ -725,7 +706,6 @@ export enum EnumWorkspaceMemberType {
 }
 
 export type Environment = {
-  __typename?: 'Environment';
   address: Scalars['String'];
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -741,7 +721,6 @@ export type GitGetInstallationUrlInput = {
 };
 
 export type GitOrganization = {
-  __typename?: 'GitOrganization';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   installationId: Scalars['String'];
@@ -761,7 +740,6 @@ export type GitOrganizationWhereInput = {
 };
 
 export type GitRepository = {
-  __typename?: 'GitRepository';
   createdAt?: Maybe<Scalars['DateTime']>;
   gitOrganization: GitOrganization;
   gitOrganizationId: Scalars['String'];
@@ -798,7 +776,6 @@ export type IntFilter = {
 };
 
 export type Invitation = {
-  __typename?: 'Invitation';
   createdAt: Scalars['DateTime'];
   email: Scalars['String'];
   id: Scalars['String'];
@@ -817,7 +794,6 @@ export type LoginInput = {
 };
 
 export type MessagePattern = {
-  __typename?: 'MessagePattern';
   topicId: Scalars['String'];
   type: EnumMessagePatternConnectionOptions;
 };
@@ -828,7 +804,6 @@ export type MessagePatternCreateInput = {
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
   addEntityPermissionField: EntityPermissionField;
   changePassword: Account;
   commit?: Maybe<Commit>;
@@ -845,6 +820,7 @@ export type Mutation = {
   createOneEntity: Entity;
   createOrganization: GitOrganization;
   createPluginInstallation: PluginInstallation;
+  createPluginInstallations?: Maybe<Array<PluginInstallation>>;
   createProject: Project;
   createResourceRole: ResourceRole;
   createService: Resource;
@@ -976,6 +952,12 @@ export type MutationCreateOrganizationArgs = {
 
 export type MutationCreatePluginInstallationArgs = {
   data: PluginInstallationCreateInput;
+};
+
+
+export type MutationCreatePluginInstallationsArgs = {
+  data: PluginInstallationsCreateInput;
+  where: WhereUniqueInput;
 };
 
 
@@ -1230,7 +1212,6 @@ export type MutationUpdateWorkspaceArgs = {
 };
 
 export type PendingChange = {
-  __typename?: 'PendingChange';
   action: EnumPendingChangeAction;
   origin: PendingChangeOrigin;
   originId: Scalars['String'];
@@ -1250,7 +1231,6 @@ export type PendingChangesFindInput = {
 };
 
 export type PluginInstallation = IBlock & {
-  __typename?: 'PluginInstallation';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1312,8 +1292,11 @@ export type PluginInstallationWhereInput = {
   updatedAt?: InputMaybe<DateTimeFilter>;
 };
 
+export type PluginInstallationsCreateInput = {
+  plugins?: InputMaybe<Array<PluginInstallationCreateInput>>;
+};
+
 export type PluginOrder = IBlock & {
-  __typename?: 'PluginOrder';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1331,7 +1314,6 @@ export type PluginOrder = IBlock & {
 };
 
 export type PluginOrderItem = {
-  __typename?: 'PluginOrderItem';
   order: Scalars['Int'];
   pluginId: Scalars['String'];
 };
@@ -1341,7 +1323,6 @@ export type PluginSetOrderInput = {
 };
 
 export type Project = {
-  __typename?: 'Project';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   name: Scalars['String'];
@@ -1350,7 +1331,6 @@ export type Project = {
 };
 
 export type ProjectConfigurationSettings = IBlock & {
-  __typename?: 'ProjectConfigurationSettings';
   baseDirectory: Scalars['String'];
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
@@ -1395,7 +1375,6 @@ export type ProjectWhereInput = {
 };
 
 export type PropertySelector = {
-  __typename?: 'PropertySelector';
   include: Scalars['Boolean'];
   propertyName: Scalars['String'];
 };
@@ -1407,21 +1386,19 @@ export type PropertySelectorInput = {
 
 export type ProvisionSubscriptionInput = {
   billingPeriod: Scalars['String'];
-  cancelUrl: Scalars['String'];
+  cancelUrl?: InputMaybe<Scalars['String']>;
   intentionType: Scalars['String'];
   planId: Scalars['String'];
-  successUrl: Scalars['String'];
+  successUrl?: InputMaybe<Scalars['String']>;
   workspaceId: Scalars['String'];
 };
 
 export type ProvisionSubscriptionResult = {
-  __typename?: 'ProvisionSubscriptionResult';
   checkoutUrl?: Maybe<Scalars['String']>;
   provisionStatus: Scalars['String'];
 };
 
 export type Query = {
-  __typename?: 'Query';
   PluginInstallation?: Maybe<PluginInstallation>;
   PluginInstallations: Array<PluginInstallation>;
   ServiceTopics?: Maybe<ServiceTopics>;
@@ -1650,7 +1627,6 @@ export enum QueryMode {
 }
 
 export type RemoteGitRepos = {
-  __typename?: 'RemoteGitRepos';
   currentPage: Scalars['Float'];
   pageSize: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
@@ -1665,7 +1641,6 @@ export type RemoteGitRepositoriesWhereUniqueInput = {
 };
 
 export type RemoteGitRepository = {
-  __typename?: 'RemoteGitRepository';
   admin: Scalars['Boolean'];
   defaultBranch: Scalars['String'];
   fullName: Scalars['String'];
@@ -1675,7 +1650,6 @@ export type RemoteGitRepository = {
 };
 
 export type Resource = {
-  __typename?: 'Resource';
   builds: Array<Build>;
   createdAt: Scalars['DateTime'];
   description: Scalars['String'];
@@ -1757,7 +1731,6 @@ export type ResourceOrderByInput = {
 };
 
 export type ResourceRole = {
-  __typename?: 'ResourceRole';
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -1823,7 +1796,6 @@ export enum Role {
 }
 
 export type ServerSettings = {
-  __typename?: 'ServerSettings';
   generateGraphQL: Scalars['Boolean'];
   generateRestApi: Scalars['Boolean'];
   serverPath: Scalars['String'];
@@ -1836,7 +1808,6 @@ export type ServerSettingsUpdateInput = {
 };
 
 export type ServiceSettings = IBlock & {
-  __typename?: 'ServiceSettings';
   adminUISettings: AdminUiSettings;
   authProvider: EnumAuthProviderType;
   blockType: EnumBlockType;
@@ -1874,7 +1845,6 @@ export type ServiceSettingsUpdateInput = {
 };
 
 export type ServiceTopics = IBlock & {
-  __typename?: 'ServiceTopics';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -1961,7 +1931,6 @@ export type StringFilter = {
 };
 
 export type Subscription = {
-  __typename?: 'Subscription';
   cancelUrl?: Maybe<Scalars['String']>;
   cancellationEffectiveDate?: Maybe<Scalars['DateTime']>;
   createdAt: Scalars['DateTime'];
@@ -1977,7 +1946,6 @@ export type Subscription = {
 };
 
 export type Topic = IBlock & {
-  __typename?: 'Topic';
   blockType: EnumBlockType;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
@@ -2035,7 +2003,6 @@ export type UpdateAccountInput = {
 };
 
 export type User = {
-  __typename?: 'User';
   account?: Maybe<Account>;
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
@@ -2046,7 +2013,6 @@ export type User = {
 };
 
 export type UserRole = {
-  __typename?: 'UserRole';
   createdAt: Scalars['DateTime'];
   id: Scalars['String'];
   role: Role;
@@ -2062,7 +2028,6 @@ export type WhereUniqueInput = {
 };
 
 export type Workspace = {
-  __typename?: 'Workspace';
   createdAt: Scalars['DateTime'];
   gitOrganizations?: Maybe<Array<GitOrganization>>;
   id: Scalars['String'];
@@ -2078,7 +2043,6 @@ export type WorkspaceCreateInput = {
 };
 
 export type WorkspaceMember = {
-  __typename?: 'WorkspaceMember';
   member: WorkspaceMemberType;
   type: EnumWorkspaceMemberType;
 };


### PR DESCRIPTION
Close: #5230 

## PR Details

Changes to the server were not resulting in models being updated. This PR updates the server build flow to generate the models.ts for the needed services and remove the typeName generated properties from the models.

From now on, running `npx nx build amplication-server` graphql schema generation and models generation will be triggered as shown in the task dependency graph
![graph](https://user-images.githubusercontent.com/2861984/219683867-9ee7387d-f7f1-45cd-bfcf-e30cbbe92231.png)

## PR Checklist

- [x] Tests for the changes have been added

- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
