### PR TITLE
refactor(server): move build manger to kafka producer and schema registry

### DIFF
--- a/libs/schema-registry/src/lib/code-generation-failure/value.ts
+++ b/libs/schema-registry/src/lib/code-generation-failure/value.ts
@@ -1,6 +1,8 @@
 import { IsString } from "class-validator";
+import { isError } from "lodash";
 
 export class Value {
   @IsString()
   buildId!: string;
+  error!: Error;
 }

--- a/packages/amplication-build-manager/src/build-logger/build-logger.controller.ts
+++ b/packages/amplication-build-manager/src/build-logger/build-logger.controller.ts
@@ -3,6 +3,7 @@ import { Body, Controller, Post } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Env } from "../env";
 import { CodeGenerationLogRequestDto } from "./dto/OnCodeGenerationLogRequest";
+import { CodeGenerationLog } from "@amplication/schema-registry";
 
 @Controller("build-logger")
 export class BuildLoggerController {
@@ -15,12 +16,13 @@ export class BuildLoggerController {
   async onCodeGenerationLog(
     @Body() logEntry: CodeGenerationLogRequestDto
   ): Promise<void> {
+    const logEvent: CodeGenerationLog.KafkaEvent = {
+      key: { buildId: logEntry.buildId },
+      value: logEntry,
+    };
     await this.producerService.emitMessage(
       this.configService.get(Env.DSG_LOG_TOPIC),
-      {
-        key: logEntry.buildId,
-        value: logEntry,
-      }
+      logEvent
     );
   }
 }

--- a/packages/amplication-build-manager/src/build-logger/build-logger.controller.ts
+++ b/packages/amplication-build-manager/src/build-logger/build-logger.controller.ts
@@ -2,7 +2,7 @@ import { KafkaProducerService } from "@amplication/util/nestjs/kafka";
 import { Body, Controller, Post } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Env } from "../env";
-import { OnCodeGenerationLogRequest } from "./dto/OnCodeGenerationLogRequest";
+import { CodeGenerationLogRequestDto } from "./dto/OnCodeGenerationLogRequest";
 
 @Controller("build-logger")
 export class BuildLoggerController {
@@ -13,7 +13,7 @@ export class BuildLoggerController {
 
   @Post("create-log")
   async onCodeGenerationLog(
-    @Body() logEntry: OnCodeGenerationLogRequest
+    @Body() logEntry: CodeGenerationLogRequestDto
   ): Promise<void> {
     await this.producerService.emitMessage(
       this.configService.get(Env.DSG_LOG_TOPIC),

--- a/packages/amplication-build-manager/src/build-logger/dto/OnCodeGenerationLogRequest.ts
+++ b/packages/amplication-build-manager/src/build-logger/dto/OnCodeGenerationLogRequest.ts
@@ -1,5 +1,5 @@
 import { LogEntry } from "@amplication/util/logging";
 
-export interface OnCodeGenerationLogRequest extends LogEntry {
+export interface CodeGenerationLogRequestDto extends LogEntry {
   buildId: string;
 }

--- a/packages/amplication-build-manager/src/build-runner/build-runner.controller.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.controller.ts
@@ -8,9 +8,9 @@ import axios from "axios";
 import { plainToInstance } from "class-transformer";
 import { Env } from "../env";
 import { BuildRunnerService } from "./build-runner.service";
-import { CodeGenerationFailure } from "./dto/CodeGenerationFailure";
-import { CodeGenerationRequest } from "./dto/CodeGenerationRequest";
-import { CodeGenerationSuccess } from "./dto/CodeGenerationSuccess";
+import { CodeGenerationFailure as CodeGenerationFailureDto } from "./dto/CodeGenerationFailure";
+import { CodeGenerationRequest as CodeGenerationRequestDto } from "./dto/CodeGenerationRequest";
+import { CodeGenerationSuccess as CodeGenerationSuccessDto } from "./dto/CodeGenerationSuccess";
 
 @Controller("build-runner")
 export class BuildRunnerController {
@@ -23,13 +23,14 @@ export class BuildRunnerController {
 
   @Post("code-generation-success")
   async onCodeGenerationSuccess(
-    @Payload() dto: CodeGenerationSuccess
+    @Payload() dto: CodeGenerationSuccessDto
   ): Promise<void> {
     try {
       await this.buildRunnerService.copyFromJobToArtifact(
         dto.resourceId,
         dto.buildId
       );
+
       await this.producerService.emitMessage(
         this.configService.get(Env.CODE_GENERATION_SUCCESS_TOPIC),
         {
@@ -51,7 +52,7 @@ export class BuildRunnerController {
 
   @Post("code-generation-failure")
   async onCodeGenerationFailure(
-    @Payload() dto: CodeGenerationFailure
+    @Payload() dto: CodeGenerationFailureDto
   ): Promise<void> {
     try {
       await this.producerService.emitMessage(
@@ -70,12 +71,12 @@ export class BuildRunnerController {
     EnvironmentVariables.instance.get(Env.CODE_GENERATION_REQUEST_TOPIC, true)
   )
   async onCodeGenerationRequest(
-    @Payload() message: CodeGenerationRequest
+    @Payload() message: CodeGenerationRequestDto
   ): Promise<void> {
     this.logger.info("Code generation request received");
-    let args: CodeGenerationRequest;
+    let args: CodeGenerationRequestDto;
     try {
-      args = plainToInstance(CodeGenerationRequest, message);
+      args = plainToInstance(CodeGenerationRequestDto, message);
       this.logger.debug("Code Generation Request", args);
       await this.buildRunnerService.saveDsgResourceData(
         args.buildId,

--- a/packages/amplication-build-manager/src/build-runner/dto/CodeGenerationFailure.ts
+++ b/packages/amplication-build-manager/src/build-runner/dto/CodeGenerationFailure.ts
@@ -1,4 +1,4 @@
-export class CodeGenerationFailure {
+export class CodeGenerationFailureDto {
   resourceId!: string;
   buildId!: string;
   error!: Error;

--- a/packages/amplication-build-manager/src/build-runner/dto/CodeGenerationRequest.ts
+++ b/packages/amplication-build-manager/src/build-runner/dto/CodeGenerationRequest.ts
@@ -1,6 +1,6 @@
 import { DSGResourceData } from "@amplication/code-gen-types";
 
-export class CodeGenerationRequest {
+export class CodeGenerationRequestDto {
   resourceId!: string;
   buildId!: string;
   dsgResourceData!: DSGResourceData;

--- a/packages/amplication-build-manager/src/build-runner/dto/CodeGenerationSuccess.ts
+++ b/packages/amplication-build-manager/src/build-runner/dto/CodeGenerationSuccess.ts
@@ -1,4 +1,4 @@
-export class CodeGenerationSuccess {
+export class CodeGenerationSuccessDto {
   resourceId!: string;
   buildId!: string;
 }


### PR DESCRIPTION
Close: #5694 

## PR Details

Move build manger to kafka producer and schema registry
⚠️  Based on #5696 

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
