### PR TITLE
fix(server): remove `apollo-server-testing`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -207,7 +207,6 @@
         "@types/triple-beam": "^1.3.2",
         "@typescript-eslint/eslint-plugin": "^5.39.0",
         "@typescript-eslint/parser": "^5.39.0",
-        "apollo-server-testing": "^2.25.3",
         "babel-jest": "^28.1.0",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.4.0",
@@ -950,73 +949,6 @@
       "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
       "dependencies": {
         "xss": "^1.0.8"
-      }
-    },
-    "node_modules/@apollographql/graphql-upload-8-fork": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-upload-8-fork/-/graphql-upload-8-fork-8.1.4.tgz",
-      "integrity": "sha512-lHAj/PUegYu02zza9Pg0bQQYH5I0ah1nyIzu2YIqOv41P0vu3GCBISAmQCfFHThK7N3dy7dLFPhoKcXlXRLPoQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/express": "*",
-        "@types/fs-capacitor": "^2.0.0",
-        "@types/koa": "*",
-        "busboy": "^0.3.1",
-        "fs-capacitor": "^2.0.4",
-        "http-errors": "^1.7.3",
-        "object-path": "^0.11.4"
-      },
-      "engines": {
-        "node": ">=8.5"
-      },
-      "peerDependencies": {
-        "graphql": "0.13.1 - 15"
-      }
-    },
-    "node_modules/@apollographql/graphql-upload-8-fork/node_modules/busboy": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
-      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
-      "dev": true,
-      "dependencies": {
-        "dicer": "0.3.0"
-      },
-      "engines": {
-        "node": ">=4.5.0"
-      }
-    },
-    "node_modules/@apollographql/graphql-upload-8-fork/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@apollographql/graphql-upload-8-fork/node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "dev": true,
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@apollographql/graphql-upload-8-fork/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/@ardatan/aggregate-error": {
@@ -13086,29 +13018,11 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/content-disposition": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
-      "integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA==",
-      "dev": true
-    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
-    },
-    "node_modules/@types/cookies": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
-      "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
-      "dev": true,
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/express": "*",
-        "@types/keygrip": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/cors": {
       "version": "2.8.12",
@@ -13225,15 +13139,6 @@
         "@types/range-parser": "*"
       }
     },
-    "node_modules/@types/fs-capacitor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz",
-      "integrity": "sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
@@ -13309,22 +13214,10 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
-    "node_modules/@types/http-assert": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.3.tgz",
-      "integrity": "sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA==",
-      "dev": true
-    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
-      "dev": true
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==",
       "dev": true
     },
     "node_modules/@types/http-proxy": {
@@ -13437,12 +13330,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/keygrip": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
-      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==",
-      "dev": true
-    },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -13450,31 +13337,6 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/koa": {
-      "version": "2.13.5",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.5.tgz",
-      "integrity": "sha512-HSUOdzKz3by4fnqagwthW/1w/yJspTgppyyalPVbgZf8jQWvdIXcVW5h2DGtw4zYntOaeRGx49r1hxoPWrD4aA==",
-      "dev": true,
-      "dependencies": {
-        "@types/accepts": "*",
-        "@types/content-disposition": "*",
-        "@types/cookies": "*",
-        "@types/http-assert": "*",
-        "@types/http-errors": "*",
-        "@types/keygrip": "*",
-        "@types/koa-compose": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/koa-compose": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
-      "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/koa": "*"
       }
     },
     "node_modules/@types/lodash": {
@@ -14841,144 +14703,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/apollo-cache-control": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.15.0.tgz",
-      "integrity": "sha512-U2uYvHZsWmR6s6CD5zlq3PepfbUAM8953CeVM2Y2QYMtJ8i4CYplEPbIWb3zTIXSPbIPeWGddM56pChI6Iz3zA==",
-      "deprecated": "The functionality provided by the `apollo-cache-control` package is built in to `apollo-server-core` starting with Apollo Server 3. See https://www.apollographql.com/docs/apollo-server/migration/#cachecontrol for details.",
-      "dev": true,
-      "dependencies": {
-        "apollo-server-env": "^3.2.0",
-        "apollo-server-plugin-base": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-cache-control/node_modules/@apollo/protobufjs": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
-      "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "apollo-pbjs": "bin/pbjs",
-        "apollo-pbts": "bin/pbts"
-      }
-    },
-    "node_modules/apollo-cache-control/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "dev": true
-    },
-    "node_modules/apollo-cache-control/node_modules/apollo-reporting-protobuf": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.8.0.tgz",
-      "integrity": "sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==",
-      "deprecated": "The `apollo-reporting-protobuf` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/usage-reporting-protobuf` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "@apollo/protobufjs": "1.2.2"
-      }
-    },
-    "node_modules/apollo-cache-control/node_modules/apollo-server-caching": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
-      "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
-      "deprecated": "This package is part of the legacy caching implementation used by Apollo Server v2 and v3, and is no longer maintained. We recommend you switch to the newer Keyv-based implementation (which is compatible with all versions of Apollo Server). See https://www.apollographql.com/docs/apollo-server/v3/performance/cache-backends#legacy-caching-implementation for more details.",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/apollo-cache-control/node_modules/apollo-server-env": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.2.0.tgz",
-      "integrity": "sha512-V+kO5e6vUo2JwqV1/Ng71ZE3J6x1hCOC+nID2/++bCYl0/fPY9iLChbBNSgN/uoFcjhgmBchOv+m4o0Nie/TFQ==",
-      "deprecated": "The `apollo-server-env` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/utils.fetcher` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "util.promisify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/apollo-cache-control/node_modules/apollo-server-plugin-base": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.14.0.tgz",
-      "integrity": "sha512-nTNSFuBhZURGjtWptdVqwemYUOdsvABj/GSKzeNvepiEubiv4N0rt4Gvy1inHDiMbo98wQTdF/7XohNcB9A77g==",
-      "deprecated": "The `apollo-server-plugin-base` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "apollo-server-types": "^0.10.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-cache-control/node_modules/apollo-server-types": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
-      "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
-      "deprecated": "The `apollo-server-types` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "apollo-reporting-protobuf": "^0.8.0",
-        "apollo-server-caching": "^0.7.0",
-        "apollo-server-env": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-cache-control/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/apollo-cache-control/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/apollo-datasource": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.2.tgz",
@@ -15006,46 +14730,6 @@
       },
       "peerDependencies": {
         "graphql": "^14.2.1 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-link": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
-      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
-      "dev": true,
-      "dependencies": {
-        "apollo-utilities": "^1.3.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.21"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-link/node_modules/ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.9.3"
-      }
-    },
-    "node_modules/apollo-link/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/apollo-link/node_modules/zen-observable-ts": {
-      "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
-      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
       }
     },
     "node_modules/apollo-reporting-protobuf": {
@@ -15232,280 +14916,6 @@
         "graphql": "^15.3.0 || ^16.0.0"
       }
     },
-    "node_modules/apollo-server-testing": {
-      "version": "2.25.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-testing/-/apollo-server-testing-2.25.3.tgz",
-      "integrity": "sha512-EELtuDk1dn//fNxeYELuwwAy8bvhV9d60WhZfs3JrXqpzRDZhJmyyGqlMoHmkvCqK/mCOkc4hL54tM9rrFhU5Q==",
-      "dev": true,
-      "dependencies": {
-        "apollo-server-core": "^2.25.3"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/@apollo/protobufjs": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
-      "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "apollo-pbjs": "bin/pbjs",
-        "apollo-pbts": "bin/pbts"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/@apollographql/graphql-playground-html": {
-      "version": "1.6.27",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.27.tgz",
-      "integrity": "sha512-tea2LweZvn6y6xFV11K0KC8ETjmm52mQrW+ezgB2O/aTQf8JGyFmMcRPFgUaQZeHbWdm8iisDC6EjOKsXu0nfw==",
-      "dev": true,
-      "dependencies": {
-        "xss": "^1.0.8"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "dev": true
-    },
-    "node_modules/apollo-server-testing/node_modules/@types/ws": {
-      "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
-      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/apollo-datasource": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.10.0.tgz",
-      "integrity": "sha512-wrLhuoM2MtA0KA0+3qyioe0H2FjAxjTvuFOlNCk6WberA887m0MQlWULZImCWTkKuN+zEAMerHfxN+F+W8+lBA==",
-      "deprecated": "The `apollo-datasource` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "apollo-server-caching": "^0.7.0",
-        "apollo-server-env": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/apollo-reporting-protobuf": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.8.0.tgz",
-      "integrity": "sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==",
-      "deprecated": "The `apollo-reporting-protobuf` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/usage-reporting-protobuf` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "@apollo/protobufjs": "1.2.2"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/apollo-server-caching": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
-      "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
-      "deprecated": "This package is part of the legacy caching implementation used by Apollo Server v2 and v3, and is no longer maintained. We recommend you switch to the newer Keyv-based implementation (which is compatible with all versions of Apollo Server). See https://www.apollographql.com/docs/apollo-server/v3/performance/cache-backends#legacy-caching-implementation for more details.",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/apollo-server-core": {
-      "version": "2.26.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.26.1.tgz",
-      "integrity": "sha512-YnO1YXhHOnCY7Q2SZ0uUtPq6SLCw+t2uI19l59mzWuCyZYdHrtSy3zUEU6pM3tR9vvUuRGkYIfMRlo/Q8a1U5g==",
-      "deprecated": "The `apollo-server-core` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "@apollographql/apollo-tools": "^0.5.0",
-        "@apollographql/graphql-playground-html": "1.6.27",
-        "@apollographql/graphql-upload-8-fork": "^8.1.4",
-        "@josephg/resolvable": "^1.0.0",
-        "@types/ws": "^7.0.0",
-        "apollo-cache-control": "^0.15.0",
-        "apollo-datasource": "^0.10.0",
-        "apollo-graphql": "^0.9.0",
-        "apollo-reporting-protobuf": "^0.8.0",
-        "apollo-server-caching": "^0.7.0",
-        "apollo-server-env": "^3.2.0",
-        "apollo-server-errors": "^2.5.0",
-        "apollo-server-plugin-base": "^0.14.0",
-        "apollo-server-types": "^0.10.0",
-        "apollo-tracing": "^0.16.0",
-        "async-retry": "^1.2.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "^0.16.0",
-        "graphql-tag": "^2.11.0",
-        "graphql-tools": "^4.0.8",
-        "loglevel": "^1.6.7",
-        "lru-cache": "^6.0.0",
-        "sha.js": "^2.4.11",
-        "subscriptions-transport-ws": "^0.9.19",
-        "uuid": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/apollo-server-env": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.2.0.tgz",
-      "integrity": "sha512-V+kO5e6vUo2JwqV1/Ng71ZE3J6x1hCOC+nID2/++bCYl0/fPY9iLChbBNSgN/uoFcjhgmBchOv+m4o0Nie/TFQ==",
-      "deprecated": "The `apollo-server-env` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/utils.fetcher` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "util.promisify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/apollo-server-errors": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.5.0.tgz",
-      "integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA==",
-      "deprecated": "The `apollo-server-errors` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/apollo-server-plugin-base": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.14.0.tgz",
-      "integrity": "sha512-nTNSFuBhZURGjtWptdVqwemYUOdsvABj/GSKzeNvepiEubiv4N0rt4Gvy1inHDiMbo98wQTdF/7XohNcB9A77g==",
-      "deprecated": "The `apollo-server-plugin-base` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "apollo-server-types": "^0.10.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/apollo-server-types": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
-      "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
-      "deprecated": "The `apollo-server-types` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "apollo-reporting-protobuf": "^0.8.0",
-        "apollo-server-caching": "^0.7.0",
-        "apollo-server-env": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "dev": true
-    },
-    "node_modules/apollo-server-testing/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/subscriptions-transport-ws": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
-      "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
-      "deprecated": "The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md",
-      "dev": true,
-      "dependencies": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependencies": {
-        "graphql": ">=0.10.0"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/apollo-server-testing/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/apollo-server-types": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.7.1.tgz",
@@ -15523,183 +14933,6 @@
       "peerDependencies": {
         "graphql": "^15.3.0 || ^16.0.0"
       }
-    },
-    "node_modules/apollo-tracing": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.16.0.tgz",
-      "integrity": "sha512-Oy8kTggB+fJ/hHXwHyMpuTl5KW7u1XetKFDErZVOobUKc2zjc/NgWiC/s7SGYZCgfLodBjvwfa6rMcvLkz7c0w==",
-      "deprecated": "The `apollo-tracing` package is no longer part of Apollo Server 3. See https://www.apollographql.com/docs/apollo-server/migration/#tracing for details",
-      "dev": true,
-      "dependencies": {
-        "apollo-server-env": "^3.2.0",
-        "apollo-server-plugin-base": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-tracing/node_modules/@apollo/protobufjs": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
-      "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "apollo-pbjs": "bin/pbjs",
-        "apollo-pbts": "bin/pbts"
-      }
-    },
-    "node_modules/apollo-tracing/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "dev": true
-    },
-    "node_modules/apollo-tracing/node_modules/apollo-reporting-protobuf": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.8.0.tgz",
-      "integrity": "sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==",
-      "deprecated": "The `apollo-reporting-protobuf` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/usage-reporting-protobuf` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "@apollo/protobufjs": "1.2.2"
-      }
-    },
-    "node_modules/apollo-tracing/node_modules/apollo-server-caching": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
-      "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
-      "deprecated": "This package is part of the legacy caching implementation used by Apollo Server v2 and v3, and is no longer maintained. We recommend you switch to the newer Keyv-based implementation (which is compatible with all versions of Apollo Server). See https://www.apollographql.com/docs/apollo-server/v3/performance/cache-backends#legacy-caching-implementation for more details.",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/apollo-tracing/node_modules/apollo-server-env": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.2.0.tgz",
-      "integrity": "sha512-V+kO5e6vUo2JwqV1/Ng71ZE3J6x1hCOC+nID2/++bCYl0/fPY9iLChbBNSgN/uoFcjhgmBchOv+m4o0Nie/TFQ==",
-      "deprecated": "The `apollo-server-env` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/utils.fetcher` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "util.promisify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/apollo-tracing/node_modules/apollo-server-plugin-base": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.14.0.tgz",
-      "integrity": "sha512-nTNSFuBhZURGjtWptdVqwemYUOdsvABj/GSKzeNvepiEubiv4N0rt4Gvy1inHDiMbo98wQTdF/7XohNcB9A77g==",
-      "deprecated": "The `apollo-server-plugin-base` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "apollo-server-types": "^0.10.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-tracing/node_modules/apollo-server-types": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
-      "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
-      "deprecated": "The `apollo-server-types` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "apollo-reporting-protobuf": "^0.8.0",
-        "apollo-server-caching": "^0.7.0",
-        "apollo-server-env": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-tracing/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/apollo-tracing/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "node_modules/apollo-utilities": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
-      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
-      "dev": true,
-      "dependencies": {
-        "@wry/equality": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-utilities/node_modules/@wry/equality": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
-      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.9.3"
-      }
-    },
-    "node_modules/apollo-utilities/node_modules/ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.9.3"
-      }
-    },
-    "node_modules/apollo-utilities/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
     },
     "node_modules/app-root-path": {
       "version": "3.1.0",
@@ -15939,25 +15172,6 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.reduce": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
-      "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -19679,12 +18893,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/deprecated-decorator": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
-      "integrity": "sha512-MHidOOnCHGlZDKsI21+mbIIhf4Fff+hhCTB7gtVg4uoIqjcrTZc5v6M+GS2zVI0sV7PqK415rb8XaOSQsQkHOw==",
-      "dev": true
-    },
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -19729,27 +18937,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
-    },
-    "node_modules/dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "dev": true,
-      "dependencies": {
-        "streamsearch": "0.1.2"
-      },
-      "engines": {
-        "node": ">=4.5.0"
-      }
-    },
-    "node_modules/dicer/node_modules/streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/diff": {
       "version": "5.1.0",
@@ -20346,12 +19533,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true
     },
     "node_modules/es-get-iterator": {
       "version": "1.1.3",
@@ -22313,15 +21494,6 @@
         }
       ]
     },
-    "node_modules/fs-capacitor": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.4.tgz",
-      "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.5"
-      }
-    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -22953,129 +22125,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/graphql-extensions": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.16.0.tgz",
-      "integrity": "sha512-rZQc/USoEIw437BGRUwoHoLPR1LA791Ltj6axONqgKIyyx2sqIO3YT9kTbB/eIUdJBrCozp4KuUeZ09xKeQDxg==",
-      "deprecated": "The `graphql-extensions` API has been removed from Apollo Server 3. Use the plugin API instead: https://www.apollographql.com/docs/apollo-server/integrations/plugins/",
-      "dev": true,
-      "dependencies": {
-        "@apollographql/apollo-tools": "^0.5.0",
-        "apollo-server-env": "^3.2.0",
-        "apollo-server-types": "^0.10.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/graphql-extensions/node_modules/@apollo/protobufjs": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
-      "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "apollo-pbjs": "bin/pbjs",
-        "apollo-pbts": "bin/pbts"
-      }
-    },
-    "node_modules/graphql-extensions/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "dev": true
-    },
-    "node_modules/graphql-extensions/node_modules/apollo-reporting-protobuf": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.8.0.tgz",
-      "integrity": "sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==",
-      "deprecated": "The `apollo-reporting-protobuf` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/usage-reporting-protobuf` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "@apollo/protobufjs": "1.2.2"
-      }
-    },
-    "node_modules/graphql-extensions/node_modules/apollo-server-caching": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
-      "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
-      "deprecated": "This package is part of the legacy caching implementation used by Apollo Server v2 and v3, and is no longer maintained. We recommend you switch to the newer Keyv-based implementation (which is compatible with all versions of Apollo Server). See https://www.apollographql.com/docs/apollo-server/v3/performance/cache-backends#legacy-caching-implementation for more details.",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/graphql-extensions/node_modules/apollo-server-env": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.2.0.tgz",
-      "integrity": "sha512-V+kO5e6vUo2JwqV1/Ng71ZE3J6x1hCOC+nID2/++bCYl0/fPY9iLChbBNSgN/uoFcjhgmBchOv+m4o0Nie/TFQ==",
-      "deprecated": "The `apollo-server-env` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/utils.fetcher` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "util.promisify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/graphql-extensions/node_modules/apollo-server-types": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
-      "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
-      "deprecated": "The `apollo-server-types` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "dev": true,
-      "dependencies": {
-        "apollo-reporting-protobuf": "^0.8.0",
-        "apollo-server-caching": "^0.7.0",
-        "apollo-server-env": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/graphql-extensions/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/graphql-extensions/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/graphql-request": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.1.0.tgz",
@@ -23129,33 +22178,6 @@
       },
       "peerDependencies": {
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/graphql-tools": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.8.tgz",
-      "integrity": "sha512-MW+ioleBrwhRjalKjYaLQbr+920pHBgy9vM/n47sswtns8+96sRn5M/G+J1eu7IMeKWiN/9p6tmwCHU7552VJg==",
-      "deprecated": "This package has been deprecated and now it only exports makeExecutableSchema.\\nAnd it will no longer receive updates.\\nWe recommend you to migrate to scoped packages such as @graphql-tools/schema, @graphql-tools/utils and etc.\\nCheck out https://www.graphql-tools.com to learn what package you should use instead",
-      "dev": true,
-      "dependencies": {
-        "apollo-link": "^1.2.14",
-        "apollo-utilities": "^1.0.1",
-        "deprecated-decorator": "^0.1.6",
-        "iterall": "^1.1.3",
-        "uuid": "^3.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/graphql-tools/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "dev": true,
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/graphql-type-json": {
@@ -30865,15 +29887,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/object-path": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
-      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.12.0"
-      }
-    },
     "node_modules/object.assign": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
@@ -30917,24 +29930,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.getownpropertydescriptors": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.5.tgz",
-      "integrity": "sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==",
-      "dev": true,
-      "dependencies": {
-        "array.prototype.reduce": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
-      },
-      "engines": {
-        "node": ">= 0.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -38915,22 +37910,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "node_modules/util.promisify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.1.1.tgz",
-      "integrity": "sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "for-each": "^0.3.3",
-        "has-symbols": "^1.0.1",
-        "object.getownpropertydescriptors": "^2.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -40638,57 +39617,6 @@
       "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
       "requires": {
         "xss": "^1.0.8"
-      }
-    },
-    "@apollographql/graphql-upload-8-fork": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-upload-8-fork/-/graphql-upload-8-fork-8.1.4.tgz",
-      "integrity": "sha512-lHAj/PUegYu02zza9Pg0bQQYH5I0ah1nyIzu2YIqOv41P0vu3GCBISAmQCfFHThK7N3dy7dLFPhoKcXlXRLPoQ==",
-      "dev": true,
-      "requires": {
-        "@types/express": "*",
-        "@types/fs-capacitor": "^2.0.0",
-        "@types/koa": "*",
-        "busboy": "^0.3.1",
-        "fs-capacitor": "^2.0.4",
-        "http-errors": "^1.7.3",
-        "object-path": "^0.11.4"
-      },
-      "dependencies": {
-        "busboy": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
-          "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
-          "dev": true,
-          "requires": {
-            "dicer": "0.3.0"
-          }
-        },
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-          "dev": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.4",
-            "setprototypeof": "1.2.0",
-            "statuses": ">= 1.5.0 < 2",
-            "toidentifier": "1.0.1"
-          }
-        },
-        "statuses": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-          "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-          "dev": true
-        }
       }
     },
     "@ardatan/aggregate-error": {
@@ -49535,29 +48463,11 @@
         "@types/node": "*"
       }
     },
-    "@types/content-disposition": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
-      "integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA==",
-      "dev": true
-    },
     "@types/cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
-    },
-    "@types/cookies": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
-      "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
-      "dev": true,
-      "requires": {
-        "@types/connect": "*",
-        "@types/express": "*",
-        "@types/keygrip": "*",
-        "@types/node": "*"
-      }
     },
     "@types/cors": {
       "version": "2.8.12",
@@ -49674,15 +48584,6 @@
         "@types/range-parser": "*"
       }
     },
-    "@types/fs-capacitor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz",
-      "integrity": "sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/fs-extra": {
       "version": "9.0.13",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
@@ -49757,22 +48658,10 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
-    "@types/http-assert": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.3.tgz",
-      "integrity": "sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA==",
-      "dev": true
-    },
     "@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
-      "dev": true
-    },
-    "@types/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==",
       "dev": true
     },
     "@types/http-proxy": {
@@ -49878,12 +48767,6 @@
         "@types/node": "*"
       }
     },
-    "@types/keygrip": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
-      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==",
-      "dev": true
-    },
     "@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -49891,31 +48774,6 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/koa": {
-      "version": "2.13.5",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.5.tgz",
-      "integrity": "sha512-HSUOdzKz3by4fnqagwthW/1w/yJspTgppyyalPVbgZf8jQWvdIXcVW5h2DGtw4zYntOaeRGx49r1hxoPWrD4aA==",
-      "dev": true,
-      "requires": {
-        "@types/accepts": "*",
-        "@types/content-disposition": "*",
-        "@types/cookies": "*",
-        "@types/http-assert": "*",
-        "@types/http-errors": "*",
-        "@types/keygrip": "*",
-        "@types/koa-compose": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/koa-compose": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
-      "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
-      "dev": true,
-      "requires": {
-        "@types/koa": "*"
       }
     },
     "@types/lodash": {
@@ -51083,108 +49941,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "apollo-cache-control": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.15.0.tgz",
-      "integrity": "sha512-U2uYvHZsWmR6s6CD5zlq3PepfbUAM8953CeVM2Y2QYMtJ8i4CYplEPbIWb3zTIXSPbIPeWGddM56pChI6Iz3zA==",
-      "dev": true,
-      "requires": {
-        "apollo-server-env": "^3.2.0",
-        "apollo-server-plugin-base": "^0.14.0"
-      },
-      "dependencies": {
-        "@apollo/protobufjs": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
-          "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
-          "dev": true,
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.0",
-            "@types/node": "^10.1.0",
-            "long": "^4.0.0"
-          }
-        },
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-          "dev": true
-        },
-        "apollo-reporting-protobuf": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.8.0.tgz",
-          "integrity": "sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==",
-          "dev": true,
-          "requires": {
-            "@apollo/protobufjs": "1.2.2"
-          }
-        },
-        "apollo-server-caching": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
-          "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "apollo-server-env": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.2.0.tgz",
-          "integrity": "sha512-V+kO5e6vUo2JwqV1/Ng71ZE3J6x1hCOC+nID2/++bCYl0/fPY9iLChbBNSgN/uoFcjhgmBchOv+m4o0Nie/TFQ==",
-          "dev": true,
-          "requires": {
-            "node-fetch": "^2.6.1",
-            "util.promisify": "^1.0.0"
-          }
-        },
-        "apollo-server-plugin-base": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.14.0.tgz",
-          "integrity": "sha512-nTNSFuBhZURGjtWptdVqwemYUOdsvABj/GSKzeNvepiEubiv4N0rt4Gvy1inHDiMbo98wQTdF/7XohNcB9A77g==",
-          "dev": true,
-          "requires": {
-            "apollo-server-types": "^0.10.0"
-          }
-        },
-        "apollo-server-types": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
-          "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
-          "dev": true,
-          "requires": {
-            "apollo-reporting-protobuf": "^0.8.0",
-            "apollo-server-caching": "^0.7.0",
-            "apollo-server-env": "^3.2.0"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
     "apollo-datasource": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.2.tgz",
@@ -51202,45 +49958,6 @@
         "core-js-pure": "^3.10.2",
         "lodash.sortby": "^4.7.0",
         "sha.js": "^2.4.11"
-      }
-    },
-    "apollo-link": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
-      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
-      "dev": true,
-      "requires": {
-        "apollo-utilities": "^1.3.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.21"
-      },
-      "dependencies": {
-        "ts-invariant": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-          "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        },
-        "zen-observable-ts": {
-          "version": "0.8.21",
-          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
-          "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.3",
-            "zen-observable": "^0.8.0"
-          }
-        }
       }
     },
     "apollo-reporting-protobuf": {
@@ -51387,207 +50104,6 @@
         "apollo-server-types": "^3.7.1"
       }
     },
-    "apollo-server-testing": {
-      "version": "2.25.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-testing/-/apollo-server-testing-2.25.3.tgz",
-      "integrity": "sha512-EELtuDk1dn//fNxeYELuwwAy8bvhV9d60WhZfs3JrXqpzRDZhJmyyGqlMoHmkvCqK/mCOkc4hL54tM9rrFhU5Q==",
-      "dev": true,
-      "requires": {
-        "apollo-server-core": "^2.25.3"
-      },
-      "dependencies": {
-        "@apollo/protobufjs": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
-          "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
-          "dev": true,
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.0",
-            "@types/node": "^10.1.0",
-            "long": "^4.0.0"
-          }
-        },
-        "@apollographql/graphql-playground-html": {
-          "version": "1.6.27",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.27.tgz",
-          "integrity": "sha512-tea2LweZvn6y6xFV11K0KC8ETjmm52mQrW+ezgB2O/aTQf8JGyFmMcRPFgUaQZeHbWdm8iisDC6EjOKsXu0nfw==",
-          "dev": true,
-          "requires": {
-            "xss": "^1.0.8"
-          }
-        },
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-          "dev": true
-        },
-        "@types/ws": {
-          "version": "7.4.7",
-          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
-          "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "apollo-datasource": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.10.0.tgz",
-          "integrity": "sha512-wrLhuoM2MtA0KA0+3qyioe0H2FjAxjTvuFOlNCk6WberA887m0MQlWULZImCWTkKuN+zEAMerHfxN+F+W8+lBA==",
-          "dev": true,
-          "requires": {
-            "apollo-server-caching": "^0.7.0",
-            "apollo-server-env": "^3.2.0"
-          }
-        },
-        "apollo-reporting-protobuf": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.8.0.tgz",
-          "integrity": "sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==",
-          "dev": true,
-          "requires": {
-            "@apollo/protobufjs": "1.2.2"
-          }
-        },
-        "apollo-server-caching": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
-          "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "apollo-server-core": {
-          "version": "2.26.1",
-          "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.26.1.tgz",
-          "integrity": "sha512-YnO1YXhHOnCY7Q2SZ0uUtPq6SLCw+t2uI19l59mzWuCyZYdHrtSy3zUEU6pM3tR9vvUuRGkYIfMRlo/Q8a1U5g==",
-          "dev": true,
-          "requires": {
-            "@apollographql/apollo-tools": "^0.5.0",
-            "@apollographql/graphql-playground-html": "1.6.27",
-            "@apollographql/graphql-upload-8-fork": "^8.1.4",
-            "@josephg/resolvable": "^1.0.0",
-            "@types/ws": "^7.0.0",
-            "apollo-cache-control": "^0.15.0",
-            "apollo-datasource": "^0.10.0",
-            "apollo-graphql": "^0.9.0",
-            "apollo-reporting-protobuf": "^0.8.0",
-            "apollo-server-caching": "^0.7.0",
-            "apollo-server-env": "^3.2.0",
-            "apollo-server-errors": "^2.5.0",
-            "apollo-server-plugin-base": "^0.14.0",
-            "apollo-server-types": "^0.10.0",
-            "apollo-tracing": "^0.16.0",
-            "async-retry": "^1.2.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "graphql-extensions": "^0.16.0",
-            "graphql-tag": "^2.11.0",
-            "graphql-tools": "^4.0.8",
-            "loglevel": "^1.6.7",
-            "lru-cache": "^6.0.0",
-            "sha.js": "^2.4.11",
-            "subscriptions-transport-ws": "^0.9.19",
-            "uuid": "^8.0.0"
-          }
-        },
-        "apollo-server-env": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.2.0.tgz",
-          "integrity": "sha512-V+kO5e6vUo2JwqV1/Ng71ZE3J6x1hCOC+nID2/++bCYl0/fPY9iLChbBNSgN/uoFcjhgmBchOv+m4o0Nie/TFQ==",
-          "dev": true,
-          "requires": {
-            "node-fetch": "^2.6.1",
-            "util.promisify": "^1.0.0"
-          }
-        },
-        "apollo-server-errors": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.5.0.tgz",
-          "integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA==",
-          "dev": true,
-          "requires": {}
-        },
-        "apollo-server-plugin-base": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.14.0.tgz",
-          "integrity": "sha512-nTNSFuBhZURGjtWptdVqwemYUOdsvABj/GSKzeNvepiEubiv4N0rt4Gvy1inHDiMbo98wQTdF/7XohNcB9A77g==",
-          "dev": true,
-          "requires": {
-            "apollo-server-types": "^0.10.0"
-          }
-        },
-        "apollo-server-types": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
-          "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
-          "dev": true,
-          "requires": {
-            "apollo-reporting-protobuf": "^0.8.0",
-            "apollo-server-caching": "^0.7.0",
-            "apollo-server-env": "^3.2.0"
-          }
-        },
-        "eventemitter3": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "subscriptions-transport-ws": {
-          "version": "0.9.19",
-          "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
-          "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
-          "dev": true,
-          "requires": {
-            "backo2": "^1.0.2",
-            "eventemitter3": "^3.1.0",
-            "iterall": "^1.2.1",
-            "symbol-observable": "^1.0.4",
-            "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-          }
-        },
-        "symbol-observable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-          "dev": true
-        },
-        "ws": {
-          "version": "7.5.9",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-          "dev": true,
-          "requires": {}
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
     "apollo-server-types": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.7.1.tgz",
@@ -51597,146 +50113,6 @@
         "@apollo/utils.logger": "^1.0.0",
         "apollo-reporting-protobuf": "^3.3.3",
         "apollo-server-env": "^4.2.1"
-      }
-    },
-    "apollo-tracing": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.16.0.tgz",
-      "integrity": "sha512-Oy8kTggB+fJ/hHXwHyMpuTl5KW7u1XetKFDErZVOobUKc2zjc/NgWiC/s7SGYZCgfLodBjvwfa6rMcvLkz7c0w==",
-      "dev": true,
-      "requires": {
-        "apollo-server-env": "^3.2.0",
-        "apollo-server-plugin-base": "^0.14.0"
-      },
-      "dependencies": {
-        "@apollo/protobufjs": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
-          "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
-          "dev": true,
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.0",
-            "@types/node": "^10.1.0",
-            "long": "^4.0.0"
-          }
-        },
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-          "dev": true
-        },
-        "apollo-reporting-protobuf": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.8.0.tgz",
-          "integrity": "sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==",
-          "dev": true,
-          "requires": {
-            "@apollo/protobufjs": "1.2.2"
-          }
-        },
-        "apollo-server-caching": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
-          "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "apollo-server-env": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.2.0.tgz",
-          "integrity": "sha512-V+kO5e6vUo2JwqV1/Ng71ZE3J6x1hCOC+nID2/++bCYl0/fPY9iLChbBNSgN/uoFcjhgmBchOv+m4o0Nie/TFQ==",
-          "dev": true,
-          "requires": {
-            "node-fetch": "^2.6.1",
-            "util.promisify": "^1.0.0"
-          }
-        },
-        "apollo-server-plugin-base": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.14.0.tgz",
-          "integrity": "sha512-nTNSFuBhZURGjtWptdVqwemYUOdsvABj/GSKzeNvepiEubiv4N0rt4Gvy1inHDiMbo98wQTdF/7XohNcB9A77g==",
-          "dev": true,
-          "requires": {
-            "apollo-server-types": "^0.10.0"
-          }
-        },
-        "apollo-server-types": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
-          "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
-          "dev": true,
-          "requires": {
-            "apollo-reporting-protobuf": "^0.8.0",
-            "apollo-server-caching": "^0.7.0",
-            "apollo-server-env": "^3.2.0"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
-    "apollo-utilities": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
-      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
-      "dev": true,
-      "requires": {
-        "@wry/equality": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "@wry/equality": {
-          "version": "0.1.11",
-          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
-          "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        },
-        "ts-invariant": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-          "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
       }
     },
     "app-root-path": {
@@ -51939,19 +50315,6 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
-      }
-    },
-    "array.prototype.reduce": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
-      "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.7"
       }
     },
     "array.prototype.tosorted": {
@@ -54891,12 +53254,6 @@
       "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
       "dev": true
     },
-    "deprecated-decorator": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
-      "integrity": "sha512-MHidOOnCHGlZDKsI21+mbIIhf4Fff+hhCTB7gtVg4uoIqjcrTZc5v6M+GS2zVI0sV7PqK415rb8XaOSQsQkHOw==",
-      "dev": true
-    },
     "deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -54928,23 +53285,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
-    },
-    "dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "dev": true,
-      "requires": {
-        "streamsearch": "0.1.2"
-      },
-      "dependencies": {
-        "streamsearch": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-          "integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==",
-          "dev": true
-        }
-      }
     },
     "diff": {
       "version": "5.1.0",
@@ -55432,12 +53772,6 @@
         "unbox-primitive": "^1.0.2",
         "which-typed-array": "^1.1.9"
       }
-    },
-    "es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true
     },
     "es-get-iterator": {
       "version": "1.1.3",
@@ -56970,12 +55304,6 @@
       "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
       "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg=="
     },
-    "fs-capacitor": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.4.tgz",
-      "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA==",
-      "dev": true
-    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -57444,100 +55772,6 @@
         }
       }
     },
-    "graphql-extensions": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.16.0.tgz",
-      "integrity": "sha512-rZQc/USoEIw437BGRUwoHoLPR1LA791Ltj6axONqgKIyyx2sqIO3YT9kTbB/eIUdJBrCozp4KuUeZ09xKeQDxg==",
-      "dev": true,
-      "requires": {
-        "@apollographql/apollo-tools": "^0.5.0",
-        "apollo-server-env": "^3.2.0",
-        "apollo-server-types": "^0.10.0"
-      },
-      "dependencies": {
-        "@apollo/protobufjs": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
-          "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
-          "dev": true,
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.0",
-            "@types/node": "^10.1.0",
-            "long": "^4.0.0"
-          }
-        },
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-          "dev": true
-        },
-        "apollo-reporting-protobuf": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.8.0.tgz",
-          "integrity": "sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==",
-          "dev": true,
-          "requires": {
-            "@apollo/protobufjs": "1.2.2"
-          }
-        },
-        "apollo-server-caching": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
-          "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "apollo-server-env": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.2.0.tgz",
-          "integrity": "sha512-V+kO5e6vUo2JwqV1/Ng71ZE3J6x1hCOC+nID2/++bCYl0/fPY9iLChbBNSgN/uoFcjhgmBchOv+m4o0Nie/TFQ==",
-          "dev": true,
-          "requires": {
-            "node-fetch": "^2.6.1",
-            "util.promisify": "^1.0.0"
-          }
-        },
-        "apollo-server-types": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.10.0.tgz",
-          "integrity": "sha512-LsB3epw1X3Co/HGiKHCGtzWG35J59gG8Ypx0p22+wgdM9AVDm1ylsNGZy+osNIVJc1lUJf3nF5kZ90vA866K/w==",
-          "dev": true,
-          "requires": {
-            "apollo-reporting-protobuf": "^0.8.0",
-            "apollo-server-caching": "^0.7.0",
-            "apollo-server-env": "^3.2.0"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
     "graphql-request": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.1.0.tgz",
@@ -57575,27 +55809,6 @@
       "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
       "requires": {
         "tslib": "^2.1.0"
-      }
-    },
-    "graphql-tools": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.8.tgz",
-      "integrity": "sha512-MW+ioleBrwhRjalKjYaLQbr+920pHBgy9vM/n47sswtns8+96sRn5M/G+J1eu7IMeKWiN/9p6tmwCHU7552VJg==",
-      "dev": true,
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-utilities": "^1.0.1",
-        "deprecated-decorator": "^0.1.6",
-        "iterall": "^1.1.3",
-        "uuid": "^3.1.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
-        }
       }
     },
     "graphql-type-json": {
@@ -63403,12 +61616,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
-    "object-path": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
-      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==",
-      "dev": true
-    },
     "object.assign": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
@@ -63437,18 +61644,6 @@
       "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
-      }
-    },
-    "object.getownpropertydescriptors": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.5.tgz",
-      "integrity": "sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==",
-      "dev": true,
-      "requires": {
-        "array.prototype.reduce": "^1.0.5",
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
@@ -69463,19 +67658,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "util.promisify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.1.1.tgz",
-      "integrity": "sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "for-each": "^0.3.3",
-        "has-symbols": "^1.0.1",
-        "object.getownpropertydescriptors": "^2.1.1"
-      }
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -219,7 +219,6 @@
     "@types/triple-beam": "^1.3.2",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
-    "apollo-server-testing": "^2.25.3",
     "babel-jest": "^28.1.0",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.4.0",

--- a/packages/amplication-server/src/core/account/account.resolver.spec.ts
+++ b/packages/amplication-server/src/core/account/account.resolver.spec.ts
@@ -1,9 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { gql } from "apollo-server-express";
-import {
-  ApolloServerTestClient,
-  createTestClient,
-} from "apollo-server-testing";
+import { ApolloServer, gql } from "apollo-server-express";
 import { INestApplication } from "@nestjs/common";
 import { GraphQLModule } from "@nestjs/graphql";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
@@ -14,6 +10,7 @@ import { mockGqlAuthGuardCanActivate } from "../../../test/gql-auth-mock";
 import { AccountResolver } from "./account.resolver";
 import { PrismaService } from "../../prisma/prisma.service";
 import { AccountService } from "./account.service";
+import { createApolloServerTestClient } from "../../tests/nestjs-apollo-testing";
 
 const EXAMPLE_USER_ID = "exampleUserId";
 
@@ -83,7 +80,7 @@ const GET_ACCOUNT_QUERY = gql`
 
 describe("AccountResolver", () => {
   let app: INestApplication;
-  let apolloClient: ApolloServerTestClient;
+  let apolloClient: ApolloServer;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -121,12 +118,11 @@ describe("AccountResolver", () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
-    const graphqlModule = moduleFixture.get(GraphQLModule) as any;
-    apolloClient = createTestClient(graphqlModule.apolloServer);
+    apolloClient = createApolloServerTestClient(moduleFixture);
   });
 
   it("should get current account", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: GET_ACCOUNT_QUERY,
     });
     expect(res.errors).toBeUndefined();
@@ -150,7 +146,7 @@ describe("AccountResolver", () => {
         lastName: EXAMPLE_UPDATED_ACCOUNT.lastName,
       },
     };
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: UPDATE_ACCOUNT_MUTATION,
       variables,
     });

--- a/packages/amplication-server/src/core/auth/auth.resolver.spec.ts
+++ b/packages/amplication-server/src/core/auth/auth.resolver.spec.ts
@@ -2,17 +2,14 @@ import { INestApplication } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { GraphQLModule } from "@nestjs/graphql";
 import { Test, TestingModule } from "@nestjs/testing";
-import { gql } from "apollo-server-express";
-import {
-  ApolloServerTestClient,
-  createTestClient,
-} from "apollo-server-testing";
+import { ApolloServer, gql } from "apollo-server-express";
 import { GqlAuthGuard } from "../../guards/gql-auth.guard";
 import { Account, Auth, User } from "../../models";
 import { mockGqlAuthGuardCanActivate } from "../../../test/gql-auth-mock";
 import { AuthResolver } from "./auth.resolver";
 import { AuthService } from "./auth.service";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
+import { createApolloServerTestClient } from "../../tests/nestjs-apollo-testing";
 
 const EXAMPLE_USER_ID = "exampleUserId";
 const EXAMPLE_TOKEN = "exampleToken";
@@ -126,7 +123,7 @@ const mockCanActivate = jest.fn(mockGqlAuthGuardCanActivate(EXAMPLE_USER));
 
 describe("AuthResolver", () => {
   let app: INestApplication;
-  let apolloClient: ApolloServerTestClient;
+  let apolloClient: ApolloServer;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -163,12 +160,11 @@ describe("AuthResolver", () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
-    const graphqlModule = moduleFixture.get(GraphQLModule) as any;
-    apolloClient = createTestClient(graphqlModule.apolloServer);
+    apolloClient = createApolloServerTestClient(moduleFixture);
   });
 
   it("should return current user", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: ME_QUERY,
     });
     expect(res.errors).toBeUndefined();
@@ -189,8 +185,8 @@ describe("AuthResolver", () => {
       lastName: EXAMPLE_LAST_NAME,
       workspaceName: EXAMPLE_WORKSPACE_NAME,
     };
-    const res = await apolloClient.mutate({
-      mutation: SIGNUP_MUTATION,
+    const res = await apolloClient.executeOperation({
+      query: SIGNUP_MUTATION,
       variables: variables,
     });
     expect(res.errors).toBeUndefined();
@@ -211,8 +207,8 @@ describe("AuthResolver", () => {
       email: EXAMPLE_EMAIL,
       password: EXAMPLE_PASSWORD,
     };
-    const res = await apolloClient.mutate({
-      mutation: LOGIN_MUTATION,
+    const res = await apolloClient.executeOperation({
+      query: LOGIN_MUTATION,
       variables: variables,
     });
     expect(res.errors).toBeUndefined();
@@ -229,8 +225,8 @@ describe("AuthResolver", () => {
   });
 
   it("should change a password", async () => {
-    const res = await apolloClient.mutate({
-      mutation: CHANGE_PASSWORD_MUTATION,
+    const res = await apolloClient.executeOperation({
+      query: CHANGE_PASSWORD_MUTATION,
       variables: {
         oldPassword: EXAMPLE_PASSWORD,
         newPassword: EXAMPLE_PASSWORD,
@@ -253,8 +249,8 @@ describe("AuthResolver", () => {
   });
 
   it("set set the current workspace", async () => {
-    const res = await apolloClient.mutate({
-      mutation: SET_WORKSPACE_MUTATION,
+    const res = await apolloClient.executeOperation({
+      query: SET_WORKSPACE_MUTATION,
       variables: { id: EXAMPLE_WORKSPACE_ID },
     });
     expect(res.errors).toBeUndefined();
@@ -274,8 +270,8 @@ describe("AuthResolver", () => {
     mockCanActivate.mockImplementation(
       mockGqlAuthGuardCanActivate(EXAMPLE_USER_WITHOUT_ACCOUNT)
     );
-    const { data, errors } = await apolloClient.mutate({
-      mutation: SET_WORKSPACE_MUTATION,
+    const { data, errors } = await apolloClient.executeOperation({
+      query: SET_WORKSPACE_MUTATION,
       variables: { id: EXAMPLE_WORKSPACE_ID },
     });
 

--- a/packages/amplication-server/src/core/build/build.resolver.spec.ts
+++ b/packages/amplication-server/src/core/build/build.resolver.spec.ts
@@ -1,9 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { gql } from "apollo-server-express";
-import {
-  ApolloServerTestClient,
-  createTestClient,
-} from "apollo-server-testing";
+import { ApolloServer, gql } from "apollo-server-express";
 import { GqlAuthGuard } from "../../guards/gql-auth.guard";
 import { INestApplication } from "@nestjs/common";
 import { GraphQLModule } from "@nestjs/graphql";
@@ -20,6 +16,7 @@ import { CommitService } from "../commit/commit.service";
 import { EnumResourceType } from "@amplication/code-gen-types/models";
 import { ResourceService } from "../resource/resource.service";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
+import { createApolloServerTestClient } from "../../tests/nestjs-apollo-testing";
 
 const EXAMPLE_BUILD_ID = "exampleBuildId";
 const EXAMPLE_COMMIT_ID = "exampleCommitId";
@@ -173,7 +170,7 @@ const mockCanActivate = jest.fn(() => true);
 
 describe("BuildResolver", () => {
   let app: INestApplication;
-  let apolloClient: ApolloServerTestClient;
+  let apolloClient: ApolloServer;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -234,12 +231,11 @@ describe("BuildResolver", () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
-    const graphqlModule = moduleFixture.get(GraphQLModule) as any;
-    apolloClient = createTestClient(graphqlModule.apolloServer);
+    apolloClient = createApolloServerTestClient(moduleFixture);
   });
 
   it("should find many builds", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_MANY_BUILDS_QUERY,
       variables: {},
     });
@@ -257,7 +253,7 @@ describe("BuildResolver", () => {
   });
 
   it("should find one build", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_ONE_BUILD_QUERY,
       variables: { id: EXAMPLE_BUILD_ID },
     });
@@ -275,7 +271,7 @@ describe("BuildResolver", () => {
   });
 
   it("should find a builds creating user", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_USER_QUERY,
       variables: { id: EXAMPLE_BUILD_ID },
     });
@@ -297,7 +293,7 @@ describe("BuildResolver", () => {
   });
 
   it("should find a builds action", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_ACTION_QUERY,
       variables: { id: EXAMPLE_BUILD_ID },
     });
@@ -317,7 +313,7 @@ describe("BuildResolver", () => {
   });
 
   it("should return the build archive URI", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: ARCHIVE_URI_QUERY,
       variables: { id: EXAMPLE_BUILD_ID },
     });
@@ -330,7 +326,7 @@ describe("BuildResolver", () => {
   });
 
   it("should get a build status", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: BUILD_STATUS_QUERY,
       variables: { id: EXAMPLE_BUILD_ID },
     });
@@ -352,8 +348,8 @@ describe("BuildResolver", () => {
         message: EXAMPLE_MESSAGE,
       },
     };
-    const res = await apolloClient.mutate({
-      mutation: CREATE_BUILD_MUTATION,
+    const res = await apolloClient.executeOperation({
+      query: CREATE_BUILD_MUTATION,
       variables: {
         resourceId: EXAMPLE_RESOURCE_ID,
         commitId: EXAMPLE_COMMIT_ID,

--- a/packages/amplication-server/src/core/commit/commit.resolver.spec.ts
+++ b/packages/amplication-server/src/core/commit/commit.resolver.spec.ts
@@ -1,9 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { gql } from "apollo-server-express";
-import {
-  ApolloServerTestClient,
-  createTestClient,
-} from "apollo-server-testing";
+import { ApolloServer, gql } from "apollo-server-express";
 import { GqlAuthGuard } from "../../guards/gql-auth.guard";
 import { INestApplication } from "@nestjs/common";
 import { GraphQLModule } from "@nestjs/graphql";
@@ -15,6 +11,7 @@ import { BuildService } from "../build/build.service";
 
 import { CommitResolver } from "./commit.resolver";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
+import { createApolloServerTestClient } from "../../tests/nestjs-apollo-testing";
 
 const EXAMPLE_COMMIT_ID = "exampleCommitId";
 const EXAMPLE_USER_ID = "exampleUserId";
@@ -78,7 +75,7 @@ const mockCanActivate = jest.fn(() => true);
 
 describe("CommitService", () => {
   let app: INestApplication;
-  let apolloClient: ApolloServerTestClient;
+  let apolloClient: ApolloServer;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -124,12 +121,11 @@ describe("CommitService", () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
-    const graphqlModule = moduleFixture.get(GraphQLModule) as any;
-    apolloClient = createTestClient(graphqlModule.apolloServer);
+    apolloClient = createApolloServerTestClient(moduleFixture);
   });
 
   it("should find committing user", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: USER_QUERY,
       variables: {
         id: EXAMPLE_COMMIT_ID,
@@ -152,7 +148,7 @@ describe("CommitService", () => {
   });
 
   it("should find one Commit", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_ONE_COMMIT_QUERY,
       variables: { id: EXAMPLE_COMMIT_ID },
     });
@@ -170,7 +166,7 @@ describe("CommitService", () => {
   });
 
   it("should find many Commits", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_MANY_COMMIT_QUERY,
       variables: {},
     });

--- a/packages/amplication-server/src/core/entity/entity.resolver.spec.ts
+++ b/packages/amplication-server/src/core/entity/entity.resolver.spec.ts
@@ -1,9 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { gql } from "apollo-server-express";
-import {
-  ApolloServerTestClient,
-  createTestClient,
-} from "apollo-server-testing";
+import { ApolloServer, gql } from "apollo-server-express";
 import { GqlAuthGuard } from "../../guards/gql-auth.guard";
 import { mockGqlAuthGuardCanActivate } from "../../../test/gql-auth-mock";
 import { EntityResolver } from "./entity.resolver";
@@ -25,6 +21,7 @@ import { EntityVersion } from "../../models/EntityVersion";
 import { Commit, EntityPermissionField } from "../../models";
 import { EntityVersionResolver } from "./entityVersion.resolver";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
+import { createApolloServerTestClient } from "../../tests/nestjs-apollo-testing";
 
 const EXAMPLE_ID = "exampleId";
 const EXAMPLE_USER_ID = "exampleUserId";
@@ -610,7 +607,7 @@ const mockCanActivate = jest.fn(mockGqlAuthGuardCanActivate(EXAMPLE_USER));
 
 describe("EntityResolver", () => {
   let app: INestApplication;
-  let apolloClient: ApolloServerTestClient;
+  let apolloClient: ApolloServer;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -674,12 +671,11 @@ describe("EntityResolver", () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
-    const graphqlModule = moduleFixture.get(GraphQLModule) as any;
-    apolloClient = createTestClient(graphqlModule.apolloServer);
+    apolloClient = createApolloServerTestClient(moduleFixture);
   });
 
   it("should find one entity", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_ONE_QUERY,
       variables: { id: EXAMPLE_ID },
     });
@@ -696,7 +692,7 @@ describe("EntityResolver", () => {
   });
 
   it("should find many entities", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_MANY_QUERY,
       variables: { id: EXAMPLE_ID },
     });
@@ -717,7 +713,7 @@ describe("EntityResolver", () => {
   });
 
   it("should create one entity", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: CREATE_ONE_QUERY,
       variables: {
         name: EXAMPLE_ENTITY.name,
@@ -749,7 +745,7 @@ describe("EntityResolver", () => {
   });
 
   it("should get entity fields", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_MANY_FIELDS_QUERY,
       variables: { entityId: EXAMPLE_ID, fieldId: EXAMPLE_ENTITY_FIELD_ID },
     });
@@ -772,7 +768,7 @@ describe("EntityResolver", () => {
   });
 
   it("should get entity permissions", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_MANY_PERMISSIONS_QUERY,
       variables: { entityId: EXAMPLE_ID },
     });
@@ -791,7 +787,7 @@ describe("EntityResolver", () => {
   });
 
   it("should return locking user", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: LOCKED_BY_USER_QUERY,
       variables: { id: EXAMPLE_ID },
     });
@@ -813,7 +809,7 @@ describe("EntityResolver", () => {
   it("should return null when no locking user", async () => {
     entityMock.mockImplementationOnce(() => EXAMPLE_UNLOCKED_ENTITY);
 
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: LOCKED_BY_USER_QUERY,
       variables: { id: EXAMPLE_UNLOCKED_ID },
     });
@@ -827,7 +823,7 @@ describe("EntityResolver", () => {
   });
 
   it("should lock an entity", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: LOCK_ENTITY_MUTATION,
       variables: { id: EXAMPLE_ID },
     });
@@ -847,7 +843,7 @@ describe("EntityResolver", () => {
   });
 
   it("should update one entity", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: UPDATE_ENTITY_MUTATION,
       variables: { id: EXAMPLE_ID },
     });
@@ -870,7 +866,7 @@ describe("EntityResolver", () => {
   });
 
   it("should delete one entity", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: DELETE_ENTITY_MUTATION,
       variables: { id: EXAMPLE_ID },
     });
@@ -890,7 +886,7 @@ describe("EntityResolver", () => {
   });
 
   it("should update an entity permission", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: UPDATE_ENTITY_PERM_MUTATUION,
       variables: {
         action: EXAMPLE_PERMISSION.action,
@@ -918,7 +914,7 @@ describe("EntityResolver", () => {
   });
 
   it("should update entity permission roles", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: UPDATE_ENTITY_PERM_ROLES_MUTATION,
       variables: { action: EXAMPLE_PERMISSION.action, entityId: EXAMPLE_ID },
     });
@@ -941,7 +937,7 @@ describe("EntityResolver", () => {
   });
 
   it("should add an entity permission field", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: ADD_ENTITY_PERM_FIELD_MUTATION,
       variables: {
         action: EXAMPLE_PERMISSION.action,
@@ -974,7 +970,7 @@ describe("EntityResolver", () => {
   });
 
   it("should delete an entity permission field", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: DELETE_ENTITY_PERM_FIELD_MUTATION,
       variables: {
         action: EXAMPLE_PERMISSION.action,
@@ -1007,7 +1003,7 @@ describe("EntityResolver", () => {
   });
 
   it("should update entity permission field roles", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: UPDATE_ENTITY_PERM_FIELD_ROLES_MUTATION,
       variables: { permissionFieldId: EXAMPLE_PERMISSION_FIELD_ID },
     });
@@ -1045,7 +1041,7 @@ describe("EntityResolver", () => {
       description: EXAMPLE_ENTITY_FIELD.description,
       entity: EXAMPLE_ID,
     };
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: CREATE_ENTITY_FIELD_MUTATION,
       variables: variables,
     });
@@ -1065,7 +1061,7 @@ describe("EntityResolver", () => {
   });
 
   it("should create entity field by display name", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: CREATE_ENTITY_FIELD_BY_DISPLAY_NAME_MUTATION,
       variables: { displayName: EXAMPLE_DISPLAY_NAME, entityId: EXAMPLE_ID },
     });
@@ -1090,7 +1086,7 @@ describe("EntityResolver", () => {
   });
 
   it("should delete an entity field", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: DELETE_ENTITY_FIELD_MUTATION,
       variables: { fieldId: EXAMPLE_ENTITY_FIELD_ID },
     });
@@ -1110,7 +1106,7 @@ describe("EntityResolver", () => {
   });
 
   it("should update an entity field", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: UPDATE_ENTITY_FIELD_MUTATION,
       variables: { fieldId: EXAMPLE_ENTITY_FIELD_ID },
     });
@@ -1130,7 +1126,7 @@ describe("EntityResolver", () => {
   });
 
   it("should create a default related field", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: CREATE_DEFAULT_RELATED_FIELD_MUTATION,
       variables: { fieldId: EXAMPLE_ENTITY_FIELD_ID },
     });
@@ -1152,7 +1148,7 @@ describe("EntityResolver", () => {
   //EntityVersion Resolver tests:
 
   it("should get a versions commit", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: GET_VERSION_COMMIT_QUERY,
       variables: { entityId: EXAMPLE_ID },
     });
@@ -1176,7 +1172,7 @@ describe("EntityResolver", () => {
   });
 
   it("should get entity version fields", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: GET_VERSION_FIELDS_QUERY,
       variables: { entityId: EXAMPLE_ID },
     });
@@ -1205,7 +1201,7 @@ describe("EntityResolver", () => {
   });
 
   it("should get entity version permissions", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: GET_VERSION_PERMISSIONS_QUERY,
       variables: { entityId: EXAMPLE_ID },
     });

--- a/packages/amplication-server/src/core/resource/resource.resolver.spec.ts
+++ b/packages/amplication-server/src/core/resource/resource.resolver.spec.ts
@@ -3,11 +3,7 @@ import { PrismaService, EnumResourceType } from "../../prisma";
 import { BuildService } from "../build/build.service";
 import { EntityService } from "../entity/entity.service";
 import { EnvironmentService } from "../environment/environment.service";
-import { gql } from "apollo-server-express";
-import {
-  ApolloServerTestClient,
-  createTestClient,
-} from "apollo-server-testing";
+import { ApolloServer, gql } from "apollo-server-express";
 import { GqlAuthGuard } from "../../guards/gql-auth.guard";
 import { ResourceResolver } from "./resource.resolver";
 import { INestApplication } from "@nestjs/common";
@@ -23,6 +19,7 @@ import { mockGqlAuthGuardCanActivate } from "../../../test/gql-auth-mock";
 import { UserService } from "../user/user.service";
 import { ResourceCreateInput } from "./dto";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
+import { createApolloServerTestClient } from "../../tests/nestjs-apollo-testing";
 
 const EXAMPLE_RESOURCE_ID = "exampleResourceId";
 const EXAMPLE_NAME = "exampleName";
@@ -325,7 +322,7 @@ const mockCanActivate = jest.fn(mockGqlAuthGuardCanActivate(EXAMPLE_USER));
 
 describe("ResourceResolver", () => {
   let app: INestApplication;
-  let apolloClient: ApolloServerTestClient;
+  let apolloClient: ApolloServer;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -390,12 +387,11 @@ describe("ResourceResolver", () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
-    const graphqlModule = moduleFixture.get(GraphQLModule) as any;
-    apolloClient = createTestClient(graphqlModule.apolloServer);
+    apolloClient = createApolloServerTestClient(moduleFixture);
   });
 
   it("should find one resource", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_ONE_RESOURCE_QUERY,
       variables: { id: EXAMPLE_RESOURCE_ID },
     });
@@ -435,7 +431,7 @@ describe("ResourceResolver", () => {
   });
 
   it("should find many entities", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_MANY_ENTITIES_QUERY,
       variables: {
         resourceId: EXAMPLE_RESOURCE_ID,
@@ -465,7 +461,7 @@ describe("ResourceResolver", () => {
   });
 
   it("should find many builds", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_MANY_BUILDS_QUERY,
       variables: { resourceId: EXAMPLE_RESOURCE_ID },
     });
@@ -488,7 +484,7 @@ describe("ResourceResolver", () => {
   });
 
   it("should find many environments", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: FIND_MANY_ENVIRONMENTS_QUERY,
       variables: { resourceId: EXAMPLE_RESOURCE_ID },
     });
@@ -517,7 +513,7 @@ describe("ResourceResolver", () => {
       resourceType: EnumResourceType.Service,
       project: { connect: { id: EXAMPLE_PROJECT_ID } },
     };
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: CREATE_SERVICE_MUTATION,
       variables: {
         data: resourceCreateInput,
@@ -562,7 +558,7 @@ describe("ResourceResolver", () => {
   });
 
   it("should delete a resource", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: DELETE_RESOURCE_MUTATION,
       variables: {
         id: EXAMPLE_RESOURCE_ID,
@@ -606,7 +602,7 @@ describe("ResourceResolver", () => {
   });
 
   it("should update a resource", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: UPDATE_RESOURCE_MUTATION,
       variables: {
         name: EXAMPLE_NAME,

--- a/packages/amplication-server/src/core/resourceRole/resourceRole.resolver.spec.ts
+++ b/packages/amplication-server/src/core/resourceRole/resourceRole.resolver.spec.ts
@@ -1,10 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { PrismaService } from "../../prisma/prisma.service";
-import { gql } from "apollo-server-express";
-import {
-  ApolloServerTestClient,
-  createTestClient,
-} from "apollo-server-testing";
+import { ApolloServer, gql } from "apollo-server-express";
 import { GqlAuthGuard } from "../../guards/gql-auth.guard";
 import { INestApplication } from "@nestjs/common";
 import { GraphQLModule } from "@nestjs/graphql";
@@ -13,6 +9,7 @@ import { ResourceRoleService } from "./resourceRole.service";
 import { ResourceRoleResolver } from "./resourceRole.resolver";
 import { ResourceRole } from "../../models";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
+import { createApolloServerTestClient } from "../../tests/nestjs-apollo-testing";
 
 const EXAMPLE_RESOURCE_ROLE_ID = "EXAMPLE_APP_ROLE_ID";
 const EXAMPLE_NAME = "EXAMPLE_NAME";
@@ -126,7 +123,7 @@ const mockCanActivate = jest.fn(() => true);
 
 describe("ResourceRoleResolver", () => {
   let app: INestApplication;
-  let apolloClient: ApolloServerTestClient;
+  let apolloClient: ApolloServer;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -169,12 +166,11 @@ describe("ResourceRoleResolver", () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
-    const graphqlModule = moduleFixture.get(GraphQLModule) as any;
-    apolloClient = createTestClient(graphqlModule.apolloServer);
+    apolloClient = createApolloServerTestClient(moduleFixture);
   });
 
   it("should get one ResourceRole", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: GET_RESOURCE_ROLE_QUERY,
       variables: { id: EXAMPLE_RESOURCE_ROLE_ID, version: EXAMPLE_VERSION },
     });
@@ -194,7 +190,7 @@ describe("ResourceRoleResolver", () => {
   });
 
   it("should get Many ResourceRoles", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: GET_RESOURCE_ROLES_QUERY,
     });
     expect(res.errors).toBeUndefined();
@@ -212,7 +208,7 @@ describe("ResourceRoleResolver", () => {
   });
 
   it("should create a resourceRole", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: CREATE_RESOURCE_ROLE_MUTATION,
       variables: {
         name: EXAMPLE_NAME,
@@ -241,7 +237,7 @@ describe("ResourceRoleResolver", () => {
   });
 
   it("should delete a resourceRole", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: DELETE_APP_ROLE_MUTATION,
       variables: { id: EXAMPLE_RESOURCE_ROLE_ID },
     });
@@ -260,7 +256,7 @@ describe("ResourceRoleResolver", () => {
   });
 
   it("should update a resourceRole", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: UPDATE_APP_ROLE_MUTATION,
       variables: {
         id: EXAMPLE_RESOURCE_ROLE_ID,

--- a/packages/amplication-server/src/core/workspace/workspace.resolver.spec.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.resolver.spec.ts
@@ -1,9 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { gql } from "apollo-server-express";
-import {
-  ApolloServerTestClient,
-  createTestClient,
-} from "apollo-server-testing";
+import { ApolloServer, gql } from "apollo-server-express";
 import { GqlAuthGuard } from "../../guards/gql-auth.guard";
 import { INestApplication } from "@nestjs/common";
 import { GraphQLModule } from "@nestjs/graphql";
@@ -19,6 +15,7 @@ import { ProjectService } from "../project/project.service";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
 import { BillingService } from "../billing/billing.service";
 import { SubscriptionService } from "../subscription/subscription.service";
+import { createApolloServerTestClient } from "../../tests/nestjs-apollo-testing";
 
 const EXAMPLE_USER_ID = "exampleUserId";
 const EXAMPLE_WORKSPACE_ID = "exampleWorkspaceId";
@@ -137,7 +134,7 @@ const mockCanActivate = jest.fn(mockGqlAuthGuardCanActivate(EXAMPLE_USER));
 
 describe("WorkspaceResolver", () => {
   let app: INestApplication;
-  let apolloClient: ApolloServerTestClient;
+  let apolloClient: ApolloServer;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -205,12 +202,11 @@ describe("WorkspaceResolver", () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
-    const graphqlModule = moduleFixture.get(GraphQLModule) as any;
-    apolloClient = createTestClient(graphqlModule.apolloServer);
+    apolloClient = createApolloServerTestClient(moduleFixture);
   });
 
   it("should get an workspace", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: GET_WORKSPACE_QUERY,
       variables: { id: EXAMPLE_WORKSPACE_ID },
     });
@@ -224,7 +220,7 @@ describe("WorkspaceResolver", () => {
   });
 
   it("should get workspace's projects", async () => {
-    const res = await apolloClient.query({
+    const res = await apolloClient.executeOperation({
       query: GET_PROJECT_QUERY,
       variables: { id: EXAMPLE_WORKSPACE_ID },
     });
@@ -247,8 +243,8 @@ describe("WorkspaceResolver", () => {
   });
 
   it("should delete an workspace", async () => {
-    const res = await apolloClient.mutate({
-      mutation: DELETE_WORKSPACE_MUTATION,
+    const res = await apolloClient.executeOperation({
+      query: DELETE_WORKSPACE_MUTATION,
       variables: { id: EXAMPLE_WORKSPACE_ID },
     });
     expect(res.errors).toBeUndefined();
@@ -266,8 +262,8 @@ describe("WorkspaceResolver", () => {
   });
 
   it("should update an workspace", async () => {
-    const res = await apolloClient.mutate({
-      mutation: UPDATE_WORKSPACE_MUTATION,
+    const res = await apolloClient.executeOperation({
+      query: UPDATE_WORKSPACE_MUTATION,
       variables: { id: EXAMPLE_WORKSPACE_ID },
     });
     expect(res.errors).toBeUndefined();
@@ -286,8 +282,8 @@ describe("WorkspaceResolver", () => {
   });
 
   it("should invite a user", async () => {
-    const res = await apolloClient.mutate({
-      mutation: INVITE_USER_MUTATION,
+    const res = await apolloClient.executeOperation({
+      query: INVITE_USER_MUTATION,
       variables: { email: EXAMPLE_EMAIL },
     });
     expect(res.errors).toBeUndefined();

--- a/packages/amplication-server/src/tests/nestjs-apollo-testing.ts
+++ b/packages/amplication-server/src/tests/nestjs-apollo-testing.ts
@@ -1,9 +1,6 @@
-import { TestingModule } from "@nestjs/testing";
 import { GraphQLModule } from "@nestjs/graphql";
-import {
-  ApolloServerTestClient,
-  createTestClient,
-} from "apollo-server-testing";
+import { TestingModule } from "@nestjs/testing";
+import { ApolloServer } from "apollo-server-express";
 
 /**
  * Wraps Apollo Server's createTestClient to easily work with Nest.js
@@ -12,8 +9,8 @@ import {
  */
 export function createApolloServerTestClient(
   testingModule: TestingModule
-): ApolloServerTestClient {
+): ApolloServer {
   // GraphQLModule doesn't expose the apolloServer property
   const graphqlModule = testingModule.get(GraphQLModule) as any;
-  return createTestClient(graphqlModule.apolloServer);
+  return graphqlModule.apolloServer;
 }

--- a/packages/amplication-server/src/tests/nestjs-apollo-testing.ts
+++ b/packages/amplication-server/src/tests/nestjs-apollo-testing.ts
@@ -3,7 +3,7 @@ import { TestingModule } from "@nestjs/testing";
 import { ApolloServer } from "apollo-server-express";
 
 /**
- * Wraps Apollo Server's createTestClient to easily work with Nest.js
+ *
  * @param testingModule the Nest.js testing module
  * @returns Apollo Server's test client
  */


### PR DESCRIPTION

Close: #5379 

## PR Details

This pull request removes all `apollo-server-testing` from Amplication.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
