### PR TITLE
fix(client): issue preventing workspace switch

### DIFF
--- a/packages/amplication-client/src/authentication/authentication.ts
+++ b/packages/amplication-client/src/authentication/authentication.ts
@@ -26,9 +26,15 @@ export function getToken(): string | null {
 
 export function setTokenFromCookie(): void {
   const tokenFromCookie = getCookie(TEMPORARY_JWT_COOKIE_NAME);
-  if (tokenFromCookie) {
+  if (tokenFromCookie && !token) {
     setToken(tokenFromCookie);
-    expireCookie(TEMPORARY_JWT_COOKIE_NAME);
+
+    const cookieDomainParts = window.location.hostname.split(".");
+    const temporaryCookieDomain = cookieDomainParts
+      .slice(Math.max(cookieDomainParts.length - 2, 0))
+      .join(".");
+
+    expireCookie(TEMPORARY_JWT_COOKIE_NAME, temporaryCookieDomain);
   }
 }
 

--- a/packages/amplication-client/src/util/cookie.ts
+++ b/packages/amplication-client/src/util/cookie.ts
@@ -14,6 +14,7 @@ export const getCookie = (cname: string) => {
   return "";
 };
 
-export const expireCookie = (cname: string): void => {
-  document.cookie = `${cname}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+export const expireCookie = (cname: string, domain?: string): void => {
+  const cookieDomain = domain ? `domain=${domain};` : "";
+  document.cookie = `${cname}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;${cookieDomain}`;
 };


### PR DESCRIPTION
Close: #5274

## PR Details

Update the auth logic that was preventing the user to switch between workspaces. The initial issue was due to the client being unable to clear the jwt cookie since it was set for the top domain.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
