### PR TITLE
feat(server/dsg): add log informarion to DSG run

### DIFF
--- a/packages/amplication-code-gen-types/package.json
+++ b/packages/amplication-code-gen-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/code-gen-types",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "This library supplies all the contracts for Amplication Code Generation. The purpose is to make the contracts available for inclusion in plugins.",
   "main": "src/index.js",
   "author": {

--- a/packages/amplication-code-gen-types/src/dsg-resource-data.ts
+++ b/packages/amplication-code-gen-types/src/dsg-resource-data.ts
@@ -11,7 +11,7 @@ import { EnumResourceType } from "./models";
 export class DSGResourceData {
   resourceType!: keyof typeof EnumResourceType;
   resourceInfo?: AppInfo;
-
+  buildId: string;
   entities?: Entity[];
   roles?: Role[];
 

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -605,6 +605,7 @@ export class BuildService {
       serviceTopics: await this.serviceTopicsService.findMany({
         where: { resource: { id: resourceId } },
       }),
+      buildId: buildId,
       resourceInfo: {
         name: resource.name,
         description: resource.description,

--- a/packages/data-service-generator/src/create-data-service.ts
+++ b/packages/data-service-generator/src/create-data-service.ts
@@ -22,7 +22,10 @@ export async function createDataService(
     const startTime = Date.now();
     await prepareContext(dSGResourceData, logger, pluginInstallationPath);
 
-    await context.logger.info("Creating application...");
+    await context.logger.info("Creating application...", {
+      resourceId: dSGResourceData.resourceInfo.id,
+      buildId: dSGResourceData.buildId,
+    });
 
     const { appInfo } = context;
     const { settings } = appInfo;

--- a/packages/data-service-generator/src/dsg-context.ts
+++ b/packages/data-service-generator/src/dsg-context.ts
@@ -18,6 +18,7 @@ import { BuildLogger } from "./build-logger";
 class DsgContext implements types.DsgContext {
   public appInfo!: types.AppInfo;
   public entities: types.Entity[] = [];
+  public buildId: string;
   public roles: types.Role[] = [];
   public modules: types.Module[] = [];
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/data-service-generator/src/generate-code.ts
+++ b/packages/data-service-generator/src/generate-code.ts
@@ -37,6 +37,12 @@ export const generateCodeByResourceData = async (
   destination: string
 ): Promise<void> => {
   const { pluginInstallations } = resourceData;
+  const dsgLogger = logger.child({
+    metadata: {
+      resourceId: resourceData.resourceInfo?.id,
+      buildId: resourceData.buildId,
+    },
+  });
 
   const allPlugins = prepareDefaultPlugins(pluginInstallations);
 
@@ -44,7 +50,7 @@ export const generateCodeByResourceData = async (
 
   const modules = await createDataService(
     { ...resourceData, pluginInstallations: allPlugins },
-    logger,
+    dsgLogger,
     join(__dirname, "..", AMPLICATION_MODULES)
   );
 

--- a/packages/data-service-generator/src/tests/create-data-service-custom-path.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-custom-path.spec.ts
@@ -35,6 +35,7 @@ describe("createDataService", () => {
     const modules = await createDataService(
       {
         entities,
+        buildId: "example_build_id",
         roles,
         resourceInfo: newAppInfo,
         resourceType: EnumResourceType.Service,

--- a/packages/data-service-generator/src/tests/create-data-service-numeric-user-id.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-numeric-user-id.spec.ts
@@ -34,6 +34,7 @@ describe("createDataService", () => {
     const modules = await createDataService(
       {
         entities,
+        buildId: "example_build_id",
         roles,
         resourceInfo: appInfo,
         resourceType: EnumResourceType.Service,

--- a/packages/data-service-generator/src/tests/create-data-service-with-kafka.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-with-kafka.spec.ts
@@ -27,6 +27,7 @@ describe("createDataService", () => {
       roles: [],
       serviceTopics: [],
       topics: [gitPullTopic],
+      buildId: "example_build_id",
       resourceInfo: {
         id: "messageBrokerId",
         description: "This is the message broker description",
@@ -42,6 +43,7 @@ describe("createDataService", () => {
       entities,
       roles,
       resourceInfo: appInfo,
+      buildId: "example_build_id",
       resourceType: EnumResourceType.Service,
       serviceTopics: [
         {

--- a/packages/data-service-generator/src/tests/create-data-service-without-graphql.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-without-graphql.spec.ts
@@ -31,6 +31,7 @@ describe("createDataService", () => {
     const modules = await createDataService(
       {
         entities,
+        buildId: "example_build_id",
         roles,
         resourceInfo: newAppInfo,
         resourceType: EnumResourceType.Service,

--- a/packages/data-service-generator/src/tests/create-data-service-without-restApi.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-without-restApi.spec.ts
@@ -31,6 +31,7 @@ describe("createDataService", () => {
     const modules = await createDataService(
       {
         entities,
+        buildId: "example_build_id",
         roles,
         resourceInfo: newAppInfo,
         resourceType: EnumResourceType.Service,

--- a/packages/data-service-generator/src/tests/create-data-service.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service.spec.ts
@@ -19,6 +19,7 @@ describe("createDataService", () => {
       {
         entities,
         roles,
+        buildId: "example_build_id",
         resourceInfo: appInfo,
         resourceType: EnumResourceType.Service,
         pluginInstallations: installedPlugins,

--- a/packages/data-service-generator/tests/e2e/postgres-basicAuth/data-service-generator.e2e.spec.ts
+++ b/packages/data-service-generator/tests/e2e/postgres-basicAuth/data-service-generator.e2e.spec.ts
@@ -83,6 +83,7 @@ describe("Data Service Generator", () => {
         entities,
         roles,
         resourceInfo,
+        buildId: "example_build_id",
         resourceType: EnumResourceType.Service,
         pluginInstallations: postgresAndBasicAuthPlugins,
       };


### PR DESCRIPTION
Close: #5625 

## PR Details

Add log information in the entry of the DSG run. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

Test case:

Run local amplication=>  run the following services: server/client/build-manager/local-data-service-generator-controller. 
generate and build an app => 
 look at the console log and see the new parameters added: resourceId and buildId:


<img width="790" alt="image" src="https://user-images.githubusercontent.com/97830649/228825847-e30de6e8-9725-4f5b-9b46-21e66d0095a1.png">


