### PR TITLE
fix(client): subscription notifications

### DIFF
--- a/packages/amplication-client/src/Entity/EntityList.tsx
+++ b/packages/amplication-client/src/Entity/EntityList.tsx
@@ -102,10 +102,6 @@ const EntityList: React.FC<Props> = ({ match, innerRoutes }) => {
   const { data: getWorkspaceData } = useQuery<GetWorkspaceResponse>(
     GET_CURRENT_WORKSPACE
   );
-  const subscription =
-    getWorkspaceData.currentWorkspace.subscription?.subscriptionPlan;
-
-  const isFreePlan = subscription === models.EnumSubscriptionPlan.Free;
 
   const { stigg } = useStiggContext();
   const hideNotifications = stigg.getBooleanEntitlement({
@@ -150,7 +146,7 @@ const EntityList: React.FC<Props> = ({ match, innerRoutes }) => {
         </div>
         {loading && <CircularProgress centerToParent />}
 
-        {isFreePlan && !hideNotifications.hasAccess && (
+        {!hideNotifications.hasAccess && (
           <LimitationNotification
             description="With the current plan, you can use to 7 entities per service."
             link={`/${getWorkspaceData.currentWorkspace.id}/purchase`}

--- a/packages/amplication-client/src/Workspaces/ResourceList.tsx
+++ b/packages/amplication-client/src/Workspaces/ResourceList.tsx
@@ -130,11 +130,6 @@ function ResourceList() {
     GET_CURRENT_WORKSPACE
   );
 
-  const subscription =
-    getWorkspaceData.currentWorkspace.subscription?.subscriptionPlan;
-
-  const isFreePlan = subscription === models.EnumSubscriptionPlan.Free;
-
   const { stigg } = useStiggContext();
   const hideNotifications = stigg.getBooleanEntitlement({
     featureId: BillingFeature.HideNotifications,
@@ -172,7 +167,7 @@ function ResourceList() {
       </div>
       {loadingResources && <CircularProgress centerToParent />}
 
-      {isFreePlan && !hideNotifications.hasAccess && (
+      {!hideNotifications.hasAccess && (
         <LimitationNotification
           description="With the current plan, you can use up to 3 services."
           link={`/${getWorkspaceData.currentWorkspace.id}/purchase`}


### PR DESCRIPTION

Close: https://github.com/amplication/private-issues/issues/13

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at eecd210</samp>

### Summary
🗑️🧹🔄

<!--
1.  🗑️ - This emoji represents the removal or deletion of code, such as the subscription plan code that is no longer needed.
2.  🧹 - This emoji represents the simplification or cleanup of code, such as the limitation notification logic that is now more concise and readable.
3.  🔄 - This emoji represents the change or update of code, such as the resource list component that now uses the stigg context for entitlements.
-->
Removed subscription plan code and simplified limitation notification logic in `EntityList.tsx` and `ResourceList.tsx`. These changes use the stigg context to handle user entitlements for entities and resources.

> _The subscription plan code was a mess_
> _So they removed it and made it less_
> _They used stigg context_
> _To handle the next_
> _Limitation notification process_

### Walkthrough
*  Remove subscription plan logic from entity list and resource list components ([link](https://github.com/amplication/amplication/pull/6125/files?diff=unified&w=0#diff-46cc6f90a9c4c5614b6c68c13f5eebf1d57a5b3df9c08fe35621958da38659c0L105-R105), [link](https://github.com/amplication/amplication/pull/6125/files?diff=unified&w=0#diff-aac70b4e1a7cb3f3a90bb5ec772319262ef9c57f3671544605c708cd53d67c22L133-L137))
*  Simplify condition for showing limitation notification to only check hideNotifications entitlement ([link](https://github.com/amplication/amplication/pull/6125/files?diff=unified&w=0#diff-46cc6f90a9c4c5614b6c68c13f5eebf1d57a5b3df9c08fe35621958da38659c0L153-R149), [link](https://github.com/amplication/amplication/pull/6125/files?diff=unified&w=0#diff-aac70b4e1a7cb3f3a90bb5ec772319262ef9c57f3671544605c708cd53d67c22L175-R170))





## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
