### PR TITLE
Related entity field still appears in the UI after removing an entity, and only after refreshing the UI is updated

### DIFF
--- a/packages/amplication-client/src/Entity/EntityFieldLinkList.tsx
+++ b/packages/amplication-client/src/Entity/EntityFieldLinkList.tsx
@@ -26,6 +26,7 @@ type Props = {
 export const EntityFieldLinkList = React.memo(({ entityId }: Props) => {
   const { currentWorkspace, currentProject } = useContext(AppContext);
   const { data, error } = useQuery<TData>(GET_FIELDS, {
+    fetchPolicy: "no-cache",
     variables: {
       id: entityId,
       orderBy: {


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)
-->

Close: #5316

## PR Details
Related entity field still appears in the UI after removing an entity, and only after refreshing the UI is updated.
- There is a caching issue.

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

## screenshots


https://user-images.githubusercontent.com/47450328/224605278-5239f35e-ace9-479c-b341-cbec412f5f17.mov

## test case results.

<img width="1154" alt="Screenshot 2023-03-13 at 9 31 24 AM" src="https://user-images.githubusercontent.com/47450328/224605347-b0cc6fe2-5e7e-4686-ba92-16f3f1b80a65.png">



IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
