### PR TITLE
chore(plugin-api): fix nx cache for prisma generated client

### DIFF
--- a/packages/amplication-plugin-api/project.json
+++ b/packages/amplication-plugin-api/project.json
@@ -77,7 +77,8 @@
     },
     "db:prisma:generate": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/prisma/generated-prisma-client"],
+      "inputs": ["{projectRoot}/prisma/schema.prisma"],
+      "outputs": ["{projectRoot}/prisma/generated-prisma-client"],
       "options": {
         "command": "prisma generate --schema ./prisma/schema.prisma",
         "cwd": "packages/amplication-plugin-api"


### PR DESCRIPTION
Close: #5683 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->
More details: https://nx.dev/concepts/how-caching-works#source-code-hash-inputs

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at af00fb7</samp>

### Summary
🛠️🚀🌐

<!--
1.  🛠️ - This emoji represents a fix or improvement to an existing feature or functionality. The change to use relative paths is an improvement that makes the task more robust and flexible.
2.  🚀 - This emoji represents a new feature or enhancement that adds value or functionality to the project. The change to use relative paths is an enhancement that enables the task to work in different scenarios and environments, and supports the portability of the amplication-plugin-api package.
3.  🌐 - This emoji represents a change that affects the compatibility or interoperability of the project with other platforms, systems, or languages. The change to use relative paths is a change that affects the compatibility of the task with different workspaces and projects that may use the same absolute paths.
-->
Updated the `db:prisma:generate` task in `project.json` to use relative paths. This improves the compatibility and portability of the amplication-plugin-api package.

> _`db:prisma:generate`_
> _Relative paths for inputs_
> _Autumn leaves no trace_

### Walkthrough
*  Update the `db:prisma:generate` task to use relative paths for inputs and outputs ([link](https://github.com/amplication/amplication/pull/6071/files?diff=unified&w=0#diff-348262706e20ca794410946a88aa063717b36c6d3d3054b29fc429ba49905c46L80-R81))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
