### PR TITLE
fix(client): add optional chaining for build

### DIFF
--- a/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceCodeGeneration.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceCodeGeneration.tsx
@@ -127,7 +127,7 @@ const CreateServiceCodeGeneration: React.FC<
     );
 
     return log?.meta?.githubUrl || null;
-  }, [data.build.action]);
+  }, [data.build?.action]);
 
   const buildRunning = data?.build?.status === models.EnumBuildStatus.Running;
 


### PR DESCRIPTION
Close: #6001 

## PR Details

add optional chaining for `build` as its an optional field

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
