### PR TITLE
feat(client): add latest version options to plugin setting

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,9 +9,14 @@
       "request": "attach",
       "name": "Attach NestJS WS",
       "port": 9229,
-      "restart": true,
-      "stopOnEntry": false,
-      "protocol": "inspector"
+      "restart": true
+    },
+    {
+      "name": "Debug Client",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3001",
+      "webRoot": "${workspaceFolder}/packages/amplication-client"
     },
     {
       "type": "node",

--- a/packages/amplication-client/src/Plugins/InstalledPluginSettings.tsx
+++ b/packages/amplication-client/src/Plugins/InstalledPluginSettings.tsx
@@ -95,9 +95,7 @@ const InstalledPluginSettings: React.FC<Props> = ({
 
   const handleSelectVersion = useCallback(
     (pluginVersion: PluginVersion) => {
-      const selectedVersion = pluginVersion.isLatest
-        ? LATEST_VERSION_TAG
-        : pluginVersion.version;
+      const selectedVersion = pluginVersion.version;
       setSelectedVersion(selectedVersion);
       pluginInstallation?.PluginInstallation.version !== selectedVersion &&
         setIsValid(false);
@@ -109,11 +107,15 @@ const InstalledPluginSettings: React.FC<Props> = ({
   const handlePluginInstalledSave = useCallback(() => {
     if (!pluginInstallation) return;
     const { enabled, id } = pluginInstallation.PluginInstallation;
+    const selectedVersionOrLatest =
+      plugin.taggedVersions[LATEST_VERSION_TAG] === selectedVersion
+        ? LATEST_VERSION_TAG
+        : selectedVersion;
     updatePluginInstallation({
       variables: {
         data: {
           enabled,
-          version: selectedVersion,
+          version: selectedVersionOrLatest,
           settings: JSON.parse(editorRef.current),
         },
         where: {
@@ -152,9 +154,7 @@ const InstalledPluginSettings: React.FC<Props> = ({
               <SelectMenu
                 title={
                   plugin.taggedVersions[LATEST_VERSION_TAG] ===
-                    selectedVersion ||
-                  pluginInstallation.PluginInstallation.version ===
-                    LATEST_VERSION_TAG
+                    selectedVersion || selectedVersion === LATEST_VERSION_TAG
                     ? LATEST_VERSION_LABEL(
                         plugin.taggedVersions[LATEST_VERSION_TAG]
                       )
@@ -172,7 +172,10 @@ const InstalledPluginSettings: React.FC<Props> = ({
                         <SelectMenuItem
                           closeAfterSelectionChange
                           itemData={pluginVersion}
-                          selected={pluginVersion.version === selectedVersion}
+                          selected={[
+                            selectedVersion,
+                            LATEST_VERSION_LABEL(pluginVersion.version),
+                          ].includes(pluginVersion.version)}
                           key={pluginVersion.id}
                           onSelectionChange={(pluginVersion) => {
                             handleSelectVersion(pluginVersion);

--- a/packages/amplication-client/src/Plugins/InstalledPluginSettings.tsx
+++ b/packages/amplication-client/src/Plugins/InstalledPluginSettings.tsx
@@ -36,6 +36,8 @@ type Props = AppRouteProps & {
 };
 
 const generatedKey = () => Math.random().toString(36).slice(2, 7);
+const LATEST_VERSION_TAG = "latest";
+const LATEST_VERSION_LABEL = (version: string) => `Latest (${version})`;
 
 const InstalledPluginSettings: React.FC<Props> = ({
   match,
@@ -93,9 +95,12 @@ const InstalledPluginSettings: React.FC<Props> = ({
 
   const handleSelectVersion = useCallback(
     (pluginVersion: PluginVersion) => {
-      setSelectedVersion(pluginVersion.version);
-      pluginInstallation?.PluginInstallation.version !==
-        pluginVersion.version && setIsValid(false);
+      const selectedVersion = pluginVersion.isLatest
+        ? LATEST_VERSION_TAG
+        : pluginVersion.version;
+      setSelectedVersion(selectedVersion);
+      pluginInstallation?.PluginInstallation.version !== selectedVersion &&
+        setIsValid(false);
       editorRef.current = pluginVersion.settings;
     },
     [setSelectedVersion, setIsValid]
@@ -146,8 +151,15 @@ const InstalledPluginSettings: React.FC<Props> = ({
               </div>
               <SelectMenu
                 title={
-                  selectedVersion ||
-                  pluginInstallation.PluginInstallation.version
+                  plugin.taggedVersions[LATEST_VERSION_TAG] ===
+                    selectedVersion ||
+                  pluginInstallation.PluginInstallation.version ===
+                    LATEST_VERSION_TAG
+                    ? LATEST_VERSION_LABEL(
+                        plugin.taggedVersions[LATEST_VERSION_TAG]
+                      )
+                    : selectedVersion ||
+                      pluginInstallation.PluginInstallation.version
                 }
                 buttonStyle={EnumButtonStyle.Secondary}
                 className={`${moduleClass}__menu`}
@@ -166,7 +178,9 @@ const InstalledPluginSettings: React.FC<Props> = ({
                             handleSelectVersion(pluginVersion);
                           }}
                         >
-                          {pluginVersion.version}
+                          {pluginVersion.isLatest
+                            ? LATEST_VERSION_LABEL(pluginVersion.version)
+                            : pluginVersion.version}
                         </SelectMenuItem>
                       ))}
                     </>

--- a/packages/amplication-client/src/Plugins/PluginsCatalogItem.tsx
+++ b/packages/amplication-client/src/Plugins/PluginsCatalogItem.tsx
@@ -56,7 +56,7 @@ function PluginsCatalogItem({
   }, [onOrderChange, order, pluginInstallation]);
 
   const handleInstall = useCallback(() => {
-    const lastVersion = plugin.versions[plugin.versions.length - 1];
+    const lastVersion = plugin.versions.find((version) => version.isLatest);
     onInstall && onInstall(plugin, lastVersion);
   }, [onInstall, plugin]);
 

--- a/packages/amplication-client/src/Plugins/hooks/usePlugins.ts
+++ b/packages/amplication-client/src/Plugins/hooks/usePlugins.ts
@@ -15,6 +15,7 @@ import { AppContext } from "../../context/appContext";
 
 export type PluginVersion = {
   version: string;
+  isLatest: boolean;
   settings: string;
   id: string;
   pluginId: string;
@@ -32,6 +33,7 @@ export type Plugin = {
   website: string;
   category: string;
   type: string;
+  taggedVersions: { [tag: string]: string };
   versions: PluginVersion[];
 };
 

--- a/packages/amplication-client/src/Plugins/queries/pluginsQueries.ts
+++ b/packages/amplication-client/src/Plugins/queries/pluginsQueries.ts
@@ -92,13 +92,15 @@ export const GET_PLUGIN_VERSIONS_CATALOG = gql`
       name
       icon
       description
+      taggedVersions
       npm
       github
       website
-      versions(where: $where) {
+      versions(where: $where, orderBy: { createdAt: Desc }) {
         id
         pluginId
         deprecated
+        isLatest
         version
         settings
       }


### PR DESCRIPTION
Close: #5556 #6136  

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 50643a3</samp>

### Summary
🛠️🐛🌟

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used for the first change that modifies the `.vscode/launch.json` file to improve the debugging experience for the client application.
2. 🐛 - This emoji represents a bug or an issue, and can be used for the second change that modifies the `handleInstall` callback function in the `PluginsCatalogItem.tsx` file to fix the logic of installing the correct version of the plugin.
3. 🌟 - This emoji represents a new feature or an enhancement, and can be used for the third and fourth changes that modify the `GET_PLUGIN_VERSIONS_CATALOG` query and the `usePlugins.ts` file to support filtering and displaying the latest and tagged versions of plugins in the UI.
-->
This pull request adds features and fixes to the plugin system of the client application. It enables filtering and displaying the latest and tagged versions of plugins, improves the UI and logic of selecting and installing plugin versions, and adds a new configuration for debugging the client using Chrome. It also updates the types and queries for the plugin and plugin version entities.

> _Sing, O Muse, of the skillful coders who modified the files_
> _To debug and install the plugins with ease and grace_
> _They changed the `launch.json` and the `handleInstall` function_
> _And added `isLatest` and `taggedVersions` to the query and the types_

### Walkthrough
*  Add a new configuration for debugging the client application using Chrome and remove unused properties from the existing configuration for attaching to the NestJS WS ([link](https://github.com/amplication/amplication/pull/6159/files?diff=unified&w=0#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L12-R21))
*  Add the `isLatest` and `taggedVersions` fields to the `Plugin` and `PluginVersion` types and modify the `GET_PLUGIN_VERSIONS_CATALOG` query to include and sort them ([link](https://github.com/amplication/amplication/pull/6159/files?diff=unified&w=0#diff-c3e9a5f0c039d20b925e8e91b4cbf497a62b30afb763eefd2dbcddee60f3c31bR18), [link](https://github.com/amplication/amplication/pull/6159/files?diff=unified&w=0#diff-c3e9a5f0c039d20b925e8e91b4cbf497a62b30afb763eefd2dbcddee60f3c31bR36), [link](https://github.com/amplication/amplication/pull/6159/files?diff=unified&w=0#diff-459a8f6edccd79d065df6a4f7b733948d34ca3f01fcb0f48912a2c06f51a5473L95-R103))
*  Handle the case when the selected version of a plugin is the latest version or the latest version tag in the `InstalledPluginSettings` component and display the `LATEST_VERSION_LABEL` accordingly ([link](https://github.com/amplication/amplication/pull/6159/files?diff=unified&w=0#diff-843c19029f891bc96024d1c8d09ee28a43c76db8821003a9de0d56343b398d57R39-R40), [link](https://github.com/amplication/amplication/pull/6159/files?diff=unified&w=0#diff-843c19029f891bc96024d1c8d09ee28a43c76db8821003a9de0d56343b398d57L96-R101), [link](https://github.com/amplication/amplication/pull/6159/files?diff=unified&w=0#diff-843c19029f891bc96024d1c8d09ee28a43c76db8821003a9de0d56343b398d57L107-R118), [link](https://github.com/amplication/amplication/pull/6159/files?diff=unified&w=0#diff-843c19029f891bc96024d1c8d09ee28a43c76db8821003a9de0d56343b398d57L149-R162), [link](https://github.com/amplication/amplication/pull/6159/files?diff=unified&w=0#diff-843c19029f891bc96024d1c8d09ee28a43c76db8821003a9de0d56343b398d57L163-R178), [link](https://github.com/amplication/amplication/pull/6159/files?diff=unified&w=0#diff-843c19029f891bc96024d1c8d09ee28a43c76db8821003a9de0d56343b398d57L169-R186))
*  Use the `isLatest` property of the plugin version to install the correct version of the plugin in the `PluginsCatalogItem` component ([link](https://github.com/amplication/amplication/pull/6159/files?diff=unified&w=0#diff-069de3b168a7ec6810b1453bcb08a63346d53aff23003da53f0ea774bd4324e1L59-R59))



## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
