### PR TITLE
feat(client): Entity field custom attribute UI

### DIFF
--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -368,6 +368,7 @@ export type EntityCreateInput = {
 
 export type EntityField = {
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   dataType: EnumDataType;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -389,6 +390,7 @@ export type EntityFieldCreateByDisplayNameInput = {
 };
 
 export type EntityFieldCreateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   dataType: EnumDataType;
   description: Scalars['String'];
   displayName: Scalars['String'];
@@ -409,6 +411,7 @@ export type EntityFieldFilter = {
 
 export type EntityFieldOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   dataType?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
@@ -423,6 +426,7 @@ export type EntityFieldOrderByInput = {
 };
 
 export type EntityFieldUpdateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   dataType?: InputMaybe<EnumDataType>;
   description?: InputMaybe<Scalars['String']>;
   displayName?: InputMaybe<Scalars['String']>;
@@ -436,6 +440,7 @@ export type EntityFieldUpdateInput = {
 
 export type EntityFieldWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   dataType?: InputMaybe<EnumDataTypeFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;

--- a/packages/amplication-client/src/Entity/DeleteEntityField.tsx
+++ b/packages/amplication-client/src/Entity/DeleteEntityField.tsx
@@ -158,6 +158,7 @@ const GET_ENTITY_WITH_SPECIFIC_FIELD = gql`
         required
         unique
         searchable
+        customAttributes
         description
       }
     }

--- a/packages/amplication-client/src/Entity/Entity.tsx
+++ b/packages/amplication-client/src/Entity/Entity.tsx
@@ -175,6 +175,7 @@ export const GET_ENTITY = gql`
         unique
         required
         searchable
+        customAttributes
         dataType
         description
       }
@@ -205,6 +206,7 @@ const UPDATE_ENTITY = gql`
         required
         unique
         searchable
+        customAttributes
         dataType
         description
       }

--- a/packages/amplication-client/src/Entity/EntityField.tsx
+++ b/packages/amplication-client/src/Entity/EntityField.tsx
@@ -228,6 +228,7 @@ const GET_ENTITY_FIELD = gql`
         required
         unique
         searchable
+        customAttributes
         description
         permanentId
       }
@@ -258,6 +259,7 @@ const UPDATE_ENTITY_FIELD = gql`
       required
       unique
       searchable
+      customAttributes
       description
     }
   }

--- a/packages/amplication-client/src/Entity/EntityFieldForm.tsx
+++ b/packages/amplication-client/src/Entity/EntityFieldForm.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { Formik, FormikErrors } from "formik";
 import { omit, isEmpty } from "lodash";
 import { getSchemaForDataType } from "@amplication/code-gen-types";
-import { ToggleField } from "@amplication/ui/design-system";
+import { TextField, ToggleField } from "@amplication/ui/design-system";
 import * as models from "../models";
 import { DisplayNameField } from "../Components/DisplayNameField";
 import { Form } from "../Components/Form";
@@ -22,6 +22,7 @@ export type Values = {
   unique: boolean;
   required: boolean;
   searchable: boolean;
+  customAttributes: string | null;
   description: string | null;
   permanentId?: string | null;
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -63,6 +64,7 @@ export const INITIAL_VALUES: Values = {
   unique: false,
   required: false,
   searchable: false,
+  customAttributes: null,
   description: "",
   properties: {},
 };
@@ -84,12 +86,6 @@ const EntityFieldForm = ({
       ...sanitizedDefaultValues,
     };
   }, [defaultValues]);
-
-  function onKeyDown(keyEvent: any) {
-    if ((keyEvent.charCode || keyEvent.keyCode) === 13) {
-      keyEvent.preventDefault();
-    }
-  }
 
   return (
     <Formik
@@ -124,7 +120,7 @@ const EntityFieldForm = ({
         const schema = getSchemaForDataType(formik.values.dataType);
 
         return (
-          <Form childrenAsBlocks onKeyDown={onKeyDown}>
+          <Form childrenAsBlocks>
             <FormikAutoSave debounceMS={1000} />
 
             <DisplayNameField
@@ -172,6 +168,14 @@ const EntityFieldForm = ({
               schema={schema}
               resourceId={resourceId}
               entity={entity}
+            />
+
+            <TextField
+              autoComplete="off"
+              textarea
+              rows={3}
+              name="customAttributes"
+              label="Custom Attributes"
             />
           </Form>
         );

--- a/packages/amplication-client/src/Entity/EntityFieldLinkList.tsx
+++ b/packages/amplication-client/src/Entity/EntityFieldLinkList.tsx
@@ -84,6 +84,7 @@ export const GET_FIELDS = gql`
         required
         unique
         searchable
+        customAttributes
         description
         properties
       }

--- a/packages/amplication-client/src/Entity/EntityFieldList.tsx
+++ b/packages/amplication-client/src/Entity/EntityFieldList.tsx
@@ -122,6 +122,7 @@ export const GET_FIELDS = gql`
         required
         unique
         searchable
+        customAttributes
         description
         properties
       }

--- a/packages/amplication-client/src/Entity/NewEntityField.tsx
+++ b/packages/amplication-client/src/Entity/NewEntityField.tsx
@@ -148,6 +148,7 @@ const CREATE_ENTITY_FIELD = gql`
       required
       unique
       searchable
+      customAttributes
       description
       properties
     }
@@ -163,6 +164,7 @@ const NEW_ENTITY_FIELD_FRAGMENT = gql`
     required
     unique
     searchable
+    customAttributes
     description
     properties
   }

--- a/packages/amplication-client/src/Entity/OptionSet.tsx
+++ b/packages/amplication-client/src/Entity/OptionSet.tsx
@@ -141,6 +141,7 @@ const OptionSetOption = ({
 
       <div className="option-set__option__action">
         <Button
+          type="button"
           buttonStyle={EnumButtonStyle.Text}
           icon="trash_2"
           onClick={handleRemoveOption}

--- a/packages/amplication-client/src/VersionControl/PendingChangeDiffEntity.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChangeDiffEntity.tsx
@@ -185,6 +185,7 @@ export const GET_ENTITY_VERSION = gql`
           required
           unique
           searchable
+          customAttributes
         }
       }
     }

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -368,6 +368,7 @@ export type EntityCreateInput = {
 
 export type EntityField = {
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   dataType: EnumDataType;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -389,6 +390,7 @@ export type EntityFieldCreateByDisplayNameInput = {
 };
 
 export type EntityFieldCreateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   dataType: EnumDataType;
   description: Scalars['String'];
   displayName: Scalars['String'];
@@ -409,6 +411,7 @@ export type EntityFieldFilter = {
 
 export type EntityFieldOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   dataType?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
@@ -423,6 +426,7 @@ export type EntityFieldOrderByInput = {
 };
 
 export type EntityFieldUpdateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   dataType?: InputMaybe<EnumDataType>;
   description?: InputMaybe<Scalars['String']>;
   displayName?: InputMaybe<Scalars['String']>;
@@ -436,6 +440,7 @@ export type EntityFieldUpdateInput = {
 
 export type EntityFieldWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   dataType?: InputMaybe<EnumDataTypeFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -368,6 +368,7 @@ export type EntityCreateInput = {
 
 export type EntityField = {
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   dataType: EnumDataType;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -389,6 +390,7 @@ export type EntityFieldCreateByDisplayNameInput = {
 };
 
 export type EntityFieldCreateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   dataType: EnumDataType;
   description: Scalars['String'];
   displayName: Scalars['String'];
@@ -409,6 +411,7 @@ export type EntityFieldFilter = {
 
 export type EntityFieldOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   dataType?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
@@ -423,6 +426,7 @@ export type EntityFieldOrderByInput = {
 };
 
 export type EntityFieldUpdateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   dataType?: InputMaybe<EnumDataType>;
   description?: InputMaybe<Scalars['String']>;
   displayName?: InputMaybe<Scalars['String']>;
@@ -436,6 +440,7 @@ export type EntityFieldUpdateInput = {
 
 export type EntityFieldWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   dataType?: InputMaybe<EnumDataTypeFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -368,6 +368,7 @@ export type EntityCreateInput = {
 
 export type EntityField = {
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   dataType: EnumDataType;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -389,6 +390,7 @@ export type EntityFieldCreateByDisplayNameInput = {
 };
 
 export type EntityFieldCreateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   dataType: EnumDataType;
   description: Scalars['String'];
   displayName: Scalars['String'];
@@ -409,6 +411,7 @@ export type EntityFieldFilter = {
 
 export type EntityFieldOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   dataType?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
@@ -423,6 +426,7 @@ export type EntityFieldOrderByInput = {
 };
 
 export type EntityFieldUpdateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   dataType?: InputMaybe<EnumDataType>;
   description?: InputMaybe<Scalars['String']>;
   displayName?: InputMaybe<Scalars['String']>;
@@ -436,6 +440,7 @@ export type EntityFieldUpdateInput = {
 
 export type EntityFieldWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   dataType?: InputMaybe<EnumDataTypeFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -456,6 +456,7 @@ type EntityField {
   unique: Boolean!
   searchable: Boolean!
   description: String
+  customAttributes: String
   position: Int
 }
 
@@ -491,6 +492,7 @@ input EntityFieldWhereInput {
   required: BooleanFilter
   unique: BooleanFilter
   searchable: BooleanFilter
+  customAttributes: StringFilter
   description: StringFilter
 }
 
@@ -517,6 +519,7 @@ input EntityFieldOrderByInput {
   required: SortOrder
   unique: SortOrder
   searchable: SortOrder
+  customAttributes: SortOrder
   description: SortOrder
   position: SortOrder
 }
@@ -1379,6 +1382,7 @@ input EntityFieldCreateInput {
   unique: Boolean!
   searchable: Boolean!
   description: String!
+  customAttributes: String
   entity: WhereParentIdInput!
   position: Int
 }
@@ -1398,6 +1402,7 @@ input EntityFieldUpdateInput {
   unique: Boolean
   searchable: Boolean
   description: String
+  customAttributes: String
   position: Int
 }
 

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -368,6 +368,7 @@ export type EntityCreateInput = {
 
 export type EntityField = {
   createdAt: Scalars['DateTime'];
+  customAttributes?: Maybe<Scalars['String']>;
   dataType: EnumDataType;
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
@@ -389,6 +390,7 @@ export type EntityFieldCreateByDisplayNameInput = {
 };
 
 export type EntityFieldCreateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   dataType: EnumDataType;
   description: Scalars['String'];
   displayName: Scalars['String'];
@@ -409,6 +411,7 @@ export type EntityFieldFilter = {
 
 export type EntityFieldOrderByInput = {
   createdAt?: InputMaybe<SortOrder>;
+  customAttributes?: InputMaybe<SortOrder>;
   dataType?: InputMaybe<SortOrder>;
   description?: InputMaybe<SortOrder>;
   displayName?: InputMaybe<SortOrder>;
@@ -423,6 +426,7 @@ export type EntityFieldOrderByInput = {
 };
 
 export type EntityFieldUpdateInput = {
+  customAttributes?: InputMaybe<Scalars['String']>;
   dataType?: InputMaybe<EnumDataType>;
   description?: InputMaybe<Scalars['String']>;
   displayName?: InputMaybe<Scalars['String']>;
@@ -436,6 +440,7 @@ export type EntityFieldUpdateInput = {
 
 export type EntityFieldWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
+  customAttributes?: InputMaybe<StringFilter>;
   dataType?: InputMaybe<EnumDataTypeFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;


### PR DESCRIPTION
Part of: https://github.com/amplication/amplication/issues/5989

## PR Details

The forth PR for the epic - add the client-side functionality for EntityField.CustomAttrbute

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3274ee3</samp>

### Summary
🏷️🛠️🆕

<!--
1.  🏷️ - This emoji represents the concept of custom attributes or tags, which are the main feature of these changes.
2.  🛠️ - This emoji represents the concept of code generation or validation, which are some of the potential use cases for custom attributes.
3.  🆕 - This emoji represents the concept of adding a new feature or functionality, which is what these changes do.
-->
This pull request adds support for custom attributes for entity fields, which are additional properties that users can define for their fields in the entity editor. It modifies several GraphQL queries and mutations, as well as React components, to include and display the `customAttributes` field. It also fixes a minor issue with the `OptionSet` component.

> _To make fields more flexible and smart_
> _We added `customAttributes` part_
> _To queries and mutations_
> _And some UI creations_
> _And fixed a bug with the `Button`'s art_

### Walkthrough
*  Add the `customAttributes` field to various GraphQL queries and mutations to support the new feature of custom attributes for entity fields ([link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-74cdb1e6eb6b8e80421a7dd658d723421ecb4065d644825ba0e92dcbaf4e937cR161), [link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-a268f028ea1e884aa67d49c9e9e7ead860be1bcb6d28faf31da95fdd5a73c96eR178), [link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-a268f028ea1e884aa67d49c9e9e7ead860be1bcb6d28faf31da95fdd5a73c96eR209), [link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-a54127751135be6c11a4a7e2da3089ecdf8dab44438e76e96c60c72a5e77a1f4R231), [link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-a54127751135be6c11a4a7e2da3089ecdf8dab44438e76e96c60c72a5e77a1f4R262), [link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-3f8bd47f89aeaf626d9b951eb5e416504f27d7e5e0d6582bc540c5fcdb64671eR87), [link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-88ae23c310cc6a5d1aede2fa33ec2cef2076dbe174c6abf408c9fc562bdd74c7R125), [link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-f0b6cc1f93832f4e7b7040eb02a5f09079a3fba05d7e07bd1d8819e1a22baaedR151), [link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-f0b6cc1f93832f4e7b7040eb02a5f09079a3fba05d7e07bd1d8819e1a22baaedR167), [link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-498dc538316dde18234b91c3e57e6a5d8f9ac0cf51c60c083f52861edd23c1fdR188))
*  Add the `TextField` component to render the `customAttributes` field in the `EntityFieldForm` component, which is used to create or edit an entity field ([link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-aefbb9769df6955c1137bbc3cb24deeb795e808fda8893c54688aece26452729L5-R5), [link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-aefbb9769df6955c1137bbc3cb24deeb795e808fda8893c54688aece26452729R25), [link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-aefbb9769df6955c1137bbc3cb24deeb795e808fda8893c54688aece26452729R67), [link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-aefbb9769df6955c1137bbc3cb24deeb795e808fda8893c54688aece26452729R172-R179))
*  Remove the `onKeyDown` function and prop from the `Form` component, which were used to prevent the default behavior of submitting the form when the user presses the enter key, and rely on the default behavior of the `Form` component instead ([link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-aefbb9769df6955c1137bbc3cb24deeb795e808fda8893c54688aece26452729L88-L93), [link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-aefbb9769df6955c1137bbc3cb24deeb795e808fda8893c54688aece26452729L127-R123))
*  Add the `type` prop to the `Button` component, which is used to render an option in the `OptionSet` component, which is used to create or edit an option set field, and set it to "button" to prevent the default behavior of submitting the form when the button is clicked ([link](https://github.com/amplication/amplication/pull/6066/files?diff=unified&w=0#diff-8ea59988e1eb9786d3ff6aa5aeba55e8c951860a8d35e54756b3ef527ac1afe6R144))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
