### PR TITLE
fix(server): change git organizatin provider properties migration

### DIFF
--- a/packages/amplication-server/migration-scripts/git-organization-provider-properties.ts
+++ b/packages/amplication-server/migration-scripts/git-organization-provider-properties.ts
@@ -2,7 +2,9 @@ import { PrismaClient } from "../src/prisma";
 
 async function main() {
   const prisma = new PrismaClient();
-  const gitOrganizations = await prisma.gitOrganization.findMany();
+  const gitOrganizations = await prisma.gitOrganization.findMany({
+    where: { providerProperties: {} },
+  });
 
   for (const gitOrg of gitOrganizations) {
     const updatedProviderProps = { installationId: gitOrg.installationId };


### PR DESCRIPTION
Close: #5561 

## PR Details
added a filter to the migration script to find and update only git organization that their provider properties field is `{}` , meaning no data

I ran it on my local data base that contains data in this field and it didn't change the data the data (the last row is the most important)
![image](https://user-images.githubusercontent.com/39680385/227311813-2227b664-9a63-4ef0-96e2-819d40b3f5f6.png)


## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
