### PR TITLE
chore(e2e): update ci nx template to checkout default branch and repo

### DIFF
--- a/.github/workflows/nx.template.yml
+++ b/.github/workflows/nx.template.yml
@@ -57,7 +57,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.nx-head }}
           fetch-depth: 0
 
       - uses: nrwl/nx-set-shas@v3


### PR DESCRIPTION

Close: #5574 

## PR Details

Update nx CI template to rely on default configuration when checking out repo.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
