### PR TITLE
test(dsg): e2e update plugin version config

### DIFF
--- a/packages/data-service-generator/tests/e2e/plugins.ts
+++ b/packages/data-service-generator/tests/e2e/plugins.ts
@@ -6,7 +6,7 @@ export const postgres: PluginInstallation[] = [
     pluginId: "db-postgres",
     npm: "@amplication/plugin-db-postgres",
     enabled: true,
-    version: "latest",
+    version: "1.3.0",
   },
 ];
 
@@ -16,7 +16,7 @@ export const mongo: PluginInstallation[] = [
     pluginId: "db-mongo",
     npm: "@amplication/plugin-db-mongo",
     enabled: true,
-    version: "latest",
+    version: "1.4.0",
   },
 ];
 
@@ -26,7 +26,7 @@ export const mysql: PluginInstallation[] = [
     pluginId: "db-mysql",
     npm: "@amplication/plugin-db-mysql",
     enabled: true,
-    version: "latest",
+    version: "1.1.0",
   },
 ];
 
@@ -36,13 +36,13 @@ export const basicAuth: PluginInstallation[] = [
     pluginId: "auth-core",
     npm: "@amplication/plugin-auth-core",
     enabled: true,
-    version: "latest",
+    version: "1.1.0",
   },
   {
     id: "auth-basic-id",
     pluginId: "auth-basic",
     npm: "@amplication/plugin-auth-basic",
     enabled: true,
-    version: "latest",
+    version: "1.4.0",
   },
 ];


### PR DESCRIPTION
Related: #5837 

## PR Details

In order to properly run e2e with the breaking changes implemented as part of #5845 we need to temporary configure the e2e to use the `beta` plugins that have been already updated.

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
