### PR TITLE
fix(server): create service broker fails

### DIFF
--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -210,7 +210,7 @@ export class ResourceService {
 
     if (
       isOnBoarding ||
-      (!gitRepositoryToCreate.isOverrideGitRepository &&
+      (!gitRepositoryToCreate?.isOverrideGitRepository &&
         !projectConfiguration.gitRepositoryId)
     ) {
       await this.prisma.resource.update({


### PR DESCRIPTION

Close: #5930 

## PR Details

Fix the error message when trying to create a new service broker. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

Test case:

Create a new service broker.
