### PR TITLE
add dynamic installation to DSG

### DIFF
--- a/packages/data-service-generator/project.json
+++ b/packages/data-service-generator/project.json
@@ -80,6 +80,14 @@
         "envFile": "packages/data-service-generator/.env"
       }
     },
+    "generate-local-code-only": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "ts-node -P tsconfig.app.json -r tsconfig-paths/register ./src/main.ts ",
+        "cwd": "packages/data-service-generator",
+        "envFile": "packages/data-service-generator/.env"
+      }
+    },
     "generate-local-code": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/data-service-generator/src/dynamic-package-installation.ts
+++ b/packages/data-service-generator/src/dynamic-package-installation.ts
@@ -21,6 +21,8 @@ export async function dynamicPackagesInstallations(
     const plugin: PackageInstallation = {
       name: plugins.npm,
       version: plugins.version,
+      settings: plugins.settings,
+      pluginId: plugins.pluginId,
     };
     await manager.install(plugin, {
       onBeforeInstall: async (plugin) => {

--- a/packages/data-service-generator/src/utils/dynamic-installation/Tarball.ts
+++ b/packages/data-service-generator/src/utils/dynamic-installation/Tarball.ts
@@ -1,7 +1,9 @@
 import downloadHelper from "download";
+import { join } from "path";
 import { packument } from "pacote";
 import { createLog } from "../../create-log";
 import { PackageInstallation } from "./DynamicPackageInstallationManager";
+import fse from "fs-extra";
 
 export class Tarball {
   constructor(
@@ -19,6 +21,24 @@ export class Tarball {
       },
     });
     return;
+  }
+
+  filterFunc(src, dest) {
+    if (src.includes("node_modules")) return false;
+
+    return true;
+  }
+
+  async copySync({ folderPath }): Promise<void> {
+    try {
+      const { name } = this.plugin;
+      fse.copySync(folderPath, join(this.modulesPath, name), {
+        overwrite: true,
+        filter: this.filterFunc,
+      });
+    } catch (error) {
+      console.log("fse.copySync", error);
+    }
   }
 
   private async packageTarball({


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #5289 

## PR Details

In order to make this plugin installation and debug work:

- First run: npx nx generate-example-input-json data-service-generator. This will create an input-example-json
- Go into .amplication/generate-local-code/input.json and add under pluginInstallations key: 
```json
{
      "id": "clb3p3ov800cplc01a8f6uwje", // uuid
      "npm":"@amplication/lusha", // name of npm package
      "enabled": true,
      "version": "0.0.1",
      "pluginId": "lusha", // plugin id
      "settings": { "local": true, "destPath": "../../../plugins/plugins/<plugin-name>" } => important !!! local key to true and the path of our dest plugin folder related to the dsg folder
    }
```
- If we want only to generate code we should use: npx nx generate-local-code-only data-service-generator
this will generate the code under .amplication/generate-local-code/genereted
- if we want to debug the code we should "npx nx generate-local-code-only data-service-generator" to main package.json under any name and run it in debug mode.

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
