### PR TITLE
fix(git-utils): issue where git apply fails due to: cannot apply binary patch to without full index line

### DIFF
--- a/packages/amplication-git-utils/src/providers/git-cli.ts
+++ b/packages/amplication-git-utils/src/providers/git-cli.ts
@@ -88,8 +88,14 @@ export class GitCli {
       .clean(CleanOptions.FORCE);
   }
 
-  async diff(ref: string[]) {
-    return this.git.diff(ref);
+  /**
+   * Returns the diff between the current branch and the given ref
+   * @param ref reference to compare to
+   * @returns diff between the current branch and the given ref
+   * @see https://git-scm.com/docs/git-diff
+   */
+  async diff(ref: string) {
+    return this.git.diff(["--full-index", ...ref]);
   }
 
   async commit(
@@ -143,7 +149,7 @@ export class GitCli {
   }
 
   async applyPatch(patches: string[], options?: string[]) {
-    options = options ?? ["--3way", "--whitespace=nowarn"];
+    options = options ?? ["--index", "--3way", "--whitespace=nowarn"];
     await this.git
       .applyPatch(patches, options)
       .commit("Amplication merge conflicts auto-resolution", undefined, {

--- a/packages/amplication-git-utils/src/providers/git.service.spec.ts
+++ b/packages/amplication-git-utils/src/providers/git.service.spec.ts
@@ -98,7 +98,7 @@ describe("GitClientService", () => {
       });
 
       expect(mockedGitLog).toBeCalledTimes(2);
-      expect(mockedGitDiff).toBeCalledWith(["sghfsjfdsfd34234"]);
+      expect(mockedGitDiff).toBeCalledWith("sghfsjfdsfd34234");
     });
   });
 
@@ -135,7 +135,7 @@ describe("GitClientService", () => {
       });
 
       expect(mockedGitLog).toBeCalledTimes(1);
-      expect(mockedGitDiff).toBeCalledWith(["sghfsjfdsfd34234"]);
+      expect(mockedGitDiff).toBeCalledWith("sghfsjfdsfd34234");
     });
 
     it("should not call the gitlog for author amplication[bot] (or amplication provider integration)", async () => {

--- a/packages/amplication-git-utils/src/providers/git.service.ts
+++ b/packages/amplication-git-utils/src/providers/git.service.ts
@@ -382,7 +382,7 @@ export class GitClientService {
       return { diff: null };
     }
 
-    const diff = await gitCli.diff([hash]);
+    const diff = await gitCli.diff(hash);
     if (!diff) {
       this.logger.warn("Diff returned empty");
       return { diff: null };


### PR DESCRIPTION
Close: #6117 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0978ebc</samp>

### Summary
:recycle::bug::wrench:

<!--
1.  :recycle: This emoji represents a refactor or code improvement, and can be used for the change in the `GitCli` class that simplifies the `diff` method.
2. :bug: This emoji represents a bug fix or error resolution, and can be used for the change in the `GitCli` class that makes the `applyPatch` method more robust and consistent with the index.
3. :wrench: This emoji represents a tooling or configuration change, and can be used for the change in the `GitClientService` class that adapts to the new interface of the `GitCli` class.
-->
Updated the `GitCli` and `GitClientService` classes in the `amplication-git-utils` module to improve the diff and patch functionality. Simplified the `GitCli.diff` method and made the `GitCli.applyPatch` method more reliable. Adjusted the `GitClientService.diff` method to match the new `GitCli.diff` interface.

> _Oh we're the coders of the sea, and we work with git and cli_
> _We make the diff and patch methods better, with every pull and commit_
> _So heave away, me hearties, heave away with all your might_
> _We'll sync the index and the working tree, and sail into the night_

### Walkthrough
*  Simplify and improve the `diff` and `applyPatch` methods of the `GitCli` class ([link](https://github.com/amplication/amplication/pull/6120/files?diff=unified&w=0#diff-045ad92d579607f503463c05f08ddd15fc7363bdcc9766e0330c2c87878613c0L91-R98), [link](https://github.com/amplication/amplication/pull/6120/files?diff=unified&w=0#diff-045ad92d579607f503463c05f08ddd15fc7363bdcc9766e0330c2c87878613c0L146-R152))
* Adapt the `diff` method of the `GitClientService` class to the new interface of the `GitCli` class ([link](https://github.com/amplication/amplication/pull/6120/files?diff=unified&w=0#diff-b026f712e26a857b3cacb53b46c272796ec54be143eca60dc53bfb31017ee4c0L385-R385))



## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
