### PR TITLE
refactor(git-client): pagination params

### DIFF
--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -1698,8 +1698,8 @@ export enum QueryMode {
 }
 
 export type RemoteGitRepos = {
-  currentPage: Scalars['Float'];
-  pageSize: Scalars['Float'];
+  page: Scalars['Float'];
+  perPage: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
   total: Scalars['Float'];
 };
@@ -1707,8 +1707,8 @@ export type RemoteGitRepos = {
 export type RemoteGitRepositoriesWhereUniqueInput = {
   gitOrganizationId: Scalars['String'];
   gitProvider: EnumGitProvider;
-  limit: Scalars['Float'];
   page: Scalars['Float'];
+  perPage: Scalars['Float'];
   repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 

--- a/packages/amplication-client/src/Resource/git/dialogs/GitRepos/GithubRepos.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitRepos/GithubRepos.tsx
@@ -125,7 +125,7 @@ function GitRepos({
                   {
                     length: Math.ceil(
                       data?.remoteGitRepositories.total /
-                        data?.remoteGitRepositories.pageSize
+                        data?.remoteGitRepositories.perPage
                     ),
                   },
                   (_, index) => index + 1
@@ -207,8 +207,8 @@ const FIND_GIT_REPOS = gql`
         admin
       }
       total
-      currentPage
-      pageSize
+      page
+      perPage
     }
   }
 `;

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -1698,8 +1698,8 @@ export enum QueryMode {
 }
 
 export type RemoteGitRepos = {
-  currentPage: Scalars['Float'];
-  pageSize: Scalars['Float'];
+  page: Scalars['Float'];
+  perPage: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
   total: Scalars['Float'];
 };
@@ -1707,8 +1707,8 @@ export type RemoteGitRepos = {
 export type RemoteGitRepositoriesWhereUniqueInput = {
   gitOrganizationId: Scalars['String'];
   gitProvider: EnumGitProvider;
-  limit: Scalars['Float'];
   page: Scalars['Float'];
+  perPage: Scalars['Float'];
   repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -1698,8 +1698,8 @@ export enum QueryMode {
 }
 
 export type RemoteGitRepos = {
-  currentPage: Scalars['Float'];
-  pageSize: Scalars['Float'];
+  page: Scalars['Float'];
+  perPage: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
   total: Scalars['Float'];
 };
@@ -1707,8 +1707,8 @@ export type RemoteGitRepos = {
 export type RemoteGitRepositoriesWhereUniqueInput = {
   gitOrganizationId: Scalars['String'];
   gitProvider: EnumGitProvider;
-  limit: Scalars['Float'];
   page: Scalars['Float'];
+  perPage: Scalars['Float'];
   repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -1698,8 +1698,8 @@ export enum QueryMode {
 }
 
 export type RemoteGitRepos = {
-  currentPage: Scalars['Float'];
-  pageSize: Scalars['Float'];
+  page: Scalars['Float'];
+  perPage: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
   total: Scalars['Float'];
 };
@@ -1707,8 +1707,8 @@ export type RemoteGitRepos = {
 export type RemoteGitRepositoriesWhereUniqueInput = {
   gitOrganizationId: Scalars['String'];
   gitProvider: EnumGitProvider;
-  limit: Scalars['Float'];
   page: Scalars['Float'];
+  perPage: Scalars['Float'];
   repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 

--- a/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
+++ b/packages/amplication-git-utils/src/providers/bitbucket/bitbucket.service.ts
@@ -217,7 +217,7 @@ export class BitBucketService implements GitProvider {
   async getRepositories(
     getRepositoriesArgs: GetRepositoriesArgs
   ): Promise<RemoteGitRepos> {
-    const { repositoryGroupName, limit, page } = getRepositoriesArgs;
+    const { repositoryGroupName, page, perPage } = getRepositoriesArgs;
 
     if (!repositoryGroupName) {
       this.logger.error("Missing repositoryGroupName");
@@ -226,7 +226,7 @@ export class BitBucketService implements GitProvider {
 
     const repositoriesInWorkspace = await repositoriesInWorkspaceRequest(
       repositoryGroupName,
-      limit,
+      perPage,
       page,
       this.auth.accessToken
     );
@@ -248,8 +248,8 @@ export class BitBucketService implements GitProvider {
     return {
       repos: gitRepos,
       total: size,
-      currentPage: page,
-      pageSize: limit,
+      page,
+      perPage,
     };
   }
 

--- a/packages/amplication-git-utils/src/providers/github/github.service.ts
+++ b/packages/amplication-git-utils/src/providers/github/github.service.ts
@@ -169,11 +169,11 @@ export class GithubService implements GitProvider {
   }
 
   private async getRepositoriesWithPagination(
-    limit = 10,
+    perPage = 10,
     page = 1
   ): Promise<RemoteGitRepos> {
     const results = await this.octokit.request(
-      `GET /installation/repositories?per_page=${limit}&page=${page}`
+      `GET /installation/repositories?per_page=${perPage}&page=${page}`
     );
     const repos = results.data.repositories.map((repo) => ({
       name: repo.name,
@@ -186,8 +186,8 @@ export class GithubService implements GitProvider {
     return {
       total: results.data.total_count,
       repos: repos,
-      pageSize: limit,
-      currentPage: page,
+      perPage,
+      page,
     };
   }
 
@@ -235,8 +235,8 @@ export class GithubService implements GitProvider {
   async getRepositories(
     getRepositoriesArgs: GetRepositoriesArgs
   ): Promise<RemoteGitRepos> {
-    const { limit, page } = getRepositoriesArgs;
-    return await this.getRepositoriesWithPagination(limit, page);
+    const { perPage, page } = getRepositoriesArgs;
+    return await this.getRepositoriesWithPagination(perPage, page);
   }
 
   async createRepository(

--- a/packages/amplication-git-utils/src/types.ts
+++ b/packages/amplication-git-utils/src/types.ts
@@ -111,8 +111,8 @@ export interface RemoteGitRepository {
 export interface RemoteGitRepos {
   repos: RemoteGitRepository[];
   total: number | null;
-  currentPage: number | null;
-  pageSize: number | null;
+  page: number | null;
+  perPage: number | null;
 }
 
 export type File = {
@@ -156,7 +156,7 @@ export interface CreateRepositoryArgs {
 }
 
 export interface GetRepositoriesArgs {
-  limit: number;
+  perPage: number;
   page: number;
   repositoryGroupName?: string;
 }

--- a/packages/amplication-git-utils/tests/providers/git.constants.ts
+++ b/packages/amplication-git-utils/tests/providers/git.constants.ts
@@ -43,8 +43,8 @@ export const TEST_GIT_REPOS: RemoteGitRepos = {
     },
   ],
   total: 2,
-  pageSize: 2,
-  currentPage: 1,
+  perPage: 2,
+  page: 1,
 };
 
 export const TEST_GIT_REPO: RemoteGitRepository = {

--- a/packages/amplication-server/src/core/git/dto/inputs/RemoteGitRepositoriesWhereUniqueInput.ts
+++ b/packages/amplication-server/src/core/git/dto/inputs/RemoteGitRepositoriesWhereUniqueInput.ts
@@ -10,7 +10,7 @@ export class RemoteGitRepositoriesWhereUniqueInput {
   gitProvider!: EnumGitProvider;
 
   @Field(() => Number, { nullable: false })
-  limit!: number;
+  perPage!: number;
 
   @Field(() => Number, { nullable: false })
   page!: number;

--- a/packages/amplication-server/src/core/git/dto/inputs/RemoteGitRepositoriesWhereUniqueInput.ts
+++ b/packages/amplication-server/src/core/git/dto/inputs/RemoteGitRepositoriesWhereUniqueInput.ts
@@ -1,5 +1,6 @@
 import { Field, InputType } from "@nestjs/graphql";
 import { EnumGitProvider } from "../enums/EnumGitProvider";
+import { Min, Max, IsInt } from "class-validator";
 
 @InputType()
 export class RemoteGitRepositoriesWhereUniqueInput {
@@ -9,10 +10,23 @@ export class RemoteGitRepositoriesWhereUniqueInput {
   @Field(() => EnumGitProvider, { nullable: false })
   gitProvider!: EnumGitProvider;
 
-  @Field(() => Number, { nullable: false })
+  @Field(() => Number, {
+    nullable: false,
+    defaultValue: 10,
+    description: "The number of items to return per page",
+  })
+  @IsInt()
+  @Min(10)
+  @Max(100)
   perPage!: number;
 
-  @Field(() => Number, { nullable: false })
+  @Field(() => Number, {
+    nullable: false,
+    defaultValue: 1,
+    description: "The page number. One-based indexing",
+  })
+  @IsInt()
+  @Min(1)
   page!: number;
 
   @Field(() => String, { nullable: true })

--- a/packages/amplication-server/src/core/git/dto/objects/RemoteGitRepository.ts
+++ b/packages/amplication-server/src/core/git/dto/objects/RemoteGitRepository.ts
@@ -34,8 +34,8 @@ export class RemoteGitRepos {
   total: number | null;
 
   @Field(() => Number)
-  currentPage: number | null;
+  page: number | null;
 
   @Field(() => Number)
-  pageSize: number | null;
+  perPage: number | null;
 }

--- a/packages/amplication-server/src/core/git/git.provider.service.ts
+++ b/packages/amplication-server/src/core/git/git.provider.service.ts
@@ -152,7 +152,7 @@ export class GitProviderService {
     });
 
     const repositoriesArgs = {
-      limit: args.limit,
+      perPage: args.perPage,
       page: args.page,
       repositoryGroupName: args.repositoryGroupName,
     };

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -1025,8 +1025,8 @@ input GitGroupInput {
 type RemoteGitRepos {
   repos: [RemoteGitRepository!]!
   total: Float!
-  currentPage: Float!
-  pageSize: Float!
+  page: Float!
+  perPage: Float!
 }
 
 type RemoteGitRepository {
@@ -1041,7 +1041,7 @@ type RemoteGitRepository {
 input RemoteGitRepositoriesWhereUniqueInput {
   gitOrganizationId: String!
   gitProvider: EnumGitProvider!
-  limit: Float!
+  perPage: Float!
   page: Float!
   repositoryGroupName: String
 }

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -1698,8 +1698,8 @@ export enum QueryMode {
 }
 
 export type RemoteGitRepos = {
-  currentPage: Scalars['Float'];
-  pageSize: Scalars['Float'];
+  page: Scalars['Float'];
+  perPage: Scalars['Float'];
   repos: Array<RemoteGitRepository>;
   total: Scalars['Float'];
 };
@@ -1707,8 +1707,8 @@ export type RemoteGitRepos = {
 export type RemoteGitRepositoriesWhereUniqueInput = {
   gitOrganizationId: Scalars['String'];
   gitProvider: EnumGitProvider;
-  limit: Scalars['Float'];
   page: Scalars['Float'];
+  perPage: Scalars['Float'];
   repositoryGroupName?: InputMaybe<Scalars['String']>;
 };
 


### PR DESCRIPTION

Close: #5702

## PR Details
1. align pagination parameters for server, client and git-utils:
- page: The page number. One-based indexing
- perPage: The number of items to return per page

2. add validation for page (min: 1) and perPage (min:10, max: 100) based on GitHub and Bitbucket API restrictions


## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
