### PR TITLE
fix(client): remove close button in onboarding process

### DIFF
--- a/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
@@ -294,6 +294,7 @@ const CreateServiceWizard: React.FC<Props> = ({
         submitLoader={loadingCreateService}
         handleCloseWizard={handleCloseWizard}
         handleWizardProgress={handleWizardProgress}
+        defineUser={defineUser}
       >
         <CreateServiceName
           moduleClass={moduleClass}

--- a/packages/amplication-client/src/Resource/create-resource/ServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/ServiceWizard.tsx
@@ -6,9 +6,11 @@ import { validate } from "../../util/formikValidateJsonSchema";
 import { WizardProgressBarInterface } from "./wizardResourceSchema";
 import WizardProgressBar from "./WizardProgressBar";
 import CreateServiceLoader from "./CreateServiceLoader";
+import { DefineUser } from "./CreateServiceWizard";
 
 interface ServiceWizardProps {
   children: ReactNode;
+  defineUser: DefineUser;
   wizardPattern: number[];
   wizardSchema: { [key: string]: any };
   wizardProgressBar: WizardProgressBarInterface[];
@@ -59,6 +61,7 @@ const ServiceWizard: React.FC<ServiceWizardProps> = ({
   submitLoader,
   handleCloseWizard,
   handleWizardProgress,
+  defineUser,
 }) => {
   const [isValidStep, setIsValidStep] = useState<boolean>(false);
   const [activePageIndex, setActivePageIndex] = useState(wizardPattern[0] || 0);
@@ -128,17 +131,19 @@ const ServiceWizard: React.FC<ServiceWizardProps> = ({
 
   return (
     <div className={`${moduleCss}__wizard_container`}>
-      <Button
-        buttonStyle={EnumButtonStyle.Clear}
-        className={`${moduleCss}__close`}
-        onClick={() =>
-          handleCloseWizard(
-            (currentPage.type as React.JSXElementConstructor<any>).name
-          )
-        }
-      >
-        x close
-      </Button>
+      {defineUser === "Create Service" && (
+        <Button
+          buttonStyle={EnumButtonStyle.Clear}
+          className={`${moduleCss}__close`}
+          onClick={() =>
+            handleCloseWizard(
+              (currentPage.type as React.JSXElementConstructor<any>).name
+            )
+          }
+        >
+          x close
+        </Button>
+      )}
       <div className={`${moduleCss}__content`}>
         <Formik
           initialValues={wizardInitialValues}

--- a/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceCodeGeneration.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceCodeGeneration.tsx
@@ -113,7 +113,7 @@ const CreateServiceCodeGeneration: React.FC<
 
   return (
     <div className={className}>
-      {buildRunning || buildRunning === undefined ? (
+      {buildRunning ? (
         <div className={`${className}__buildLog`}>
           <div className={`${className}__title`}>
             <h1>We’re generating your service...</h1>


### PR DESCRIPTION
Close: #5670

## PR Details

Remove the close button in the onboarding process.
## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

Test case:

Assign with a new user => Make sure the close button doesn't appear in the onboarding process.
