### PR TITLE
fix(client): remove index limitation

### DIFF
--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -135,7 +135,6 @@ export class ResourceService {
 
     let index = 1;
     while (
-      index < 10 &&
       existingResources.find((resource) => {
         return resource.name.toLowerCase() === args.data.name.toLowerCase();
       })


### PR DESCRIPTION
Close: #4008 

## PR Details

The fix is so simple, **index** limitation was removed `index < 10` which will allow the user to create unlimited message-brokers.

see the image, showing the message brokers that were created with index greater than **9**

![Screenshot 2023-03-23 at 14 52 56](https://user-images.githubusercontent.com/74118584/227213126-c79132a5-7b8b-4517-a913-b062b9b77cc9.png)


## PR Checklist

- [yes] Tests for the changes have been added
- [yes] `npm test` doesn't throw any error
