### PR TITLE
fix(git-utils): get repositories pagination

### DIFF
--- a/packages/amplication-client/src/Resource/git/dialogs/GitRepos/GithubRepos.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitRepos/GithubRepos.tsx
@@ -25,7 +25,7 @@ import GitRepoItem from "./GitRepoItem/GitRepoItem";
 import "./GitRepos.scss";
 
 const CLASS_NAME = "git-repos";
-const MAX_ITEMS_PER_PAGE = 50;
+const MAX_ITEMS_PER_PAGE = 10; // aligned with server for both github and bitbucket
 
 type Props = {
   gitOrganizationId: string;

--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
@@ -217,7 +217,7 @@ export class BitBucketService implements GitProvider {
   async getRepositories(
     getRepositoriesArgs: GetRepositoriesArgs
   ): Promise<RemoteGitRepos> {
-    const { repositoryGroupName } = getRepositoriesArgs;
+    const { repositoryGroupName, limit, page } = getRepositoriesArgs;
 
     if (!repositoryGroupName) {
       this.logger.error("Missing repositoryGroupName");
@@ -226,10 +226,12 @@ export class BitBucketService implements GitProvider {
 
     const repositoriesInWorkspace = await repositoriesInWorkspaceRequest(
       repositoryGroupName,
+      limit,
+      page,
       this.auth.accessToken
     );
 
-    const { size, page, pagelen, values } = repositoriesInWorkspace;
+    const { size, values } = repositoriesInWorkspace;
     const gitRepos = values.map(
       ({ name, is_private, links, full_name, mainbranch, accessLevel }) => {
         return {
@@ -247,7 +249,7 @@ export class BitBucketService implements GitProvider {
       repos: gitRepos,
       total: size,
       currentPage: page,
-      pageSize: pagelen,
+      pageSize: limit,
     };
   }
 

--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.types.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.types.ts
@@ -41,6 +41,22 @@ export interface Account {
   uuid: string;
 }
 
+// pagination: https://developer.atlassian.com/cloud/bitbucket/rest/intro#pagination
+/**
+ * @param size: total number of objects in the response.
+ * This is an optional element that is not provided in all responses, as it can be expensive to compute
+ * @param page: Page number of the current results.
+ * This is an optional element that is not provided in all responses.
+ * @param pagelen: current number of objects on the existing page.
+ * Globally, the minimum length is 10 and the maximum is 100. Some APIs may specify a different default
+ * @param next: link to the next page if it exists. The last page of a collection does not have this value.
+ * Use this link to navigate the result set and refrain from constructing your own URLs
+ * @param previous: link to previous page if it exists. A collections first page does not have this value.
+ * This is an optional element that is not provided in all responses.
+ * Some result sets strictly support forward navigation and never provide previous links. Clients must anticipate that backwards navigation is not always available. Use this link to navigate the result set and refrain from constructing your own URLs
+ * @param values: the list of objects. This contains at most pagelen objects.
+ */
+
 // https://developer.atlassian.com/cloud/bitbucket/rest/api-group-workspaces/#api-user-permissions-workspaces-get
 export interface PaginatedWorkspaceMembership {
   size: number;

--- a/packages/amplication-git-utils/src/providers/bitbucket/requests.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/requests.ts
@@ -40,10 +40,10 @@ const CURRENT_USER_WORKSPACES_URL = `${BITBUCKET_API_URL}/user/permissions/works
 
 const REPOSITORIES_IN_WORKSPACE_URL = (
   workspaceSlug: string,
-  pageln = 10,
+  pagelen = 10,
   page = 1
 ) =>
-  `${BITBUCKET_API_URL}/repositories/${workspaceSlug}?pageln=${pageln}&page=${page}`;
+  `${BITBUCKET_API_URL}/repositories/${workspaceSlug}?pageln=${pagelen}&page=${page}`;
 
 const REPOSITORY_URL = (workspaceSlug: string, repositorySlug: string) =>
   `${BITBUCKET_API_URL}/repositories/${workspaceSlug}/${repositorySlug}`;
@@ -195,12 +195,12 @@ export async function currentUserWorkspacesRequest(
 
 export async function repositoriesInWorkspaceRequest(
   workspaceSlug: string,
-  pageln: number,
+  pagelen: number,
   page: number,
   accessToken: string
 ): Promise<PaginatedRepositories> {
   return requestWrapper(
-    REPOSITORIES_IN_WORKSPACE_URL(workspaceSlug, pageln, page),
+    REPOSITORIES_IN_WORKSPACE_URL(workspaceSlug, pagelen, page),
     {
       method: "GET",
       headers: getRequestHeaders(accessToken),

--- a/packages/amplication-git-utils/src/providers/bitbucket/requests.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/requests.ts
@@ -38,8 +38,12 @@ const ACCESS_TOKEN_URL = `${BITBUCKET_SITE_URL}/oauth2/access_token`;
 const CURRENT_USER_URL = `${BITBUCKET_API_URL}/user`;
 const CURRENT_USER_WORKSPACES_URL = `${BITBUCKET_API_URL}/user/permissions/workspaces`;
 
-const REPOSITORIES_IN_WORKSPACE_URL = (workspaceSlug: string) =>
-  `${BITBUCKET_API_URL}/repositories/${workspaceSlug}`;
+const REPOSITORIES_IN_WORKSPACE_URL = (
+  workspaceSlug: string,
+  pageln = 10,
+  page = 1
+) =>
+  `${BITBUCKET_API_URL}/repositories/${workspaceSlug}?pageln=${pageln}&page=${page}`;
 
 const REPOSITORY_URL = (workspaceSlug: string, repositorySlug: string) =>
   `${BITBUCKET_API_URL}/repositories/${workspaceSlug}/${repositorySlug}`;
@@ -54,9 +58,6 @@ const GET_FILE_URL = (
   pathToFile: string
 ) =>
   `${BITBUCKET_API_URL}/repositories/${workspaceSlug}/${repositorySlug}/src/${branchName}/${pathToFile}`;
-
-const CREATE_COMMIT_URL = (workspaceSlug: string, repositorySlug: string) =>
-  `${BITBUCKET_API_URL}/repositories//${workspaceSlug}/${repositorySlug}/src`;
 
 const GET_BRANCH_COMMITS_URL = (
   workspaceSlug: string,
@@ -194,12 +195,17 @@ export async function currentUserWorkspacesRequest(
 
 export async function repositoriesInWorkspaceRequest(
   workspaceSlug: string,
+  pageln: number,
+  page: number,
   accessToken: string
 ): Promise<PaginatedRepositories> {
-  return requestWrapper(REPOSITORIES_IN_WORKSPACE_URL(workspaceSlug), {
-    method: "GET",
-    headers: getRequestHeaders(accessToken),
-  });
+  return requestWrapper(
+    REPOSITORIES_IN_WORKSPACE_URL(workspaceSlug, pageln, page),
+    {
+      method: "GET",
+      headers: getRequestHeaders(accessToken),
+    }
+  );
 }
 
 export async function repositoryRequest(


### PR DESCRIPTION
Close: #5701

## PR Details

fix pagination for bitbucket get repositories

### page 1:
https://api.bitbucket.org/2.0/repositories/barletza?page=1&pagelen=1

![image](https://user-images.githubusercontent.com/39680385/232034433-b07588ba-bd59-4930-8dc2-e5b3ac3a507c.png)

### page 2:
https://api.bitbucket.org/2.0/repositories/barletza?page=2&pagelen=1

![image](https://user-images.githubusercontent.com/39680385/232034679-3dc0b100-0e59-4a23-ba36-8fbdc94dc815.png)



https://user-images.githubusercontent.com/39680385/232045342-a6cd5463-7dd6-4879-a75d-a515836f3cab.mov




## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
