### PR TITLE
refactor(pull-request-service): to handle better git cloned directory creation and deletion

### DIFF
--- a/packages/amplication-git-utils/src/providers/git-cli.types.ts
+++ b/packages/amplication-git-utils/src/providers/git-cli.types.ts
@@ -1,0 +1,10 @@
+export interface GitCliOptions {
+  /**
+   * The local path to the repository directory
+   */
+  repositoryDir: string;
+  /**
+   * The remote repository URL
+   */
+  originUrl: string;
+}

--- a/packages/amplication-git-utils/src/providers/git.service.ts
+++ b/packages/amplication-git-utils/src/providers/git.service.ts
@@ -132,16 +132,18 @@ export class GitClientService {
         buildId
       )
     );
+    const cloneUrl = await this.provider.getCloneUrl({
+      owner,
+      repositoryName,
+      repositoryGroupName,
+    });
 
-    const gitCli = new GitCli(this.logger, gitRepoDir);
+    const gitCli = new GitCli(this.logger, {
+      originUrl: cloneUrl,
+      repositoryDir: gitRepoDir,
+    });
 
     try {
-      const cloneUrl = await this.provider.getCloneUrl({
-        owner,
-        repositoryName,
-        repositoryGroupName,
-      });
-
       const { defaultBranch } = await this.provider.getRepository({
         owner,
         repositoryName,
@@ -157,7 +159,7 @@ export class GitClientService {
         });
 
       if (haveFirstCommitInDefaultBranch === false) {
-        await gitCli.clone(cloneUrl);
+        await gitCli.clone();
         await this.createInitialCommit({
           gitRepoDir,
           gitCli,
@@ -247,7 +249,7 @@ export class GitClientService {
       repositoryGroupName,
     } = options;
 
-    await gitCli.clone(cloneUrl);
+    await gitCli.clone();
     await this.restoreAmplicationBranchIfNotExists({
       owner,
       repositoryName,

--- a/packages/amplication-git-utils/src/providers/git.service.ts
+++ b/packages/amplication-git-utils/src/providers/git.service.ts
@@ -217,9 +217,7 @@ export class GitClientService {
           throw new InvalidPullRequestMode();
       }
 
-      if (isCloned === true) {
-        await rm(gitRepoDir, { recursive: true, force: true });
-      }
+      await rm(gitRepoDir, { recursive: true, force: true, maxRetries: 3 });
 
       return pullRequestUrl;
     } catch (error) {


### PR DESCRIPTION
Related: #6062

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 67b0e91</samp>

### Summary
:sparkles::recycle::bug:

<!--
1.  :sparkles: This emoji is often used to indicate new features or enhancements, and in this case it could represent the addition of the property and method to the `GitCli` class that enable cloning and deleting repositories.
2.  :recycle: This emoji is often used to indicate refactoring or code improvement, and in this case it could represent the removal of the `isCloned` variable and parameter from the `GitClientService` class and the use of the `GitCli` class instead, which simplifies the code and avoids duplication of logic.
3.  :bug: This emoji is often used to indicate bug fixes or error handling, and in this case it could represent the improvement of the error handling and logging of the `deleteRepositoryDir` method, which makes the code more robust and informative.
-->
Refactored the `GitClientService` and `GitCli` classes to handle cloning and deleting repositories more efficiently and consistently. Removed unnecessary code and improved error handling and logging.
**This change also fix the issue related to repo dir not being deleted for smart git sync.**

> _To manage the repos with ease_
> _They added a `GitCli` class_
> _No more `isCloned` to pass_
> _Just clone and delete as you please_
> _The `GitClientService` is now less of a mess_

### Walkthrough
*  Add `isCloned` property to `GitCli` class to track cloning status ([link](https://github.com/amplication/amplication/pull/6083/files?diff=unified&w=0#diff-045ad92d579607f503463c05f08ddd15fc7363bdcc9766e0330c2c87878613c0R10))
*  Modify `clone` method of `GitCli` class to check and set `isCloned` property ([link](https://github.com/amplication/amplication/pull/6083/files?diff=unified&w=0#diff-045ad92d579607f503463c05f08ddd15fc7363bdcc9766e0330c2c87878613c0L31-R54))
*  Add `deleteRepositoryDir` method to `GitCli` class to delete repository directory and reset `isCloned` property ([link](https://github.com/amplication/amplication/pull/6083/files?diff=unified&w=0#diff-045ad92d579607f503463c05f08ddd15fc7363bdcc9766e0330c2c87878613c0L31-R54))
*  Remove `isCloned` variable and check from `GitClientService` class as they are handled by `GitCli` class ([link](https://github.com/amplication/amplication/pull/6083/files?diff=unified&w=0#diff-b026f712e26a857b3cacb53b46c272796ec54be143eca60dc53bfb31017ee4c0L136-R138), [link](https://github.com/amplication/amplication/pull/6083/files?diff=unified&w=0#diff-b026f712e26a857b3cacb53b46c272796ec54be143eca60dc53bfb31017ee4c0L161-R160), [link](https://github.com/amplication/amplication/pull/6083/files?diff=unified&w=0#diff-b026f712e26a857b3cacb53b46c272796ec54be143eca60dc53bfb31017ee4c0L262-R250))
*  Remove `isCloned` parameter from `createPullRequest` and `createCommit` methods of `GitClientService` class as they are handled by `GitCli` class ([link](https://github.com/amplication/amplication/pull/6083/files?diff=unified&w=0#diff-b026f712e26a857b3cacb53b46c272796ec54be143eca60dc53bfb31017ee4c0L212), [link](https://github.com/amplication/amplication/pull/6083/files?diff=unified&w=0#diff-b026f712e26a857b3cacb53b46c272796ec54be143eca60dc53bfb31017ee4c0L249))
*  Replace `rm` call with `deleteRepositoryDir` method of `GitCli` class in `catch` block of `createPullRequest` method of `GitClientService` class to simplify code and ensure consistency ([link](https://github.com/amplication/amplication/pull/6083/files?diff=unified&w=0#diff-b026f712e26a857b3cacb53b46c272796ec54be143eca60dc53bfb31017ee4c0L220-R220))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
