### PR TITLE
feat(server): add customAttributes to Entity

### DIFF
--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -318,6 +318,7 @@ export type DateTimeFilter = {
 
 export type Entity = {
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
   fields?: Maybe<Array<EntityField>>;
@@ -357,6 +358,7 @@ export type EntityAddPermissionFieldInput = {
 };
 
 export type EntityCreateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   description?: InputMaybe<Scalars['String']>;
   displayName: Scalars['String'];
   name: Scalars['String'];
@@ -448,6 +450,7 @@ export type EntityFieldWhereInput = {
 
 export type EntityOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
   id?: InputMaybe<SortOrder>;
@@ -492,6 +495,7 @@ export type EntityPermissionRole = {
 };
 
 export type EntityUpdateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   description?: InputMaybe<Scalars['String']>;
   displayName?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
@@ -519,6 +523,7 @@ export type EntityUpdatePermissionRolesInput = {
 export type EntityVersion = {
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
   entity: Entity;
@@ -542,6 +547,7 @@ export type EntityVersionFieldsArgs = {
 
 export type EntityVersionOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
   id?: InputMaybe<SortOrder>;
@@ -554,6 +560,7 @@ export type EntityVersionOrderByInput = {
 
 export type EntityVersionWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
   entity?: InputMaybe<WhereUniqueInput>;
@@ -567,6 +574,7 @@ export type EntityVersionWhereInput = {
 
 export type EntityWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
   fields?: InputMaybe<EntityFieldFilter>;

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -318,6 +318,7 @@ export type DateTimeFilter = {
 
 export type Entity = {
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
   fields?: Maybe<Array<EntityField>>;
@@ -357,6 +358,7 @@ export type EntityAddPermissionFieldInput = {
 };
 
 export type EntityCreateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   description?: InputMaybe<Scalars['String']>;
   displayName: Scalars['String'];
   name: Scalars['String'];
@@ -448,6 +450,7 @@ export type EntityFieldWhereInput = {
 
 export type EntityOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
   id?: InputMaybe<SortOrder>;
@@ -492,6 +495,7 @@ export type EntityPermissionRole = {
 };
 
 export type EntityUpdateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   description?: InputMaybe<Scalars['String']>;
   displayName?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
@@ -519,6 +523,7 @@ export type EntityUpdatePermissionRolesInput = {
 export type EntityVersion = {
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
   entity: Entity;
@@ -542,6 +547,7 @@ export type EntityVersionFieldsArgs = {
 
 export type EntityVersionOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
   id?: InputMaybe<SortOrder>;
@@ -554,6 +560,7 @@ export type EntityVersionOrderByInput = {
 
 export type EntityVersionWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
   entity?: InputMaybe<WhereUniqueInput>;
@@ -567,6 +574,7 @@ export type EntityVersionWhereInput = {
 
 export type EntityWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
   fields?: InputMaybe<EntityFieldFilter>;

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -318,6 +318,7 @@ export type DateTimeFilter = {
 
 export type Entity = {
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
   fields?: Maybe<Array<EntityField>>;
@@ -357,6 +358,7 @@ export type EntityAddPermissionFieldInput = {
 };
 
 export type EntityCreateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   description?: InputMaybe<Scalars['String']>;
   displayName: Scalars['String'];
   name: Scalars['String'];
@@ -448,6 +450,7 @@ export type EntityFieldWhereInput = {
 
 export type EntityOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
   id?: InputMaybe<SortOrder>;
@@ -492,6 +495,7 @@ export type EntityPermissionRole = {
 };
 
 export type EntityUpdateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   description?: InputMaybe<Scalars['String']>;
   displayName?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
@@ -519,6 +523,7 @@ export type EntityUpdatePermissionRolesInput = {
 export type EntityVersion = {
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
   entity: Entity;
@@ -542,6 +547,7 @@ export type EntityVersionFieldsArgs = {
 
 export type EntityVersionOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
   id?: InputMaybe<SortOrder>;
@@ -554,6 +560,7 @@ export type EntityVersionOrderByInput = {
 
 export type EntityVersionWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
   entity?: InputMaybe<WhereUniqueInput>;
@@ -567,6 +574,7 @@ export type EntityVersionWhereInput = {
 
 export type EntityWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
   fields?: InputMaybe<EntityFieldFilter>;

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -318,6 +318,7 @@ export type DateTimeFilter = {
 
 export type Entity = {
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
   fields?: Maybe<Array<EntityField>>;
@@ -357,6 +358,7 @@ export type EntityAddPermissionFieldInput = {
 };
 
 export type EntityCreateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   description?: InputMaybe<Scalars['String']>;
   displayName: Scalars['String'];
   name: Scalars['String'];
@@ -448,6 +450,7 @@ export type EntityFieldWhereInput = {
 
 export type EntityOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
   id?: InputMaybe<SortOrder>;
@@ -492,6 +495,7 @@ export type EntityPermissionRole = {
 };
 
 export type EntityUpdateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   description?: InputMaybe<Scalars['String']>;
   displayName?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
@@ -519,6 +523,7 @@ export type EntityUpdatePermissionRolesInput = {
 export type EntityVersion = {
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
   entity: Entity;
@@ -542,6 +547,7 @@ export type EntityVersionFieldsArgs = {
 
 export type EntityVersionOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
   id?: InputMaybe<SortOrder>;
@@ -554,6 +560,7 @@ export type EntityVersionOrderByInput = {
 
 export type EntityVersionWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
   entity?: InputMaybe<WhereUniqueInput>;
@@ -567,6 +574,7 @@ export type EntityVersionWhereInput = {
 
 export type EntityWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
   fields?: InputMaybe<EntityFieldFilter>;

--- a/packages/amplication-prisma-db/prisma/migrations/20230519161506_/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20230519161506_/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Entity" ADD COLUMN     "customAttributes" TEXT;
+
+-- AlterTable
+ALTER TABLE "EntityVersion" ADD COLUMN     "customAttributes" TEXT;

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -195,6 +195,7 @@ model Entity {
   displayName       String
   pluralDisplayName String
   description       String?
+  customAttributes  String?
   lockedByUserId    String?
   lockedAt          DateTime?
   deletedAt         DateTime?
@@ -217,6 +218,7 @@ model EntityVersion {
   displayName       String
   pluralDisplayName String
   description       String?
+  customAttributes  String?
   commitId          String?
   deleted           Boolean?
   commit            Commit?            @relation(fields: [commitId], references: [id])

--- a/packages/amplication-server/src/core/entity/constants.ts
+++ b/packages/amplication-server/src/core/entity/constants.ts
@@ -106,6 +106,7 @@ export const DEFAULT_ENTITIES: EntityData[] = [
     name: USER_ENTITY_NAME,
     displayName: "User",
     pluralDisplayName: "Users",
+    customAttributes: "",
     description:
       "An automatically created entity to manage users in the service",
     fields: [

--- a/packages/amplication-server/src/core/entity/dto/EntityCreateInput.ts
+++ b/packages/amplication-server/src/core/entity/dto/EntityCreateInput.ts
@@ -23,6 +23,11 @@ export class EntityCreateInput {
   @Field(() => String, {
     nullable: true,
   })
+  customAttributes?: string;
+
+  @Field(() => String, {
+    nullable: true,
+  })
   description?: string;
 
   @Field(() => WhereParentIdInput, {

--- a/packages/amplication-server/src/core/entity/dto/EntityOrderByInput.ts
+++ b/packages/amplication-server/src/core/entity/dto/EntityOrderByInput.ts
@@ -38,5 +38,10 @@ export class EntityOrderByInput {
   @Field(() => SortOrder, {
     nullable: true,
   })
+  customAttributes?: SortOrder | null;
+
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
   description?: SortOrder | null;
 }

--- a/packages/amplication-server/src/core/entity/dto/EntityUpdateInput.ts
+++ b/packages/amplication-server/src/core/entity/dto/EntityUpdateInput.ts
@@ -22,5 +22,10 @@ export class EntityUpdateInput {
   @Field(() => String, {
     nullable: true,
   })
+  customAttributes?: string | null;
+
+  @Field(() => String, {
+    nullable: true,
+  })
   description?: string | null;
 }

--- a/packages/amplication-server/src/core/entity/dto/EntityVersionOrderByInput.ts
+++ b/packages/amplication-server/src/core/entity/dto/EntityVersionOrderByInput.ts
@@ -43,6 +43,11 @@ export class EntityVersionOrderByInput {
   @Field(() => SortOrder, {
     nullable: true,
   })
+  customAttributes?: SortOrder | null;
+
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
   description?: SortOrder | null;
 
   @Field(() => SortOrder, {

--- a/packages/amplication-server/src/core/entity/dto/EntityVersionWhereInput.ts
+++ b/packages/amplication-server/src/core/entity/dto/EntityVersionWhereInput.ts
@@ -48,6 +48,11 @@ export class EntityVersionWhereInput {
   @Field(() => StringFilter, {
     nullable: true,
   })
+  customAttributes?: StringFilter | null;
+
+  @Field(() => StringFilter, {
+    nullable: true,
+  })
   description?: StringFilter | null;
 
   @Field(() => StringFilter, {

--- a/packages/amplication-server/src/core/entity/dto/EntityWhereInput.ts
+++ b/packages/amplication-server/src/core/entity/dto/EntityWhereInput.ts
@@ -39,6 +39,11 @@ export class EntityWhereInput {
   @Field(() => StringFilter, {
     nullable: true,
   })
+  customAttributes?: StringFilter | null;
+
+  @Field(() => StringFilter, {
+    nullable: true,
+  })
   description?: StringFilter | null;
 
   @Field(() => EntityFieldFilter, {

--- a/packages/amplication-server/src/core/entity/entity.resolver.spec.ts
+++ b/packages/amplication-server/src/core/entity/entity.resolver.spec.ts
@@ -37,6 +37,7 @@ const EXAMPLE_VERSION_NUMBER = 1;
 const EXAMPLE_NAME = "exampleName";
 const EXAMPLE_DISPLAY_NAME = "exampleDisplayName";
 const EXAMPLE_PLURAL_DISPLAY_NAME = "examplePluralDisplayName";
+const EXAMPLE_CUSTOM_ATTRIBUTES = "exampleCustomAttributes";
 
 const EXAMPLE_UNLOCKED_ID = "exampleUnlockedId";
 
@@ -54,6 +55,7 @@ const EXAMPLE_ENTITY: Entity = {
   name: EXAMPLE_NAME,
   displayName: EXAMPLE_DISPLAY_NAME,
   pluralDisplayName: EXAMPLE_PLURAL_DISPLAY_NAME,
+  customAttributes: EXAMPLE_CUSTOM_ATTRIBUTES,
   lockedByUserId: EXAMPLE_USER_ID,
 };
 
@@ -123,6 +125,7 @@ const EXAMPLE_VERSION: EntityVersion = {
   name: EXAMPLE_NAME,
   displayName: EXAMPLE_DISPLAY_NAME,
   pluralDisplayName: EXAMPLE_PLURAL_DISPLAY_NAME,
+  customAttributes: EXAMPLE_CUSTOM_ATTRIBUTES,
   commit: EXAMPLE_COMMIT,
 };
 
@@ -136,6 +139,7 @@ const FIND_ONE_QUERY = gql`
       name
       displayName
       pluralDisplayName
+      customAttributes
       lockedByUserId
     }
   }
@@ -151,6 +155,7 @@ const FIND_MANY_QUERY = gql`
       name
       displayName
       pluralDisplayName
+      customAttributes
       lockedByUserId
     }
   }
@@ -161,6 +166,7 @@ const CREATE_ONE_QUERY = gql`
     $name: String!
     $displayName: String!
     $pluralDisplayName: String!
+    $customAttributes: String
     $id: String!
   ) {
     createOneEntity(
@@ -168,6 +174,7 @@ const CREATE_ONE_QUERY = gql`
         name: $name
         displayName: $displayName
         pluralDisplayName: $pluralDisplayName
+        customAttributes: $customAttributes
         resource: { connect: { id: $id } }
       }
     ) {
@@ -178,6 +185,7 @@ const CREATE_ONE_QUERY = gql`
       name
       displayName
       pluralDisplayName
+      customAttributes
       lockedByUserId
     }
   }
@@ -239,6 +247,7 @@ const LOCK_ENTITY_MUTATION = gql`
       name
       displayName
       pluralDisplayName
+      customAttributes
       lockedByUserId
     }
   }
@@ -254,6 +263,7 @@ const UPDATE_ENTITY_MUTATION = gql`
       name
       displayName
       pluralDisplayName
+      customAttributes
       lockedByUserId
     }
   }
@@ -269,6 +279,7 @@ const DELETE_ENTITY_MUTATION = gql`
       name
       displayName
       pluralDisplayName
+      customAttributes
       lockedByUserId
     }
   }
@@ -729,6 +740,7 @@ describe("EntityResolver", () => {
         name: EXAMPLE_ENTITY.name,
         displayName: EXAMPLE_ENTITY.displayName,
         pluralDisplayName: EXAMPLE_ENTITY.pluralDisplayName,
+        customAttributes: EXAMPLE_ENTITY.customAttributes,
         id: EXAMPLE_ID,
       },
     });
@@ -747,6 +759,7 @@ describe("EntityResolver", () => {
           name: EXAMPLE_ENTITY.name,
           displayName: EXAMPLE_ENTITY.displayName,
           pluralDisplayName: EXAMPLE_ENTITY.pluralDisplayName,
+          customAttributes: EXAMPLE_ENTITY.customAttributes,
           resource: { connect: { id: EXAMPLE_ID } },
         },
       },

--- a/packages/amplication-server/src/core/entity/entity.service.spec.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.spec.ts
@@ -94,6 +94,7 @@ const EXAMPLE_ENTITY: Entity = {
   name: "exampleEntity",
   displayName: "example entity",
   pluralDisplayName: "exampleEntities",
+  customAttributes: "customAttributes",
   description: "example entity",
   lockedByUserId: undefined,
   lockedAt: null,
@@ -136,6 +137,7 @@ const EXAMPLE_CURRENT_ENTITY_VERSION: EntityVersion = {
   name: "exampleEntity",
   displayName: "example entity",
   pluralDisplayName: "exampleEntities",
+  customAttributes: "customAttributes",
   description: "example entity",
 };
 
@@ -193,6 +195,7 @@ const EXAMPLE_LAST_ENTITY_VERSION: EntityVersion = {
   name: "exampleEntity",
   displayName: "example entity",
   pluralDisplayName: "exampleEntities",
+  customAttributes: "customAttributes",
   description: "example entity",
   fields: [
     {
@@ -493,6 +496,7 @@ describe("EntityService", () => {
           displayName: EXAMPLE_ENTITY.displayName,
           description: EXAMPLE_ENTITY.description,
           pluralDisplayName: EXAMPLE_ENTITY.pluralDisplayName,
+          customAttributes: EXAMPLE_ENTITY.customAttributes,
           resource: { connect: { id: EXAMPLE_ENTITY.resourceId } },
         },
       },
@@ -514,6 +518,7 @@ describe("EntityService", () => {
             name: createArgs.args.data.name,
             displayName: createArgs.args.data.displayName,
             pluralDisplayName: createArgs.args.data.pluralDisplayName,
+            customAttributes: createArgs.args.data.customAttributes,
             description: createArgs.args.data.description,
             permissions: {
               create: DEFAULT_PERMISSIONS,
@@ -615,6 +620,7 @@ describe("EntityService", () => {
           name: EXAMPLE_ENTITY.name,
           displayName: EXAMPLE_ENTITY.displayName,
           pluralDisplayName: EXAMPLE_ENTITY.pluralDisplayName,
+          customAttributes: EXAMPLE_ENTITY.customAttributes,
           description: EXAMPLE_ENTITY.description,
         },
       },
@@ -642,6 +648,7 @@ describe("EntityService", () => {
               name: updateArgs.args.data.name,
               displayName: updateArgs.args.data.displayName,
               pluralDisplayName: updateArgs.args.data.pluralDisplayName,
+              customAttributes: updateArgs.args.data.customAttributes,
               description: updateArgs.args.data.description,
             },
           },
@@ -695,6 +702,7 @@ describe("EntityService", () => {
         name: EXAMPLE_ENTITY.name,
         displayName: EXAMPLE_ENTITY.displayName,
         pluralDisplayName: EXAMPLE_ENTITY.pluralDisplayName,
+        customAttributes: EXAMPLE_ENTITY.customAttributes,
         description: EXAMPLE_ENTITY.description,
         commit: {
           connect: {
@@ -714,6 +722,7 @@ describe("EntityService", () => {
       "name",
       "displayName",
       "pluralDisplayName",
+      "customAttributes",
       "description",
     ]);
 
@@ -813,6 +822,7 @@ describe("EntityService", () => {
       "name",
       "displayName",
       "pluralDisplayName",
+      "customAttributes",
       "description",
     ]);
 
@@ -1430,6 +1440,7 @@ describe("EntityService", () => {
           displayName: EXAMPLE_ENTITY.displayName,
           description: EXAMPLE_ENTITY.description,
           pluralDisplayName: EXAMPLE_ENTITY.pluralDisplayName,
+          customAttributes: EXAMPLE_ENTITY.customAttributes,
           resource: { connect: { id: EXAMPLE_ENTITY.resourceId } },
         },
       },

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -266,6 +266,7 @@ export class EntityService {
             name: args.data.name,
             displayName: args.data.displayName,
             pluralDisplayName: args.data.pluralDisplayName,
+            customAttributes: args.data.customAttributes,
             description: args.data.description,
             permissions: {
               create: DEFAULT_PERMISSIONS,
@@ -346,6 +347,7 @@ export class EntityService {
           "name",
           "displayName",
           "pluralDisplayName",
+          "customAttributes",
           "description",
         ]);
         return this.prisma.entity.create({
@@ -635,6 +637,7 @@ export class EntityService {
                 displayName: args.data.displayName,
                 pluralDisplayName: args.data.pluralDisplayName,
                 description: args.data.description,
+                customAttributes: args.data.customAttributes,
               },
             },
           },
@@ -872,6 +875,7 @@ export class EntityService {
         displayName: firstEntityVersion.displayName,
         pluralDisplayName: firstEntityVersion.pluralDisplayName,
         description: firstEntityVersion.description,
+        customAttributes: firstEntityVersion.customAttributes,
         commit: {
           connect: {
             id: args.data.commit.connect.id,
@@ -1016,6 +1020,7 @@ export class EntityService {
       "name",
       "displayName",
       "pluralDisplayName",
+      "customAttributes",
       "description",
     ]);
 

--- a/packages/amplication-server/src/core/project/project.resolver.spec.ts
+++ b/packages/amplication-server/src/core/project/project.resolver.spec.ts
@@ -38,6 +38,7 @@ const EXAMPLE_NAME = "exampleName";
 const EXAMPLE_DESCRIPTION = "exampleDescription";
 const EXAMPLE_DISPLAY_NAME = "exampleDisplayName";
 const EXAMPLE_PLURAL_DISPLAY_NAME = "examplePluralDisplayName";
+const EXAMPLE_CUSTOM_ATTRIBUTES = "exampleCustomAttributes";
 const EXAMPLE_BUILD_ID = "exampleBuildId";
 const EXAMPLE_VERSION = "exampleVersion";
 const EXAMPLE_ACTION_ID = "exampleActionId";
@@ -86,6 +87,7 @@ const EXAMPLE_ENTITY: Entity = {
   name: EXAMPLE_NAME,
   displayName: EXAMPLE_DISPLAY_NAME,
   pluralDisplayName: EXAMPLE_PLURAL_DISPLAY_NAME,
+  customAttributes: EXAMPLE_CUSTOM_ATTRIBUTES,
 };
 
 const EXAMPLE_RESOURCE: Resource = {
@@ -146,6 +148,7 @@ const PENDING_CHANGE_QUERY = gql`
           name
           displayName
           pluralDisplayName
+          customAttributes
         }
         ... on Block {
           id
@@ -169,6 +172,7 @@ const PENDING_CHANGE_QUERY = gql`
           name
           displayName
           pluralDisplayName
+          customAttributes
         }
         builds {
           id

--- a/packages/amplication-server/src/core/project/project.service.spec.ts
+++ b/packages/amplication-server/src/core/project/project.service.spec.ts
@@ -44,6 +44,7 @@ const EXAMPLE_NAME = "exampleName";
 const EXAMPLE_DESCRIPTION = "exampleDescription";
 const EXAMPLE_DISPLAY_NAME = "exampleDisplayName";
 const EXAMPLE_PLURAL_DISPLAY_NAME = "examplePluralDisplayName";
+const EXAMPLE_CUSTOM_ATTRIBUTES = "exampleCustomAttributes";
 const EXAMPLE_BUILD_ID = "exampleBuildId";
 const EXAMPLE_VERSION = "exampleVersion";
 const EXAMPLE_ACTION_ID = "exampleActionId";
@@ -117,6 +118,7 @@ const EXAMPLE_ENTITY: Entity = {
   name: EXAMPLE_NAME,
   displayName: EXAMPLE_DISPLAY_NAME,
   pluralDisplayName: EXAMPLE_PLURAL_DISPLAY_NAME,
+  customAttributes: EXAMPLE_CUSTOM_ATTRIBUTES,
 };
 
 const EXAMPLE_BLOCK: Block = {
@@ -171,6 +173,7 @@ const EXAMPLE_ENTITY_VERSION: EntityVersion = {
   name: EXAMPLE_ENTITY_NAME,
   displayName: EXAMPLE_ENTITY_DISPLAY_NAME,
   pluralDisplayName: EXAMPLE_ENTITY_PLURAL_DISPLAY_NAME,
+  customAttributes: EXAMPLE_CUSTOM_ATTRIBUTES,
 };
 
 const EXAMPLE_BLOCK_VERSION: BlockVersion = {

--- a/packages/amplication-server/src/core/resource/resource.resolver.spec.ts
+++ b/packages/amplication-server/src/core/resource/resource.resolver.spec.ts
@@ -31,6 +31,7 @@ const EXAMPLE_NAME = "exampleName";
 const EXAMPLE_DESCRIPTION = "exampleDescription";
 const EXAMPLE_DISPLAY_NAME = "exampleDisplayName";
 const EXAMPLE_PLURAL_DISPLAY_NAME = "examplePluralDisplayName";
+const EXAMPLE_CUSTOM_ATTRIBUTES = "exampleCustomAttributes";
 
 const EXAMPLE_BUILD_ID = "exampleBuildId";
 const EXAMPLE_USER_ID = "exampleUserId";
@@ -73,6 +74,7 @@ const EXAMPLE_ENTITY: Entity = {
   name: EXAMPLE_NAME,
   displayName: EXAMPLE_DISPLAY_NAME,
   pluralDisplayName: EXAMPLE_PLURAL_DISPLAY_NAME,
+  customAttributes: EXAMPLE_CUSTOM_ATTRIBUTES,
 };
 
 const EXAMPLE_RESOURCE: Resource = {
@@ -113,6 +115,7 @@ const FIND_ONE_RESOURCE_QUERY = gql`
         name
         displayName
         pluralDisplayName
+        customAttributes
       }
       builds {
         id
@@ -146,6 +149,7 @@ const FIND_MANY_ENTITIES_QUERY = gql`
         name
         displayName
         pluralDisplayName
+        customAttributes
       }
     }
   }
@@ -200,6 +204,7 @@ const CREATE_SERVICE_MUTATION = gql`
         name
         displayName
         pluralDisplayName
+        customAttributes
       }
       builds {
         id
@@ -239,6 +244,7 @@ const DELETE_RESOURCE_MUTATION = gql`
         name
         displayName
         pluralDisplayName
+        customAttributes
       }
       builds {
         id
@@ -278,6 +284,7 @@ const UPDATE_RESOURCE_MUTATION = gql`
         name
         displayName
         pluralDisplayName
+        customAttributes
       }
       builds {
         id

--- a/packages/amplication-server/src/core/resource/resource.service.spec.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.spec.ts
@@ -211,6 +211,7 @@ const EXAMPLE_ENTITY_ID = "exampleEntityId";
 const EXAMPLE_ENTITY_NAME = "ExampleEntityName";
 const EXAMPLE_ENTITY_DISPLAY_NAME = "Example Entity Name";
 const EXAMPLE_ENTITY_PLURAL_DISPLAY_NAME = "Example Entity Names";
+const EXAMPLE_CUSTOM_ATTRIBUTES = "ExampleCustomAttributes";
 const EXAMPLE_ENTITY_FIELD_NAME = "exampleEntityFieldName";
 
 const EXAMPLE_BLOCK_ID = "exampleBlockId";
@@ -224,6 +225,7 @@ const EXAMPLE_ENTITY: Entity = {
   name: EXAMPLE_ENTITY_NAME,
   displayName: EXAMPLE_ENTITY_DISPLAY_NAME,
   pluralDisplayName: EXAMPLE_ENTITY_PLURAL_DISPLAY_NAME,
+  customAttributes: EXAMPLE_CUSTOM_ATTRIBUTES,
 };
 
 const EXAMPLE_BLOCK: Block = {
@@ -284,6 +286,7 @@ const EXAMPLE_ENTITY_VERSION: EntityVersion = {
   name: EXAMPLE_ENTITY_NAME,
   displayName: EXAMPLE_ENTITY_DISPLAY_NAME,
   pluralDisplayName: EXAMPLE_ENTITY_PLURAL_DISPLAY_NAME,
+  customAttributes: EXAMPLE_CUSTOM_ATTRIBUTES,
 };
 
 const EXAMPLE_BLOCK_VERSION: BlockVersion = {

--- a/packages/amplication-server/src/models/Entity.ts
+++ b/packages/amplication-server/src/models/Entity.ts
@@ -52,6 +52,11 @@ export class Entity {
   @Field(() => String, {
     nullable: true,
   })
+  customAttributes?: string;
+
+  @Field(() => String, {
+    nullable: true,
+  })
   description?: string;
 
   @Field(() => [EntityVersion], {

--- a/packages/amplication-server/src/models/EntityVersion.ts
+++ b/packages/amplication-server/src/models/EntityVersion.ts
@@ -56,6 +56,11 @@ export class EntityVersion {
   @Field(() => String, {
     nullable: true,
   })
+  customAttributes?: string;
+
+  @Field(() => String, {
+    nullable: true,
+  })
   description?: string;
 
   commitId?: string | null;

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -169,6 +169,7 @@ type Entity {
   name: String!
   displayName: String!
   pluralDisplayName: String!
+  customAttributes: String
   description: String
   versions(where: EntityVersionWhereInput, orderBy: EntityVersionOrderByInput, skip: Int, take: Int): [EntityVersion!]
   fields(where: EntityFieldWhereInput, orderBy: EntityFieldOrderByInput, skip: Int, take: Int): [EntityField!]
@@ -188,6 +189,7 @@ type EntityVersion {
   name: String!
   displayName: String!
   pluralDisplayName: String!
+  customAttributes: String
   description: String
   commit: Commit
   fields(where: EntityFieldWhereInput, orderBy: EntityFieldOrderByInput, skip: Int, take: Int): [EntityField!]!
@@ -580,6 +582,7 @@ input EntityVersionWhereInput {
   name: StringFilter
   displayName: StringFilter
   pluralDisplayName: StringFilter
+  customAttributes: StringFilter
   description: StringFilter
   label: StringFilter
   entity: WhereUniqueInput
@@ -593,6 +596,7 @@ input EntityVersionOrderByInput {
   name: SortOrder
   displayName: SortOrder
   pluralDisplayName: SortOrder
+  customAttributes: SortOrder
   description: SortOrder
   label: SortOrder
 }
@@ -604,6 +608,7 @@ input EntityWhereInput {
   name: StringFilter
   displayName: StringFilter
   pluralDisplayName: StringFilter
+  customAttributes: StringFilter
   description: StringFilter
   fields: EntityFieldFilter
   resource: WhereUniqueInput
@@ -622,6 +627,7 @@ input EntityOrderByInput {
   name: SortOrder
   displayName: SortOrder
   pluralDisplayName: SortOrder
+  customAttributes: SortOrder
   description: SortOrder
 }
 
@@ -1321,6 +1327,7 @@ input EntityCreateInput {
   name: String!
   displayName: String!
   pluralDisplayName: String!
+  customAttributes: String
   description: String
   resource: WhereParentIdInput!
 }
@@ -1329,6 +1336,7 @@ input EntityUpdateInput {
   name: String
   displayName: String
   pluralDisplayName: String
+  customAttributes: String
   description: String
 }
 

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -318,6 +318,7 @@ export type DateTimeFilter = {
 
 export type Entity = {
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
   fields?: Maybe<Array<EntityField>>;
@@ -357,6 +358,7 @@ export type EntityAddPermissionFieldInput = {
 };
 
 export type EntityCreateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   description?: InputMaybe<Scalars['String']>;
   displayName: Scalars['String'];
   name: Scalars['String'];
@@ -448,6 +450,7 @@ export type EntityFieldWhereInput = {
 
 export type EntityOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
   id?: InputMaybe<SortOrder>;
@@ -492,6 +495,7 @@ export type EntityPermissionRole = {
 };
 
 export type EntityUpdateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   description?: InputMaybe<Scalars['String']>;
   displayName?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
@@ -519,6 +523,7 @@ export type EntityUpdatePermissionRolesInput = {
 export type EntityVersion = {
   commit?: Maybe<Commit>;
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
   entity: Entity;
@@ -542,6 +547,7 @@ export type EntityVersionFieldsArgs = {
 
 export type EntityVersionOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
   id?: InputMaybe<SortOrder>;
@@ -554,6 +560,7 @@ export type EntityVersionOrderByInput = {
 
 export type EntityVersionWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
   entity?: InputMaybe<WhereUniqueInput>;
@@ -567,6 +574,7 @@ export type EntityVersionWhereInput = {
 
 export type EntityWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
   fields?: InputMaybe<EntityFieldFilter>;


### PR DESCRIPTION

part of: https://github.com/amplication/amplication/issues/5989

## PR Details

The first PR for the epic - add the server-side functionality for Entity.CustomAttrbute

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2e23e5f</samp>

### Summary
🏷️🛠️🧪

<!--
1.  🏷️ - This emoji represents the concept of labels or tags, which is similar to custom attributes. It also conveys the idea of adding or editing metadata or information to entities and entity versions.
2.  🛠️ - This emoji represents the concept of tools or building, which is related to the app builder feature that allows users to define custom attributes for their entities. It also conveys the idea of modifying or improving the functionality of the app.
3.  🧪 - This emoji represents the concept of testing or experimentation, which is related to the changes in the test files and the GraphQL schema. It also conveys the idea of verifying or validating the custom attributes feature.
-->
This pull request adds support for custom attributes on entities and entity versions in the app builder. It modifies the Prisma schema, the database migrations, the GraphQL schema, the TypeScript models, the service and resolver files, and the input and output classes to include a `customAttributes` field as a string. It also updates the test files to cover the new functionality.

> _`customAttributes`_
> _add new dimensions to `Entity`_
> _autumn of data_

### Walkthrough
*  Add `customAttributes` columns to `Entity` and `EntityVersion` tables in the database to store custom attributes as text ([link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-d36fe5bf978b58391b22823fd08c817bbe7f94cd8a630fa3069de31b3f305d44R1-R5))
*  Add `customAttributes` fields to `Entity` and `EntityVersion` models in the Prisma schema to map the columns and generate TypeScript types and queries ([link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-f83d54c896f6ae6f938ed753a6856094bef91365a576da08c393e51868d3ce76R198), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-f83d54c896f6ae6f938ed753a6856094bef91365a576da08c393e51868d3ce76R221))
*  Add `customAttributes` field to `Entity` class in the TypeScript code and the GraphQL schema to represent the entity model and allow users to query and mutate the custom attributes as a string ([link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-2cd807f2fc9c992efd228b62d3d63ebfd6306433cb90bc3c73eddfc057b02914R55-R59), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75R172))
*  Add `customAttributes` field to `EntityVersion` class in the TypeScript code and the GraphQL schema to represent the entity version model and allow users to query and mutate the custom attributes as a string ([link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-eb15282379a19f4e51ff8651bb4287c7787ecfb1681d6371dfc245ac849b0cb7R59-R63), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75R192))
*  Add `customAttributes` field to various input types in the GraphQL schema to enable filtering, sorting, creating, and updating entities and entity versions by their custom attributes ([link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75R585), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75R599), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75R611), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75R630), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75R1330), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75R1339))
*  Add `customAttributes` field to various input classes and interfaces in the TypeScript code to match the GraphQL schema and pass the user input to the Prisma methods ([link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-0adb4a7aff177a95ba87a1fec785bd715a5fea8751f33d9d39a36ef8619b6ef8R26-R30), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-caa8c072ff03aad8faa0e0a9e545243dc5c0746477000af2254c33ae333b192bR41-R45), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-c379a50ee18e6f32c7175b8413e550c21e762cfdf722649ffd0316cf5c82351aR25-R29), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-366c96e282c1493aeb71bbe2b1700a50a113cb50a3533a898502ebac3c643500R46-R50), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-0042d9d4ae84609f6e2b982e5572e3529c9e0d2fe15482684c46cfdfc1332986R51-R55), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-15bfbae7fdb923929d023921cc14fb68756b2f5597f6bb707f7e1adadb7e1978R42-R46), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R269), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R640), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R878))
*  Add `customAttributes` field to various output arrays and interfaces in the TypeScript code to request and return the custom attributes from the Prisma methods ([link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R350), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R1023), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R725), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R825))
*  Add `customAttributes` field to various queries and mutations in the resolver test files to provide, request, and assert the custom attributes in the test cases ([link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R142), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R158), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R169), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R177), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R188), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R250), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R266), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R282), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-97b903b873a00ec934516eaf17e879ffd33f092ec185cb4c0eaf65546eee3b4eR151), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-97b903b873a00ec934516eaf17e879ffd33f092ec185cb4c0eaf65546eee3b4eR175), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-30310df35643147b98b45a3cb4b52cb6e2fb67bafe207fa9b06734cc62ceb209R118), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-30310df35643147b98b45a3cb4b52cb6e2fb67bafe207fa9b06734cc62ceb209R152), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-30310df35643147b98b45a3cb4b52cb6e2fb67bafe207fa9b06734cc62ceb209R207), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-30310df35643147b98b45a3cb4b52cb6e2fb67bafe207fa9b06734cc62ceb209R247), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-30310df35643147b98b45a3cb4b52cb6e2fb67bafe207fa9b06734cc62ceb209R287))
*  Add example custom attributes to various mock objects and inputs in the service and resolver test files to mock and assert the entity and entity version data in the test cases ([link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R40), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R58), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R128), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R743), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R762), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R97), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R140), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R198), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R499), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R521), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R623), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R651), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R705), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R1443), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-97b903b873a00ec934516eaf17e879ffd33f092ec185cb4c0eaf65546eee3b4eR41), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-97b903b873a00ec934516eaf17e879ffd33f092ec185cb4c0eaf65546eee3b4eR90), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-30310df35643147b98b45a3cb4b52cb6e2fb67bafe207fa9b06734cc62ceb209R34), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-30310df35643147b98b45a3cb4b52cb6e2fb67bafe207fa9b06734cc62ceb209R77), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7157baf015d6ba96dffa13d558b797bcaa563bd6fd9d4b6f9fbebf8b0145afdeR214), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7157baf015d6ba96dffa13d558b797bcaa563bd6fd9d4b6f9fbebf8b0145afdeR228), [link](https://github.com/amplication/amplication/pull/6063/files?diff=unified&w=0#diff-7157baf015d6ba96dffa13d558b797bcaa563bd6fd9d4b6f9fbebf8b0145afdeR289))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
