### PR TITLE
fix(client): show the "create repository" button from the select repository modal only if the organization type is Organization and not User

### DIFF
--- a/packages/amplication-client/src/Resource/git/dialogs/GitRepos/GithubRepos.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitRepos/GithubRepos.tsx
@@ -223,16 +223,18 @@ function GitRepos({
           )}
         </div>
         <div className={`${CLASS_NAME}__header-right`}>
-          <Button
-            className={`${CLASS_NAME}__header-create`}
-            buttonStyle={EnumButtonStyle.Outline}
-            onClick={(e) => {
-              openCreateNewRepo();
-            }}
-            type="button"
-          >
-            Create repository
-          </Button>
+          {gitOrganization.type === EnumGitOrganizationType.Organization && (
+            <Button
+              className={`${CLASS_NAME}__header-create`}
+              buttonStyle={EnumButtonStyle.Outline}
+              onClick={(e) => {
+                openCreateNewRepo();
+              }}
+              type="button"
+            >
+              Create repository
+            </Button>
+          )}
         </div>
       </div>
       {networkStatus !== NetworkStatus.refetch && // hide data if refetch


### PR DESCRIPTION
Close: #6016 

## PR Details
show the  "create repository" button from the select repository modal only if the organization type is Organization and not User

GitHub User
![Screenshot 2023-05-16 at 17 24 04](https://github.com/amplication/amplication/assets/39680385/2e67d832-5491-476e-bc54-74a469a12ac6)

GitHub Organization

![Screenshot 2023-05-16 at 17 39 19](https://github.com/amplication/amplication/assets/39680385/792c80d2-1083-43a9-90b0-51b80a635efe)


## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
