### PR TITLE
fix(client): init repo values when override project settings

### DIFF
--- a/packages/amplication-client/src/Resource/git/ServiceWizardConfigurationGitSettings.tsx
+++ b/packages/amplication-client/src/Resource/git/ServiceWizardConfigurationGitSettings.tsx
@@ -56,6 +56,17 @@ const ServiceWizardConfigurationGitSettings: React.FC<Props> = ({
           },
           true
         );
+      } else {
+        formik.setValues(
+          {
+            ...formik.values,
+            gitRepositoryName: null,
+            gitOrganizationId: null,
+            gitRepositoryUrl: null,
+            isOverrideGitRepository: true,
+          },
+          true
+        );
       }
       trackEvent({
         eventName: AnalyticsEventNames.ResourceInfoUpdate,


### PR DESCRIPTION
Close: #5692

## PR Details

Init GitHub settings when clock on override option
## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
