### PR TITLE
fix(client): changed flex to flex-end

### DIFF
--- a/packages/amplication-client/src/Profile/ProfileForm.scss
+++ b/packages/amplication-client/src/Profile/ProfileForm.scss
@@ -19,7 +19,7 @@
 
   &__submitButton {
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
     .amp-button {
       width: auto;
     }


### PR DESCRIPTION
Close: #[5141]
 
## PR Details

the following warning was solved 

WARNING in ./src/Profile/ProfileForm.scss (../../node_modules/@nrwl/webpack/src/utils/webpack/plugins/raw-css-loader.js!../../node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[3].oneOf[5].use[2]!../../node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[3].oneOf[5].use[3]!./src/Profile/ProfileForm.scss)
Module Warning (from ../../node_modules/postcss-loader/dist/cjs.js):
Warning

(57:3) autoprefixer: end value has mixed support, consider using flex-end instead


the "end" value is being used in a flexbox layout property, and that value has mixed support across different web browsers. The recommendation given in the warning is to consider using the "flex-end" value instead, which is more widely supported.