### PR TITLE
fix(server): gitRepository null

### DIFF
--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -444,11 +444,15 @@ export class ResourceService {
     });
 
     const { gitRepository, serviceSettings } = data.resource;
-    const { provider } = await this.gitOrganizationByResource({
-      where: {
-        id: resource.id,
-      },
-    });
+    const provider =
+      gitRepository &&
+      (
+        await this.gitOrganizationByResource({
+          where: {
+            id: resource.id,
+          },
+        })
+      ).provider;
     await this.analytics.track({
       userId: user.account.id,
       event: EnumEventType.ServiceWizardServiceGenerated,
@@ -696,7 +700,7 @@ export class ResourceService {
         ...args,
         include: { gitRepository: { include: { gitOrganization: true } } },
       })
-    ).gitRepository.gitOrganization;
+    ).gitRepository?.gitOrganization;
   }
 
   async project(resourceId: string): Promise<Project> {


### PR DESCRIPTION
Close: #6124 

## PR Details

Fix the gitOrganization null error when a user doesn't choose a repo in the service wizard. 
copilot:all

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

Test case:

Open the service wizard => Try to create a service without a git repository. 
