### PR TITLE
add pagination to get commit & use commit on layout application

### DIFF
--- a/packages/amplication-client/src/Resource/code-view/CodeViewExplorer.tsx
+++ b/packages/amplication-client/src/Resource/code-view/CodeViewExplorer.tsx
@@ -8,7 +8,6 @@ import "./CodeViewBar.scss";
 import CodeViewExplorerTree from "./CodeViewExplorerTree";
 import { FileDetails } from "./CodeViewPage";
 import { NodeTypeEnum } from "./NodeTypeEnum";
-import useCommit from "../../VersionControl/hooks/useCommits";
 
 const CLASS_NAME = "code-view-bar";
 
@@ -25,8 +24,7 @@ export type FileMeta = {
 };
 
 const CodeViewExplorer: React.FC<Props> = ({ onFileSelected }) => {
-  const { resources } = useContext(AppContext);
-  const { commits } = useCommit();
+  const { resources, commitUtils } = useContext(AppContext);
 
   const [selectedCommit, setSelectedCommit] = useState<Commit | null>(null);
   const [selectedResource, setSelectedResource] = useState<Resource | null>(
@@ -43,8 +41,8 @@ const CodeViewExplorer: React.FC<Props> = ({ onFileSelected }) => {
   };
 
   useEffect(() => {
-    setSelectedCommit(commits[0]);
-  }, [commits]);
+    setSelectedCommit(commitUtils.commits[0]);
+  }, [commitUtils.commits]);
 
   useEffect(() => {
     setSelectedResource(resources[0]);
@@ -60,7 +58,7 @@ const CodeViewExplorer: React.FC<Props> = ({ onFileSelected }) => {
     <div className={CLASS_NAME}>
       <div>
         <CommitSelector
-          commits={commits}
+          commits={commitUtils.commits}
           selectedCommit={selectedCommit}
           onSelectCommit={handleSelectedCommit}
         />

--- a/packages/amplication-client/src/VersionControl/ChangesPage.tsx
+++ b/packages/amplication-client/src/VersionControl/ChangesPage.tsx
@@ -7,7 +7,6 @@ import PageContent from "../Layout/PageContent";
 import { PendingChange } from "../models";
 import { AppRouteProps } from "../routes/routesUtil";
 import { formatError } from "../util/error";
-import useCommits from "./hooks/useCommits";
 import { EnumCompareType } from "./PendingChangeDiffEntity";
 import "./PendingChangesPage.scss";
 import PendingChangeWithCompare from "./PendingChangeWithCompare";
@@ -35,12 +34,12 @@ const ChangesPage: React.FC<Props> = ({ match }) => {
   const resourceId = match.params.resource;
   const [splitView, setSplitView] = useState<boolean>(false);
   const pageTitle = "Changes";
-  const { commitChangesByResource, commitsError } = useCommits();
-  const { currentProject, currentWorkspace } = useContext(AppContext);
+  const { currentProject, currentWorkspace, commitUtils } =
+    useContext(AppContext);
 
-  const commitResourceChanges = commitChangesByResource(commitId).find(
-    (resource) => resource.resourceId === resourceId
-  )?.changes;
+  const commitResourceChanges = commitUtils
+    .commitChangesByResource(commitId)
+    .find((resource) => resource.resourceId === resourceId)?.changes;
 
   const handleChangeType = useCallback(
     (type: string) => {
@@ -49,7 +48,7 @@ const ChangesPage: React.FC<Props> = ({ match }) => {
     [setSplitView]
   );
 
-  const errorMessage = formatError(commitsError);
+  const errorMessage = formatError(commitUtils.commitsError);
 
   return (
     <>
@@ -81,7 +80,10 @@ const ChangesPage: React.FC<Props> = ({ match }) => {
             ))}
         </div>
       </PageContent>
-      <Snackbar open={Boolean(commitsError)} message={errorMessage} />
+      <Snackbar
+        open={Boolean(commitUtils.commitsError)}
+        message={errorMessage}
+      />
     </>
   );
 };

--- a/packages/amplication-client/src/VersionControl/Commit.tsx
+++ b/packages/amplication-client/src/VersionControl/Commit.tsx
@@ -17,7 +17,6 @@ import { formatError } from "../util/error";
 import { CROSS_OS_CTRL_ENTER } from "../util/hotkeys";
 import { commitPath } from "../util/paths";
 import "./Commit.scss";
-import useCommit from "./hooks/useCommits";
 
 const LIMITATION_ERROR_PREFIX = "LimitationError: ";
 
@@ -63,9 +62,8 @@ const Commit = ({ projectId, noChanges }: Props) => {
     setPendingChangesError,
     currentWorkspace,
     currentProject,
+    commitUtils,
   } = useContext(AppContext);
-
-  const { refetchCommits } = useCommit();
 
   const redirectToPurchase = () => {
     const path = `/${match.params.workspace}/purchase`;
@@ -85,7 +83,7 @@ const Commit = ({ projectId, noChanges }: Props) => {
       setCommitRunning(false);
       setPendingChangesError(false);
       resetPendingChanges();
-      refetchCommits();
+      commitUtils.refetchCommitsData(true);
       const path = commitPath(
         currentWorkspace?.id,
         currentProject?.id,

--- a/packages/amplication-client/src/VersionControl/CommitList.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitList.tsx
@@ -2,7 +2,12 @@ import React, { useContext } from "react";
 import { ApolloError } from "@apollo/client";
 import { formatError } from "../util/error";
 import * as models from "../models";
-import { Snackbar, CircularProgress } from "@amplication/ui/design-system";
+import {
+  Snackbar,
+  CircularProgress,
+  EnumButtonStyle,
+  Button,
+} from "@amplication/ui/design-system";
 import { AppContext } from "../context/appContext";
 import { CommitListItem } from "./CommitListItem";
 
@@ -12,11 +17,19 @@ type Props = {
   commits: models.Commit[];
   error: ApolloError | undefined;
   loading: boolean;
+  onLoadMoreClick: () => void;
+  disableLoadMore: boolean;
 };
 
 const CLASS_NAME = "commit-list";
 
-const CommitList = ({ commits, error, loading }: Props) => {
+const CommitList = ({
+  commits,
+  error,
+  loading,
+  onLoadMoreClick,
+  disableLoadMore,
+}: Props) => {
   const { currentProject } = useContext(AppContext);
 
   const errorMessage = formatError(error);
@@ -33,6 +46,13 @@ const CommitList = ({ commits, error, loading }: Props) => {
             projectId={currentProject.id}
           />
         ))}
+      <Button
+        disabled={disableLoadMore}
+        buttonStyle={EnumButtonStyle.Outline}
+        onClick={onLoadMoreClick}
+      >
+        Load more...
+      </Button>
       <Snackbar open={Boolean(error)} message={errorMessage} />
     </div>
   );

--- a/packages/amplication-client/src/VersionControl/CommitResourceList.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitResourceList.tsx
@@ -5,13 +5,18 @@ import DataPanel, { TitleDataType } from "./DataPanel";
 import "./CommitResourceList.scss";
 import { EnumImages } from "../Components/SvgThemeImage";
 import { EmptyState } from "../Components/EmptyState";
+import { CommitChangesByResource } from "./hooks/useCommits";
 
 type Props = {
   commit: models.Commit;
+  commitChangesByResource: CommitChangesByResource;
 };
 
 const CLASS_NAME = "commit-resource-list";
-const CommitResourceList: React.FC<Props> = ({ commit }) => {
+const CommitResourceList: React.FC<Props> = ({
+  commit,
+  commitChangesByResource,
+}) => {
   return (
     <div className={CLASS_NAME}>
       <DataPanel
@@ -26,7 +31,11 @@ const CommitResourceList: React.FC<Props> = ({ commit }) => {
         )}
         {commit.builds && commit.builds.length ? (
           commit.builds.map((build: models.Build) => (
-            <CommitResourceListItem key={build.id} build={build} />
+            <CommitResourceListItem
+              key={build.id}
+              build={build}
+              commitChangesByResource={commitChangesByResource}
+            />
           ))
         ) : (
           <EmptyState

--- a/packages/amplication-client/src/VersionControl/CommitResourceListItem.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitResourceListItem.tsx
@@ -20,7 +20,6 @@ type Props = {
 
 const CommitResourceListItem = ({ build, commitChangesByResource }: Props) => {
   const { currentWorkspace, currentProject } = useContext(AppContext);
-  //const { commitChangesByResource } = useCommits();
   const { data } = useBuildWatchStatus(build);
   const handleBuildLinkClick = useCallback((event) => {
     event.stopPropagation();

--- a/packages/amplication-client/src/VersionControl/CommitResourceListItem.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitResourceListItem.tsx
@@ -8,18 +8,19 @@ import { Build } from "../models";
 import { AnalyticsEventNames } from "../util/analytics-events.types";
 import { CommitBuildsStatusIcon } from "./CommitBuildsStatusIcon";
 import "./CommitResourceListItem.scss";
-import useCommits from "./hooks/useCommits";
+import { CommitChangesByResource } from "./hooks/useCommits";
 import useBuildWatchStatus from "./useBuildWatchStatus";
 
 const CLASS_NAME = "commit-resource-list-item";
 
 type Props = {
   build: Build;
+  commitChangesByResource: CommitChangesByResource;
 };
 
-const CommitResourceListItem = ({ build }: Props) => {
+const CommitResourceListItem = ({ build, commitChangesByResource }: Props) => {
   const { currentWorkspace, currentProject } = useContext(AppContext);
-  const { commitChangesByResource } = useCommits();
+  //const { commitChangesByResource } = useCommits();
   const { data } = useBuildWatchStatus(build);
   const handleBuildLinkClick = useCallback((event) => {
     event.stopPropagation();

--- a/packages/amplication-client/src/VersionControl/CommitsPage.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitsPage.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useEffect, useMemo } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { match, useHistory } from "react-router-dom";
 import { EnumImages } from "../Components/SvgThemeImage";
 import { AppContext } from "../context/appContext";
@@ -10,6 +16,7 @@ import useCommit from "./hooks/useCommits";
 import "./CommitsPage.scss";
 import { EmptyState } from "../Components/EmptyState";
 import { CircularProgress } from "@amplication/ui/design-system";
+import { Commit } from "../models";
 
 type Props = AppRouteProps & {
   match: match<{
@@ -20,42 +27,81 @@ type Props = AppRouteProps & {
   }>;
 };
 
+const MAX_ITEMS_PER_LOADING = 20;
+
 const CommitsPage: React.FC<Props> = ({ match, moduleClass }) => {
   const commitId = match.params.commit;
   const history = useHistory();
 
   const { currentProject, currentWorkspace } = useContext(AppContext);
+  const [commitsCount, setCommitsCount] = useState(1);
+  const [disableLoadMore, setDisableLoadMore] = useState(false);
 
-  const { commits, commitsError, commitsLoading } = useCommit();
+  const { commits, commitsError, commitsLoading, refetchCommits } = useCommit(
+    MAX_ITEMS_PER_LOADING
+  );
+
+  const [commitsData, setCommitsData] = useState<Commit[]>([]);
+
+  useEffect(() => {
+    if (commits?.length < 0 || commitsCount > 1) return;
+    setCommitsData(commits);
+  }, [commits]);
+
+  useEffect(() => {
+    setCommitsCount(1);
+  }, []);
+
+  const handleOnLoadMoreClick = useCallback(() => {
+    setCommitsCount(commitsCount + 1);
+    const getNextCommits = {
+      variables: {
+        skip: commitsCount * MAX_ITEMS_PER_LOADING,
+        take: MAX_ITEMS_PER_LOADING,
+      },
+    };
+
+    refetchCommits(getNextCommits.variables).then((results) => {
+      setCommitsData([...commitsData, ...results.data.commits]);
+      !results.data.commits.length && setDisableLoadMore(true);
+    });
+  }, [commitsData, refetchCommits, setCommitsData, setDisableLoadMore]);
 
   const currentCommit = useMemo(() => {
-    return commits.find((commit) => commit.id === commitId);
-  }, [commitId, commits]);
-  const hasCommits = commits.length > 0;
+    return commitsData?.find((commit) => commit.id === commitId);
+  }, [commitId, commitsData]);
 
   useEffect(() => {
     if (commitId) return;
-    commits.length &&
+    commitsData.length &&
       history.push(
-        `/${currentWorkspace?.id}/${currentProject?.id}/commits/${commits[0].id}`
+        `/${currentWorkspace?.id}/${currentProject?.id}/commits/${commitsData[0].id}`
       );
-  }, [commitId, commits, currentProject?.id, currentWorkspace?.id, history]);
+  }, [
+    commitId,
+    commitsData,
+    currentProject?.id,
+    currentWorkspace?.id,
+    history,
+  ]);
 
   return (
     <PageContent
       className={moduleClass}
       pageTitle={`Commit Page ${commitId ? commitId : ""}`}
       sideContent={
-        hasCommits ? (
+        commitsData.length ? (
           <CommitList
-            commits={commits}
+            commits={commitsData}
             error={commitsError}
             loading={commitsLoading}
+            onLoadMoreClick={handleOnLoadMoreClick}
+            disableLoadMore={disableLoadMore}
           />
         ) : null
       }
     >
-      {hasCommits && currentCommit ? (
+      {commitsData.length && currentCommit ? (
         <CommitResourceList commit={currentCommit} />
       ) : commitsLoading ? (
         <CircularProgress centerToParent />

--- a/packages/amplication-client/src/VersionControl/CommitsPage.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitsPage.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useCallback, useContext, useEffect, useMemo } from "react";
 import { match, useHistory } from "react-router-dom";
 import { EnumImages } from "../Components/SvgThemeImage";
 import { AppContext } from "../context/appContext";
@@ -12,7 +6,6 @@ import PageContent from "../Layout/PageContent";
 import { AppRouteProps } from "../routes/routesUtil";
 import CommitList from "./CommitList";
 import CommitResourceList from "./CommitResourceList";
-import useCommit from "./hooks/useCommits";
 import "./CommitsPage.scss";
 import { EmptyState } from "../Components/EmptyState";
 import { CircularProgress } from "@amplication/ui/design-system";
@@ -30,55 +23,53 @@ const CommitsPage: React.FC<Props> = ({ match, moduleClass }) => {
   const commitId = match.params.commit;
   const history = useHistory();
 
-  const { currentProject, currentWorkspace } = useContext(AppContext);
-
-  const {
-    commits,
-    commitsError,
-    commitsLoading,
-    refetchCommitsData,
-    disableLoadMore,
-    commitChangesByResource,
-  } = useCommit();
+  const { currentProject, currentWorkspace, commitUtils } =
+    useContext(AppContext);
 
   const handleOnLoadMoreClick = useCallback(() => {
-    refetchCommitsData();
-  }, [refetchCommitsData]);
+    commitUtils.refetchCommitsData();
+  }, [commitUtils.refetchCommitsData]);
 
   const currentCommit = useMemo(() => {
-    return commits?.find((commit) => commit.id === commitId);
-  }, [commitId, commits]);
+    return commitUtils.commits?.find((commit) => commit.id === commitId);
+  }, [commitId, commitUtils.commits]);
 
   useEffect(() => {
     if (commitId) return;
-    commits.length &&
+    commitUtils.commits.length &&
       history.push(
-        `/${currentWorkspace?.id}/${currentProject?.id}/commits/${commits[0].id}`
+        `/${currentWorkspace?.id}/${currentProject?.id}/commits/${commitUtils.commits[0].id}`
       );
-  }, [commitId, commits, currentProject?.id, currentWorkspace?.id, history]);
+  }, [
+    commitId,
+    commitUtils.commits,
+    currentProject?.id,
+    currentWorkspace?.id,
+    history,
+  ]);
 
   return (
     <PageContent
       className={moduleClass}
       pageTitle={`Commit Page ${commitId ? commitId : ""}`}
       sideContent={
-        commits.length ? (
+        commitUtils.commits?.length ? (
           <CommitList
-            commits={commits}
-            error={commitsError}
-            loading={commitsLoading}
+            commits={commitUtils.commits}
+            error={commitUtils.commitsError}
+            loading={commitUtils.commitsLoading}
             onLoadMoreClick={handleOnLoadMoreClick}
-            disableLoadMore={disableLoadMore}
+            disableLoadMore={commitUtils.disableLoadMore}
           />
         ) : null
       }
     >
-      {commits.length && currentCommit ? (
+      {commitUtils.commits.length && currentCommit ? (
         <CommitResourceList
           commit={currentCommit}
-          commitChangesByResource={commitChangesByResource}
+          commitChangesByResource={commitUtils.commitChangesByResource}
         />
-      ) : commitsLoading ? (
+      ) : commitUtils.commitsLoading ? (
         <CircularProgress centerToParent />
       ) : (
         <EmptyState

--- a/packages/amplication-client/src/VersionControl/LastCommit.tsx
+++ b/packages/amplication-client/src/VersionControl/LastCommit.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import classNames from "classnames";
 import { Button, EnumButtonStyle } from "@amplication/ui/design-system";
 import { ClickableId } from "../Components/ClickableId";
@@ -9,25 +9,17 @@ import { formatDistanceToNow } from "date-fns";
 import { useCommitStatus } from "./hooks/useCommitStatus";
 import { CommitBuildsStatusIcon } from "./CommitBuildsStatusIcon";
 import { AnalyticsEventNames } from "../util/analytics-events.types";
-import useCommit from "./hooks/useCommits";
+import { Commit } from "../models";
 
 type Props = {
-  resourceId?: string;
+  lastCommit: Commit;
 };
 
 const CLASS_NAME = "last-commit";
 
-const LastCommit = ({ resourceId }: Props) => {
+const LastCommit = ({ lastCommit }: Props) => {
   const { currentWorkspace, currentProject, commitRunning } =
     useContext(AppContext);
-
-  const { lastCommit, refetchCommits, commits } = useCommit();
-  console.log({ lastCommit });
-  console.log({ commits });
-
-  useEffect(() => {
-    refetchCommits();
-  }, [resourceId]);
 
   const { commitStatus } = useCommitStatus(lastCommit);
   if (!lastCommit) return null;

--- a/packages/amplication-client/src/VersionControl/LastCommit.tsx
+++ b/packages/amplication-client/src/VersionControl/LastCommit.tsx
@@ -1,11 +1,6 @@
 import { useContext, useEffect } from "react";
 import classNames from "classnames";
-import { isEmpty } from "lodash";
-import {
-  Tooltip,
-  Button,
-  EnumButtonStyle,
-} from "@amplication/ui/design-system";
+import { Button, EnumButtonStyle } from "@amplication/ui/design-system";
 import { ClickableId } from "../Components/ClickableId";
 import "./LastCommit.scss";
 import { AppContext } from "../context/appContext";
@@ -26,7 +21,9 @@ const LastCommit = ({ resourceId }: Props) => {
   const { currentWorkspace, currentProject, commitRunning } =
     useContext(AppContext);
 
-  const { lastCommit, refetchCommits } = useCommit();
+  const { lastCommit, refetchCommits, commits } = useCommit();
+  console.log({ lastCommit });
+  console.log({ commits });
 
   useEffect(() => {
     refetchCommits();

--- a/packages/amplication-client/src/VersionControl/hooks/commitQueries.ts
+++ b/packages/amplication-client/src/VersionControl/hooks/commitQueries.ts
@@ -1,8 +1,18 @@
 import { gql } from "@apollo/client";
 
 export const GET_COMMITS = gql`
-  query commits($projectId: String!, $orderBy: CommitOrderByInput) {
-    commits(where: { project: { id: $projectId } }, orderBy: $orderBy) {
+  query commits(
+    $projectId: String!
+    $take: Int!
+    $skip: Int!
+    $orderBy: CommitOrderByInput
+  ) {
+    commits(
+      where: { project: { id: $projectId } }
+      take: $take
+      skip: $skip
+      orderBy: $orderBy
+    ) {
       id
       message
       createdAt

--- a/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
+++ b/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
@@ -5,7 +5,7 @@ import { useQuery } from "@apollo/client";
 import { AppContext } from "../../context/appContext";
 import { groupBy } from "lodash";
 
-const useCommits = () => {
+const useCommits = (maxCommits?: number) => {
   const { currentProject } = useContext(AppContext);
   const [commits, setCommits] = useState<Commit[]>([]);
 
@@ -19,6 +19,8 @@ const useCommits = () => {
     notifyOnNetworkStatusChange: true,
     variables: {
       projectId: currentProject?.id,
+      take: maxCommits || 20,
+      skip: 0,
       orderBy: {
         createdAt: SortOrder.Desc,
       },

--- a/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
+++ b/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
@@ -1,36 +1,77 @@
 import { GET_COMMITS } from "./commitQueries";
-import { useContext, useEffect, useMemo, useState } from "react";
-import { Commit, SortOrder } from "../../models";
-import { useQuery } from "@apollo/client";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { Commit, PendingChange, SortOrder } from "../../models";
+import { useMutation, useQuery } from "@apollo/client";
 import { AppContext } from "../../context/appContext";
 import { groupBy } from "lodash";
+
+const MAX_ITEMS_PER_LOADING = 20;
+
+type CommitData = {
+  commits: Commit[];
+};
+export type CommitChangesByResource = (commitId: string) => {
+  resourceId: string;
+  changes: PendingChange[];
+}[];
 
 const useCommits = (maxCommits?: number) => {
   const { currentProject } = useContext(AppContext);
   const [commits, setCommits] = useState<Commit[]>([]);
-
-  const {
-    data: commitsData,
-    error: commitsError,
-    loading: commitsLoading,
-    refetch: refetchCommits,
-  } = useQuery(GET_COMMITS, {
-    skip: !currentProject?.id && !commits.length,
-    notifyOnNetworkStatusChange: true,
-    variables: {
-      projectId: currentProject?.id,
-      take: maxCommits || 20,
-      skip: 0,
-      orderBy: {
-        createdAt: SortOrder.Desc,
+  const [commitsCount, setCommitsCount] = useState(1);
+  const [disableLoadMore, setDisableLoadMore] = useState(false);
+  const [fetchCommits, { error: commitsError, loading: commitsLoading }] =
+    useMutation<CommitData>(GET_COMMITS);
+  // const {
+  //   data: commitsData,
+  //   error: commitsError,
+  //   loading: commitsLoading,
+  //   refetch: refetchCommits,
+  // } = useQuery(GET_COMMITS, {
+  //   skip: !currentProject?.id && !commits.length,
+  //   notifyOnNetworkStatusChange: true,
+  //   variables: {
+  //     projectId: currentProject?.id,
+  //     take: maxCommits || MAX_ITEMS_PER_LOADING,
+  //     skip: 0,
+  //     orderBy: {
+  //       createdAt: SortOrder.Desc,
+  //     },
+  //   },
+  // });
+  const initialFetchCommits = useCallback(() => {
+    fetchCommits({
+      variables: {
+        projectId: currentProject?.id,
+        take: maxCommits || MAX_ITEMS_PER_LOADING,
+        skip: 0,
+        orderBy: {
+          createdAt: SortOrder.Desc,
+        },
       },
+    });
+  }, []);
+
+  const refetchCommitsData = useCallback(
+    (baseCommitsCount?: number) => {
+      setCommitsCount(commitsCount + 1);
+      const getNextCommits = {
+        variables: {
+          skip: baseCommitsCount || commitsCount * MAX_ITEMS_PER_LOADING,
+          take: MAX_ITEMS_PER_LOADING,
+        },
+      };
+      refetchCommits(getNextCommits.variables);
     },
-  });
+    [refetchCommits, setCommitsCount, commitsCount]
+  );
 
   useEffect(() => {
-    if (!commitsData) return;
-    setCommits(commitsData.commits);
-  }, [commitsData]);
+    if (!commitsData?.commits?.length) return;
+    console.log("fetch commits");
+    setCommits([...commits, ...commitsData.commits]);
+    !commitsData?.commits?.length && setDisableLoadMore(true);
+  }, [commitsData?.commits]);
 
   const getCommitIdx = (commits: Commit[], commitId: string): number =>
     commits.findIndex((commit) => commit.id === commitId);
@@ -61,7 +102,9 @@ const useCommits = (maxCommits?: number) => {
     commitsError,
     commitsLoading,
     commitChangesByResource,
+    refetchCommitsData,
     refetchCommits,
+    disableLoadMore,
   };
 };
 

--- a/packages/amplication-client/src/Workspaces/WorkspaceFooter.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceFooter.tsx
@@ -7,14 +7,13 @@ import { AppContext } from "../context/appContext";
 import GitRepoDetails from "../Resource/git/GitRepoDetails";
 import { AnalyticsEventNames } from "../util/analytics-events.types";
 import { PUSH_TO_GIT_STEP_NAME } from "../VersionControl/BuildSteps";
-import useCommit from "../VersionControl/hooks/useCommits";
 import "./WorkspaceFooter.scss";
-import { EnumGitProvider } from "../models";
+import { Commit, EnumGitProvider } from "../models";
 import { gitProviderIconMap } from "../Resource/git/git-provider-icon-map";
 
 const CLASS_NAME = "workspace-footer";
 
-const WorkspaceFooter: React.FC<unknown> = () => {
+const WorkspaceFooter: React.FC<{ lastCommit: Commit }> = ({ lastCommit }) => {
   const {
     currentWorkspace,
     currentProject,
@@ -25,8 +24,6 @@ const WorkspaceFooter: React.FC<unknown> = () => {
     projectConfigurationResource,
     gitRepositoryOrganizationProvider,
   } = useContext(AppContext);
-
-  const { lastCommit } = useCommit();
 
   const lastResourceBuild = useMemo(() => {
     if (!lastCommit) return null;

--- a/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
@@ -24,6 +24,7 @@ import useWorkspaceSelector from "./hooks/useWorkspaceSelector";
 import WorkspaceFooter from "./WorkspaceFooter";
 import WorkspaceHeader from "./WorkspaceHeader/WorkspaceHeader";
 import "./WorkspaceLayout.scss";
+import useCommits from "../VersionControl/hooks/useCommits";
 
 const MobileMessage = lazy(() => import("../Layout/MobileMessage"));
 
@@ -72,6 +73,8 @@ const WorkspaceLayout: React.FC<Props> = ({ innerRoutes, moduleClass }) => {
     setResetPendingChangesIndicator,
   } = usePendingChanges(currentProject);
 
+  const commitUtils = useCommits(currentProject?.id);
+
   const {
     resources,
     projectConfigurationResource,
@@ -91,6 +94,10 @@ const WorkspaceLayout: React.FC<Props> = ({ innerRoutes, moduleClass }) => {
     loadingCreateMessageBroker,
     createServiceWithEntitiesResult,
   } = useResources(currentWorkspace, currentProject, addBlock, addEntity);
+
+  useEffect(() => {
+    commitUtils.refetchLastCommit();
+  }, [currentResource?.id]);
 
   const { trackEvent, Track } = useTracking<{ [key: string]: any }>({
     workspaceId: currentWorkspace?.id,
@@ -167,6 +174,7 @@ const WorkspaceLayout: React.FC<Props> = ({ innerRoutes, moduleClass }) => {
         setResetPendingChangesIndicator,
         openHubSpotChat,
         createServiceWithEntitiesResult,
+        commitUtils,
       }}
     >
       {isMobileOnly ? (
@@ -188,12 +196,12 @@ const WorkspaceLayout: React.FC<Props> = ({ innerRoutes, moduleClass }) => {
                   {currentProject ? (
                     <PendingChanges projectId={currentProject.id} />
                   ) : null}
-                  {currentProject && (
-                    <LastCommit resourceId={currentResource?.id} />
+                  {currentProject && commitUtils.lastCommit && (
+                    <LastCommit lastCommit={commitUtils.lastCommit} />
                   )}
                 </div>
               </div>
-              <WorkspaceFooter />
+              <WorkspaceFooter lastCommit={commitUtils.lastCommit} />
               <HubSpotChatComponent
                 setChatStatus={setChatStatus}
                 chatStatus={chatStatus}

--- a/packages/amplication-client/src/context/appContext.tsx
+++ b/packages/amplication-client/src/context/appContext.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import * as models from "../models";
 import { PendingChangeItem } from "../Workspaces/hooks/usePendingChanges";
 import { CreateWorkspaceType } from "../Workspaces/hooks/workspace";
+import { CommitUtils } from "../VersionControl/hooks/useCommits";
 
 export interface AppContextInterface {
   currentWorkspace: models.Workspace | undefined;
@@ -53,6 +54,7 @@ export interface AppContextInterface {
   setResetPendingChangesIndicator: (reset: boolean) => void;
   openHubSpotChat: () => void;
   createServiceWithEntitiesResult: models.ResourceCreateWithEntitiesResult;
+  commitUtils: CommitUtils;
 }
 
 const initialContext: AppContextInterface = {
@@ -98,6 +100,21 @@ const initialContext: AppContextInterface = {
   setResetPendingChangesIndicator: () => {},
   openHubSpotChat: () => {},
   createServiceWithEntitiesResult: undefined,
+  commitUtils: {
+    commits: [],
+    lastCommit: null,
+    commitsError: null,
+    commitsLoading: false,
+    commitChangesByResource: (commitId: string) => [
+      {
+        resourceId: "",
+        changes: [],
+      },
+    ],
+    refetchCommitsData: () => {},
+    refetchLastCommit: () => {},
+    disableLoadMore: false,
+  },
 };
 
 export const AppContext =


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #5945

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a524ed7</samp>

### Summary
📊🛠️📝

<!--
1.  📊 This emoji represents the addition of pagination and sorting features to the `GET_COMMITS` query, which improves the performance and usability of the app.
2.  🛠️ This emoji represents the refactoring and simplification of the code using the `commitUtils` object from the app context, which reduces duplication and complexity.
3.  📝 This emoji represents the enhancement of the UI components to display more details about the commit changes by resource, which provides more information and clarity to the user.
-->
This pull request adds pagination and refetching features to the commits data, and refactors the app components to use a `commitUtils` object from the app context. It also improves the UI of the commits page and the workspace footer by showing more details about the changes by resource. It affects the files `packages/amplication-client/src/context/appContext.tsx`, `packages/amplication-client/src/Resource/code-view/CodeViewExplorer.tsx`, `packages/amplication-client/src/VersionControl/ChangesPage.tsx`, `packages/amplication-client/src/VersionControl/Commit.tsx`, `packages/amplication-client/src/VersionControl/CommitList.tsx`, `packages/amplication-client/src/VersionControl/CommitResourceList.tsx`, `packages/amplication-client/src/VersionControl/CommitResourceListItem.tsx`, `packages/amplication-client/src/VersionControl/CommitsPage.tsx`, `packages/amplication-client/src/VersionControl/hooks/useCommits.ts`, `packages/amplication-client/src/VersionControl/LastCommit.tsx`, `packages/amplication-client/src/Workspaces/WorkspaceFooter.tsx`, `packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx`, and `packages/amplication-client/src/VersionControl/hooks/commitQueries.ts`.

> _We're the masters of the code, we control the `commitUtils`_
> _We can fetch and sort and group, we can show the changes too_
> _We don't need no hooks or queries, we use the app context_
> _We're the lords of the `CommitsPage`, we can load more with a click_

### Walkthrough
*  Refactor the commits data fetching and pagination logic to use a custom `useCommits` hook and a `commitUtils` object in the app context (  )
*  Remove the unused `useCommit` hook and its imports from various components ([link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-ad8b34ac3c3b43c686fc6cd319cba91ed7b26e8ddf727910cf25b6d59dee6262L11), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-5265fd434e757a6ec16888930b7f8ad49eb1eca9998a2ab5744f84d61a5281c2L10), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-6d3ad95a9761963847af064dcfc4c410db091775a917cf476e70b672740ebee6L20), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-7be9a998fcd4bbb4ed0e929aae9f12dd2917522f9594faf174348cc599811886L11-R11), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-6bf2f4394daff58a8501cd2097f39550370ef58b42fe9d65f86de3da7a3793ccL9), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-6754fe9a4edc2f4882029df071322261fe7ee99a7eee7b244db209921841ff6eL29-L30))
*  Add the `commitChangesByResource` function to the `CommitResourceList` and `CommitResourceListItem` components to group the changes by resource for each commit ([link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-dceb6600e9ea1ce04eec1ee1fcc8577849a359b496cfbfd9734a575f99aa493dL8-R19), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-dceb6600e9ea1ce04eec1ee1fcc8577849a359b496cfbfd9734a575f99aa493dL29-R38))
*  Add the `Button` component to the `CommitList` component to render a load more button and pass the `onLoadMoreClick` and `disableLoadMore` props to control its functionality ([link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-c9afe8e64d6197dfa7e81e35b03786d154363b6d4c28c6a53c3a58029818a869L5-R10), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-c9afe8e64d6197dfa7e81e35b03786d154363b6d4c28c6a53c3a58029818a869L15-R32), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-c9afe8e64d6197dfa7e81e35b03786d154363b6d4c28c6a53c3a58029818a869R49-R55), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-6bf2f4394daff58a8501cd2097f39550370ef58b42fe9d65f86de3da7a3793ccL27-R49), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-6bf2f4394daff58a8501cd2097f39550370ef58b42fe9d65f86de3da7a3793ccL49-R72))
*  Add the `take`, `skip`, and `orderBy` parameters to the `GET_COMMITS` query to fetch a subset of commits with a specified order from the server ([link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-db8c254272e005e7b5da98024ffff3e1e3bf86c2bf9abf077100cb46c0d7734aL4-R15))
*  Add the `handleOnLoadMoreClick` function to the `CommitsPage` component to call the `commitUtils.refetchCommitsData` function with the appropriate pagination parameters ([link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-6bf2f4394daff58a8501cd2097f39550370ef58b42fe9d65f86de3da7a3793ccL1-R1), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-6bf2f4394daff58a8501cd2097f39550370ef58b42fe9d65f86de3da7a3793ccL27-R49))
*  Add an effect to the `WorkspaceLayout` component to call the `commitUtils.refetchLastCommit` function whenever the `currentResource?.id` changes ([link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-03267d3c067a6a362b6fbfa605791ab35df55bd9a6243e3e24fb53de9b1e5b35R98-R101))
*  Replace the `resourceId` prop with the `lastCommit` prop in the `LastCommit` and `WorkspaceFooter` components and pass the `commitUtils.lastCommit` object to them ([link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-047889aa3c50ee4f2d0bdf5b0c5182948a3e492c318728867393bd36a1d52d53L17-R23), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-6754fe9a4edc2f4882029df071322261fe7ee99a7eee7b244db209921841ff6eL10-R16), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-03267d3c067a6a362b6fbfa605791ab35df55bd9a6243e3e24fb53de9b1e5b35L191-R204))
*  Replace the `commits`, `commitsError`, `commitsLoading`, and `refetchCommits` variables with the corresponding properties from the `commitUtils` object in various components ([link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-ad8b34ac3c3b43c686fc6cd319cba91ed7b26e8ddf727910cf25b6d59dee6262L46-R45), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-ad8b34ac3c3b43c686fc6cd319cba91ed7b26e8ddf727910cf25b6d59dee6262L63-R61), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-5265fd434e757a6ec16888930b7f8ad49eb1eca9998a2ab5744f84d61a5281c2L38-R42), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-5265fd434e757a6ec16888930b7f8ad49eb1eca9998a2ab5744f84d61a5281c2L52-R51), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-5265fd434e757a6ec16888930b7f8ad49eb1eca9998a2ab5744f84d61a5281c2L84-R86), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-6d3ad95a9761963847af064dcfc4c410db091775a917cf476e70b672740ebee6L66-R67), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-6d3ad95a9761963847af064dcfc4c410db091775a917cf476e70b672740ebee6L88-R86), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-6bf2f4394daff58a8501cd2097f39550370ef58b42fe9d65f86de3da7a3793ccL27-R49), [link](https://github.com/amplication/amplication/pull/6093/files?diff=unified&w=0#diff-6bf2f4394daff58a8501cd2097f39550370ef58b42fe9d65f86de3da7a3793ccL49-R72))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
