### PR TITLE
feat: add recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,6 +13,8 @@
     "sleistner.vscode-fileutils",
     "eamodio.gitlens",
     "nrwl.angular-console",
-    "firsttris.vscode-jest-runner"
+    "firsttris.vscode-jest-runner",
+    "znck.grammarly",
+    "PKief.material-icon-theme"
   ]
 }


### PR DESCRIPTION
This pull request adds the `grammarly` extension and the `material-icon-theme` extension