### PR TITLE
hotfix(client): update cache of entity field list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amplication",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "amplication",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "hasInstallScript": true,
       "dependencies": {
         "@amplication/react-compound-timer": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplication",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "scripts": {
     "postinstall": "nx run-many --target=install",
     "format:check": "npx nx format:check --all",

--- a/packages/amplication-client/src/Entity/EntityFieldLinkList.tsx
+++ b/packages/amplication-client/src/Entity/EntityFieldLinkList.tsx
@@ -26,7 +26,6 @@ type Props = {
 export const EntityFieldLinkList = React.memo(({ entityId }: Props) => {
   const { currentWorkspace, currentProject } = useContext(AppContext);
   const { data, error } = useQuery<TData>(GET_FIELDS, {
-    fetchPolicy: "no-cache",
     variables: {
       id: entityId,
       orderBy: {


### PR DESCRIPTION
Close: #5512 

## PR Details

This pull request returns the cache logic to the entity field link list.
This is a hotfix to the problem that has been happened by the pr #5400 issue #5512 that affects the UI.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
