### PR TITLE
chore(e2e): fix issue due to cypress missing in CI cache

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,6 +36,7 @@ env:
   NX_FORCE_ALL: ${{ fromJSON('["", "--all"]')[ inputs.nx-force-all ] }} # This relies on type coercion, an implicit cast from boolean true to 1 or false to 0, which is then used as array index.
   NX_SKIP_NX_CACHE: ${{ inputs.nx-skip-cache || false }}
   BASE: ${{ github.base_ref || inputs.nx-base || github.event.repository.default_branch }}
+  CYPRESS_CACHE_FOLDER: node_modules/.cache/Cypress
 
 jobs:
   nx:

--- a/.github/workflows/nx.template.yml
+++ b/.github/workflows/nx.template.yml
@@ -43,7 +43,8 @@ env:
   BRANCH: ${{ github.event.workflow_run.head_branch }}
   NX_FORCE_ALL: ${{ fromJSON('["", "--all"]')[ inputs.nx-force-all ] }}  # This relies on type coercion, an implicit cast from boolean true to 1 or false to 0, which is then used as array index.
   NX_SKIP_NX_CACHE: ${{ inputs.nx-skip-cache || false }}
-
+  CYPRESS_CACHE_FOLDER: node_modules/.cache/Cypress
+  
 jobs:
   nx:
     name: Nx Affected

--- a/.github/workflows/release.template.yml
+++ b/.github/workflows/release.template.yml
@@ -37,6 +37,7 @@ on:
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.nx-cloud-access-token }}
   BRANCH: ${{ inputs.branch }}
+  CYPRESS_CACHE_FOLDER: node_modules/.cache/Cypress
 
 jobs:
   package:


### PR DESCRIPTION
Close: #5568 

## PR Details

Fix the issue reported, due to CI cache being generated without including cypress dependencies.
The solution is to fix the cypress bin into the cached node_modules folder https://docs.cypress.io/guides/references/advanced-installation#Binary-cache

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
