### PR TITLE
Fix project gitReposiotry settings

### DIFF
--- a/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/GithubSyncDetails.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/GithubSyncDetails.tsx
@@ -2,9 +2,8 @@ import { Snackbar } from "@amplication/ui/design-system";
 import { useMutation } from "@apollo/client";
 import classNames from "classnames";
 import { AnalyticsEventNames } from "../../../../util/analytics-events.types";
-import { useCallback, useContext } from "react";
+import { useCallback } from "react";
 import { Button, EnumButtonStyle } from "../../../../Components/Button";
-import { AppContext } from "../../../../context/appContext";
 import { Resource } from "../../../../models";
 import { formatError } from "../../../../util/error";
 import { DISCONNECT_GIT_REPOSITORY } from "../../../../Workspaces/queries/resourcesQueries";
@@ -24,8 +23,6 @@ function GithubSyncDetails({
   className,
   showGitRepositoryBtn = true,
 }: Props) {
-  const { gitRepositoryUrl, gitRepositoryFullName } = useContext(AppContext);
-
   const [disconnectGitRepository, { error: disconnectErrorUpdate }] =
     useMutation(DISCONNECT_GIT_REPOSITORY, {
       variables: { resourceId: resourceWithRepository.id },
@@ -36,9 +33,9 @@ function GithubSyncDetails({
       variables: { resourceId: resourceWithRepository.id },
     }).catch(console.error);
   }, [disconnectGitRepository, resourceWithRepository.id]);
-
   const errorMessage = formatError(disconnectErrorUpdate);
-
+  const gitRepositoryFullName = `${resourceWithRepository.gitRepository?.gitOrganization.name}/${resourceWithRepository.gitRepository?.name}`;
+  const gitRepositoryUrl = `https://github.com/${gitRepositoryFullName}`;
   return (
     <div className={CLASS_NAME}>
       <div className={`${CLASS_NAME}__body`}>


### PR DESCRIPTION
Close: #5722 

## PR Details

Fix project configuration resource => gitRepository settings. 
Show the project git repository details instead the current resource gitRepository details. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

Test case:

Create a new account and go over the onboarding process (choose an empty repo to get an error in the build process). 
After the build fails => go to resource home and refresh the page.
Goto create a new service. 
In the git Repository selection, you need to see by default the project configuration settings. 

