### PR TITLE
feature(client): Add edit icon and bright overlay on the banner

### DIFF
--- a/packages/amplication-client/src/Resource/ResourceHome.scss
+++ b/packages/amplication-client/src/Resource/ResourceHome.scss
@@ -2,6 +2,10 @@
 
 @import "../style/index.scss";
 
+:root {
+  --white-overlay-background: #ffffff99;
+}
+
 $info-panel-height: 180px;
 $application-badge-size-large: 100px;
 $app-icon-large-font-size: 70px;
@@ -36,7 +40,7 @@ $circle-badge-border: 2px;
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: #ffffff99;
+    background-color: var(--white-overlay-background);
   }
   .circle-badge-container {
     z-index: 10;

--- a/packages/amplication-client/src/Resource/ResourceHome.scss
+++ b/packages/amplication-client/src/Resource/ResourceHome.scss
@@ -28,6 +28,19 @@ $circle-badge-border: 2px;
     align-items: center;
     justify-content: center;
   }
+  &__header:hover::before {
+    z-index: 1;
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ffffff99;
+  }
+  .circle-badge-container {
+    z-index: 10;
+  }
 
   .circle-badge {
     width: $application-badge-size-large;

--- a/packages/amplication-client/src/Resource/ResourceHome.tsx
+++ b/packages/amplication-client/src/Resource/ResourceHome.tsx
@@ -54,13 +54,15 @@ const ResourceHome = ({ match, innerRoutes }: Props) => {
               currentResource={currentResource}
               resourceId={resourceId}
             />
-            <CircleBadge
-              name={currentResource?.name || ""}
-              color={
-                resourceThemeMap[currentResource?.resourceType].color ||
-                "transparent"
-              }
-            />
+            <div className="circle-badge-container">
+              <CircleBadge
+                name={currentResource?.name || ""}
+                color={
+                  resourceThemeMap[currentResource?.resourceType].color ||
+                  "transparent"
+                }
+              />
+            </div>
           </div>
           <div className={`${CLASS_NAME}__tiles`}>
             {currentResource?.resourceType === EnumResourceType.Service && (

--- a/packages/amplication-client/src/Resource/ResourceNameField.scss
+++ b/packages/amplication-client/src/Resource/ResourceNameField.scss
@@ -1,4 +1,7 @@
 .resource-namefield {
+  &__input__container {
+    z-index: 10;
+  }
   &__form {
     display: flex;
     flex-direction: column;
@@ -12,9 +15,7 @@
     font-size: inherit;
     font-family: inherit;
   }
-  &__text:hover {
-    cursor: pointer;
-  }
+
   &__saved {
     color: var(--positive-default);
   }
@@ -26,6 +27,18 @@
     border: 1px solid var(--negative);
     background-color: var(--white);
     color: var(--black100);
+  }
+  &__edit {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+  &__edit_icon {
+    cursor: pointer;
+    position: relative;
+    top: 2px;
+    left: 5px;
   }
 }
 

--- a/packages/amplication-client/src/Resource/ResourceNameField.tsx
+++ b/packages/amplication-client/src/Resource/ResourceNameField.tsx
@@ -36,6 +36,7 @@ const FORM_SCHEMA = {
 const ResourceNameField = ({ currentResource, resourceId }: Props) => {
   const [isEditing, setIsEditing] = useState(false);
   const [showTick, setShowTick] = useState(false);
+  const [hovered, setHovered] = useState(false);
 
   const { trackEvent } = useTracking();
   const [updateResource] = useMutation<TData>(UPDATE_RESOURCE, {
@@ -50,6 +51,7 @@ const ResourceNameField = ({ currentResource, resourceId }: Props) => {
     if (isValid) {
       setIsEditing(false);
       setShowTick(false);
+      setHovered(false);
     }
   };
 
@@ -75,6 +77,13 @@ const ResourceNameField = ({ currentResource, resourceId }: Props) => {
     [updateResource, resourceId, trackEvent]
   );
 
+  const handleMouseEnter = () => {
+    setHovered(true);
+  };
+
+  const handleMouseLeave = () => {
+    setHovered(false);
+  };
   return (
     <div className={`${CLASS_NAME}__input__container`}>
       <Formik
@@ -120,12 +129,21 @@ const ResourceNameField = ({ currentResource, resourceId }: Props) => {
                   )}
                 </Form>
               ) : (
-                <span
-                  className={`${CLASS_NAME}__text`}
-                  onClick={() => setIsEditing(true)}
+                <div
+                  className={`${CLASS_NAME}__edit`}
+                  onMouseEnter={handleMouseEnter}
+                  onMouseLeave={handleMouseLeave}
                 >
-                  {currentResource?.name}
-                </span>
+                  <span className={`${CLASS_NAME}__text`}>
+                    {currentResource?.name}
+                  </span>
+                  <div
+                    onClick={() => setIsEditing(true)}
+                    className={`${CLASS_NAME}__edit_icon`}
+                  >
+                    {hovered && <Icon icon="edit_2" size="medium" />}
+                  </div>
+                </div>
               )}
             </div>
           );


### PR DESCRIPTION
Close: #4457 

## PR Details

- Added Edit icon when hovered on the Resource name
- Added a bright overlay on the banner on hover

https://user-images.githubusercontent.com/74011196/227755309-abcbe4e2-bf8b-43fc-9b5e-f1a0d4b2adf2.mov


<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
