### PR TITLE
fix(dsg): fix error: id must be an integer number on API

### DIFF
--- a/packages/data-service-generator/src/server/resource/dto/create-field-class-property.ts
+++ b/packages/data-service-generator/src/server/resource/dto/create-field-class-property.ts
@@ -196,6 +196,32 @@ export function createFieldClassProperty(
             ]
           : [];
         decorators.push(builders.decorator(builders.callExpression(id, args)));
+        if (
+          inputType === EntityDtoTypeEnum.WhereUniqueInput &&
+          prismaField.type === ScalarType.Int
+        ) {
+          decorators.push(
+            builders.decorator(
+              builders.callExpression(builders.identifier("Transform"), [
+                builders.arrowFunctionExpression(
+                  [builders.identifier("prop")],
+                  builders.callExpression(builders.identifier("parseInt"), [
+                    builders.memberExpression(
+                      builders.identifier("prop"),
+                      builders.identifier("value")
+                    ),
+                  ])
+                ),
+                builders.objectExpression([
+                  builders.objectProperty(
+                    builders.identifier("toClassOnly"),
+                    builders.booleanLiteral(true)
+                  ),
+                ]),
+              ])
+            )
+          );
+        }
       }
     }
     const swaggerType = !isQuery

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -4425,6 +4425,7 @@ https://docs.amplication.com/how-to/custom-code
 import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsInt } from \\"class-validator\\";
+import { Transform } from \\"class-transformer\\";
 
 @InputType()
 class CustomerWhereUniqueInput {
@@ -4433,6 +4434,9 @@ class CustomerWhereUniqueInput {
     type: Number,
   })
   @IsInt()
+  @Transform((prop) => parseInt(prop.value), {
+    toClassOnly: true,
+  })
   @Field(() => Number)
   id!: number;
 }
@@ -10371,6 +10375,7 @@ https://docs.amplication.com/how-to/custom-code
 import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsInt } from \\"class-validator\\";
+import { Transform } from \\"class-transformer\\";
 
 @InputType()
 class ProfileWhereUniqueInput {
@@ -10379,6 +10384,9 @@ class ProfileWhereUniqueInput {
     type: Number,
   })
   @IsInt()
+  @Transform((prop) => parseInt(prop.value), {
+    toClassOnly: true,
+  })
   @Field(() => Number)
   id!: number;
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -4425,6 +4425,7 @@ https://docs.amplication.com/how-to/custom-code
 import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsInt } from \\"class-validator\\";
+import { Transform } from \\"class-transformer\\";
 
 @InputType()
 class CustomerWhereUniqueInput {
@@ -4433,6 +4434,9 @@ class CustomerWhereUniqueInput {
     type: Number,
   })
   @IsInt()
+  @Transform((prop) => parseInt(prop.value), {
+    toClassOnly: true,
+  })
   @Field(() => Number)
   id!: number;
 }
@@ -10371,6 +10375,7 @@ https://docs.amplication.com/how-to/custom-code
 import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsInt } from \\"class-validator\\";
+import { Transform } from \\"class-transformer\\";
 
 @InputType()
 class ProfileWhereUniqueInput {
@@ -10379,6 +10384,9 @@ class ProfileWhereUniqueInput {
     type: Number,
   })
   @IsInt()
+  @Transform((prop) => parseInt(prop.value), {
+    toClassOnly: true,
+  })
   @Field(() => Number)
   id!: number;
 }
@@ -12554,6 +12562,7 @@ https://docs.amplication.com/how-to/custom-code
 import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsInt } from \\"class-validator\\";
+import { Transform } from \\"class-transformer\\";
 
 @InputType()
 class UserWhereUniqueInput {
@@ -12562,6 +12571,9 @@ class UserWhereUniqueInput {
     type: Number,
   })
   @IsInt()
+  @Transform((prop) => parseInt(prop.value), {
+    toClassOnly: true,
+  })
   @Field(() => Number)
   id!: number;
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -4425,6 +4425,7 @@ https://docs.amplication.com/how-to/custom-code
 import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsInt } from \\"class-validator\\";
+import { Transform } from \\"class-transformer\\";
 
 @InputType()
 class CustomerWhereUniqueInput {
@@ -4433,6 +4434,9 @@ class CustomerWhereUniqueInput {
     type: Number,
   })
   @IsInt()
+  @Transform((prop) => parseInt(prop.value), {
+    toClassOnly: true,
+  })
   @Field(() => Number)
   id!: number;
 }
@@ -10375,6 +10379,7 @@ https://docs.amplication.com/how-to/custom-code
 import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsInt } from \\"class-validator\\";
+import { Transform } from \\"class-transformer\\";
 
 @InputType()
 class ProfileWhereUniqueInput {
@@ -10383,6 +10388,9 @@ class ProfileWhereUniqueInput {
     type: Number,
   })
   @IsInt()
+  @Transform((prop) => parseInt(prop.value), {
+    toClassOnly: true,
+  })
   @Field(() => Number)
   id!: number;
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -4425,6 +4425,7 @@ https://docs.amplication.com/how-to/custom-code
 import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsInt } from \\"class-validator\\";
+import { Transform } from \\"class-transformer\\";
 
 @InputType()
 class CustomerWhereUniqueInput {
@@ -4433,6 +4434,9 @@ class CustomerWhereUniqueInput {
     type: Number,
   })
   @IsInt()
+  @Transform((prop) => parseInt(prop.value), {
+    toClassOnly: true,
+  })
   @Field(() => Number)
   id!: number;
 }
@@ -9798,6 +9802,7 @@ https://docs.amplication.com/how-to/custom-code
 import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsInt } from \\"class-validator\\";
+import { Transform } from \\"class-transformer\\";
 
 @InputType()
 class ProfileWhereUniqueInput {
@@ -9806,6 +9811,9 @@ class ProfileWhereUniqueInput {
     type: Number,
   })
   @IsInt()
+  @Transform((prop) => parseInt(prop.value), {
+    toClassOnly: true,
+  })
   @Field(() => Number)
   id!: number;
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -4425,6 +4425,7 @@ https://docs.amplication.com/how-to/custom-code
 import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsInt } from \\"class-validator\\";
+import { Transform } from \\"class-transformer\\";
 
 @InputType()
 class CustomerWhereUniqueInput {
@@ -4433,6 +4434,9 @@ class CustomerWhereUniqueInput {
     type: Number,
   })
   @IsInt()
+  @Transform((prop) => parseInt(prop.value), {
+    toClassOnly: true,
+  })
   @Field(() => Number)
   id!: number;
 }
@@ -8378,6 +8382,7 @@ https://docs.amplication.com/how-to/custom-code
 import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsInt } from \\"class-validator\\";
+import { Transform } from \\"class-transformer\\";
 
 @InputType()
 class ProfileWhereUniqueInput {
@@ -8386,6 +8391,9 @@ class ProfileWhereUniqueInput {
     type: Number,
   })
   @IsInt()
+  @Transform((prop) => parseInt(prop.value), {
+    toClassOnly: true,
+  })
   @Field(() => Number)
   id!: number;
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -4425,6 +4425,7 @@ https://docs.amplication.com/how-to/custom-code
 import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsInt } from \\"class-validator\\";
+import { Transform } from \\"class-transformer\\";
 
 @InputType()
 class CustomerWhereUniqueInput {
@@ -4433,6 +4434,9 @@ class CustomerWhereUniqueInput {
     type: Number,
   })
   @IsInt()
+  @Transform((prop) => parseInt(prop.value), {
+    toClassOnly: true,
+  })
   @Field(() => Number)
   id!: number;
 }
@@ -10371,6 +10375,7 @@ https://docs.amplication.com/how-to/custom-code
 import { InputType, Field } from \\"@nestjs/graphql\\";
 import { ApiProperty } from \\"@nestjs/swagger\\";
 import { IsInt } from \\"class-validator\\";
+import { Transform } from \\"class-transformer\\";
 
 @InputType()
 class ProfileWhereUniqueInput {
@@ -10379,6 +10384,9 @@ class ProfileWhereUniqueInput {
     type: Number,
   })
   @IsInt()
+  @Transform((prop) => parseInt(prop.value), {
+    toClassOnly: true,
+  })
   @Field(() => Number)
   id!: number;
 }


### PR DESCRIPTION
Close: #5437 

## PR Details

Fix id must be an integer number error on rest API. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

Test case: 

Generate a new service with at least one entity with Id of type AUTO_INCREMENT
Follow the readme for starting the server with docker-compose
perform a request to GET the entity by id like http://localhost:3000/api/customers/1
Observe the response
