### PR TITLE
Refactor(client): refactor bitbucket lock tooltip text

### DIFF
--- a/libs/ui/design-system/src/lib/components/LimitationNotification/LimitationNotification.scss
+++ b/libs/ui/design-system/src/lib/components/LimitationNotification/LimitationNotification.scss
@@ -8,7 +8,8 @@
   min-height: 42px;
 }
 
-.upgrade-link {
+.upgrade-link,
+.contact-us-link {
   color: #53dbee;
   text-decoration: underline;
   font-weight: 500;

--- a/libs/ui/design-system/src/lib/components/LimitationNotification/LimitationNotification.tsx
+++ b/libs/ui/design-system/src/lib/components/LimitationNotification/LimitationNotification.tsx
@@ -5,6 +5,7 @@ import "./LimitationNotification.scss";
 
 const LIMIT_CLASS_NAME = "limitation-notification";
 const UPGRADE_LINK_CLASS_NAME = "upgrade-link";
+const CONTACT_US_LINK_CLASS_NAME = "contact-us-link";
 
 export type Props = {
   description: string;
@@ -13,6 +14,26 @@ export type Props = {
 export type LinkProps = {
   link: string;
   handleClick: () => void;
+};
+
+export const ContactUsLinkForEnterprise = ({
+  link,
+  handleClick,
+}: LinkProps) => {
+  return (
+    <a
+      href={link}
+      onClick={(e) => {
+        e.preventDefault();
+        handleClick();
+      }}
+      className={CONTACT_US_LINK_CLASS_NAME}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Contact Us Now
+    </a>
+  );
 };
 
 export const UpgradeLink = ({ link, handleClick }: LinkProps) => {

--- a/libs/ui/design-system/src/lib/components/LimitationNotification/LimitationNotification.tsx
+++ b/libs/ui/design-system/src/lib/components/LimitationNotification/LimitationNotification.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { Link } from "react-router-dom";
 
 import "./LimitationNotification.scss";
@@ -20,13 +20,18 @@ export const ContactUsLinkForEnterprise = ({
   link,
   handleClick,
 }: LinkProps) => {
+  const handleContactUsLinkClick = useCallback(
+    (e: { preventDefault: () => void }) => {
+      e.preventDefault();
+      handleClick();
+    },
+    [handleClick]
+  );
+
   return (
     <a
       href={link}
-      onClick={(e) => {
-        e.preventDefault();
-        handleClick();
-      }}
+      onClick={handleContactUsLinkClick}
       className={CONTACT_US_LINK_CLASS_NAME}
       target="_blank"
       rel="noopener noreferrer"

--- a/libs/ui/design-system/src/lib/index.ts
+++ b/libs/ui/design-system/src/lib/index.ts
@@ -172,5 +172,8 @@ export type { Props as LimitationNotificationProps } from "./components/Limitati
 export { UpgradeLink } from "./components/LimitationNotification/LimitationNotification";
 export type { LinkProps as UpgradeLinkProps } from "./components/LimitationNotification/LimitationNotification";
 
+export { ContactUsLinkForEnterprise } from "./components/LimitationNotification/LimitationNotification";
+export type { LinkProps as ContactUsLinkForEnterpriseProps } from "./components/LimitationNotification/LimitationNotification";
+
 export { PlanUpgradeConfirmation } from "./components/PlanUpgradeConfirmation/PlanUpgradeConfirmation";
 export type { Props as PlanUpgradeConfirmationProps } from "./components/PlanUpgradeConfirmation/PlanUpgradeConfirmation";

--- a/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnection.scss
+++ b/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnection.scss
@@ -41,7 +41,8 @@
     }
 
     &__info {
-      .upgrade-link {
+      .upgrade-link,
+      .contact-us-link {
         font-weight: 600;
       }
     }

--- a/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnection.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnection.tsx
@@ -1,4 +1,9 @@
-import { Button, EnumButtonStyle, Icon } from "@amplication/ui/design-system";
+import {
+  Button,
+  EnumButtonStyle,
+  Icon,
+  ContactUsLinkForEnterprise,
+} from "@amplication/ui/design-system";
 import { EnumGitProvider } from "../../../models";
 import { useCallback } from "react";
 
@@ -7,7 +12,6 @@ import classNames from "classnames";
 
 import { styled } from "@mui/material/styles";
 import Tooltip, { TooltipProps, tooltipClasses } from "@mui/material/Tooltip";
-import { ContactUsLinkForEnterprise } from "libs/ui/design-system/src/lib/components/LimitationNotification/LimitationNotification";
 
 const WarningTooltip = styled(({ className, ...props }: TooltipProps) => (
   <Tooltip {...props} classes={{ popper: className }} />

--- a/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnection.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnection.tsx
@@ -1,18 +1,12 @@
-import {
-  Button,
-  EnumButtonStyle,
-  Icon,
-  UpgradeLink,
-} from "@amplication/ui/design-system";
+import { Button, EnumButtonStyle, Icon } from "@amplication/ui/design-system";
 import { EnumGitProvider } from "../../../models";
-import { useCallback, useContext } from "react";
+import { useCallback } from "react";
 
 import "./GitProviderConnection.scss";
 import classNames from "classnames";
 
 import { styled } from "@mui/material/styles";
 import Tooltip, { TooltipProps, tooltipClasses } from "@mui/material/Tooltip";
-import { AppContext } from "../../../../src/context/appContext";
 import { ContactUsLinkForEnterprise } from "libs/ui/design-system/src/lib/components/LimitationNotification/LimitationNotification";
 
 const WarningTooltip = styled(({ className, ...props }: TooltipProps) => (
@@ -53,7 +47,6 @@ export default function GitProviderConnection({
     onSyncNewGitOrganizationClick(provider);
   }, [provider]);
 
-  const { currentWorkspace } = useContext(AppContext);
   const contactUsLink = "https://amplication.com/contact-us";
 
   return (

--- a/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnection.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnection.tsx
@@ -13,6 +13,7 @@ import classNames from "classnames";
 import { styled } from "@mui/material/styles";
 import Tooltip, { TooltipProps, tooltipClasses } from "@mui/material/Tooltip";
 import { AppContext } from "../../../../src/context/appContext";
+import { ContactUsLinkForEnterprise } from "libs/ui/design-system/src/lib/components/LimitationNotification/LimitationNotification";
 
 const WarningTooltip = styled(({ className, ...props }: TooltipProps) => (
   <Tooltip {...props} classes={{ popper: className }} />
@@ -53,7 +54,7 @@ export default function GitProviderConnection({
   }, [provider]);
 
   const { currentWorkspace } = useContext(AppContext);
-  const upgradeLink = `/${currentWorkspace?.id}/purchase`;
+  const contactUsLink = "https://amplication.com/contact-us";
 
   return (
     <div
@@ -74,10 +75,16 @@ export default function GitProviderConnection({
                 <Icon icon="info_circle" />
                 <div className={`${CLASS_NAME}__tooltip__window__info`}>
                   <span>
-                    This feature requires an Enterprise plan, Upgrade now to
-                    access Bitbucket and other premium features
+                    This feature requires an Enterprise plan.
+                    <br />
+                    For more information,
                   </span>{" "}
-                  <UpgradeLink link={upgradeLink} handleClick={() => {}} />
+                  <ContactUsLinkForEnterprise
+                    link={contactUsLink}
+                    handleClick={() => {
+                      window.open(contactUsLink, "_blank");
+                    }}
+                  />
                 </div>
               </div>
             }


### PR DESCRIPTION
Close: #5995

## PR Details

- design system - add new component to limit notfication to handle contact us for enterprise
- client - use the new component to open the link in a new tab and without concatinate the link to the window location that the use came from (amplication wizard or git sync page)


https://github.com/amplication/amplication/assets/39680385/71715bcb-5980-4457-87f2-dcd3ba29be3e


## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
