### PR TITLE
feat(kafka): add client consumer config for rebalancing timeout

### DIFF
--- a/libs/util/kafka/src/lib/kafkaEnv.ts
+++ b/libs/util/kafka/src/lib/kafkaEnv.ts
@@ -63,4 +63,9 @@ export class KafkaEnvironmentVariables {
     );
     return heartbeat ? parseInt(heartbeat) : 10000;
   }
+
+  getConsumerRebalanceTimeout(): number {
+    const rebalanceTimeout = this.getConsumerSessionTimeout();
+    return rebalanceTimeout * 2;
+  }
 }

--- a/libs/util/nestjs/kafka/src/createNestjsKafkaConfig.ts
+++ b/libs/util/nestjs/kafka/src/createNestjsKafkaConfig.ts
@@ -13,6 +13,7 @@ export function createNestjsKafkaConfig(envSuffix = ""): KafkaOptions {
     consumer = {
       groupId,
       sessionTimeout: kafkaEnv.getConsumerSessionTimeout(),
+      rebalanceTimeout: kafkaEnv.getConsumerRebalanceTimeout(),
       heartbeatInterval: kafkaEnv.getConsumerHeartbeat(),
     };
   }


### PR DESCRIPTION
Close: [#6062](https://github.com/amplication/amplication/issues/6062)

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 938f2c0</samp>

### Summary
🆕🕑🔄

<!--
1.  🆕 - This emoji can be used to indicate that a new method and a new property were added to the existing classes and interfaces.
2.  🕑 - This emoji can be used to indicate that the changes are related to time settings, such as the consumer rebalance timeout and the consumer session timeout.
3.  🔄 - This emoji can be used to indicate that the changes are related to rebalancing, which is a process of redistributing the partitions among the consumers in a group.
-->
Added a new `rebalanceTimeout` option to the NestJS Kafka module configuration, based on the consumer session timeout from the `KafkaEnv` class. This option controls how long a consumer group waits for members to join in a rebalance.

> _`KafkaEnv` knows_
> _consumer rebalance timeout_
> _twice the session time_

### Walkthrough
*  Add `rebalanceTimeout` property to `KafkaConfig` interface to configure the maximum time for consumer group rebalancing ([link](https://github.com/amplication/amplication/pull/6095/files?diff=unified&w=0#diff-5961ee4f29a8b06f8ee6199c8b107272d33d1359a81297484b530f4d4f6f9ae6R16))
*  Implement `getConsumerRebalanceTimeout` method in `KafkaEnv` class to return twice the consumer session timeout ([link](https://github.com/amplication/amplication/pull/6095/files?diff=unified&w=0#diff-2e076e55bb11bb27f9304ad7436e9012a313a438914772b2a42e64da56e00770R66-R70))
*  Use `getConsumerRebalanceTimeout` method to set the `rebalanceTimeout` property in `createNestjsKafkaConfig` function, which creates the options for the NestJS Kafka module in `libs/util/nestjs/kafka/src/createNestjsKafkaConfig.ts` ([link](https://github.com/amplication/amplication/pull/6095/files?diff=unified&w=0#diff-5961ee4f29a8b06f8ee6199c8b107272d33d1359a81297484b530f4d4f6f9ae6R16), [link](https://github.com/amplication/amplication/pull/6095/files?diff=unified&w=0#diff-2e076e55bb11bb27f9304ad7436e9012a313a438914772b2a42e64da56e00770R66-R70))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
