### PR TITLE
chore: add safety net for commits to `master` or `next` branch

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,18 @@
 #!/usr/bin/env sh
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+RED='\033[0;31;1m'
+CLEAR='\033[0m'
 
 . "$(dirname -- "$0")/_/husky.sh"
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "master" ] | [ "$branch" = "main" ] | [ "$branch" = "next" ]; then  
+  echo;
+  echo "${RED}========== You cannot pass! 🧙 ==========${CLEAR}";
+  echo "${RED}You can't commit directly to master branch${CLEAR}"; echo;
+  exit 1;
+fi
 
 npm run precommit


### PR DESCRIPTION
Close: #6146 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7d2e1d6</samp>

### Summary
🎨🌲🚫

<!--
1.  🎨 - This emoji is used for improving the format or structure of the code, which is what the color variable does by adding some color to the output messages.
2.  🌲 - This emoji is used for adding or updating environment variables, which is what the branch variable does by capturing the current branch name from the git command.
3.  🚫 - This emoji is used for preventing or blocking something, which is what the if statement does by preventing direct commits to the main branches.
-->
Prevent direct commits to master, main, or next branches using a pre-commit hook. Modify `.husky/pre-commit` to check the branch name and use color variables for output.

> _`color` and `branch`_
> _help to avoid bad commits_
> _autumn leaves falling_

### Walkthrough
* Add a color variable and a branch variable to the pre-commit hook script (.husky/pre-commit) ([link](https://github.com/amplication/amplication/pull/6147/files?diff=unified&w=0#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dL4-R17))
* Use the color variable to print messages in different colors depending on the status of the commit ([link](https://github.com/amplication/amplication/pull/6147/files?diff=unified&w=0#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dL4-R17))
* Use the branch variable to get the current branch name using git rev-parse ([link](https://github.com/amplication/amplication/pull/6147/files?diff=unified&w=0#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dL4-R17))
* Prevent committing directly to master, main, or next branches by using an if statement that checks the branch variable and exits with an error message if it matches one of those names ([link](https://github.com/amplication/amplication/pull/6147/files?diff=unified&w=0#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dL4-R17))
* Run the lint-staged command to check and fix the code style and formatting of the staged files ([link](https://github.com/amplication/amplication/pull/6147/files?diff=unified&w=0#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dL4-R17))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
