### PR TITLE
fix(pull-request-service): issue related to parent folders created by other processes

### DIFF
--- a/packages/amplication-git-pull-request-service/src/pull-request/pull-request.service.ts
+++ b/packages/amplication-git-pull-request-service/src/pull-request/pull-request.service.ts
@@ -110,7 +110,9 @@ export class PullRequestService {
       pullRequestMode,
       gitResourceMeta,
       files: PullRequestService.removeFirstSlashFromPath(changedFiles),
+      buildId: newBuildId,
     });
+
     logger.info("Opened a new pull request", { prUrl });
     return prUrl;
   }

--- a/packages/amplication-git-utils/src/providers/git-cli.ts
+++ b/packages/amplication-git-utils/src/providers/git-cli.ts
@@ -22,6 +22,7 @@ export class GitCli {
         `user.name=${this.gitAuthorUserName}`,
         `user.email=${this.gitAuthorUserEmail}`,
         `push.autoSetupRemote=true`,
+        `safe.directory=${repositoryDir}`,
       ],
     });
   }

--- a/packages/amplication-git-utils/src/providers/git.service.ts
+++ b/packages/amplication-git-utils/src/providers/git.service.ts
@@ -117,15 +117,19 @@ export class GitClientService {
       pullRequestMode,
       gitResourceMeta,
       files,
+      cloneDirPath,
+      buildId,
     } = createPullRequestArgs;
 
     const gitRepoDir = normalize(
       join(
-        createPullRequestArgs.cloneDirPath,
+        cloneDirPath,
         this.provider.name,
         owner,
-        repositoryName,
-        v4()
+        repositoryGroupName
+          ? join(repositoryGroupName, repositoryName)
+          : repositoryName,
+        buildId
       )
     );
 

--- a/packages/amplication-git-utils/src/types.ts
+++ b/packages/amplication-git-utils/src/types.ts
@@ -190,6 +190,7 @@ export interface CreatePullRequestArgs {
   gitResourceMeta: GitResourceMeta;
   files: File[];
   cloneDirPath: string;
+  buildId: string;
 }
 
 export interface CreatePullRequestFromFilesArgs {


### PR DESCRIPTION
Relates to #6062

## PR Details

With the changes brought by https://github.com/amplication/amplication-manifests/pull/120, the clone directory parent folder may be created by another process causing errors from the git cli due to the security risk prevention implemented in git ( read more here https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9)

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 79e1df9</samp>


### Walkthrough
*  **Use `safe.directory` option in `git clone` command to prevent overwriting existing files or directories** ([link](https://github.com/amplication/amplication/pull/6073/files?diff=unified&w=0#diff-045ad92d579607f503463c05f08ddd15fc7363bdcc9766e0330c2c87878613c0R25))
*  Handle errors and delete cloned directories in `finally` clause of `createPullRequest` method in `GitClientService` class ([link](https://github.com/amplication/amplication/pull/6073/files?diff=unified&w=0#diff-b026f712e26a857b3cacb53b46c272796ec54be143eca60dc53bfb31017ee4c0L120-R236))
*  Modify `gitRepoDir` variable to use `cloneDirPath`, `provider.name`, `owner`, `repositoryGroupName`, `repositoryName`, and `buildId` in `pull-request.service.ts` and `git.service.ts` ([link](https://github.com/amplication/amplication/pull/6073/files?diff=unified&w=0#diff-3525809e7dc1407c8313cc71237f560419a3051b1f1dbef432dd41276a8a5d28L113-R115), [link](https://github.com/amplication/amplication/pull/6073/files?diff=unified&w=0#diff-b026f712e26a857b3cacb53b46c272796ec54be143eca60dc53bfb31017ee4c0L120-R236))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
