### PR TITLE
refactor(git-utils): switch to amplication logger

### DIFF
--- a/packages/amplication-git-pull-request-service/src/pull-request/pull-request.service.ts
+++ b/packages/amplication-git-pull-request-service/src/pull-request/pull-request.service.ts
@@ -43,10 +43,13 @@ export class PullRequestService {
       "The changed files have returned from the diff service listOfChangedFiles are",
       { lengthOfFile: changedFiles.length }
     );
-    const gitClientService = await new GitClientService().create({
-      provider: gitProvider,
-      installationId,
-    });
+    const gitClientService = await new GitClientService().create(
+      {
+        provider: gitProvider,
+        installationId,
+      },
+      this.logger
+    );
     const prUrl = await gitClientService.createPullRequest({
       owner,
       repositoryName: repo,

--- a/packages/amplication-git-utils/src/git/git-factory.ts
+++ b/packages/amplication-git-utils/src/git/git-factory.ts
@@ -1,3 +1,4 @@
+import { ILogger } from "@amplication/util/logging";
 import { GitProvider } from "../git-provider.interface.ts";
 import { EnumGitProvider, GitProviderArgs } from "../types";
 import { INVALID_SOURCE_CONTROL_ERROR_MESSAGE } from "./git.constants";
@@ -5,13 +6,14 @@ import { GithubService } from "./github.service";
 
 export class GitFactory {
   public static async getProvider(
-    gitProviderArgs: GitProviderArgs
+    gitProviderArgs: GitProviderArgs,
+    logger: ILogger
   ): Promise<GitProvider> {
     let gitProvider: GitProvider;
 
     switch (gitProviderArgs.provider) {
       case EnumGitProvider.Github:
-        gitProvider = new GithubService(gitProviderArgs);
+        gitProvider = new GithubService(gitProviderArgs, logger);
         await gitProvider.init();
         return gitProvider;
       default:

--- a/packages/amplication-git-utils/src/git/git.service.ts
+++ b/packages/amplication-git-utils/src/git/git.service.ts
@@ -28,11 +28,17 @@ import { AmplicationIgnoreManger } from "../utils/amplication-ignore-manger";
 import { prepareFilesForPullRequest } from "../utils/prepare-files-for-pull-request";
 import { GitClient } from "./git-client";
 import { GitFactory } from "./git-factory";
+import { ILogger } from "@amplication/util/logging";
 
 export class GitClientService {
   private provider: GitProvider;
-  async create(gitProviderArgs: GitProviderArgs): Promise<GitClientService> {
+  private logger: ILogger;
+  async create(
+    gitProviderArgs: GitProviderArgs,
+    logger: ILogger
+  ): Promise<GitClientService> {
     this.provider = await GitFactory.getProvider(gitProviderArgs);
+    this.logger = logger;
     return this;
   }
 
@@ -84,7 +90,7 @@ export class GitClientService {
       amplicationIgnoreManger
     );
 
-    console.log(`Got a ${pullRequestMode} pull request mode`);
+    this.logger.info(`Got a ${pullRequestMode} pull request mode`);
     if (pullRequestMode === EnumPullRequestMode.Basic) {
       return this.provider.createPullRequestFromFiles({
         owner,
@@ -155,7 +161,7 @@ export class GitClientService {
         const diffPath = join(diffFolder, "diff.patch");
         await writeFile(diffPath, diff);
         const fullDiffPath = resolve(diffPath);
-        console.log("Saving diff to: ", fullDiffPath);
+        this.logger.info(`Saving diff to: ${fullDiffPath}`);
         await this.postCommitProcess({
           diffPath: fullDiffPath,
           gitClient,
@@ -206,7 +212,7 @@ export class GitClientService {
     owner,
     repositoryName,
   }: PreCommitProcessArgs): PreCommitProcessResult {
-    console.log("Pre commit process");
+    this.logger.info("Pre commit process");
     await gitClient.git.checkout(branchName);
 
     const commitsList = await this.provider.getCurrentUserCommitList({
@@ -218,21 +224,23 @@ export class GitClientService {
     const latestCommit = commitsList[0];
 
     if (!latestCommit) {
-      console.log("Didn't find a commit that has been created by Amplication");
+      this.logger.info(
+        "Didn't find a commit that has been created by Amplication"
+      );
       return { diff: null };
     }
 
     const { sha } = latestCommit;
     const diff = await gitClient.git.diff([sha]);
     if (diff.length === 0) {
-      console.log("Diff returned empty");
+      this.logger.info("Diff returned empty");
       return { diff: null };
     }
     // Reset the branch to the latest commit
     await gitClient.git.reset([sha]);
     await gitClient.git.push(["--force"]);
     await gitClient.resetState();
-    console.log("Diff returned");
+    this.logger.info("Diff returned");
     return { diff };
   }
 
@@ -316,10 +324,10 @@ export class GitClientService {
           return "";
         }
         const { content, htmlUrl, name } = file;
-        console.log(`Got ${name} file ${htmlUrl}`);
+        this.logger.info(`Got ${name} file ${htmlUrl}`);
         return content;
       } catch (error) {
-        console.log("Repository does not have a .amplicationignore file");
+        this.logger.info("Repository does not have a .amplicationignore file");
         return "";
       }
     });

--- a/packages/amplication-git-utils/src/git/git.service.ts
+++ b/packages/amplication-git-utils/src/git/git.service.ts
@@ -37,7 +37,7 @@ export class GitClientService {
     gitProviderArgs: GitProviderArgs,
     logger: ILogger
   ): Promise<GitClientService> {
-    this.provider = await GitFactory.getProvider(gitProviderArgs);
+    this.provider = await GitFactory.getProvider(gitProviderArgs, logger);
     this.logger = logger;
     return this;
   }

--- a/packages/amplication-git-utils/src/git/github.service.ts
+++ b/packages/amplication-git-utils/src/git/github.service.ts
@@ -1,3 +1,4 @@
+import { ILogger } from "@amplication/util/logging";
 import { createAppAuth } from "@octokit/auth-app";
 import { components } from "@octokit/openapi-types";
 import { App, Octokit } from "octokit";
@@ -51,7 +52,10 @@ export class GithubService implements GitProvider {
   private octokit: Octokit;
   public readonly name = EnumGitProvider.Github;
   public readonly domain = "github.com";
-  constructor(private readonly gitProviderArgs: GitProviderConstructorArgs) {
+  constructor(
+    private readonly gitProviderArgs: GitProviderConstructorArgs,
+    private readonly logger: ILogger
+  ) {
     const {
       GITHUB_APP_INSTALLATION_URL,
       GITHUB_APP_APP_ID,
@@ -502,7 +506,7 @@ export class GithubService implements GitProvider {
       branchName
     );
 
-    console.log(`Got last commit with url ${lastCommit.html_url}`);
+    this.logger.info(`Got last commit with url ${lastCommit.html_url}`);
 
     if (!lastCommit) {
       throw new Error("No last commit found");
@@ -520,7 +524,7 @@ export class GithubService implements GitProvider {
       throw new Error("Missing tree sha");
     }
 
-    console.info(`Created tree for for ${owner}/${repositoryName}`);
+    this.logger.info(`Created tree for for ${owner}/${repositoryName}`);
 
     const { data: commit } = await this.octokit.rest.git.createCommit({
       message: commitMessage,
@@ -530,7 +534,7 @@ export class GithubService implements GitProvider {
       parents: [lastCommit.sha],
     });
 
-    console.info(`Created commit for ${owner}/${repositoryName}`);
+    this.logger.info(`Created commit for ${owner}/${repositoryName}`);
 
     await this.octokit.rest.git.updateRef({
       owner,
@@ -539,7 +543,9 @@ export class GithubService implements GitProvider {
       ref: `heads/${branchName}`,
     });
 
-    console.info(`Updated branch ${branchName} for ${owner}/${repositoryName}`);
+    this.logger.info(
+      `Updated branch ${branchName} for ${owner}/${repositoryName}`
+    );
   }
 
   async getPullRequestForBranch({
@@ -622,7 +628,7 @@ export class GithubService implements GitProvider {
         repo: repositoryName,
         ref: `heads/${branchName}`,
       });
-      console.log(
+      this.logger.info(
         `Got branch ${owner}/${repositoryName}/${branchName} with url ${ref.url}`
       );
       return { sha: ref.object.sha, name: branchName };
@@ -753,7 +759,7 @@ export class GithubService implements GitProvider {
       throw new Error("Branch not found");
     }
 
-    console.log(
+    this.logger.info(
       `Got branch ${owner}/${repositoryName}/${branch.name} with sha ${branch.sha}`
     );
 


### PR DESCRIPTION
Close: #5308 

## PR Details

This pull request switches the git utils to use the amplication logger instead of the console.log

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
