### PR TITLE
fix(client): add missing property to the query

### DIFF
--- a/packages/amplication-client/src/Workspaces/queries/resourcesQueries.ts
+++ b/packages/amplication-client/src/Workspaces/queries/resourcesQueries.ts
@@ -23,6 +23,7 @@ export const GET_RESOURCES = gql`
           name
           type
           provider
+          useGroupingForRepositories
         }
       }
       builds(orderBy: { createdAt: Desc }, take: 1) {


### PR DESCRIPTION
Close: #5978

## PR Details

fix open with bitbucket broken link

The source of the problem was that we got the organization from a query that didn't return the `useGroupingForRepositories` and that's why we got `${organizationName}/${repositoryName}`

```
  const {
    name: organizationName,
    useGroupingForRepositories,
    provider,
  } = organization;

  // if the provider supports grouping for repositories, we use the group name, but we need to make sure it exists first,
  // otherwise we use the organization name
  let repositoryFullName = "";

  if (useGroupingForRepositories) {
    repositoryFullName = groupName ? `${groupName}/${repositoryName}` : null;
  } else {
    repositoryFullName = `${organizationName}/${repositoryName}`;
  }
```

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
