### PR TITLE
fix(client): fix continue button name in all wizard steps

### DIFF
--- a/packages/amplication-client/src/Resource/create-resource/ServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/ServiceWizard.tsx
@@ -262,11 +262,7 @@ const ServiceWizard: React.FC<ServiceWizardProps> = ({
                               : goNextPage
                           }
                           disabled={isInvalidStep}
-                          buttonName={
-                            activePageIndex === submitFormPage
-                              ? "Create Service"
-                              : "Continue"
-                          }
+                          buttonName={"Continue"}
                         />
                       )}
                     </div>


### PR DESCRIPTION
Close: #5735 

## PR Details

The continue button name is always "Continue" and doesn't change according to the current step. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

Test case:

Open the service wizard and create a new service => 
Ensure the continue button name doesn't change to "Create service" in the last step. 

