### PR TITLE
fix(git-utils): using a generated token for a clone process

### DIFF
--- a/packages/amplication-git-utils/src/git-provider.interface.ts.ts
+++ b/packages/amplication-git-utils/src/git-provider.interface.ts.ts
@@ -54,4 +54,5 @@ export interface GitProvider {
   getCurrentUserCommitList: (args: GetBranchArgs) => Promise<Commit[]>;
   getCloneUrl: (args: CloneUrlArgs) => string;
   commentOnPullRequest: (args: CreatePullRequestCommentArgs) => Promise<void>;
+  getToken(): Promise<string>;
 }

--- a/packages/amplication-git-utils/src/git/git.service.ts
+++ b/packages/amplication-git-utils/src/git/git.service.ts
@@ -111,10 +111,12 @@ export class GitClientService {
       }
 
       const randomUUID = v4();
+      const cloneToken = await this.provider.getToken();
 
       const cloneUrl = this.provider.getCloneUrl({
         owner,
         repositoryName,
+        token: cloneToken,
       });
 
       const cloneDir = normalize(

--- a/packages/amplication-git-utils/src/git/github.service.ts
+++ b/packages/amplication-git-utils/src/git/github.service.ts
@@ -81,8 +81,8 @@ export class GithubService implements GitProvider {
     });
   }
 
-  getCloneUrl({ owner, repositoryName }: CloneUrlArgs) {
-    return `https://${this.domain}/${owner}/${repositoryName}.git`;
+  getCloneUrl({ owner, repositoryName, token }: CloneUrlArgs) {
+    return `https://x-access-token:${token}@${this.domain}/${owner}/${repositoryName}.git`;
   }
 
   async getCurrentUserCommitList(args: GetBranchArgs): Promise<Commit[]> {
@@ -631,6 +631,7 @@ export class GithubService implements GitProvider {
       this.logger.info(
         `Got branch ${owner}/${repositoryName}/${branchName} with url ${ref.url}`
       );
+
       return { sha: ref.object.sha, name: branchName };
     } catch (error) {
       return null;
@@ -931,6 +932,15 @@ export class GithubService implements GitProvider {
       issue_number: issueNumber,
     });
     return;
+  }
+
+  async getToken(): Promise<string> {
+    const { data: installationTokenData } =
+      await this.octokit.rest.apps.createInstallationAccessToken({
+        installation_id: Number(this.gitProviderArgs.installationId),
+      });
+    const { token } = installationTokenData;
+    return token;
   }
 }
 

--- a/packages/amplication-git-utils/src/types.ts
+++ b/packages/amplication-git-utils/src/types.ts
@@ -174,6 +174,7 @@ export interface GitUser {
 export interface CloneUrlArgs {
   owner: string;
   repositoryName: string;
+  token: string;
 }
 
 export interface PreCommitProcessArgs {


### PR DESCRIPTION

Close: #5297 

## PR Details

This pull request add the token to the git clone action 
## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
