### PR TITLE
fest(server): Entity field custom attribute

### DIFF
--- a/packages/amplication-prisma-db/prisma/migrations/20230520070233_/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20230520070233_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EntityField" ADD COLUMN     "customAttributes" TEXT;

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -267,22 +267,23 @@ model EntityPermissionField {
 }
 
 model EntityField {
-  id              String                  @id @default(cuid())
-  createdAt       DateTime                @default(now())
-  updatedAt       DateTime                @updatedAt
-  entityVersionId String
-  permanentId     String                  @default(cuid())
-  name            String
-  displayName     String
-  dataType        EnumDataType
-  properties      Json
-  required        Boolean
-  searchable      Boolean
-  description     String
-  position        Int?
-  unique          Boolean                 @default(false)
-  entityVersion   EntityVersion           @relation(fields: [entityVersionId], references: [id], onDelete: Cascade)
-  permissionField EntityPermissionField[]
+  id               String                  @id @default(cuid())
+  createdAt        DateTime                @default(now())
+  updatedAt        DateTime                @updatedAt
+  entityVersionId  String
+  permanentId      String                  @default(cuid())
+  name             String
+  displayName      String
+  dataType         EnumDataType
+  properties       Json
+  required         Boolean
+  searchable       Boolean
+  customAttributes String?
+  description      String
+  position         Int?
+  unique           Boolean                 @default(false)
+  entityVersion    EntityVersion           @relation(fields: [entityVersionId], references: [id], onDelete: Cascade)
+  permissionField  EntityPermissionField[]
 
   @@unique([entityVersionId, displayName], map: "EntityField.entityVersionId_displayName_unique")
   @@unique([entityVersionId, name], map: "EntityField.entityVersionId_name_unique")

--- a/packages/amplication-server/src/core/entity/dto/EntityFieldCreateInput.ts
+++ b/packages/amplication-server/src/core/entity/dto/EntityFieldCreateInput.ts
@@ -48,6 +48,11 @@ export class EntityFieldCreateInput {
   })
   description!: string;
 
+  @Field(() => String, {
+    nullable: true,
+  })
+  customAttributes?: string;
+
   @Field(() => WhereParentIdInput, {
     nullable: false,
   })

--- a/packages/amplication-server/src/core/entity/dto/EntityFieldOrderByInput.ts
+++ b/packages/amplication-server/src/core/entity/dto/EntityFieldOrderByInput.ts
@@ -58,6 +58,11 @@ export class EntityFieldOrderByInput {
   @Field(() => SortOrder, {
     nullable: true,
   })
+  customAttributes?: SortOrder | null;
+
+  @Field(() => SortOrder, {
+    nullable: true,
+  })
   description?: SortOrder | null;
 
   @Field(() => SortOrder, {

--- a/packages/amplication-server/src/core/entity/dto/EntityFieldUpdateInput.ts
+++ b/packages/amplication-server/src/core/entity/dto/EntityFieldUpdateInput.ts
@@ -47,6 +47,11 @@ export class EntityFieldUpdateInput {
   })
   description?: string | null;
 
+  @Field(() => String, {
+    nullable: true,
+  })
+  customAttributes?: string | null;
+
   @Field(() => Int, {
     nullable: true,
   })

--- a/packages/amplication-server/src/core/entity/dto/EntityFieldWhereInput.ts
+++ b/packages/amplication-server/src/core/entity/dto/EntityFieldWhereInput.ts
@@ -60,5 +60,10 @@ export class EntityFieldWhereInput {
   @Field(() => StringFilter, {
     nullable: true,
   })
+  customAttributes?: StringFilter | null;
+
+  @Field(() => StringFilter, {
+    nullable: true,
+  })
   description?: StringFilter | null;
 }

--- a/packages/amplication-server/src/core/entity/entity.resolver.spec.ts
+++ b/packages/amplication-server/src/core/entity/entity.resolver.spec.ts
@@ -77,6 +77,7 @@ const EXAMPLE_ENTITY_FIELD: EntityField = {
   unique: false,
   searchable: true,
   description: "exampleDescription",
+  customAttributes: "ExampleCustomAttributes",
   properties: {},
 };
 
@@ -205,6 +206,7 @@ const FIND_MANY_FIELDS_QUERY = gql`
         required
         unique
         searchable
+        customAttributes
         description
         properties
       }
@@ -344,6 +346,7 @@ const ADD_ENTITY_PERM_FIELD_MUTATION = gql`
         required
         unique
         searchable
+        customAttributes
         description
         properties
       }
@@ -379,6 +382,7 @@ const DELETE_ENTITY_PERM_FIELD_MUTATION = gql`
         required
         unique
         searchable
+        customAttributes
         description
         properties
       }
@@ -406,6 +410,7 @@ const UPDATE_ENTITY_PERM_FIELD_ROLES_MUTATION = gql`
         required
         unique
         searchable
+        customAttributes
         description
         properties
       }
@@ -422,6 +427,7 @@ const CREATE_ENTITY_FIELD_MUTATION = gql`
     $required: Boolean!
     $unique: Boolean!
     $searchable: Boolean!
+    $customAttributes: String
     $description: String!
     $entity: String!
   ) {
@@ -434,6 +440,7 @@ const CREATE_ENTITY_FIELD_MUTATION = gql`
         required: $required
         unique: $unique
         searchable: $searchable
+        customAttributes: $customAttributes
         description: $description
         entity: { connect: { id: $entity } }
       }
@@ -448,6 +455,7 @@ const CREATE_ENTITY_FIELD_MUTATION = gql`
       required
       unique
       searchable
+      customAttributes
       description
       properties
     }
@@ -472,6 +480,7 @@ const CREATE_ENTITY_FIELD_BY_DISPLAY_NAME_MUTATION = gql`
       required
       unique
       searchable
+      customAttributes
       description
       properties
     }
@@ -491,6 +500,7 @@ const DELETE_ENTITY_FIELD_MUTATION = gql`
       required
       unique
       searchable
+      customAttributes
       description
       properties
     }
@@ -510,6 +520,7 @@ const UPDATE_ENTITY_FIELD_MUTATION = gql`
       required
       unique
       searchable
+      customAttributes
       description
       properties
     }
@@ -529,6 +540,7 @@ const CREATE_DEFAULT_RELATED_FIELD_MUTATION = gql`
       required
       unique
       searchable
+      customAttributes
       description
       properties
     }
@@ -565,6 +577,7 @@ const GET_VERSION_FIELDS_QUERY = gql`
           required
           unique
           searchable
+          customAttributes
           description
           properties
         }
@@ -1061,6 +1074,7 @@ describe("EntityResolver", () => {
       required: EXAMPLE_ENTITY_FIELD.required,
       unique: EXAMPLE_ENTITY_FIELD.unique,
       searchable: EXAMPLE_ENTITY_FIELD.searchable,
+      customAttributes: EXAMPLE_ENTITY_FIELD.customAttributes,
       description: EXAMPLE_ENTITY_FIELD.description,
       entity: EXAMPLE_ID,
     };

--- a/packages/amplication-server/src/core/entity/entity.service.spec.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.spec.ts
@@ -127,6 +127,7 @@ const EXAMPLE_ENTITY_FIELD: EntityField = {
   unique: false,
   searchable: true,
   description: "example field",
+  customAttributes: "ExampleCustomAttributes",
 };
 
 const EXAMPLE_CURRENT_ENTITY_VERSION: EntityVersion = {
@@ -221,6 +222,7 @@ const EXAMPLE_ENTITY_FIELD_DATA = {
   unique: false,
   searchable: false,
   description: "",
+  customAttributes: "ExampleCustomAttributes",
   dataType: EnumDataType.SingleLineText,
   properties: {
     maxLength: 42,
@@ -245,6 +247,7 @@ const EXAMPLE_ENTITY_FIELD_DATA_WITH_INVALID_MINIMUM_VALUE = {
   unique: false,
   searchable: true,
   description: "",
+  customAttributes: "ExampleCustomAttributes",
 };
 const EXAMPLE_ENTITY_FIELD_DATA_WITH_VALID_MINIMUM_VALUE = {
   name: "exampleEntityFieldNameWithInvalidMinimumValue",
@@ -255,6 +258,7 @@ const EXAMPLE_ENTITY_FIELD_DATA_WITH_VALID_MINIMUM_VALUE = {
   unique: false,
   searchable: true,
   description: "",
+  customAttributes: "ExampleCustomAttributes",
 };
 const EXAMPLE_ENTITY_FIELD_WHOLE_NUMBER: EntityField = {
   createdAt: new Date(),
@@ -270,6 +274,7 @@ const EXAMPLE_ENTITY_FIELD_WHOLE_NUMBER: EntityField = {
   searchable: true,
   unique: false,
   updatedAt: new Date(),
+  customAttributes: "ExampleCustomAttributes",
 };
 
 const EXAMPLE_ACCOUNT_ID = "exampleAccountId";

--- a/packages/amplication-server/src/core/resource/resource.service.spec.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.spec.ts
@@ -253,6 +253,7 @@ const EXAMPLE_ENTITY_FIELD: EntityField = {
   required: false,
   unique: false,
   searchable: false,
+  customAttributes: "ExampleCustomAttributes",
 };
 
 const EXAMPLE_CHANGED_ENTITY: PendingChange = {

--- a/packages/amplication-server/src/models/EntityField.ts
+++ b/packages/amplication-server/src/models/EntityField.ts
@@ -72,6 +72,11 @@ export class EntityField {
   })
   description: string;
 
+  @Field(() => String, {
+    nullable: true,
+  })
+  customAttributes?: string;
+
   @Field(() => Int, {
     nullable: true,
   })


### PR DESCRIPTION
Part of: https://github.com/amplication/amplication/issues/5989

## PR Details

The third PR for the epic - add the server-side functionality for EntityField.CustomAttrbute

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at efba08e</samp>

### Summary
🆕🗃️🧪

<!--
1.  🆕 - This emoji indicates that a new feature or functionality has been added, such as a new field or column.
2.  🗃️ - This emoji indicates that a database-related change has been made, such as adding or modifying a table or column.
3.  🧪 - This emoji indicates that a testing-related change has been made, such as adding or updating a test case or mock data.
-->
This pull request adds a new field `customAttributes` to the entity field model, database, and GraphQL schema. This field can be used to store any custom attributes for the entity field, such as validation rules, UI hints, or other metadata. The pull request also updates the relevant tests and migrations to include the new field.

> _To store some extra metadata_
> _We added `customAttributes`_
> _To the entity field model and schema_
> _And to the GraphQL resolver_
> _And to the tests that check the data_

### Walkthrough
*  Add a new column `customAttributes` to the `EntityField` table in the database to store custom attributes for entity fields ([link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-463808c52686fcf6ee8eeb9e7f3018207371e5906663281da43375bb09da3270R1-R2))
*  Add a corresponding field `customAttributes` to the `EntityField` model in the Prisma schema with a type of `String` and optional ([link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-f83d54c896f6ae6f938ed753a6856094bef91365a576da08c393e51868d3ce76L270-R286))
*  Add a GraphQL input field `customAttributes` to the `EntityFieldCreateInput`, `EntityFieldUpdateInput`, `EntityFieldWhereInput`, and `EntityFieldOrderByInput` classes in the entity module with a type of `String` and optional and nullable ([link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-af2f5a25fc11324fb450c54f9dffd668c60549f4ce8f87dfa9fe525e8afee6f6R51-R55), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-df7f923e8427bf2627d7c69886465adbe13265242654b873f33c1e3169cfcc18R50-R54), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-05212513f6dffe771cb1f1ab8b7ac0a5e60593bc3ab9231550b282ffaf4c4ee1R63-R67), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-bf459ca6a22887ce86056cb387027ff9a102d34da43c5bb1c3cc37ac988bb2f9R61-R65))
*  Add a TypeORM column and a GraphQL field `customAttributes` to the `EntityField` class in the models module with a type of `string` and `String` respectively and nullable and optional ([link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-17758846aea93eb37dcff62901a2365df77efea29e26e58168dfcc09ed8a8089R75-R79))
*  Add a mock value for `customAttributes` to the `EXAMPLE_ENTITY_FIELD` constant in the entity resolver and service test files and the resource service test file ([link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R80), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R130), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7157baf015d6ba96dffa13d558b797bcaa563bd6fd9d4b6f9fbebf8b0145afdeR256))
*  Add a mock value for `customAttributes` to the `EXAMPLE_ENTITY_FIELD_DATA` and related constants in the entity service test file ([link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R225), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R250), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R261), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-aa07326c891b090e3d5c18991a6e07f30aaa0b8e581e6ffc9903e8c23ab5d216R277))
*  Add a selection for `customAttributes` to the GraphQL queries and mutations for entity fields in the entity resolver test file ([link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R209), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R349), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R385), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R413), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R443), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R458), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R483), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R503), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R523), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R543), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R580))
*  Add a variable and an argument for `customAttributes` to the GraphQL mutation for creating an entity field in the entity resolver test file ([link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R430), [link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R443))
*  Add an assertion for `customAttributes` to the expected object for the `createEntityField` mutation in the entity resolver test file ([link](https://github.com/amplication/amplication/pull/6065/files?diff=unified&w=0#diff-7e075b970e2cad0b7c2a6bd947008292c79127895a4154d8f00433ec21025797R1077))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
