### PR TITLE
Refactor(client): git provider icons

### DIFF
--- a/packages/amplication-client/src/Resource/git/GitActions/ExistingConnectionsMenu.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/ExistingConnectionsMenu.tsx
@@ -7,18 +7,11 @@ import {
   SelectMenuList,
   SelectMenuModal,
 } from "@amplication/ui/design-system";
-import BitbucketLogo from "../../../assets/images/bitbucket.svg";
-import GithubLogo from "../../../assets/images/github.svg";
+import { gitLogoMap } from "../git-provider-icon-map";
 import { GitOrganizationFromGitRepository } from "../SyncWithGithubPage";
 import "./ExistingConnectionsMenu.scss";
 import { GitOrganizationMenuItemContent } from "./GitOrganizationMenuItemContent";
-import * as models from "../../../models";
 import { useRef } from "react";
-
-export const gitLogoMap = {
-  [models.EnumGitProvider.Bitbucket]: BitbucketLogo,
-  [models.EnumGitProvider.Github]: GithubLogo,
-};
 
 type Props = {
   gitOrganizations: GitOrganizationFromGitRepository[];

--- a/packages/amplication-client/src/Resource/git/git-provider-icon-map.ts
+++ b/packages/amplication-client/src/Resource/git/git-provider-icon-map.ts
@@ -1,0 +1,13 @@
+import { EnumGitProvider } from "../../models";
+import BitbucketLogo from "../../assets/images/bitbucket.svg";
+import GithubLogo from "../../assets/images/github.svg";
+
+export const gitProviderIconMap = {
+  [EnumGitProvider.Github]: "github",
+  [EnumGitProvider.Bitbucket]: "git-sync",
+};
+
+export const gitLogoMap = {
+  [EnumGitProvider.Bitbucket]: BitbucketLogo,
+  [EnumGitProvider.Github]: GithubLogo,
+};

--- a/packages/amplication-client/src/Resource/git/git-provider-icon-map.ts
+++ b/packages/amplication-client/src/Resource/git/git-provider-icon-map.ts
@@ -4,7 +4,7 @@ import GithubLogo from "../../assets/images/github.svg";
 
 export const gitProviderIconMap = {
   [EnumGitProvider.Github]: "github",
-  [EnumGitProvider.Bitbucket]: "git-sync",
+  [EnumGitProvider.Bitbucket]: "git-sync", // TODO: replace with bitbucket icon (once we have one)
 };
 
 export const gitLogoMap = {

--- a/packages/amplication-client/src/Resource/git/select/GitSelectMenu.tsx
+++ b/packages/amplication-client/src/Resource/git/select/GitSelectMenu.tsx
@@ -9,7 +9,7 @@ import { GitSelectMenuItemContent } from "./GitSelectMenuItemContent";
 
 import "./GitSelectMenu.scss";
 import { EnumGitProvider } from "../../../models";
-import { gitLogoMap } from "../GitActions/ExistingConnectionsMenu";
+import { gitLogoMap } from "../git-provider-icon-map";
 
 const CLASS_NAME = "git-select-menu";
 

--- a/packages/amplication-client/src/VersionControl/BuildSteps.tsx
+++ b/packages/amplication-client/src/VersionControl/BuildSteps.tsx
@@ -12,6 +12,7 @@ import { BuildStepsStatus } from "./BuildStepsStatus";
 import "./BuildSteps.scss";
 import { AnalyticsEventNames } from "../util/analytics-events.types";
 import { AppContext } from "../context/appContext";
+import { gitProviderIconMap } from "../Resource/git/git-provider-icon-map";
 
 const CLASS_NAME = "build-steps";
 
@@ -88,7 +89,7 @@ const BuildSteps = ({ build }: Props) => {
           className={`${CLASS_NAME}__step`}
           panelStyle={EnumPanelStyle.Bordered}
         >
-          <Icon icon="git-sync" />
+          <Icon icon={gitProviderIconMap[gitRepositoryOrganizationProvider]} />
           <span>{`Push Changes to ${gitRepositoryOrganizationProvider}`}</span>
           <BuildStepsStatus status={stepGithub.status} />
           <span className="spacer" />

--- a/packages/amplication-client/src/Workspaces/ResourceListItem.tsx
+++ b/packages/amplication-client/src/Workspaces/ResourceListItem.tsx
@@ -17,6 +17,7 @@ import {
 import ResourceCircleBadge from "../Components/ResourceCircleBadge";
 import { AppContext } from "../context/appContext";
 import classNames from "classnames";
+import { gitProviderIconMap } from "../Resource/git/git-provider-icon-map";
 
 type Props = {
   resource: models.Resource;
@@ -117,7 +118,7 @@ function ResourceListItem({ resource, onDelete }: Props) {
                 })}
               >
                 <Icon
-                  icon="git-sync"
+                  icon={gitProviderIconMap[provider]}
                   size="small"
                   className={`${CLASS_NAME}__git-sync-repo__icon${
                     !gitRepo ? "-not-connected" : ""

--- a/packages/amplication-client/src/Workspaces/WorkspaceFooter.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceFooter.tsx
@@ -10,6 +10,7 @@ import { PUSH_TO_GITHUB_STEP_NAME } from "../VersionControl/BuildSteps";
 import useCommit from "../VersionControl/hooks/useCommits";
 import "./WorkspaceFooter.scss";
 import { EnumGitProvider } from "../models";
+import { gitProviderIconMap } from "../Resource/git/git-provider-icon-map";
 
 const CLASS_NAME = "workspace-footer";
 
@@ -80,7 +81,7 @@ const WorkspaceFooter: React.FC<unknown> = () => {
         {gitRepositoryFullName?.includes("/") ? (
           <div className={`${CLASS_NAME}__git-connection`}>
             <Icon
-              icon="git-sync"
+              icon={gitProviderIconMap[gitRepositoryOrganizationProvider]}
               size="small"
               className={`${CLASS_NAME}__git-icon`}
             />


### PR DESCRIPTION
Close: #5971

## PR Details

1. Create a git provider icon map to load the icon according to the connected git provider.
- resource item
- workspace footer
- build a log page

2. Move our git provider image map to the same file and refactor usage

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
