### PR TITLE
feat(code-gen-types): improve dsg context logger type

### DIFF
--- a/packages/amplication-code-gen-types/package.json
+++ b/packages/amplication-code-gen-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/code-gen-types",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "This library supplies all the contracts for Amplication Code Generation. The purpose is to make the contracts available for inclusion in plugins.",
   "main": "src/index.js",
   "author": {

--- a/packages/amplication-code-gen-types/package.json
+++ b/packages/amplication-code-gen-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/code-gen-types",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "This library supplies all the contracts for Amplication Code Generation. The purpose is to make the contracts available for inclusion in plugins.",
   "main": "src/index.js",
   "author": {

--- a/packages/amplication-code-gen-types/src/plugins-types.ts
+++ b/packages/amplication-code-gen-types/src/plugins-types.ts
@@ -51,10 +51,17 @@ export interface ContextUtil {
   abort: boolean;
   importStaticModules: (source: string, basePath: string) => Promise<Module[]>;
 }
+
 export interface DsgContext extends DSGResourceData {
+  /*
+   * List of generated files.
+   */
   modules: Module[];
   DTOs: DTOs;
   plugins: PluginMap;
+  /*
+   * Logger for user facing logs. Logs will be visible in the build log.
+   */
   logger: ILogger;
   utils: ContextUtil;
   clientDirectories: clientDirectories;

--- a/packages/amplication-code-gen-types/src/plugins-types.ts
+++ b/packages/amplication-code-gen-types/src/plugins-types.ts
@@ -8,16 +8,45 @@ import {
 import { DSGResourceData } from "./dsg-resource-data";
 import { Events } from "./plugin-events";
 
-interface ILogger {
-  debug: (message: string, params?: Record<string, unknown>) => void;
-  info: (message: string, params?: Record<string, unknown>) => void;
-  warn: (message: string, params?: Record<string, unknown>) => void;
+export interface BuildLogger {
+  /**
+   *
+   * @param message  Log message
+   * @param params Additional application internal log params. Not diplayed in the build log.
+   * @param userFriendlyMessage  User facing log message. It will be displayed in the build log. Default: @param message
+   * @returns
+   */
+  info: (
+    message: string,
+    params?: Record<string, unknown>,
+    userFriendlyMessage?: string
+  ) => Promise<void>;
+  /**
+   *
+   * @param message  Log message
+   * @param params Additional application internal log params. Not diplayed in the build log.
+   * @param userFriendlyMessage  User facing log message. It will be displayed in the build log. Default: @param message
+   * @returns
+   */
+  warn: (
+    message: string,
+    params?: Record<string, unknown>,
+    userFriendlyMessage?: string
+  ) => Promise<void>;
+  /**
+   *
+   * @param message  Log message
+   * @param params Additional application internal log params. Not diplayed in the build log.
+   * @param userFriendlyMessage  User facing log message. It will be displayed in the build log. Default: @param message
+   * @param error Error
+   * @returns
+   */
   error: (
     message: string,
     params?: Record<string, unknown>,
-    err?: Error
-  ) => void;
-  child: (metadata?: Record<string, unknown>) => ILogger;
+    userFriendlyMessage?: string,
+    error?: Error
+  ) => Promise<void>;
 }
 
 export interface EventParams {}
@@ -62,7 +91,7 @@ export interface DsgContext extends DSGResourceData {
   /*
    * Logger for user facing logs. Logs will be visible in the build log.
    */
-  logger: ILogger;
+  logger: BuildLogger;
   utils: ContextUtil;
   clientDirectories: clientDirectories;
   serverDirectories: serverDirectories;


### PR DESCRIPTION
Close: #5560 

## PR Details

In order to simplify the logging experience of plugins and include more details to the DSG build log, the PR improve the logger type exposed in the context and its documentation.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
