### PR TITLE
Refactor(client): UX of create public-private repo

### DIFF
--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -290,7 +290,7 @@ export type CreateGitRepositoryBaseInput = {
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   groupName?: InputMaybe<Scalars['String']>;
-  isPrivate: Scalars['Boolean'];
+  isPublic: Scalars['Boolean'];
   name: Scalars['String'];
 };
 
@@ -300,7 +300,7 @@ export type CreateGitRepositoryInput = {
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   groupName?: InputMaybe<Scalars['String']>;
-  isPrivate: Scalars['Boolean'];
+  isPublic: Scalars['Boolean'];
   name: Scalars['String'];
   resourceId: Scalars['String'];
 };

--- a/packages/amplication-client/src/Resource/git/AuthResourceWithGit.tsx
+++ b/packages/amplication-client/src/Resource/git/AuthResourceWithGit.tsx
@@ -93,7 +93,7 @@ function AuthResourceWithGit({ resource, onDone }: Props) {
           name: data.name,
           gitOrganizationId: gitOrganization.id,
           gitProvider: gitOrganization.provider,
-          isPrivate: data.isPrivate,
+          isPublic: data.isPublic,
           resourceId: resource.id,
           groupName: data.groupName,
         },
@@ -206,13 +206,13 @@ const CREATE_GIT_REPOSITORY_IN_ORGANIZATION = gql`
     $gitOrganizationId: String!
     $resourceId: String!
     $name: String!
-    $isPrivate: Boolean!
+    $isPublic: Boolean!
     $groupName: String
   ) {
     createGitRepository(
       data: {
         name: $name
-        isPrivate: $isPrivate
+        isPublic: $isPublic
         gitOrganizationId: $gitOrganizationId
         resourceId: $resourceId
         gitProvider: $gitProvider

--- a/packages/amplication-client/src/Resource/git/AuthWithGit.tsx
+++ b/packages/amplication-client/src/Resource/git/AuthWithGit.tsx
@@ -117,7 +117,7 @@ function AuthWithGit({
           gitOrganizationId: data.gitOrganizationId,
           gitProvider: data.gitProvider,
           groupName: data.groupName,
-          isPrivate: data.isPrivate,
+          isPublic: data.isPublic,
         },
         onCompleted() {
           setCreateNewRepoOpen(false);
@@ -255,13 +255,13 @@ const CREATE_GIT_REMOTE_REPOSITORY = gql`
     $gitProvider: EnumGitProvider!
     $gitOrganizationId: String!
     $name: String!
-    $isPrivate: Boolean!
+    $isPublic: Boolean!
     $groupName: String
   ) {
     createRemoteGitRepository(
       data: {
         name: $name
-        isPrivate: $isPrivate
+        isPublic: $isPublic
         gitOrganizationId: $gitOrganizationId
         gitProvider: $gitProvider
         gitOrganizationType: Organization

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/CreateGitFormSchema/CreateGitFormSchema.spec.ts
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/CreateGitFormSchema/CreateGitFormSchema.spec.ts
@@ -1,16 +1,16 @@
 import { CreateGitFormSchema } from "./CreateGitFormSchema";
 
 describe("Testing the CreateGitFormSchema", () => {
-  const validObject = { name: "ofek", isPrivate: true };
-  const UnValidObjectPublic = { name: "ofek", isPrivate: 45 };
-  const UnValidObjectNameShort = { name: "o", isPrivate: true };
+  const validObject = { name: "ofek", isPublic: true };
+  const UnValidObjectPublic = { name: "ofek", isPublic: 45 };
+  const UnValidObjectNameShort = { name: "o", isPublic: true };
 
   it("should pass the validate", () => {
     return expect(CreateGitFormSchema.validate(validObject)).resolves.toBe(
       validObject
     );
   });
-  it("should throw error if getting invalid value for isPrivate property", async () => {
+  it("should throw error if getting invalid value for isPublic property", async () => {
     return expect(
       CreateGitFormSchema.validate(UnValidObjectPublic)
     ).rejects.toThrowError();

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/CreateGitFormSchema/CreateGitFormSchema.ts
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/CreateGitFormSchema/CreateGitFormSchema.ts
@@ -4,5 +4,5 @@ export const CreateGitFormSchema = object().shape({
   name: string()
     .min(2, "Git repository name require minimum of 2 characters")
     .required("Repository name is missing"),
-  isPrivate: bool().required("Must select if repo is private"),
+  isPublic: bool().required("Must select if repo is private"),
 });

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/GitCreateRepo.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/GitCreateRepo.tsx
@@ -34,7 +34,7 @@ export default function GitCreateRepo({
 }: Props) {
   const initialValues: Partial<CreateGitRepositoryInput> = {
     name: "",
-    isPrivate: false,
+    isPublic: true,
   };
 
   const { data: gitGroupsData } = useQuery(GET_GROUPS, {
@@ -92,9 +92,9 @@ export default function GitCreateRepo({
 
           <div>
             <Toggle
-              name="isPrivate"
-              label={values.isPrivate ? "Private Repo" : "Public Repo"}
-              checked={values.isPrivate}
+              name="isPublic"
+              label="Public Repository"
+              checked={values.isPublic}
               onChange={handleChange}
             />
           </div>

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/WizardGitCreateRepo.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/WizardGitCreateRepo.tsx
@@ -18,7 +18,7 @@ import { GitSelectMenu } from "../../select/GitSelectMenu";
 
 type createRepositoryInput = {
   name: string;
-  isPrivate: boolean;
+  isPublic: boolean;
   groupName?: string;
 };
 type Props = {
@@ -41,7 +41,7 @@ export default function WizardGitCreateRepo({
     useState<createRepositoryInput>({
       name: "",
       groupName: "",
-      isPrivate: false,
+      isPublic: true,
     });
   const [gitRepositoryUrl, setGitRepositoryUrl] = useState<string>("");
 
@@ -98,14 +98,14 @@ export default function WizardGitCreateRepo({
       gitProvider: gitOrganization?.provider,
       name: createRepositoryInput.name,
       groupName: createRepositoryInput.groupName,
-      isPrivate: createRepositoryInput.isPrivate,
+      isPublic: createRepositoryInput.isPublic,
       gitRepositoryUrl: gitRepositoryUrl,
     });
   }, [
     onCreateGitRepository,
     createRepositoryInput.name,
     createRepositoryInput.groupName,
-    createRepositoryInput.isPrivate,
+    createRepositoryInput.isPublic,
   ]);
 
   return (
@@ -132,15 +132,13 @@ export default function WizardGitCreateRepo({
       <br />
       <div>
         <Toggle
-          name="isPrivate"
-          label={
-            createRepositoryInput.isPrivate ? "Private Repo" : "Public Repo"
-          }
-          checked={createRepositoryInput.isPrivate}
+          name="isPublic"
+          label="Public Repo"
+          checked={createRepositoryInput.isPublic}
           onChange={(event, checked) => {
             setCreateRepositoryInput({
               ...createRepositoryInput,
-              isPrivate: checked,
+              isPublic: checked,
             });
           }}
         />

--- a/packages/amplication-client/src/Resource/git/dialogs/GitRepos/GithubRepos.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitRepos/GithubRepos.tsx
@@ -49,7 +49,7 @@ export type GitRepositoryCreatedData = {
   gitOrganizationId: string;
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
-  isPrivate: boolean;
+  isPublic: boolean;
   groupName?: string;
   gitRepositoryUrl?: string;
 };

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -290,7 +290,7 @@ export type CreateGitRepositoryBaseInput = {
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   groupName?: InputMaybe<Scalars['String']>;
-  isPrivate: Scalars['Boolean'];
+  isPublic: Scalars['Boolean'];
   name: Scalars['String'];
 };
 
@@ -300,7 +300,7 @@ export type CreateGitRepositoryInput = {
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   groupName?: InputMaybe<Scalars['String']>;
-  isPrivate: Scalars['Boolean'];
+  isPublic: Scalars['Boolean'];
   name: Scalars['String'];
   resourceId: Scalars['String'];
 };

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -290,7 +290,7 @@ export type CreateGitRepositoryBaseInput = {
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   groupName?: InputMaybe<Scalars['String']>;
-  isPrivate: Scalars['Boolean'];
+  isPublic: Scalars['Boolean'];
   name: Scalars['String'];
 };
 
@@ -300,7 +300,7 @@ export type CreateGitRepositoryInput = {
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   groupName?: InputMaybe<Scalars['String']>;
-  isPrivate: Scalars['Boolean'];
+  isPublic: Scalars['Boolean'];
   name: Scalars['String'];
   resourceId: Scalars['String'];
 };

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -290,7 +290,7 @@ export type CreateGitRepositoryBaseInput = {
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   groupName?: InputMaybe<Scalars['String']>;
-  isPrivate: Scalars['Boolean'];
+  isPublic: Scalars['Boolean'];
   name: Scalars['String'];
 };
 
@@ -300,7 +300,7 @@ export type CreateGitRepositoryInput = {
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   groupName?: InputMaybe<Scalars['String']>;
-  isPrivate: Scalars['Boolean'];
+  isPublic: Scalars['Boolean'];
   name: Scalars['String'];
   resourceId: Scalars['String'];
 };

--- a/packages/amplication-server/src/core/git/dto/inputs/CreateGitRepositoryBaseInput.ts
+++ b/packages/amplication-server/src/core/git/dto/inputs/CreateGitRepositoryBaseInput.ts
@@ -20,7 +20,7 @@ export class CreateGitRepositoryBaseInput {
   @Field(() => Boolean, {
     nullable: false,
   })
-  isPrivate!: boolean;
+  isPublic!: boolean;
 
   @Field(() => String, {
     nullable: false,

--- a/packages/amplication-server/src/core/git/git.provider.service.ts
+++ b/packages/amplication-server/src/core/git/git.provider.service.ts
@@ -174,6 +174,8 @@ export class GitProviderService {
   async createRemoteGitRepository(
     args: CreateGitRepositoryInput
   ): Promise<Resource> {
+    // negate the isPublic flag to get the isPrivate flag
+    const isPrivateRepository = args.isPublic ? !args.isPublic : true;
     const organization = await this.getGitOrganization({
       where: {
         id: args.gitOrganizationId,
@@ -195,7 +197,7 @@ export class GitProviderService {
       },
       groupName: args.groupName,
       owner: organization.name,
-      isPrivate: args.isPrivate,
+      isPrivate: isPrivateRepository,
     };
 
     const gitClientService = await this.createGitClient(organization);
@@ -220,6 +222,8 @@ export class GitProviderService {
   async createRemoteGitRepositoryWithoutConnect(
     args: CreateGitRepositoryBaseInput
   ): Promise<boolean> {
+    // negate the isPublic flag to get the isPrivate flag
+    const isPrivateRepository = args.isPublic ? !args.isPublic : true;
     const organization = await this.getGitOrganization({
       where: {
         id: args.gitOrganizationId,
@@ -234,7 +238,7 @@ export class GitProviderService {
       },
       groupName: args.groupName,
       owner: organization.name,
-      isPrivate: args.isPrivate,
+      isPrivate: isPrivateRepository,
     };
 
     const gitClientService = await this.createGitClient(organization);

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -1472,7 +1472,7 @@ input CreateGitRepositoryInput {
   Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true
   """
   groupName: String
-  isPrivate: Boolean!
+  isPublic: Boolean!
   gitOrganizationId: String!
   gitProvider: EnumGitProvider!
   gitOrganizationType: EnumGitOrganizationType!
@@ -1486,7 +1486,7 @@ input CreateGitRepositoryBaseInput {
   Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true
   """
   groupName: String
-  isPrivate: Boolean!
+  isPublic: Boolean!
   gitOrganizationId: String!
   gitProvider: EnumGitProvider!
   gitOrganizationType: EnumGitOrganizationType!

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -290,7 +290,7 @@ export type CreateGitRepositoryBaseInput = {
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   groupName?: InputMaybe<Scalars['String']>;
-  isPrivate: Scalars['Boolean'];
+  isPublic: Scalars['Boolean'];
   name: Scalars['String'];
 };
 
@@ -300,7 +300,7 @@ export type CreateGitRepositoryInput = {
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
   groupName?: InputMaybe<Scalars['String']>;
-  isPrivate: Scalars['Boolean'];
+  isPublic: Scalars['Boolean'];
   name: Scalars['String'];
   resourceId: Scalars['String'];
 };


### PR DESCRIPTION
Close: #5994

## PR Details

- change the property to `isPublic` for the client and set it to `true`, so the toggle will be checked by default
- handle the conversion (negate the value of isPublic) in the server

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
