### PR TITLE
fix(client): main content padding right

### DIFF
--- a/packages/amplication-client/src/Layout/PageContent.scss
+++ b/packages/amplication-client/src/Layout/PageContent.scss
@@ -7,6 +7,7 @@ $tabs-width: 300px;
   flex: 1;
   gap: var(--large-spacing);
   padding: var(--large-spacing);
+  padding-right: 0;
   background: var(--page-content-background);
   box-sizing: border-box;
   overflow: hidden;
@@ -29,7 +30,8 @@ $tabs-width: 300px;
   }
 
   &__main {
-    @include scrollbars(1px, var(--black60), transparent);
+    @include scrollbars(16px, var(--black60), transparent);
+    padding-right: var(--large-spacing);
     flex: 1;
     overflow: auto;
     position: relative;

--- a/packages/amplication-client/src/Layout/PageContent.scss
+++ b/packages/amplication-client/src/Layout/PageContent.scss
@@ -29,7 +29,7 @@ $tabs-width: 300px;
   }
 
   &__main {
-    @include scrollbars(16px, var(--black60), transparent);
+    @include scrollbars(1px, var(--black60), transparent);
     flex: 1;
     overflow: auto;
     position: relative;

--- a/packages/amplication-client/src/Layout/PageContent.scss
+++ b/packages/amplication-client/src/Layout/PageContent.scss
@@ -6,7 +6,7 @@ $tabs-width: 300px;
   display: flex;
   flex: 1;
   gap: var(--large-spacing);
-  padding: var(--large-spacing) 0 var(--large-spacing) var(--large-spacing);
+  padding: var(--large-spacing);
   background: var(--page-content-background);
   box-sizing: border-box;
   overflow: hidden;

--- a/packages/amplication-client/src/style/mixin.scss
+++ b/packages/amplication-client/src/style/mixin.scss
@@ -228,7 +228,8 @@ $bullet-size: 6px;
 @mixin scrollbars(
   $size,
   $foreground-color,
-  $background-color: mix($foreground-color, white, 50%)
+  $background-color: mix($foreground-color, white, 50%),
+  $transparent-color: var(--black10)
 ) {
   // For Google Chrome
   &::-webkit-scrollbar {
@@ -242,7 +243,7 @@ $bullet-size: 6px;
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: $foreground-color;
+    background-color: $transparent-color;
     border-radius: $size * 0.5;
     background-clip: padding-box;
     border: math.div($size, 3) solid transparent;
@@ -251,6 +252,12 @@ $bullet-size: 6px;
   &::-webkit-scrollbar-track {
     background-color: $background-color;
     margin: math.div(-$size, 3);
+  }
+
+  &:hover {
+    &::-webkit-scrollbar-thumb {
+      background-color: $foreground-color;
+    }
   }
 
   &::-webkit-scrollbar-corner {

--- a/packages/amplication-client/src/style/mixin.scss
+++ b/packages/amplication-client/src/style/mixin.scss
@@ -242,7 +242,7 @@ $bullet-size: 6px;
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: rgba($foreground-color, 0.5);
+    background-color: $foreground-color;
     border-radius: $size * 0.5;
     background-clip: padding-box;
     border: math.div($size, 3) solid transparent;
@@ -251,12 +251,6 @@ $bullet-size: 6px;
   &::-webkit-scrollbar-track {
     background-color: $background-color;
     margin: math.div(-$size, 3);
-  }
-
-  &:hover {
-    &::-webkit-scrollbar-thumb {
-      background-color: $foreground-color;
-    }
   }
 
   &::-webkit-scrollbar-corner {


### PR DESCRIPTION


Close: #6029 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b5f6252</samp>

### Summary
🖥️🖨️🎨

<!--
1.  🖥️ - This emoji can be used to indicate a change related to screen display, such as the padding adjustment of the page content element.
2. 🖨️ - This emoji can be used to indicate a change related to printing, such as the padding adjustment of the page content element.
3. 🎨 - This emoji can be used to indicate a change related to the style or appearance of the UI, such as the scrollbar style update.
-->
This pull request improves the appearance and usability of the page content and scrollbar elements in the client package. It adjusts the padding of the `page content` element and updates the scrollbar style in `mixin.scss` to match the design system.

> _`page content` padded_
> _scrollbar style harmonized_
> _winter web design_

### Walkthrough
* Remove right padding of page content element to align with sidebar and header ([link](https://github.com/amplication/amplication/pull/6165/files?diff=unified&w=0#diff-e6fa601f11c49c9c943c08a0cb5257e3312266477ab55e2c43ac7f2abbfda3daL9-R10))
* Restore right padding of page content element for print media query to prevent overflow ([link](https://github.com/amplication/amplication/pull/6165/files?diff=unified&w=0#diff-e6fa601f11c49c9c943c08a0cb5257e3312266477ab55e2c43ac7f2abbfda3daR34))
* Increase opacity of scrollbar thumb to improve visibility ([link](https://github.com/amplication/amplication/pull/6165/files?diff=unified&w=0#diff-32a6894d90022b03852964ffb2a469cfec9880bdb60788a78e9c09f693cba5e0L245-R245))
* Remove hover effect of scrollbar thumb to simplify style ([link](https://github.com/amplication/amplication/pull/6165/files?diff=unified&w=0#diff-32a6894d90022b03852964ffb2a469cfec9880bdb60788a78e9c09f693cba5e0L256-L261))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
