### PR TITLE
fix(ci): fix prod deployment step to compare with master

### DIFF
--- a/.github/workflows/nx.template.yml
+++ b/.github/workflows/nx.template.yml
@@ -57,6 +57,7 @@ jobs:
           fetch-depth: 0
 
       - uses: nrwl/nx-set-shas@v3
+        if: inputs.nx-force-all == false
         with:
           main-branch-name: ${{ inputs.nx-base }}
 


### PR DESCRIPTION
Close: #5243 

## PR Details

Skipping the nx sha step when we force nx to ignore it to calculate the affected projects. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
