### PR TITLE
feat(server): create prisma migration script for git provider properties

### DIFF
--- a/packages/amplication-server/migration-scripts/git-organization-provider-properties.ts
+++ b/packages/amplication-server/migration-scripts/git-organization-provider-properties.ts
@@ -1,0 +1,17 @@
+import { PrismaClient } from "../src/prisma";
+
+async function main() {
+  const prisma = new PrismaClient();
+  const gitOrganizations = await prisma.gitOrganization.findMany();
+
+  for (const gitOrg of gitOrganizations) {
+    const updatedProviderProps = { installationId: gitOrg.installationId };
+
+    await prisma.gitOrganization.update({
+      where: { id: gitOrg.id },
+      data: { providerProperties: updatedProviderProps },
+    });
+  }
+}
+
+main().catch(console.error);


### PR DESCRIPTION
Close: #5458

## PR Details

I decided to go with option 2: 
- create a `migration.ts` file => `git-organization-provider-properites.ts`
- run it locally while I had in the database and empty object in the providerProperties column
- run it locally while in the providerProperties column I had `{github: {installationId: <installationId>}}` (this is what we have now in production for new users)

On both cases I got what I expect to: `{installationId: <installationId>}`

![image](https://user-images.githubusercontent.com/39680385/225944400-390931b9-6dd8-42d1-a4a4-615211dd7c0a.png)


## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
