### PR TITLE
Fix(client): Update code generation request function name in build manager

### DIFF
--- a/packages/amplication-build-manager/src/build-runner/build-runner.controller.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.controller.ts
@@ -59,7 +59,9 @@ export class BuildRunnerController {
   @EventPattern(
     EnvironmentVariables.instance.get(Env.CODE_GENERATION_REQUEST_TOPIC, true)
   )
-  async onCreatePRRequest(@Payload() message: KafkaMessage): Promise<void> {
+  async onCodeGenerationRequest(
+    @Payload() message: KafkaMessage
+  ): Promise<void> {
     console.log("Code generation request received");
     let args: CodeGenerationRequest;
     try {


### PR DESCRIPTION
Close: #5031 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->
In the file `packages/amplication-build-manager/src/build-runner/build-runner.controller.ts`, I replaced the function name from `onCreatePRRequest` to `onCodeGenerationRequest` as the `CODE_GENERATION_REQUEST_TOPIC ` event is triggered on code generation request and not on PR request
## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
