### PR TITLE
feat(server):  persist repository group for a repository

### DIFF
--- a/libs/schema-registry/src/lib/create-pr-request/value.ts
+++ b/libs/schema-registry/src/lib/create-pr-request/value.ts
@@ -34,13 +34,13 @@ export class Value {
   gitOrganizationName!: string;
   @IsString()
   gitRepositoryName!: string;
+  @IsString()
+  @IsOptional()
+  gitRepositoryGroupName?: string;
   @ValidateNested()
   commit!: Commit;
   @ValidateNested()
   gitResourceMeta!: GitResourceMeta;
   @IsString()
   pullRequestMode!: EnumPullRequestMode;
-  @IsString()
-  @IsOptional()
-  gitGroupName?: string;
 }

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -1257,13 +1257,15 @@ export type MutationUpdateWorkspaceArgs = {
   where: WhereUniqueInput;
 };
 
+/** Returns a paginated list of repository groups available to select. */
 export type PaginatedGitGroup = {
   groups?: Maybe<Array<GitGroup>>;
-  next?: Maybe<Scalars['String']>;
+  /** Page number */
   page: Scalars['Float'];
-  pagelen: Scalars['Float'];
-  previous?: Maybe<Scalars['String']>;
-  size: Scalars['Float'];
+  /** Number of groups per page */
+  pageSize: Scalars['Float'];
+  /** Total number of groups */
+  total: Scalars['Float'];
 };
 
 export type PendingChange = {
@@ -1691,11 +1693,10 @@ export type RemoteGitRepos = {
   currentPage: Scalars['Float'];
   pageSize: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
-  totalRepos: Scalars['Float'];
+  total: Scalars['Float'];
 };
 
 export type RemoteGitRepositoriesWhereUniqueInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitProvider: EnumGitProvider;
   limit: Scalars['Float'];

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -277,27 +277,29 @@ export type CompleteInvitationInput = {
 
 export type ConnectGitRepositoryInput = {
   gitOrganizationId: Scalars['String'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
+  groupName?: InputMaybe<Scalars['String']>;
   isOverrideGitRepository?: InputMaybe<Scalars['Boolean']>;
   name: Scalars['String'];
   resourceId: Scalars['String'];
 };
 
 export type CreateGitRepositoryBaseInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
 export type CreateGitRepositoryInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
   resourceId: Scalars['String'];
 };
 
@@ -732,6 +734,7 @@ export type GitGetInstallationUrlInput = {
   gitProvider: EnumGitProvider;
 };
 
+/** Group of Repositories */
 export type GitGroup = {
   id: Scalars['String'];
   name: Scalars['String'];
@@ -755,6 +758,7 @@ export type GitOrganization = {
   provider: EnumGitProvider;
   type: EnumGitOrganizationType;
   updatedAt: Scalars['DateTime'];
+  /** Defines if a git organisation needs defined repository groups */
   useGroupingForRepositories: Scalars['Boolean'];
 };
 
@@ -1701,6 +1705,7 @@ export type RemoteGitRepositoriesWhereUniqueInput = {
   gitProvider: EnumGitProvider;
   limit: Scalars['Float'];
   page: Scalars['Float'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
 export type RemoteGitRepository = {

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -290,6 +290,7 @@ export type CreateGitRepositoryBaseInput = {
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
@@ -299,6 +300,7 @@ export type CreateGitRepositoryInput = {
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   repositoryGroupName?: InputMaybe<Scalars['String']>;
   resourceId: Scalars['String'];
 };

--- a/packages/amplication-client/src/Resource/git/dialogs/GitRepos/GithubRepos.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitRepos/GithubRepos.tsx
@@ -124,7 +124,7 @@ function GitRepos({
                 {Array.from(
                   {
                     length: Math.ceil(
-                      data?.remoteGitRepositories.totalRepos /
+                      data?.remoteGitRepositories.total /
                         data?.remoteGitRepositories.pageSize
                     ),
                   },
@@ -206,7 +206,7 @@ const FIND_GIT_REPOS = gql`
         fullName
         admin
       }
-      totalRepos
+      total
       currentPage
       pageSize
     }

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -1257,13 +1257,15 @@ export type MutationUpdateWorkspaceArgs = {
   where: WhereUniqueInput;
 };
 
+/** Returns a paginated list of repository groups available to select. */
 export type PaginatedGitGroup = {
   groups?: Maybe<Array<GitGroup>>;
-  next?: Maybe<Scalars['String']>;
+  /** Page number */
   page: Scalars['Float'];
-  pagelen: Scalars['Float'];
-  previous?: Maybe<Scalars['String']>;
-  size: Scalars['Float'];
+  /** Number of groups per page */
+  pageSize: Scalars['Float'];
+  /** Total number of groups */
+  total: Scalars['Float'];
 };
 
 export type PendingChange = {
@@ -1691,11 +1693,10 @@ export type RemoteGitRepos = {
   currentPage: Scalars['Float'];
   pageSize: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
-  totalRepos: Scalars['Float'];
+  total: Scalars['Float'];
 };
 
 export type RemoteGitRepositoriesWhereUniqueInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitProvider: EnumGitProvider;
   limit: Scalars['Float'];

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -277,27 +277,29 @@ export type CompleteInvitationInput = {
 
 export type ConnectGitRepositoryInput = {
   gitOrganizationId: Scalars['String'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
+  groupName?: InputMaybe<Scalars['String']>;
   isOverrideGitRepository?: InputMaybe<Scalars['Boolean']>;
   name: Scalars['String'];
   resourceId: Scalars['String'];
 };
 
 export type CreateGitRepositoryBaseInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
 export type CreateGitRepositoryInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
   resourceId: Scalars['String'];
 };
 
@@ -732,6 +734,7 @@ export type GitGetInstallationUrlInput = {
   gitProvider: EnumGitProvider;
 };
 
+/** Group of Repositories */
 export type GitGroup = {
   id: Scalars['String'];
   name: Scalars['String'];
@@ -755,6 +758,7 @@ export type GitOrganization = {
   provider: EnumGitProvider;
   type: EnumGitOrganizationType;
   updatedAt: Scalars['DateTime'];
+  /** Defines if a git organisation needs defined repository groups */
   useGroupingForRepositories: Scalars['Boolean'];
 };
 
@@ -1701,6 +1705,7 @@ export type RemoteGitRepositoriesWhereUniqueInput = {
   gitProvider: EnumGitProvider;
   limit: Scalars['Float'];
   page: Scalars['Float'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
 export type RemoteGitRepository = {

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -290,6 +290,7 @@ export type CreateGitRepositoryBaseInput = {
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
@@ -299,6 +300,7 @@ export type CreateGitRepositoryInput = {
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   repositoryGroupName?: InputMaybe<Scalars['String']>;
   resourceId: Scalars['String'];
 };

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -1257,13 +1257,15 @@ export type MutationUpdateWorkspaceArgs = {
   where: WhereUniqueInput;
 };
 
+/** Returns a paginated list of repository groups available to select. */
 export type PaginatedGitGroup = {
   groups?: Maybe<Array<GitGroup>>;
-  next?: Maybe<Scalars['String']>;
+  /** Page number */
   page: Scalars['Float'];
-  pagelen: Scalars['Float'];
-  previous?: Maybe<Scalars['String']>;
-  size: Scalars['Float'];
+  /** Number of groups per page */
+  pageSize: Scalars['Float'];
+  /** Total number of groups */
+  total: Scalars['Float'];
 };
 
 export type PendingChange = {
@@ -1691,7 +1693,7 @@ export type RemoteGitRepos = {
   currentPage: Scalars['Float'];
   pageSize: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
-  totalRepos: Scalars['Float'];
+  total: Scalars['Float'];
 };
 
 export type RemoteGitRepositoriesWhereUniqueInput = {

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -290,6 +290,7 @@ export type CreateGitRepositoryBaseInput = {
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
@@ -299,6 +300,7 @@ export type CreateGitRepositoryInput = {
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   repositoryGroupName?: InputMaybe<Scalars['String']>;
   resourceId: Scalars['String'];
 };

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -277,27 +277,29 @@ export type CompleteInvitationInput = {
 
 export type ConnectGitRepositoryInput = {
   gitOrganizationId: Scalars['String'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
+  groupName?: InputMaybe<Scalars['String']>;
   isOverrideGitRepository?: InputMaybe<Scalars['Boolean']>;
   name: Scalars['String'];
   resourceId: Scalars['String'];
 };
 
 export type CreateGitRepositoryBaseInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
 export type CreateGitRepositoryInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
   resourceId: Scalars['String'];
 };
 
@@ -732,6 +734,7 @@ export type GitGetInstallationUrlInput = {
   gitProvider: EnumGitProvider;
 };
 
+/** Group of Repositories */
 export type GitGroup = {
   id: Scalars['String'];
   name: Scalars['String'];
@@ -755,6 +758,7 @@ export type GitOrganization = {
   provider: EnumGitProvider;
   type: EnumGitOrganizationType;
   updatedAt: Scalars['DateTime'];
+  /** Defines if a git organisation needs defined repository groups */
   useGroupingForRepositories: Scalars['Boolean'];
 };
 
@@ -1697,11 +1701,11 @@ export type RemoteGitRepos = {
 };
 
 export type RemoteGitRepositoriesWhereUniqueInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitProvider: EnumGitProvider;
   limit: Scalars['Float'];
   page: Scalars['Float'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
 export type RemoteGitRepository = {

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -1257,13 +1257,15 @@ export type MutationUpdateWorkspaceArgs = {
   where: WhereUniqueInput;
 };
 
+/** Returns a paginated list of repository groups available to select. */
 export type PaginatedGitGroup = {
   groups?: Maybe<Array<GitGroup>>;
-  next?: Maybe<Scalars['String']>;
+  /** Page number */
   page: Scalars['Float'];
-  pagelen: Scalars['Float'];
-  previous?: Maybe<Scalars['String']>;
-  size: Scalars['Float'];
+  /** Number of groups per page */
+  pageSize: Scalars['Float'];
+  /** Total number of groups */
+  total: Scalars['Float'];
 };
 
 export type PendingChange = {
@@ -1691,7 +1693,7 @@ export type RemoteGitRepos = {
   currentPage: Scalars['Float'];
   pageSize: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
-  totalRepos: Scalars['Float'];
+  total: Scalars['Float'];
 };
 
 export type RemoteGitRepositoriesWhereUniqueInput = {

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -290,6 +290,7 @@ export type CreateGitRepositoryBaseInput = {
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
@@ -299,6 +300,7 @@ export type CreateGitRepositoryInput = {
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   repositoryGroupName?: InputMaybe<Scalars['String']>;
   resourceId: Scalars['String'];
 };

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -277,27 +277,29 @@ export type CompleteInvitationInput = {
 
 export type ConnectGitRepositoryInput = {
   gitOrganizationId: Scalars['String'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
+  groupName?: InputMaybe<Scalars['String']>;
   isOverrideGitRepository?: InputMaybe<Scalars['Boolean']>;
   name: Scalars['String'];
   resourceId: Scalars['String'];
 };
 
 export type CreateGitRepositoryBaseInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
 export type CreateGitRepositoryInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
   resourceId: Scalars['String'];
 };
 
@@ -732,6 +734,7 @@ export type GitGetInstallationUrlInput = {
   gitProvider: EnumGitProvider;
 };
 
+/** Group of Repositories */
 export type GitGroup = {
   id: Scalars['String'];
   name: Scalars['String'];
@@ -755,6 +758,7 @@ export type GitOrganization = {
   provider: EnumGitProvider;
   type: EnumGitOrganizationType;
   updatedAt: Scalars['DateTime'];
+  /** Defines if a git organisation needs defined repository groups */
   useGroupingForRepositories: Scalars['Boolean'];
 };
 
@@ -1697,11 +1701,11 @@ export type RemoteGitRepos = {
 };
 
 export type RemoteGitRepositoriesWhereUniqueInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitProvider: EnumGitProvider;
   limit: Scalars['Float'];
   page: Scalars['Float'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
 export type RemoteGitRepository = {

--- a/packages/amplication-git-pull-request-service/src/pull-request/pull-request.service.ts
+++ b/packages/amplication-git-pull-request-service/src/pull-request/pull-request.service.ts
@@ -67,7 +67,7 @@ export class PullRequestService {
     commit,
     gitResourceMeta,
     pullRequestMode,
-    gitGroupName,
+    gitRepositoryGroupName,
   }: CreatePrRequest.Value): Promise<string> {
     const { body, title } = commit;
     const head =
@@ -98,6 +98,7 @@ export class PullRequestService {
       owner,
       cloneDirPath,
       repositoryName: repo,
+      repositoryGroupName: gitRepositoryGroupName,
       branchName: head,
       commitMessage: commit.body,
       pullRequestTitle: title,
@@ -105,7 +106,6 @@ export class PullRequestService {
       pullRequestMode,
       gitResourceMeta,
       files: PullRequestService.removeFirstSlashFromPath(changedFiles),
-      gitGroupName,
     });
     this.logger.info("Opened a new pull request", { prUrl });
     return prUrl;

--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.spec.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.spec.ts
@@ -164,7 +164,7 @@ describe("bitbucket.service", () => {
           repositoryName: "myrepo",
         });
       } catch (e) {
-        expect(e.message).toBe("Missing gitGroupName");
+        expect(e.message).toBe("Missing repositoryGroupName");
       }
     });
 
@@ -261,7 +261,7 @@ describe("bitbucket.service", () => {
         owner: "maccheroni",
         branchName: "master",
         repositoryName: mockedGetFirstCommitResponse.repository.name,
-        gitGroupName:
+        repositoryGroupName:
           mockedGetFirstCommitResponse.repository.full_name.split("/")[0],
       });
 
@@ -282,14 +282,14 @@ describe("bitbucket.service", () => {
           token: "my-token",
         });
       } catch (e) {
-        expect(e.message).toBe("Missing gitGroupName");
+        expect(e.message).toBe("Missing repositoryGroupName");
       }
     });
     it("returns the clone url", async () => {
       const result = await service.getCloneUrl({
         owner: "maccheroni",
         repositoryName: "myrepo",
-        gitGroupName: "mygroup",
+        repositoryGroupName: "mygroup",
         token: "my-token",
       });
 
@@ -309,7 +309,7 @@ describe("bitbucket.service", () => {
           repositoryName: "myrepo",
         });
       } catch (e) {
-        expect(e.message).toBe("Missing gitGroupName");
+        expect(e.message).toBe("Missing repositoryGroupName");
       }
     });
 
@@ -422,7 +422,7 @@ describe("bitbucket.service", () => {
         owner: "maccheroni",
         branchName: "master",
         repositoryName: "my-repo",
-        gitGroupName: "my-group",
+        repositoryGroupName: "my-group",
       });
 
       const expectedResult = {
@@ -445,7 +445,7 @@ describe("bitbucket.service", () => {
           repositoryName: "myrepo",
         });
       } catch (e) {
-        expect(e.message).toBe("Missing gitGroupName");
+        expect(e.message).toBe("Missing repositoryGroupName");
       }
     });
 
@@ -559,7 +559,7 @@ describe("bitbucket.service", () => {
         repositoryName: "my-repo",
         branchName: "amit-test",
         pointingSha: "bbfe95276c624e76c50aa640e7dba4af31b84961",
-        gitGroupName: "my-group",
+        repositoryGroupName: "my-group",
       });
 
       const expectedResult = {
@@ -585,7 +585,7 @@ describe("bitbucket.service", () => {
           data: { body: "this is my comment for the pull request" },
         });
       } catch (e) {
-        expect(e.message).toBe("Missing gitGroupName");
+        expect(e.message).toBe("Missing repositoryGroupName");
       }
     });
 
@@ -652,7 +652,7 @@ describe("bitbucket.service", () => {
           issueNumber: 1,
           owner: "maccheroni",
           repositoryName: "my-repo",
-          gitGroupName: "my-group",
+          repositoryGroupName: "my-group",
         },
         data: { body: "this is my comment for the pull request" },
       });
@@ -678,7 +678,7 @@ describe("bitbucket.service", () => {
           repositoryName: "myrepo",
         });
       } catch (e) {
-        expect(e.message).toBe("Missing gitGroupName");
+        expect(e.message).toBe("Missing repositoryGroupName");
       }
     });
 
@@ -845,7 +845,8 @@ describe("bitbucket.service", () => {
         owner: "maccheroni",
         branchName: pullRequest.source.branch.name,
         repositoryName: pullRequest.source.repository.name,
-        gitGroupName: pullRequest.source.repository.full_name.split("/")[0],
+        repositoryGroupName:
+          pullRequest.source.repository.full_name.split("/")[0],
       });
 
       const expectedResult = {
@@ -871,7 +872,7 @@ describe("bitbucket.service", () => {
           pullRequestBody: "my pull request body",
         });
       } catch (e) {
-        expect(e.message).toBe("Missing gitGroupName");
+        expect(e.message).toBe("Missing repositoryGroupName");
       }
     });
 
@@ -1050,7 +1051,7 @@ describe("bitbucket.service", () => {
           mockedCreatePullRequestResponse.destination.branch.name,
         pullRequestTitle: mockedCreatePullRequestResponse.title,
         pullRequestBody: "description for my pull request",
-        gitGroupName: "ab-2",
+        repositoryGroupName: "ab-2",
       });
 
       const expectedResult = {

--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
@@ -177,15 +177,15 @@ export class BitBucketService implements GitProvider {
   async getRepository(
     getRepositoryArgs: GetRepositoryArgs
   ): Promise<RemoteGitRepository> {
-    const { gitGroupName, repositoryName } = getRepositoryArgs;
+    const { repositoryGroupName, repositoryName } = getRepositoryArgs;
 
-    if (!gitGroupName) {
-      this.logger.error("Missing gitGroupName");
-      throw new CustomError("Missing gitGroupName");
+    if (!repositoryGroupName) {
+      this.logger.error("Missing repositoryGroupName");
+      throw new CustomError("Missing repositoryGroupName");
     }
 
     const repository = await repositoryRequest(
-      gitGroupName,
+      repositoryGroupName,
       repositoryName,
       this.accessToken
     );
@@ -205,15 +205,15 @@ export class BitBucketService implements GitProvider {
   async getRepositories(
     getRepositoriesArgs: GetRepositoriesArgs
   ): Promise<RemoteGitRepos> {
-    const { gitGroupName } = getRepositoriesArgs;
+    const { repositoryGroupName } = getRepositoriesArgs;
 
-    if (!gitGroupName) {
-      this.logger.error("Missing gitGroupName");
-      throw new CustomError("Missing gitGroupName");
+    if (!repositoryGroupName) {
+      this.logger.error("Missing repositoryGroupName");
+      throw new CustomError("Missing repositoryGroupName");
     }
 
     const repositoriesInWorkspace = await repositoriesInWorkspaceRequest(
-      gitGroupName,
+      repositoryGroupName,
       this.accessToken
     );
 
@@ -243,19 +243,19 @@ export class BitBucketService implements GitProvider {
     createRepositoryArgs: CreateRepositoryArgs
   ): Promise<RemoteGitRepository> {
     const {
-      gitGroupName,
+      repositoryGroupName,
       repositoryName,
       isPrivateRepository,
       gitOrganization,
     } = createRepositoryArgs;
 
-    if (!gitGroupName) {
-      this.logger.error("Missing gitGroupName");
-      throw new CustomError("Missing gitGroupName");
+    if (!repositoryGroupName) {
+      this.logger.error("Missing repositoryGroupName");
+      throw new CustomError("Missing repositoryGroupName");
     }
 
     const newRepository = await repositoryCreateRequest(
-      gitGroupName,
+      repositoryGroupName,
       repositoryName,
       {
         is_private: isPrivateRepository,
@@ -334,13 +334,14 @@ export class BitBucketService implements GitProvider {
   async getPullRequest(
     getPullRequestArgs: GitProviderGetPullRequestArgs
   ): Promise<{ url: string; number: number }> {
-    const { gitGroupName, repositoryName, branchName } = getPullRequestArgs;
-    if (!gitGroupName) {
-      this.logger.error("Missing gitGroupName");
-      throw new CustomError("Missing gitGroupName");
+    const { repositoryGroupName, repositoryName, branchName } =
+      getPullRequestArgs;
+    if (!repositoryGroupName) {
+      this.logger.error("Missing repositoryGroupName");
+      throw new CustomError("Missing repositoryGroupName");
     }
     const pullRequest = await getPullRequestByBranchNameRequest(
-      gitGroupName,
+      repositoryGroupName,
       repositoryName,
       branchName,
       this.accessToken
@@ -357,16 +358,16 @@ export class BitBucketService implements GitProvider {
     createPullRequestArgs: GitProviderCreatePullRequestArgs
   ): Promise<PullRequest> {
     const {
-      gitGroupName,
+      repositoryGroupName,
       repositoryName,
       branchName,
       defaultBranchName,
       pullRequestTitle,
       pullRequestBody,
     } = createPullRequestArgs;
-    if (!gitGroupName) {
-      this.logger.error("Missing gitGroupName");
-      throw new CustomError("Missing gitGroupName");
+    if (!repositoryGroupName) {
+      this.logger.error("Missing repositoryGroupName");
+      throw new CustomError("Missing repositoryGroupName");
     }
 
     const pullRequestData = {
@@ -387,7 +388,7 @@ export class BitBucketService implements GitProvider {
     };
 
     const newPullRequest = await createPullRequestFromRequest(
-      gitGroupName,
+      repositoryGroupName,
       repositoryName,
       pullRequestData,
       this.accessToken
@@ -400,13 +401,13 @@ export class BitBucketService implements GitProvider {
   }
 
   async getBranch(args: GetBranchArgs): Promise<Branch | null> {
-    const { gitGroupName, repositoryName, branchName } = args;
-    if (!gitGroupName) {
-      this.logger.error("Missing gitGroupName");
-      throw new CustomError("Missing gitGroupName");
+    const { repositoryGroupName, repositoryName, branchName } = args;
+    if (!repositoryGroupName) {
+      this.logger.error("Missing repositoryGroupName");
+      throw new CustomError("Missing repositoryGroupName");
     }
     const branch = await getBranchRequest(
-      gitGroupName,
+      repositoryGroupName,
       repositoryName,
       branchName,
       this.accessToken
@@ -418,14 +419,15 @@ export class BitBucketService implements GitProvider {
   }
 
   async createBranch(args: CreateBranchArgs): Promise<Branch> {
-    const { gitGroupName, repositoryName, branchName, pointingSha } = args;
-    if (!gitGroupName) {
-      this.logger.error("Missing gitGroupName");
-      throw new CustomError("Missing gitGroupName");
+    const { repositoryGroupName, repositoryName, branchName, pointingSha } =
+      args;
+    if (!repositoryGroupName) {
+      this.logger.error("Missing repositoryGroupName");
+      throw new CustomError("Missing repositoryGroupName");
     }
 
     const branch = await createBranchRequest(
-      gitGroupName,
+      repositoryGroupName,
       repositoryName,
       { name: branchName, target: { hash: pointingSha } },
       this.accessToken
@@ -438,13 +440,13 @@ export class BitBucketService implements GitProvider {
   }
 
   async getFirstCommitOnBranch(args: GetBranchArgs): Promise<Commit> {
-    const { gitGroupName, repositoryName, branchName } = args;
-    if (!gitGroupName) {
-      this.logger.error("Missing gitGroupName");
-      throw new CustomError("Missing gitGroupName");
+    const { repositoryGroupName, repositoryName, branchName } = args;
+    if (!repositoryGroupName) {
+      this.logger.error("Missing repositoryGroupName");
+      throw new CustomError("Missing repositoryGroupName");
     }
     const firstCommit = await getFirstCommitRequest(
-      gitGroupName,
+      repositoryGroupName,
       repositoryName,
       branchName,
       this.accessToken
@@ -456,12 +458,12 @@ export class BitBucketService implements GitProvider {
   }
 
   getCloneUrl(args: CloneUrlArgs): string {
-    const { gitGroupName, repositoryName, token } = args;
-    if (!gitGroupName) {
-      this.logger.error("Missing gitGroupName");
-      throw new CustomError("Missing gitGroupName");
+    const { repositoryGroupName, repositoryName, token } = args;
+    if (!repositoryGroupName) {
+      this.logger.error("Missing repositoryGroupName");
+      throw new CustomError("Missing repositoryGroupName");
     }
-    return `https://x-token-auth:${token}@bitbucket.org/${gitGroupName}/${repositoryName}.git`;
+    return `https://x-token-auth:${token}@bitbucket.org/${repositoryGroupName}/${repositoryName}.git`;
   }
 
   async createPullRequestComment(
@@ -469,15 +471,19 @@ export class BitBucketService implements GitProvider {
   ): Promise<void> {
     const {
       data: { body },
-      where: { gitGroupName, repositoryName, issueNumber: pullRequestId },
+      where: {
+        repositoryGroupName,
+        repositoryName,
+        issueNumber: pullRequestId,
+      },
     } = args;
 
-    if (!gitGroupName) {
-      this.logger.error("Missing gitGroupName");
-      throw new CustomError("Missing gitGroupName");
+    if (!repositoryGroupName) {
+      this.logger.error("Missing repositoryGroupName");
+      throw new CustomError("Missing repositoryGroupName");
     }
     await createCommentOnPrRequest(
-      gitGroupName,
+      repositoryGroupName,
       repositoryName,
       pullRequestId,
       body,

--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
@@ -141,8 +141,14 @@ export class BitBucketService implements GitProvider {
       this.accessToken
     );
 
-    const { size, page, pagelen, next, previous, values } =
-      paginatedWorkspaceMembership;
+    const {
+      size: total,
+      page,
+      pagelen: pageSize,
+      next,
+      previous,
+      values,
+    } = paginatedWorkspaceMembership;
     const gitGroups = values.map(({ workspace }) => {
       const { uuid: workspaceUuid, name, slug } = workspace;
       return {
@@ -155,9 +161,9 @@ export class BitBucketService implements GitProvider {
     this.logger.info("BitBucketService getGitGroups");
 
     return {
-      size,
+      total,
       page,
-      pagelen,
+      pageSize,
       next,
       previous,
       groups: gitGroups,
@@ -227,7 +233,7 @@ export class BitBucketService implements GitProvider {
 
     return {
       repos: gitRepos,
-      totalRepos: size,
+      total: size,
       currentPage: page,
       pageSize: pagelen,
     };

--- a/packages/amplication-git-utils/src/providers/git.service.ts
+++ b/packages/amplication-git-utils/src/providers/git.service.ts
@@ -105,6 +105,7 @@ export class GitClientService {
     const {
       owner,
       repositoryName,
+      repositoryGroupName,
       branchName,
       commitMessage,
       pullRequestTitle,
@@ -112,7 +113,6 @@ export class GitClientService {
       pullRequestMode,
       gitResourceMeta,
       files,
-      gitGroupName,
     } = createPullRequestArgs;
     const amplicationIgnoreManger = await this.manageAmplicationIgnoreFile(
       owner,
@@ -157,7 +157,7 @@ export class GitClientService {
         owner,
         repositoryName,
         token: cloneToken,
-        gitGroupName,
+        repositoryGroupName,
       });
 
       await gitCli.clone(cloneUrl);
@@ -204,8 +204,8 @@ export class GitClientService {
       const existingPullRequest = await this.provider.getPullRequest({
         owner,
         repositoryName,
+        repositoryGroupName,
         branchName,
-        gitGroupName,
       });
 
       let pullRequest = existingPullRequest;
@@ -226,7 +226,7 @@ export class GitClientService {
           issueNumber: pullRequest.number,
           owner,
           repositoryName,
-          gitGroupName,
+          repositoryGroupName,
         },
         data: { body: pullRequestBody },
       });
@@ -343,7 +343,8 @@ export class GitClientService {
   private async restoreAmplicationBranchIfNotExists(
     args: CreateBranchIfNotExistsArgs
   ): Promise<Branch> {
-    const { branchName, owner, repositoryName, gitCli, gitGroupName } = args;
+    const { branchName, owner, repositoryName, gitCli, repositoryGroupName } =
+      args;
     const branch = await this.provider.getBranch(args);
     if (branch) {
       return branch;
@@ -354,7 +355,7 @@ export class GitClientService {
         owner,
         repositoryName,
         branchName: defaultBranch,
-        gitGroupName,
+        repositoryGroupName,
       });
     const newBranch = await this.provider.createBranch({
       owner,

--- a/packages/amplication-git-utils/src/providers/github/github.service.ts
+++ b/packages/amplication-git-utils/src/providers/github/github.service.ts
@@ -184,7 +184,7 @@ export class GithubService implements GitProvider {
     }));
 
     return {
-      totalRepos: results.data.total_count,
+      total: results.data.total_count,
       repos: repos,
       pageSize: limit,
       currentPage: page,

--- a/packages/amplication-git-utils/src/types.ts
+++ b/packages/amplication-git-utils/src/types.ts
@@ -98,7 +98,7 @@ export interface GitResourceMeta {
 export interface GetRepositoryArgs {
   owner: string;
   repositoryName: string;
-  gitGroupName?: string;
+  repositoryGroupName?: string;
 }
 
 export interface CreateRepositoryArgs {
@@ -106,13 +106,13 @@ export interface CreateRepositoryArgs {
   owner: string;
   repositoryName: string;
   isPrivateRepository: boolean;
-  gitGroupName?: string;
+  repositoryGroupName?: string;
 }
 
 export interface GetRepositoriesArgs {
   limit: number;
   page: number;
-  gitGroupName?: string;
+  repositoryGroupName?: string;
 }
 
 export interface GetFileArgs {
@@ -125,6 +125,7 @@ export interface GetFileArgs {
 export interface CreatePullRequestArgs {
   owner: string;
   repositoryName: string;
+  repositoryGroupName?: string;
   branchName: string;
   commitMessage: string;
   pullRequestTitle: string;
@@ -132,7 +133,6 @@ export interface CreatePullRequestArgs {
   pullRequestMode: EnumPullRequestMode;
   gitResourceMeta: GitResourceMeta;
   files: File[];
-  gitGroupName?: string;
   cloneDirPath: string;
 }
 
@@ -149,8 +149,8 @@ export interface CreatePullRequestFromFilesArgs {
 export interface GitProviderGetPullRequestArgs {
   owner: string;
   repositoryName: string;
+  repositoryGroupName?: string;
   branchName: string;
-  gitGroupName?: string;
 }
 
 export interface GitProviderCreatePullRequestArgs {
@@ -160,7 +160,7 @@ export interface GitProviderCreatePullRequestArgs {
   defaultBranchName: string;
   pullRequestTitle: string;
   pullRequestBody: string;
-  gitGroupName?: string;
+  repositoryGroupName?: string;
 }
 
 export interface LinksMetadata {
@@ -210,7 +210,7 @@ export interface GetBranchArgs {
   owner: string;
   repositoryName: string;
   branchName: string;
-  gitGroupName?: string;
+  repositoryGroupName?: string;
 }
 
 export interface CreateBranchIfNotExistsArgs {
@@ -218,7 +218,7 @@ export interface CreateBranchIfNotExistsArgs {
   repositoryName: string;
   branchName: string;
   gitCli: GitCli;
-  gitGroupName?: string;
+  repositoryGroupName?: string;
 }
 
 export interface CreateBranchArgs {
@@ -226,7 +226,7 @@ export interface CreateBranchArgs {
   repositoryName: string;
   branchName: string;
   pointingSha: string;
-  gitGroupName?: string;
+  repositoryGroupName?: string;
 }
 
 export interface Commit {
@@ -242,8 +242,8 @@ export interface Bot {
 export interface CloneUrlArgs {
   owner: string;
   repositoryName: string;
+  repositoryGroupName?: string;
   token: string;
-  gitGroupName?: string;
 }
 
 export interface PreCommitProcessArgs {
@@ -264,8 +264,8 @@ export interface PostCommitProcessArgs {
 export interface FindOneIssueInput {
   owner: string;
   repositoryName: string;
+  repositoryGroupName?: string;
   issueNumber: number;
-  gitGroupName?: string;
 }
 
 interface CreatePullRequestCommentInput {

--- a/packages/amplication-git-utils/src/types.ts
+++ b/packages/amplication-git-utils/src/types.ts
@@ -64,7 +64,7 @@ export interface RemoteGitRepository {
 
 export interface RemoteGitRepos {
   repos: RemoteGitRepository[];
-  totalRepos: number | null;
+  total: number | null;
   currentPage: number | null;
   pageSize: number | null;
 }
@@ -192,9 +192,9 @@ export interface OAuth2FlowArgs {
 }
 
 export interface PaginatedGitGroup {
-  size: number;
+  total: number;
   page: number;
-  pagelen: number;
+  pageSize: number;
   next: string;
   previous: string;
   groups: GitGroup[];

--- a/packages/amplication-git-utils/tests/providers/git.constants.ts
+++ b/packages/amplication-git-utils/tests/providers/git.constants.ts
@@ -20,6 +20,7 @@ export const GIT_HUB_FILE: GitFile = {
 export const TEST_GIT_REMOTE_ORGANIZATION: RemoteGitOrganization = {
   name: "testGitRemoteOrganization",
   type: EnumGitOrganizationType.Organization,
+  useGroupingForRepositories: false,
 };
 
 export const TEST_GIT_REPOS: RemoteGitRepos = {
@@ -41,7 +42,7 @@ export const TEST_GIT_REPOS: RemoteGitRepos = {
       defaultBranch: "main",
     },
   ],
-  totalRepos: 2,
+  total: 2,
   pageSize: 2,
   currentPage: 1,
 };

--- a/packages/amplication-prisma-db/prisma/migrations/20230405132558_add_group_name_to_repository/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20230405132558_add_group_name_to_repository/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "GitRepository" ADD COLUMN     "groupName" TEXT;

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -75,6 +75,7 @@ model GitOrganization {
 model GitRepository {
   id                String          @id @default(cuid())
   name              String
+  groupName         String?
   createdAt         DateTime        @default(now())
   updatedAt         DateTime        @updatedAt
   gitOrganizationId String

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -488,7 +488,7 @@ export class BuildService {
             gitRepositoryName: resourceRepository.name,
             gitRepositoryGroupName: resourceRepository.groupName,
             resourceId: resource.id,
-            gitProvider: EnumGitProvider.Github,
+            gitProvider: EnumGitProvider[gitOrganization.provider],
             installationId: gitOrganization.installationId,
             newBuildId: build.id,
             oldBuildId: oldBuild?.id,

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -486,6 +486,7 @@ export class BuildService {
           const createPullRequestMessage: CreatePrRequest.Value = {
             gitOrganizationName: gitOrganization.name,
             gitRepositoryName: resourceRepository.name,
+            gitRepositoryGroupName: resourceRepository.groupName,
             resourceId: resource.id,
             gitProvider: EnumGitProvider.Github,
             installationId: gitOrganization.installationId,

--- a/packages/amplication-server/src/core/git/dto/enums/EnumGitProvider.ts
+++ b/packages/amplication-server/src/core/git/dto/enums/EnumGitProvider.ts
@@ -1,10 +1,8 @@
 import { registerEnumType } from "@nestjs/graphql";
-
-export enum EnumGitProvider {
-  Github = "Github",
-  Bitbucket = "Bitbucket",
-}
+import { EnumGitProvider } from "@amplication/git-utils";
 
 registerEnumType(EnumGitProvider, {
   name: "EnumGitProvider",
 });
+
+export { EnumGitProvider };

--- a/packages/amplication-server/src/core/git/dto/inputs/ConnectGitRepositoryInput.ts
+++ b/packages/amplication-server/src/core/git/dto/inputs/ConnectGitRepositoryInput.ts
@@ -8,6 +8,13 @@ export class ConnectGitRepositoryInput {
   @Field(() => String, { nullable: false })
   name!: string;
 
+  @Field(() => String, {
+    nullable: true,
+    description:
+      "Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true",
+  })
+  groupName?: string;
+
   @Field(() => String, { nullable: false })
   resourceId!: string;
 

--- a/packages/amplication-server/src/core/git/dto/inputs/CreateGitRepositoryBaseInput.ts
+++ b/packages/amplication-server/src/core/git/dto/inputs/CreateGitRepositoryBaseInput.ts
@@ -10,6 +10,13 @@ export class CreateGitRepositoryBaseInput {
     nullable: false,
   })
   name!: string;
+  @Field(() => String, {
+    nullable: true,
+    description:
+      "Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true",
+  })
+  repositoryGroupName?: string;
+
   @Field(() => Boolean, {
     nullable: false,
   })
@@ -29,7 +36,4 @@ export class CreateGitRepositoryBaseInput {
     nullable: false,
   })
   gitOrganizationType!: EnumGitOrganizationType;
-
-  @Field(() => String, { nullable: true })
-  gitGroupName?: string;
 }

--- a/packages/amplication-server/src/core/git/dto/inputs/CreateGitRepositoryBaseInput.ts
+++ b/packages/amplication-server/src/core/git/dto/inputs/CreateGitRepositoryBaseInput.ts
@@ -20,11 +20,6 @@ export class CreateGitRepositoryBaseInput {
   })
   gitOrganizationId!: string;
 
-  @Field(() => String, {
-    nullable: true,
-  })
-  gitGroupName?: string;
-
   @Field(() => EnumGitProvider, {
     nullable: false,
   })
@@ -34,4 +29,7 @@ export class CreateGitRepositoryBaseInput {
     nullable: false,
   })
   gitOrganizationType!: EnumGitOrganizationType;
+
+  @Field(() => String, { nullable: true })
+  gitGroupName?: string;
 }

--- a/packages/amplication-server/src/core/git/dto/inputs/CreateGitRepositoryInput.ts
+++ b/packages/amplication-server/src/core/git/dto/inputs/CreateGitRepositoryInput.ts
@@ -1,40 +1,12 @@
 import { Field, InputType } from "@nestjs/graphql";
-import { EnumGitOrganizationType } from "../enums/EnumGitOrganizationType";
-import { EnumGitProvider } from "../enums/EnumGitProvider";
+import { CreateGitRepositoryBaseInput } from "./CreateGitRepositoryBaseInput";
 
 @InputType({
   isAbstract: true,
 })
-export class CreateGitRepositoryInput {
-  @Field(() => String, {
-    nullable: false,
-  })
-  name!: string;
-  @Field(() => Boolean, {
-    nullable: false,
-  })
-  public!: boolean;
-
+export class CreateGitRepositoryInput extends CreateGitRepositoryBaseInput {
   @Field(() => String, {
     nullable: false,
   })
   resourceId!: string;
-
-  @Field(() => String, {
-    nullable: false,
-  })
-  gitOrganizationId!: string;
-
-  @Field(() => EnumGitProvider, {
-    nullable: false,
-  })
-  gitProvider!: EnumGitProvider;
-
-  @Field(() => EnumGitOrganizationType, {
-    nullable: false,
-  })
-  gitOrganizationType!: EnumGitOrganizationType;
-
-  @Field(() => String, { nullable: true })
-  gitGroupName?: string;
 }

--- a/packages/amplication-server/src/core/git/dto/inputs/RemoteGitRepositoriesWhereUniqueInput.ts
+++ b/packages/amplication-server/src/core/git/dto/inputs/RemoteGitRepositoriesWhereUniqueInput.ts
@@ -16,5 +16,5 @@ export class RemoteGitRepositoriesWhereUniqueInput {
   page!: number;
 
   @Field(() => String, { nullable: true })
-  gitGroupName?: string;
+  repositoryGroupName?: string;
 }

--- a/packages/amplication-server/src/core/git/dto/objects/PaginatedGitGroup.ts
+++ b/packages/amplication-server/src/core/git/dto/objects/PaginatedGitGroup.ts
@@ -2,6 +2,7 @@ import { Field, ObjectType } from "@nestjs/graphql";
 
 @ObjectType({
   isAbstract: true,
+  description: "Group of Repositories",
 })
 class GitGroup {
   @Field(() => String, { nullable: false })
@@ -16,22 +17,24 @@ class GitGroup {
 
 @ObjectType({
   isAbstract: true,
+  description:
+    "Returns a paginated list of repository groups available to select.",
 })
 export class PaginatedGitGroup {
-  @Field(() => Number, { nullable: false })
-  size: number;
+  @Field(() => Number, {
+    nullable: false,
+    description: "Total number of groups",
+  })
+  total: number;
 
-  @Field(() => Number, { nullable: false })
+  @Field(() => Number, { nullable: false, description: "Page number" })
   page: number;
 
-  @Field(() => Number, { nullable: false })
-  pagelen: number;
-
-  @Field(() => String, { nullable: true })
-  next: string;
-
-  @Field(() => String, { nullable: true })
-  previous: string;
+  @Field(() => Number, {
+    nullable: false,
+    description: "Number of groups per page",
+  })
+  pageSize: number;
 
   @Field(() => [GitGroup], { nullable: true })
   groups: GitGroup[];

--- a/packages/amplication-server/src/core/git/dto/objects/RemoteGitRepository.ts
+++ b/packages/amplication-server/src/core/git/dto/objects/RemoteGitRepository.ts
@@ -31,7 +31,7 @@ export class RemoteGitRepos {
   repos: RemoteGitRepository[];
 
   @Field(() => Number)
-  totalRepos: number | null;
+  total: number | null;
 
   @Field(() => Number)
   currentPage: number | null;

--- a/packages/amplication-server/src/core/git/git.provider.service.ts
+++ b/packages/amplication-server/src/core/git/git.provider.service.ts
@@ -150,7 +150,7 @@ export class GitProviderService {
         type: EnumGitOrganizationType[organization.type],
         useGroupingForRepositories: organization.useGroupingForRepositories,
       },
-      gitGroupName: args.gitGroupName,
+      repositoryGroupName: args.repositoryGroupName,
       owner: organization.name,
       isPrivateRepository: args.public,
     };

--- a/packages/amplication-server/src/core/git/git.provider.service.ts
+++ b/packages/amplication-server/src/core/git/git.provider.service.ts
@@ -32,6 +32,7 @@ import { CreateGitRepositoryBaseInput } from "./dto/inputs/CreateGitRepositoryBa
 import { GitGroupArgs } from "./dto/args/GitGroupArgs";
 import { PaginatedGitGroup } from "./dto/objects/PaginatedGitGroup";
 import { EnumGitProvider } from "./dto/enums/EnumGitProvider";
+import { ValidationError } from "../../errors/ValidationError";
 
 const GIT_REPOSITORY_EXIST =
   "Git Repository already connected to an other Resource";
@@ -116,7 +117,7 @@ export class GitProviderService {
     const repositoriesArgs = {
       limit: args.limit,
       page: args.page,
-      gitGroupName: args.gitGroupName,
+      repositoryGroupName: args.repositoryGroupName,
     };
 
     const gitProviderArgs = await this.updateProviderOrganizationProperties(
@@ -142,6 +143,12 @@ export class GitProviderService {
         id: args.gitOrganizationId,
       },
     });
+
+    if (organization.useGroupingForRepositories && !args.repositoryGroupName) {
+      throw new ValidationError(
+        `${organization.provider} requires a group to create a new repository. repositoryGroupName is missing`
+      );
+    }
 
     const repository = {
       repositoryName: args.name,
@@ -179,6 +186,7 @@ export class GitProviderService {
 
     return await this.connectResourceGitRepository({
       name: remoteRepository.name,
+      groupName: args.repositoryGroupName,
       gitOrganizationId: args.gitOrganizationId,
       resourceId: args.resourceId,
     });
@@ -199,7 +207,7 @@ export class GitProviderService {
         type: EnumGitOrganizationType[organization.type],
         useGroupingForRepositories: organization.useGroupingForRepositories,
       },
-      gitGroupName: args.gitGroupName,
+      repositoryGroupName: args.repositoryGroupName,
       owner: organization.name,
       isPrivateRepository: args.public,
     };
@@ -339,6 +347,7 @@ export class GitProviderService {
     resourceId,
     name,
     gitOrganizationId,
+    groupName,
   }: ConnectGitRepositoryInput): Promise<Resource> {
     const gitRepository = await this.prisma.gitRepository.findFirst({
       where: { resources: { some: { id: resourceId } } },
@@ -363,16 +372,13 @@ export class GitProviderService {
     await this.prisma.gitRepository.create({
       data: {
         name: name,
+        groupName: groupName,
         resources: { connect: resourcesToConnect },
         gitOrganization: { connect: { id: gitOrganizationId } },
       },
     });
 
-    return await this.prisma.resource.findUnique({
-      where: {
-        id: resourceId,
-      },
-    });
+    return resource;
   }
 
   // installation id flow (GitHub ONLY!)

--- a/packages/amplication-server/src/core/resource/resource.service.spec.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.spec.ts
@@ -109,6 +109,7 @@ const EXAMPLE_GIT_REPOSITORY: GitRepository = {
   createdAt: new Date(),
   updatedAt: new Date(),
   gitOrganization: EXAMPLE_GIT_ORGANISATION,
+  groupName: "",
 };
 
 const SAMPLE_SERVICE_DATA: ResourceCreateInput = {

--- a/packages/amplication-server/src/models/GitOrganization.ts
+++ b/packages/amplication-server/src/models/GitOrganization.ts
@@ -28,7 +28,11 @@ export class GitOrganization {
   @Field(() => EnumGitOrganizationType, { nullable: false })
   type!: keyof typeof EnumGitOrganizationType;
 
-  @Field(() => Boolean, { nullable: false })
+  @Field(() => Boolean, {
+    nullable: false,
+    description:
+      "Defines if a git organisation needs defined repository groups",
+  })
   useGroupingForRepositories!: boolean;
 
   // don't use field decorator to avoid exposing properties to the client

--- a/packages/amplication-server/src/models/GitRepository.ts
+++ b/packages/amplication-server/src/models/GitRepository.ts
@@ -16,6 +16,9 @@ export class GitRepository {
   @Field(() => String, { nullable: false })
   name!: string;
 
+  @Field(() => String, { nullable: true })
+  groupName?: string;
+
   @Field(() => Date, { nullable: true })
   createdAt?: Date;
 

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -1487,21 +1487,29 @@ input CompleteInvitationInput {
 
 input CreateGitRepositoryInput {
   name: String!
+
+  """
+  Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true
+  """
+  repositoryGroupName: String
   public: Boolean!
   gitOrganizationId: String!
   gitProvider: EnumGitProvider!
   gitOrganizationType: EnumGitOrganizationType!
-  repositoryGroupName: String
   resourceId: String!
 }
 
 input CreateGitRepositoryBaseInput {
   name: String!
+
+  """
+  Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true
+  """
+  repositoryGroupName: String
   public: Boolean!
   gitOrganizationId: String!
   gitProvider: EnumGitProvider!
   gitOrganizationType: EnumGitOrganizationType!
-  repositoryGroupName: String
 }
 
 input GitOrganizationCreateInput {

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -144,6 +144,8 @@ type GitOrganization {
   createdAt: DateTime!
   updatedAt: DateTime!
   type: EnumGitOrganizationType!
+
+  """Defines if a git organisation needs defined repository groups"""
   useGroupingForRepositories: Boolean!
 }
 
@@ -1068,7 +1070,7 @@ input RemoteGitRepositoriesWhereUniqueInput {
   gitProvider: EnumGitProvider!
   limit: Float!
   page: Float!
-  gitGroupName: String
+  repositoryGroupName: String
 }
 
 input GitOrganizationWhereInput {
@@ -1227,6 +1229,11 @@ input ServerSettingsUpdateInput {
 
 input ConnectGitRepositoryInput {
   name: String!
+
+  """
+  Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true
+  """
+  groupName: String
   resourceId: String!
   gitOrganizationId: String!
   isOverrideGitRepository: Boolean
@@ -1481,20 +1488,20 @@ input CompleteInvitationInput {
 input CreateGitRepositoryInput {
   name: String!
   public: Boolean!
-  resourceId: String!
   gitOrganizationId: String!
   gitProvider: EnumGitProvider!
   gitOrganizationType: EnumGitOrganizationType!
-  gitGroupName: String
+  repositoryGroupName: String
+  resourceId: String!
 }
 
 input CreateGitRepositoryBaseInput {
   name: String!
   public: Boolean!
   gitOrganizationId: String!
-  gitGroupName: String
   gitProvider: EnumGitProvider!
   gitOrganizationType: EnumGitOrganizationType!
+  repositoryGroupName: String
 }
 
 input GitOrganizationCreateInput {

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -1023,15 +1023,20 @@ type ApiToken {
   lastAccessAt: DateTime!
 }
 
+"""Returns a paginated list of repository groups available to select."""
 type PaginatedGitGroup {
-  size: Float!
+  """Total number of groups"""
+  total: Float!
+
+  """Page number"""
   page: Float!
-  pagelen: Float!
-  next: String
-  previous: String
+
+  """Number of groups per page"""
+  pageSize: Float!
   groups: [GitGroup!]
 }
 
+"""Group of Repositories"""
 type GitGroup {
   id: String!
   name: String!
@@ -1044,7 +1049,7 @@ input GitGroupInput {
 
 type RemoteGitRepos {
   repos: [RemoteGitRepository!]!
-  totalRepos: Float!
+  total: Float!
   currentPage: Float!
   pageSize: Float!
 }

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -1257,13 +1257,15 @@ export type MutationUpdateWorkspaceArgs = {
   where: WhereUniqueInput;
 };
 
+/** Returns a paginated list of repository groups available to select. */
 export type PaginatedGitGroup = {
   groups?: Maybe<Array<GitGroup>>;
-  next?: Maybe<Scalars['String']>;
+  /** Page number */
   page: Scalars['Float'];
-  pagelen: Scalars['Float'];
-  previous?: Maybe<Scalars['String']>;
-  size: Scalars['Float'];
+  /** Number of groups per page */
+  pageSize: Scalars['Float'];
+  /** Total number of groups */
+  total: Scalars['Float'];
 };
 
 export type PendingChange = {
@@ -1691,7 +1693,7 @@ export type RemoteGitRepos = {
   currentPage: Scalars['Float'];
   pageSize: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
-  totalRepos: Scalars['Float'];
+  total: Scalars['Float'];
 };
 
 export type RemoteGitRepositoriesWhereUniqueInput = {

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -290,6 +290,7 @@ export type CreateGitRepositoryBaseInput = {
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
@@ -299,6 +300,7 @@ export type CreateGitRepositoryInput = {
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   repositoryGroupName?: InputMaybe<Scalars['String']>;
   resourceId: Scalars['String'];
 };

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -277,27 +277,29 @@ export type CompleteInvitationInput = {
 
 export type ConnectGitRepositoryInput = {
   gitOrganizationId: Scalars['String'];
+  /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
+  groupName?: InputMaybe<Scalars['String']>;
   isOverrideGitRepository?: InputMaybe<Scalars['Boolean']>;
   name: Scalars['String'];
   resourceId: Scalars['String'];
 };
 
 export type CreateGitRepositoryBaseInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
 export type CreateGitRepositoryInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   name: Scalars['String'];
   public: Scalars['Boolean'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
   resourceId: Scalars['String'];
 };
 
@@ -732,6 +734,7 @@ export type GitGetInstallationUrlInput = {
   gitProvider: EnumGitProvider;
 };
 
+/** Group of Repositories */
 export type GitGroup = {
   id: Scalars['String'];
   name: Scalars['String'];
@@ -755,6 +758,7 @@ export type GitOrganization = {
   provider: EnumGitProvider;
   type: EnumGitOrganizationType;
   updatedAt: Scalars['DateTime'];
+  /** Defines if a git organisation needs defined repository groups */
   useGroupingForRepositories: Scalars['Boolean'];
 };
 
@@ -1697,11 +1701,11 @@ export type RemoteGitRepos = {
 };
 
 export type RemoteGitRepositoriesWhereUniqueInput = {
-  gitGroupName?: InputMaybe<Scalars['String']>;
   gitOrganizationId: Scalars['String'];
   gitProvider: EnumGitProvider;
   limit: Scalars['Float'];
   page: Scalars['Float'];
+  repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 
 export type RemoteGitRepository = {


### PR DESCRIPTION
Close: #5699 

## PR Details

This PR standardise the naming for repository group and add support to persist the group name into the repository record to allow the creation of PRs.

⚠️  Based on #5697. To be merged after that PR

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
