### PR TITLE
fix(logging): issue related to missing metadata in logs and add additional build info to related log entries

### DIFF
--- a/libs/util/logging/src/lib/cli-format.spec.ts
+++ b/libs/util/logging/src/lib/cli-format.spec.ts
@@ -50,7 +50,6 @@ describe("customFormat", () => {
           {
             foo: "bar",
             baz: 123,
-            i: ["TEST"],
           },
           {
             colors: true,

--- a/libs/util/logging/src/lib/cli-format.ts
+++ b/libs/util/logging/src/lib/cli-format.ts
@@ -30,16 +30,10 @@ export const customFormat = (): Format =>
       component: componentName,
       [LEVEL]: metaLevel,
       [MESSAGE]: metaMessage,
-      [SPLAT]: splat,
+      [SPLAT]: metaSplat,
       ...metadata
     } = meta;
 
-    if (splat) {
-      const splatObj = splat.filter((s: unknown) => s);
-      if (splatObj.length > 0) {
-        metadata["i"] = [...splatObj];
-      }
-    }
     const formattedMeta = inspect(metadata, {
       colors: true,
       depth: null,

--- a/libs/util/logging/src/lib/logging.getFormat.spec.ts
+++ b/libs/util/logging/src/lib/logging.getFormat.spec.ts
@@ -1,12 +1,10 @@
 import { Logger } from "./logging";
 import { LoggerOptions, LogLevel } from "./types";
 import { format } from "winston";
-import { Colorizer, Format } from "logform";
-import { customFormat } from "./cli-format";
+import { Format } from "logform";
 
-const FORMAT_COLORIZE = "colorize";
 const FORMAT_ERRORS = "errors";
-const FORMAT_SIMPLE = "simple";
+const FORMAT_SPLAT = "splat";
 const FORMAT_JSON = "json";
 const FORMAT_TIMESTAMP = "timestamp";
 
@@ -19,6 +17,9 @@ describe("getLoggerFormat", () => {
     spyOnCombineFormat = jest
       .spyOn(format, "combine")
       .mockReturnValue({} as unknown as Format);
+    jest
+      .spyOn(format, "splat")
+      .mockReturnValue(FORMAT_SPLAT as unknown as Format);
     jest
       .spyOn(format, "errors")
       .mockReturnValue(FORMAT_ERRORS as unknown as Format);
@@ -50,8 +51,9 @@ describe("getLoggerFormat", () => {
     new Logger(options);
 
     expect(spyOnCombineFormat).toHaveBeenCalledWith(
-      FORMAT_ERRORS,
       FORMAT_TIMESTAMP,
+      FORMAT_ERRORS,
+      FORMAT_SPLAT,
       { template: expect.any(Function) }
     );
   });
@@ -61,8 +63,9 @@ describe("getLoggerFormat", () => {
     new Logger(options);
 
     expect(spyOnCombineFormat).toHaveBeenCalledWith(
-      FORMAT_ERRORS,
       FORMAT_TIMESTAMP,
+      FORMAT_ERRORS,
+      FORMAT_SPLAT,
       FORMAT_JSON
     );
   });

--- a/libs/util/logging/src/lib/logging.spec.ts
+++ b/libs/util/logging/src/lib/logging.spec.ts
@@ -7,6 +7,7 @@ jest.mock("winston", () => ({
     colorize: jest.fn().mockReturnValue("colorize"),
     errors: jest.fn().mockReturnValue("errors"),
     simple: jest.fn().mockReturnValue("simple"),
+    splat: jest.fn().mockReturnValue("splat"),
     json: jest.fn().mockReturnValue("json"),
     timestamp: jest.fn().mockReturnValue("timestamp"),
     combine: jest.fn().mockImplementation((...args) => args),

--- a/libs/util/logging/src/lib/logging.ts
+++ b/libs/util/logging/src/lib/logging.ts
@@ -35,8 +35,8 @@ export class Logger implements ILogger {
   public getLoggerFormat(): Format {
     const developmentFormats: Format[] = [
       format.timestamp(),
-      format.splat(),
       format.errors({ stack: true }),
+      format.splat(),
       customFormat(),
     ];
     if (this.options.additionalDevelopmentFormats) {

--- a/libs/util/logging/src/lib/logging.ts
+++ b/libs/util/logging/src/lib/logging.ts
@@ -34,8 +34,9 @@ export class Logger implements ILogger {
 
   public getLoggerFormat(): Format {
     const developmentFormats: Format[] = [
-      format.errors({ stack: true }),
       format.timestamp(),
+      format.splat(),
+      format.errors({ stack: true }),
       customFormat(),
     ];
     if (this.options.additionalDevelopmentFormats) {
@@ -46,8 +47,9 @@ export class Logger implements ILogger {
     }
 
     const productionFormats: Format[] = [
-      format.errors({ stack: true }),
       format.timestamp(),
+      format.errors({ stack: true }),
+      format.splat(),
       format.json(),
     ];
     if (this.options.additionalFormats) {
@@ -82,7 +84,7 @@ export class Logger implements ILogger {
   child(metadata?: Pick<LoggerOptions, "metadata">): Logger {
     return new Logger({
       ...this.options,
-      metadata: { ...this.options.metadata, metadata },
+      metadata: { ...this.options.metadata, ...metadata },
     });
   }
 }

--- a/libs/util/nestjs/logging/src/logger.service.ts
+++ b/libs/util/nestjs/logging/src/logger.service.ts
@@ -24,28 +24,42 @@ export class AmplicationLogger implements LoggerService, ILogger {
     this.logger = new Logger(this.loggerOptions);
   }
 
+  private argsToObject(...args: any[]): Record<string, unknown>[] {
+    return args.map((arg) => {
+      if (typeof arg === "object") {
+        return arg;
+      }
+      return { [args.indexOf(arg).toString()]: arg };
+    });
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public debug(message: string, ...args: any[]): void {
+    args = args.filter((arg) => typeof arg === "object");
     this.logger.debug(message, ...args);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public info(message: string, ...args: any[]): void {
+    args = args.filter((arg) => typeof arg === "object");
     this.logger.info(message, ...args);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public warn(message: string, ...args: any[]): void {
+    args = args.filter((arg) => typeof arg === "object");
     this.logger.warn(message, ...args);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public error(message: string, error?: Error, ...args: any[]): void {
+    args = args.filter((arg) => typeof arg === "object");
     this.logger.error(message, error, ...args);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public log(message: string, ...args: any[]): void {
+    args = args.filter((arg) => typeof arg === "object");
     this.logger.info(message, ...args);
   }
 
@@ -59,7 +73,7 @@ export class AmplicationLogger implements LoggerService, ILogger {
       ...this.loggerOptions,
       metadata: {
         ...this.loggerOptions.metadata,
-        metadata,
+        ...metadata,
       },
     };
 

--- a/packages/amplication-git-pull-request-service/src/app.module.ts
+++ b/packages/amplication-git-pull-request-service/src/app.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule } from "@nestjs/config";
 import { DiffModule } from "./diff/diff.module";
 import { PullRequestModule } from "./pull-request/pull-request.module";
 import { Logger } from "@amplication/util/logging";
+import { Env } from "./env";
 
 @Module({
   imports: [
@@ -14,13 +15,13 @@ import { Logger } from "@amplication/util/logging";
       envFilePath: [".env.local", ".env"],
     }),
     AmplicationLoggerModule.forRoot({
-      serviceName: SERVICE_NAME,
+      serviceName: Env.SERVICE_NAME,
     }),
   ],
 })
 export class AppModule implements OnApplicationShutdown {
   onApplicationShutdown(signal: string) {
-    new Logger({ serviceName: SERVICE_NAME, isProduction: true }).debug(
+    new Logger({ serviceName: Env.SERVICE_NAME, isProduction: true }).debug(
       `Application shut down (signal: ${signal})`
     );
   }

--- a/packages/amplication-git-pull-request-service/src/app.module.ts
+++ b/packages/amplication-git-pull-request-service/src/app.module.ts
@@ -3,6 +3,7 @@ import { Module, OnApplicationShutdown } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { DiffModule } from "./diff/diff.module";
 import { PullRequestModule } from "./pull-request/pull-request.module";
+import { Logger } from "@amplication/util/logging";
 
 @Module({
   imports: [
@@ -13,12 +14,14 @@ import { PullRequestModule } from "./pull-request/pull-request.module";
       envFilePath: [".env.local", ".env"],
     }),
     AmplicationLoggerModule.forRoot({
-      serviceName: "amplication-git-pull-request-service",
+      serviceName: SERVICE_NAME,
     }),
   ],
 })
 export class AppModule implements OnApplicationShutdown {
   onApplicationShutdown(signal: string) {
-    console.trace(`Application shut down (signal: ${signal})`);
+    new Logger({ serviceName: SERVICE_NAME, isProduction: true }).debug(
+      `Application shut down (signal: ${signal})`
+    );
   }
 }

--- a/packages/amplication-git-pull-request-service/src/env.ts
+++ b/packages/amplication-git-pull-request-service/src/env.ts
@@ -18,4 +18,5 @@ export class Env {
 
   static readonly BUILD_ARTIFACTS_BASE_FOLDER = "BUILD_ARTIFACTS_BASE_FOLDER";
   static readonly BUILD_ARTIFACTS_CODE_FOLDER = "BUILD_ARTIFACTS_CODE_FOLDER";
+  static readonly SERVICE_NAME = "amplication-git-pull-request-service";
 }

--- a/packages/amplication-git-pull-request-service/src/main.ts
+++ b/packages/amplication-git-pull-request-service/src/main.ts
@@ -3,6 +3,8 @@ import { createNestjsKafkaConfig } from "@amplication/util/nestjs/kafka";
 import { NestFactory } from "@nestjs/core";
 import { MicroserviceOptions } from "@nestjs/microservices";
 import { AppModule } from "./app.module";
+import { Logger } from "@amplication/util/logging";
+import { Env } from "./env";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
@@ -15,6 +17,9 @@ async function bootstrap() {
 }
 
 bootstrap().catch((error) => {
-  console.error(error);
+  new Logger({ serviceName: Env.SERVICE_NAME, isProduction: true }).error(
+    error.message,
+    error
+  );
   process.exit(1);
 });

--- a/packages/amplication-git-pull-request-service/src/pull-request/pull-request.controller.ts
+++ b/packages/amplication-git-pull-request-service/src/pull-request/pull-request.controller.ts
@@ -36,13 +36,16 @@ export class PullRequestController {
     const offset = context.getMessage().offset;
     const topic = context.getTopic();
     const partition = context.getPartition();
+    const logger = this.logger.child({
+      resourceId: validArgs.resourceId,
+      buildId: validArgs.newBuildId,
+    });
 
-    this.logger.info(`Got a new generate pull request item from queue.`, {
+    logger.info(`Got a new generate pull request item from queue.`, {
       topic,
       partition,
       offset: context.getMessage().offset,
       class: this.constructor.name,
-      args: validArgs,
     });
 
     try {
@@ -50,12 +53,11 @@ export class PullRequestController {
         validArgs
       );
 
-      this.logger.info(`Finish process, committing`, {
+      logger.info(`Finish process, committing`, {
         topic,
         partition,
         offset,
         class: this.constructor.name,
-        buildId: validArgs.newBuildId,
       });
 
       const response = { url: pullRequest, buildId: validArgs.newBuildId };
@@ -65,10 +67,9 @@ export class PullRequestController {
         JSON.stringify(response)
       );
     } catch (error) {
-      this.logger.error(error.message, error, {
+      logger.error(error.message, error, {
         class: PullRequestController.name,
         offset,
-        buildId: validArgs.newBuildId,
       });
 
       const response = {

--- a/packages/amplication-git-pull-request-service/src/pull-request/pull-request.service.ts
+++ b/packages/amplication-git-pull-request-service/src/pull-request/pull-request.service.ts
@@ -66,7 +66,7 @@ export class PullRequestService {
     commit,
     gitResourceMeta,
     pullRequestMode,
-  }: CreatePrRequest.Value): Promise<string> {
+  }: CreatePullRequestArgs): Promise<string> {
     const logger = this.logger.child({ resourceId, buildId: newBuildId });
     const { body, title } = commit;
     const head =

--- a/packages/amplication-git-pull-request-service/src/pull-request/pull-request.service.ts
+++ b/packages/amplication-git-pull-request-service/src/pull-request/pull-request.service.ts
@@ -66,7 +66,8 @@ export class PullRequestService {
     commit,
     gitResourceMeta,
     pullRequestMode,
-  }: CreatePullRequestArgs): Promise<string> {
+  }: CreatePrRequest.Value): Promise<string> {
+    const logger = this.logger.child({ resourceId, buildId: newBuildId });
     const { body, title } = commit;
     const head =
       commit.head || pullRequestMode === EnumPullRequestMode.Accumulative
@@ -78,9 +79,11 @@ export class PullRequestService {
       newBuildId
     );
 
-    this.logger.info(
+    logger.info(
       "The changed files have returned from the diff service listOfChangedFiles are",
-      { lengthOfFile: changedFiles.length }
+      {
+        lengthOfFile: changedFiles.length,
+      }
     );
     const gitClientService = await new GitClientService().create(
       {
@@ -88,7 +91,7 @@ export class PullRequestService {
         providerOrganizationProperties: { installationId },
       },
       this.gitProvidersConfiguration,
-      this.logger
+      logger
     );
     const prUrl = await gitClientService.createPullRequest({
       owner,
@@ -101,7 +104,7 @@ export class PullRequestService {
       gitResourceMeta,
       files: PullRequestService.removeFirstSlashFromPath(changedFiles),
     });
-    this.logger.info("Opened a new pull request", { prUrl });
+    logger.info("Opened a new pull request", { prUrl });
     return prUrl;
   }
 

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -38,6 +38,7 @@ import { BillingService } from "../billing/billing.service";
 import { EnumPullRequestMode } from "@amplication/git-utils";
 import { SendPullRequestArgs } from "./dto/sendPullRequest";
 import { BillingFeature } from "../billing/billing.types";
+import { ILogger } from "@amplication/util/logging";
 
 export const HOST_VAR = "HOST";
 export const CLIENT_HOST_VAR = "CLIENT_HOST";
@@ -214,6 +215,9 @@ export class BuildService {
 
     const logger = this.logger.child({
       buildId: build.id,
+      resourceId: build.resourceId,
+      userId: build.userId,
+      user,
     });
 
     const resource = await this.resourceService.findOne({
@@ -225,7 +229,7 @@ export class BuildService {
     }
 
     logger.info(JOB_STARTED_LOG);
-    await this.generate(build, user);
+    await this.generate(logger, build, user);
 
     return build;
   }
@@ -292,7 +296,11 @@ export class BuildService {
    * @param build the build object to generate code for
    * @param user the user that triggered the build
    */
-  private async generate(build: Build, user: User): Promise<string> {
+  private async generate(
+    logger: ILogger,
+    build: Build,
+    user: User
+  ): Promise<string> {
     return this.actionService.run(
       build.actionId,
       GENERATE_STEP_NAME,
@@ -300,10 +308,7 @@ export class BuildService {
       async (step) => {
         const { resourceId, id: buildId, version: buildVersion } = build;
 
-        const logger = this.logger.child({
-          buildId: build.id,
-        });
-        this.logger.info("Preparing build generation message");
+        logger.info("Preparing build generation message");
 
         const dsgResourceData = await this.getDSGResourceData(
           resourceId,
@@ -396,18 +401,25 @@ export class BuildService {
       build.createdAt
     );
 
+    const user = await this.userService.findUser({
+      where: { id: build.userId },
+    });
+
+    const logger = this.logger.child({
+      buildId: build.id,
+      resourceId: build.resourceId,
+      userId: build.userId,
+      user,
+    });
+
     const resource = await this.resourceService.resource({
       where: { id: build.resourceId },
     });
 
     if (!resource) {
-      this.logger.warn("Resource was not found during pushing code to git");
+      logger.warn("Resource was not found during pushing code to git");
       return;
     }
-
-    const user = await this.userService.findUser({
-      where: { id: build.userId },
-    });
 
     const dSGResourceData = await this.getDSGResourceData(
       build.resourceId,
@@ -498,10 +510,7 @@ export class BuildService {
             JSON.stringify(createPullRequestArgs)
           );
         } catch (error) {
-          this.logger.error(
-            "Failed to emit Create Pull Request Message.",
-            error
-          );
+          logger.error("Failed to emit Create Pull Request Message.", error);
         }
       },
       true


### PR DESCRIPTION
Close: #5961

## PR Details

Add additional metadata (`buildId`, `resourceId`, and `userId` where available) to log entries that are related to the code generation process to simplify the log consumption.

This changes will help investigating https://github.com/amplication/amplication/issues/5944  

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
