### PR TITLE
fix(client): commits pagination bugs

### DIFF
--- a/packages/amplication-client/src/VersionControl/CommitsPage.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitsPage.tsx
@@ -27,7 +27,7 @@ const CommitsPage: React.FC<Props> = ({ match, moduleClass }) => {
     useContext(AppContext);
 
   const handleOnLoadMoreClick = useCallback(() => {
-    commitUtils.refetchCommitsData();
+    commitUtils.refetchCommitsData(false);
   }, [commitUtils.refetchCommitsData]);
 
   const currentCommit = useMemo(() => {

--- a/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
+++ b/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
@@ -50,7 +50,8 @@ const useCommits = (currentProjectId: string, maxCommits?: number) => {
       },
     },
     onCompleted: (data) => {
-      if (!data?.commits.length) setDisableLoadMore(true);
+      if (!data?.commits.length || data?.commits.length < MAX_ITEMS_PER_LOADING)
+        setDisableLoadMore(true);
     },
   });
 
@@ -81,6 +82,7 @@ const useCommits = (currentProjectId: string, maxCommits?: number) => {
         take: MAX_ITEMS_PER_LOADING,
       });
       refetchFromStart && setCommits([]);
+
       setCommitsCount(refetchFromStart ? 1 : commitsCount + 1);
     },
     [refetchCommits, setCommitsCount, commitsCount]

--- a/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
+++ b/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
@@ -82,7 +82,6 @@ const useCommits = (currentProjectId: string, maxCommits?: number) => {
         take: MAX_ITEMS_PER_LOADING,
       });
       refetchFromStart && setCommits([]);
-
       setCommitsCount(refetchFromStart ? 1 : commitsCount + 1);
     },
     [refetchCommits, setCommitsCount, commitsCount]

--- a/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
@@ -96,8 +96,9 @@ const WorkspaceLayout: React.FC<Props> = ({ innerRoutes, moduleClass }) => {
   } = useResources(currentWorkspace, currentProject, addBlock, addEntity);
 
   useEffect(() => {
-    commitUtils.refetchLastCommit();
-  }, [currentResource?.id]);
+    if (!currentProject?.id) return;
+    commitUtils.refetchCommitsData(true);
+  }, [currentProject?.id]);
 
   const { trackEvent, Track } = useTracking<{ [key: string]: any }>({
     workspaceId: currentWorkspace?.id,


### PR DESCRIPTION
Close: #6115 #6127 #6129 #6098 

## PR Details

Fix commits pagination bugs. 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c62bcdf</samp>

### Summary
🐛♻️🔥

<!--
1.  🐛 for the bug fix in the `handleOnLoadMoreClick` function.
2.  ♻️ for the refactor in the `useEffect` hook in the `WorkspaceLayout` component.
3.  🔥 for the removal of unnecessary code in the `useCommits` hook.
-->
Fix a bug in the version control page that showed a load more button when there were no more commits to fetch. Refactor the logic of fetching and displaying commits data in the workspace layout. Modify the arguments of the `refetchCommitsData` function to indicate the source of the refetching.

> _We're refetching the data of doom_
> _No more duplicates in the `commits` room_
> _We're simplifying the logic of the `useEffect` hook_
> _No more load more button when there's nothing to look_

### Walkthrough
*  Fix a bug that caused duplicate commits to appear on the commits page
  - Pass a `false` argument to `refetchCommitsData` when loading more data ([link](https://github.com/amplication/amplication/pull/6130/files?diff=unified&w=0#diff-6bf2f4394daff58a8501cd2097f39550370ef58b42fe9d65f86de3da7a3793ccL30-R30))
  - Hide the load more button when there are no more commits to fetch ([link](https://github.com/amplication/amplication/pull/6130/files?diff=unified&w=0#diff-ea74f30898d4da9abefb6e4d32bac377f69bb638c3d77eabbd941c71cd80d5c1L53-R54))
  - Call `refetchCommitsData` with a `true` argument instead of `refetchLastCommit` in `WorkspaceLayout.tsx` ([link](https://github.com/amplication/amplication/pull/6130/files?diff=unified&w=0#diff-03267d3c067a6a362b6fbfa605791ab35df55bd9a6243e3e24fb53de9b1e5b35L99-R101))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
