### PR TITLE
Fix(server): bitbucket refresh token calculation

### DIFF
--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
@@ -89,7 +89,7 @@ export class BitBucketService implements GitProvider {
       refreshToken: authData.refresh_token,
       scopes: authData.scopes.split(" "),
       tokenType: authData.token_type,
-      expiresAt: Math.floor(Date.now() / 1000) + authData.expires_in, // 7200 seconds = 2 hours
+      expiresAt: Date.now() + ( authData.expires_in * 1000 ), // 7200 seconds = 2 hours
     };
   }
 

--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
@@ -89,7 +89,7 @@ export class BitBucketService implements GitProvider {
       refreshToken: authData.refresh_token,
       scopes: authData.scopes.split(" "),
       tokenType: authData.token_type,
-      expiresAt: Date.now() + authData.expires_in,
+      expiresAt: Math.floor(Date.now() / 1000) + authData.expires_in, // 7200 seconds = 2 hours
     };
   }
 
@@ -107,7 +107,7 @@ export class BitBucketService implements GitProvider {
       refreshToken: newOAuthData.refresh_token,
       scopes: newOAuthData.scopes.split(" "),
       tokenType: newOAuthData.token_type,
-      expiresAt: Date.now() + newOAuthData.expires_in,
+      expiresAt: Math.floor(Date.now() / 1000) + newOAuthData.expires_in, // 7200 seconds = 2 hours
     };
   }
 

--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
@@ -89,7 +89,7 @@ export class BitBucketService implements GitProvider {
       refreshToken: authData.refresh_token,
       scopes: authData.scopes.split(" "),
       tokenType: authData.token_type,
-      expiresAt: Date.now() + ( authData.expires_in * 1000 ), // 7200 seconds = 2 hours
+      expiresAt: Date.now() + authData.expires_in * 1000, // 7200 seconds = 2 hours
     };
   }
 
@@ -107,7 +107,7 @@ export class BitBucketService implements GitProvider {
       refreshToken: newOAuthData.refresh_token,
       scopes: newOAuthData.scopes.split(" "),
       tokenType: newOAuthData.token_type,
-      expiresAt: Math.floor(Date.now() / 1000) + newOAuthData.expires_in, // 7200 seconds = 2 hours
+      expiresAt: Date.now() + newOAuthData.expires_in * 1000, // 7200 seconds = 2 hours
     };
   }
 

--- a/packages/amplication-server/src/core/git/git.provider.service.ts
+++ b/packages/amplication-server/src/core/git/git.provider.service.ts
@@ -436,8 +436,6 @@ export class GitProviderService {
 
     this.logger.info("Time left before token expires:", {
       value: `${timeInMsLeft / 60000} minutes`,
-      exporisAt: providerProperties["expiresAt"],
-      now: Date.now(),
     });
 
     if (timeInMsLeft > 5 * 60 * 1000) {

--- a/packages/amplication-server/src/core/git/git.provider.service.ts
+++ b/packages/amplication-server/src/core/git/git.provider.service.ts
@@ -432,16 +432,15 @@ export class GitProviderService {
       return gitProviderArgs;
     }
 
-    const notificationUnixTimestamp = providerProperties["expiresAt"] - 300; // 5 minutes before token expires
-    const currentUnixTimestamp = Math.floor(Date.now() / 1000);
+    const timeInMsLeft = providerProperties["expiresAt"] - Date.now();
 
     this.logger.info("Time left before token expires:", {
-      value: `${
-        (providerProperties["expiresAt"] - currentUnixTimestamp) / 60
-      } minutes`,
+      value: `${timeInMsLeft / 60000} minutes`,
+      exporisAt: providerProperties["expiresAt"],
+      now: Date.now(),
     });
 
-    if (currentUnixTimestamp < notificationUnixTimestamp) {
+    if (timeInMsLeft > 5 * 60 * 1000) {
       this.logger.info("Token is still valid");
       return gitProviderArgs;
     }

--- a/packages/amplication-server/src/core/git/git.provider.service.ts
+++ b/packages/amplication-server/src/core/git/git.provider.service.ts
@@ -435,6 +435,12 @@ export class GitProviderService {
     const notificationUnixTimestamp = providerProperties["expiresAt"] - 300; // 5 minutes before token expires
     const currentUnixTimestamp = Math.floor(Date.now() / 1000);
 
+    this.logger.info("Time left before token expires:", {
+      value: `${
+        (providerProperties["expiresAt"] - currentUnixTimestamp) / 60
+      } minutes`,
+    });
+
     if (currentUnixTimestamp < notificationUnixTimestamp) {
       this.logger.info("Token is still valid");
       return gitProviderArgs;

--- a/packages/amplication-server/src/core/git/git.provider.service.ts
+++ b/packages/amplication-server/src/core/git/git.provider.service.ts
@@ -432,8 +432,10 @@ export class GitProviderService {
       return gitProviderArgs;
     }
 
-    const timeInMsLeft = providerProperties["expiresAt"] - Date.now();
-    if (timeInMsLeft > 5 * 60 * 1000) {
+    const notificationUnixTimestamp = providerProperties["expiresAt"] - 300; // 5 minutes before token expires
+    const currentUnixTimestamp = Math.floor(Date.now() / 1000);
+
+    if (currentUnixTimestamp < notificationUnixTimestamp) {
       this.logger.info("Token is still valid");
       return gitProviderArgs;
     }

--- a/packages/amplication-server/src/core/git/git.provider.service.ts
+++ b/packages/amplication-server/src/core/git/git.provider.service.ts
@@ -450,6 +450,7 @@ export class GitProviderService {
     };
 
     const gitClientService = await this.createGitClient(newGitProviderArgs);
+    this.logger.info("Token is going to be expired, refreshing...");
     const newOAuthData = await gitClientService.refreshAccessToken(
       providerProperties["refreshToken"]
     );


### PR DESCRIPTION
Part of: #5261 

## PR Details
fix the refresh token calculation

## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
