### PR TITLE
refactor(client): hard coded git provider

### DIFF
--- a/packages/amplication-client/src/Resource/git/AuthWithGit.tsx
+++ b/packages/amplication-client/src/Resource/git/AuthWithGit.tsx
@@ -18,6 +18,7 @@ import WizardRepositoryActions from "./GitActions/RepositoryActions/WizardReposi
 import WizardNewConnection from "./GitActions/WizardNewConnection";
 import GitSyncNotes from "./GitSyncNotes";
 import { GitOrganizationFromGitRepository } from "./SyncWithGithubPage";
+import * as models from "../../models";
 
 type DType = {
   getGitResourceInstallationUrl: AuthorizeResourceWithGitResult;
@@ -139,16 +140,20 @@ function AuthWithGit({
     setSelectRepoOpen(true);
   }, []);
 
-  const handleAuthWithGitClick = useCallback(() => {
-    trackEvent({
-      eventName: AnalyticsEventNames.GitHubAuthResourceStart,
-    });
-    authWithGit({
-      variables: {
-        gitProvider: "Github",
-      },
-    }).catch(console.error);
-  }, [authWithGit, trackEvent]);
+  const handleAuthWithGitClick = useCallback(
+    (provider: models.EnumGitProvider) => {
+      trackEvent({
+        eventName: AnalyticsEventNames.AddGitProviderClick,
+        provider,
+      });
+      authWithGit({
+        variables: {
+          gitProvider: provider,
+        },
+      }).catch(console.error);
+    },
+    [authWithGit, trackEvent]
+  );
 
   triggerOnDone = () => {
     onDone();

--- a/packages/amplication-client/src/Resource/git/GitActions/ExistingConnectionsMenu.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/ExistingConnectionsMenu.tsx
@@ -22,13 +22,13 @@ type Props = {
 
 const CLASS_NAME = "git-organization-select-menu";
 
+// should be removed after creating a modal for adding a new git organization for a selected provider
 const GIT_PROVIDERS: { provider: models.EnumGitProvider; label: string }[] = [
   { provider: models.EnumGitProvider.Github, label: "Add GitHub Organization" },
-  // comment until we fully support Bitbucket
-  // {
-  //   provider: models.EnumGitProvider.Bitbucket,
-  //   label: "Add BitBucket Account",
-  // },
+  {
+    provider: models.EnumGitProvider.Bitbucket,
+    label: "Add BitBucket Account",
+  },
 ];
 
 export default function ExistingConnectionsMenu({

--- a/packages/amplication-client/src/Resource/git/GitActions/ProviderItem.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/ProviderItem.tsx
@@ -18,7 +18,10 @@ export default function ProviderItem({
   return (
     <div className="auth-with-git__providerItem">
       <div className="auth-with-git__providerIcon">
-        <Icon icon={"github"} size={"medium"}></Icon>
+        <Icon
+          icon={EnumGitProvider[provider].toLowerCase()}
+          size={"medium"}
+        ></Icon>
         {EnumGitProvider[provider]}
       </div>
       <Button buttonStyle={EnumButtonStyle.Primary} onClick={handleClick}>

--- a/packages/amplication-client/src/Resource/git/GitActions/ProviderItem.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/ProviderItem.tsx
@@ -19,7 +19,7 @@ export default function ProviderItem({
     <div className="auth-with-git__providerItem">
       <div className="auth-with-git__providerIcon">
         <Icon icon={"github"} size={"medium"}></Icon>
-        {provider === EnumGitProvider.Github ? "GitHub" : ""}
+        {EnumGitProvider[provider]}
       </div>
       <Button buttonStyle={EnumButtonStyle.Primary} onClick={handleClick}>
         {`Connect`}

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/WizardGitCreateRepo.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/WizardGitCreateRepo.tsx
@@ -56,7 +56,7 @@ export default function WizardGitCreateRepo({
     onCreateGitRepository({
       gitOrganizationId: gitOrganizationId,
       gitOrganizationType: EnumGitOrganizationType.Organization,
-      gitProvider: EnumGitProvider.Github,
+      gitProvider,
       name: createRepositoryInput.name,
       public: createRepositoryInput.public,
       gitRepositoryUrl: `https://github.com/${createRepositoryInput.name}`,


### PR DESCRIPTION
Close: #5801 

## PR Details

Use dynamic git provider value instead of hard-coded "GitHub"

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
