### PR TITLE
chore(code-gen-types): update DSG context to use ILogger interface instead of winston logger

### DIFF
--- a/packages/amplication-code-gen-types/package.json
+++ b/packages/amplication-code-gen-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/code-gen-types",
-  "version": "1.1.25",
+  "version": "1.2.0",
   "description": "This library supplies all the contracts for Amplication Code Generation. The purpose is to make the contracts available for inclusion in plugins.",
   "main": "src/index.js",
   "author": {

--- a/packages/amplication-code-gen-types/src/plugins-types.ts
+++ b/packages/amplication-code-gen-types/src/plugins-types.ts
@@ -1,14 +1,24 @@
 import type { Promisable } from "type-fest";
-import winston from "winston";
 import {
   clientDirectories,
   DTOs,
-  EntityField,
   Module,
   serverDirectories,
 } from "./code-gen-types";
 import { DSGResourceData } from "./dsg-resource-data";
 import { Events } from "./plugin-events";
+
+interface ILogger {
+  debug: (message: string, params?: Record<string, unknown>) => void;
+  info: (message: string, params?: Record<string, unknown>) => void;
+  warn: (message: string, params?: Record<string, unknown>) => void;
+  error: (
+    message: string,
+    params?: Record<string, unknown>,
+    err?: Error
+  ) => void;
+  child: (metadata?: Record<string, unknown>) => ILogger;
+}
 
 export interface EventParams {}
 
@@ -45,7 +55,7 @@ export interface DsgContext extends DSGResourceData {
   modules: Module[];
   DTOs: DTOs;
   plugins: PluginMap;
-  logger: winston.Logger;
+  logger: ILogger;
   utils: ContextUtil;
   clientDirectories: clientDirectories;
   serverDirectories: serverDirectories;


### PR DESCRIPTION
Relates: #5499 

## PR Details

Migrate `code-gen-types` library to use amplication logger interface

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
