### PR TITLE
fix(git-utils): getfile logic and parameters 

### DIFF
--- a/libs/schema-registry/src/lib/create-pr-request/value.ts
+++ b/libs/schema-registry/src/lib/create-pr-request/value.ts
@@ -7,12 +7,6 @@ import { IsOptional, IsString, ValidateNested } from "class-validator";
 
 class Commit {
   @IsString()
-  @IsOptional()
-  base?: string | undefined;
-  @IsOptional()
-  @IsString()
-  head?: string | undefined;
-  @IsString()
   title!: string;
   @IsString()
   body!: string;

--- a/packages/amplication-git-pull-request-service/src/pull-request/pull-request.service.ts
+++ b/packages/amplication-git-pull-request-service/src/pull-request/pull-request.service.ts
@@ -71,7 +71,7 @@ export class PullRequestService {
   }: CreatePrRequest.Value): Promise<string> {
     const { body, title } = commit;
     const head =
-      commit.head || pullRequestMode === EnumPullRequestMode.Accumulative
+      pullRequestMode === EnumPullRequestMode.Accumulative
         ? "amplication"
         : `amplication-build-${newBuildId}`;
     const changedFiles = await this.diffService.listOfChangedFiles(
@@ -100,7 +100,7 @@ export class PullRequestService {
       repositoryName: repo,
       repositoryGroupName: gitRepositoryGroupName,
       branchName: head,
-      commitMessage: commit.body,
+      commitMessage: body,
       pullRequestTitle: title,
       pullRequestBody: body,
       pullRequestMode,

--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.spec.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.spec.ts
@@ -137,7 +137,7 @@ describe("bitbucket.service", () => {
         path: "tests/__init__.py",
         owner: "mr-bucket",
         repositoryName: "my-repo",
-        baseBranchName: "main",
+        ref: "main",
       });
 
       const expectedResult = {

--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.spec.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.spec.ts
@@ -54,7 +54,9 @@ describe("bitbucket.service", () => {
           repositoryName: "myrepo",
         });
       } catch (e) {
-        expect(e.message).toBe("Missing baseBranchName");
+        expect(e.message).toBe(
+          "Missing repositoryGroupName. repositoryGroupName is mandatory for BitBucket provider"
+        );
       }
     });
 
@@ -86,7 +88,8 @@ describe("bitbucket.service", () => {
           path: "tests/",
           owner: "mr-bucket",
           repositoryName: "my-repo",
-          baseBranchName: "main",
+          repositoryGroupName: "my-group",
+          ref: "main",
         });
       } catch (e) {
         expect(e.message).toBe(
@@ -137,6 +140,7 @@ describe("bitbucket.service", () => {
         path: "tests/__init__.py",
         owner: "mr-bucket",
         repositoryName: "my-repo",
+        repositoryGroupName: "my-group",
         ref: "main",
       });
 

--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
@@ -33,14 +33,12 @@ import {
   authorizeRequest,
   createBranchRequest,
   createCommentOnPrRequest,
-  createCommitRequest,
   currentUserRequest,
   currentUserWorkspacesRequest,
   getBranchRequest,
   getFileMetaRequest,
   getFileRequest,
   getFirstCommitRequest,
-  getLastCommitRequest,
   refreshTokenRequest,
   repositoriesInWorkspaceRequest,
   repositoryCreateRequest,
@@ -55,7 +53,6 @@ export class BitBucketService implements GitProvider {
   private clientId: string;
   private clientSecret: string;
   private accessToken: string;
-  private refreshToken: string;
   public readonly name = EnumGitProvider.Bitbucket;
   public readonly domain = "bitbucket.com";
 
@@ -67,8 +64,7 @@ export class BitBucketService implements GitProvider {
 
   async init(): Promise<void> {
     this.logger.info("BitbucketService init");
-    const { accessToken, refreshToken } =
-      this.gitProviderArgs.providerOrganizationProperties;
+    const { accessToken } = this.gitProviderArgs.providerOrganizationProperties;
     const { clientId, clientSecret } = this.providerConfiguration;
 
     if (!clientId || !clientSecret) {
@@ -79,7 +75,6 @@ export class BitBucketService implements GitProvider {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.accessToken = accessToken;
-    this.refreshToken = refreshToken;
   }
 
   getGitInstallationUrl(amplicationWorkspaceId: string): Promise<string> {

--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
@@ -274,28 +274,40 @@ export class BitBucketService implements GitProvider {
     throw NotImplementedError;
   }
 
-  // pull request flow
-
   async getFile(file: GetFileArgs): Promise<GitFile | null> {
-    const { owner, repositoryName, ref, path } = file;
+    let gitReference: string;
+    const { owner, repositoryName, repositoryGroupName, ref, path } = file;
 
-    if (!baseBranchName) {
-      this.logger.error("Missing baseBranchName");
-      throw new CustomError("Missing baseBranchName");
+    if (!repositoryGroupName) {
+      throw new CustomError(
+        "Missing repositoryGroupName. repositoryGroupName is mandatory for BitBucket provider"
+      );
+    }
+
+    if (!ref) {
+      // Default to
+      const repo = await this.getRepository({
+        owner,
+        repositoryName,
+        repositoryGroupName,
+      });
+      gitReference = repo.defaultBranch;
+    } else {
+      gitReference = ref;
     }
 
     const fileResponse = await getFileMetaRequest(
-      owner,
+      repositoryGroupName,
       repositoryName,
-      ref,
+      gitReference,
       path,
       this.accessToken
     );
 
     const fileBufferResponse = await getFileRequest(
-      owner,
+      repositoryGroupName,
       repositoryName,
-      ref,
+      gitReference,
       path,
       this.accessToken
     );

--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
@@ -277,7 +277,7 @@ export class BitBucketService implements GitProvider {
   // pull request flow
 
   async getFile(file: GetFileArgs): Promise<GitFile | null> {
-    const { owner, repositoryName, baseBranchName, path } = file;
+    const { owner, repositoryName, ref, path } = file;
 
     if (!baseBranchName) {
       this.logger.error("Missing baseBranchName");
@@ -287,7 +287,7 @@ export class BitBucketService implements GitProvider {
     const fileResponse = await getFileMetaRequest(
       owner,
       repositoryName,
-      baseBranchName,
+      ref,
       path,
       this.accessToken
     );
@@ -295,7 +295,7 @@ export class BitBucketService implements GitProvider {
     const fileBufferResponse = await getFileRequest(
       owner,
       repositoryName,
-      baseBranchName,
+      ref,
       path,
       this.accessToken
     );

--- a/packages/amplication-git-utils/src/providers/bitbucket/requests.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/requests.ts
@@ -253,38 +253,6 @@ export async function getFileRequest(
   return response.buffer();
 }
 
-export function createCommitRequest(
-  workspaceSlug: string,
-  repositorySlug: string,
-  commitData: unknown,
-  accessToken: string
-) {
-  return requestWrapper(CREATE_COMMIT_URL(workspaceSlug, repositorySlug), {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: JSON.stringify(commitData),
-  });
-}
-
-export async function getLastCommitRequest(
-  workspaceSlug: string,
-  repositorySlug: string,
-  branchName: string,
-  accessToken: string
-): Promise<Commit> {
-  const [branchCommits] = await requestWrapper(
-    GET_BRANCH_COMMITS_URL(workspaceSlug, repositorySlug, branchName),
-    {
-      method: "GET",
-      headers: getRequestHeaders(accessToken),
-    }
-  );
-  return branchCommits.values;
-}
-
 export async function getFirstCommitRequest(
   workspaceSlug: string,
   repositorySlug: string,

--- a/packages/amplication-git-utils/src/providers/git.service.ts
+++ b/packages/amplication-git-utils/src/providers/git.service.ts
@@ -114,10 +114,13 @@ export class GitClientService {
       gitResourceMeta,
       files,
     } = createPullRequestArgs;
+
     const amplicationIgnoreManger = await this.manageAmplicationIgnoreFile(
       owner,
-      repositoryName
+      repositoryName,
+      repositoryGroupName
     );
+
     const preparedFiles = await prepareFilesForPullRequest(
       gitResourceMeta,
       files,
@@ -395,14 +398,21 @@ export class GitClientService {
     await gitCli.push();
   }
 
-  private async manageAmplicationIgnoreFile(owner, repositoryName) {
+  private async manageAmplicationIgnoreFile(
+    owner: string,
+    repositoryName: string,
+    repositoryGroupName?: string,
+    gitRef?: string
+  ) {
     const amplicationIgnoreManger = new AmplicationIgnoreManger();
     await amplicationIgnoreManger.init(async (fileName) => {
       try {
         const file = await this.provider.getFile({
           owner,
           repositoryName,
+          repositoryGroupName,
           path: fileName,
+          ref: gitRef,
         });
         if (!file) {
           return "";
@@ -411,7 +421,10 @@ export class GitClientService {
         this.logger.info(`Got ${name} file ${htmlUrl}`);
         return content;
       } catch (error) {
-        this.logger.info("Repository does not have a .amplicationignore file");
+        this.logger.warn(
+          "Repository does not have a .amplicationignore file",
+          error
+        );
         return "";
       }
     });

--- a/packages/amplication-git-utils/src/providers/github/github.service.ts
+++ b/packages/amplication-git-utils/src/providers/github/github.service.ts
@@ -313,13 +313,13 @@ export class GithubService implements GitProvider {
   }
 
   async getFile(file: GetFileArgs): Promise<GitFile | null> {
-    const { owner, repositoryName, path, baseBranchName } = file;
+    const { owner, repositoryName, path, ref } = file;
 
     const content = await this.octokit.rest.repos.getContent({
       owner,
       repo: repositoryName,
       path,
-      ref: baseBranchName ? baseBranchName : undefined,
+      ref,
     });
 
     if (!Array.isArray(content)) {

--- a/packages/amplication-git-utils/src/types.ts
+++ b/packages/amplication-git-utils/src/types.ts
@@ -119,7 +119,11 @@ export interface GetFileArgs {
   owner: string;
   repositoryName: string;
   path: string;
-  baseBranchName?: string;
+  /**
+   * Revision reference of the file to request.
+   * It can be a branch name, commit SHA, git tag
+   */
+  ref: string;
 }
 
 export interface CreatePullRequestArgs {

--- a/packages/amplication-git-utils/src/types.ts
+++ b/packages/amplication-git-utils/src/types.ts
@@ -118,12 +118,14 @@ export interface GetRepositoriesArgs {
 export interface GetFileArgs {
   owner: string;
   repositoryName: string;
+  repositoryGroupName?: string;
   path: string;
   /**
    * Revision reference of the file to request.
-   * It can be a branch name, commit SHA, git tag
+   * It can be a branch name, commit SHA, git tag.
+   * Default: default branch name HEAD
    */
-  ref: string;
+  ref?: string;
 }
 
 export interface CreatePullRequestArgs {

--- a/packages/amplication-server/src/core/build/build.controller.ts
+++ b/packages/amplication-server/src/core/build/build.controller.ts
@@ -86,7 +86,7 @@ export class BuildController {
   @EventPattern(
     EnvironmentVariables.instance.get(Env.CREATE_PR_FAILURE_TOPIC, true)
   )
-  async onCreatePRFailure(
+  async onPullRequestFailure(
     @Payload() message: CreatePrFailure.Value
   ): Promise<void> {
     try {


### PR DESCRIPTION
Close: #5440 

## PR Details

- Made groupName and git reference parameters of get file to make easier to understand logic
- default GetFile to collect file from HEAD of default branch if git reference is not passed

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
