### PR TITLE
Feat/initial commit message - fix

### DIFF
--- a/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceCodeGeneration.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceCodeGeneration.tsx
@@ -17,12 +17,6 @@ import { PUSH_TO_GIT_STEP_NAME } from "../../../VersionControl/BuildSteps";
 import { isEmpty } from "lodash";
 
 const className = "create-service-code-generation";
-const INITIAL_COMMIT_MESSAGE = `Congratulations on your first commit with Amplication! 
-We encourage you to continue exploring the many ways Amplication can supercharge your development. 
- 
-If you find Amplication useful, please show your support and give our GitHub repo a star ⭐️   
-This simple action helps our open-source project grow and reach more developers like you. 
-Thank you and happy coding!`;
 
 type TData = {
   commit: models.Commit;
@@ -110,7 +104,7 @@ const CreateServiceCodeGeneration: React.FC<
     trackWizardPageEvent(AnalyticsEventNames.ServiceWizardError_TryAgain);
     commit({
       variables: {
-        message: INITIAL_COMMIT_MESSAGE,
+        message: "Initial commit",
         projectId: currentProject.id,
       },
     }).catch(console.error);

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -113,6 +113,13 @@ export const ACTION_LOG_LEVEL: {
 
 const META_KEYS_TO_OMIT = [LEVEL, MESSAGE, SPLAT, "level"];
 
+const INITIAL_ONBOARDING_COMMIT_MESSAGE_BODY = `Congratulations on your first commit with Amplication! 
+We encourage you to continue exploring the many ways Amplication can supercharge your development. 
+ 
+If you find Amplication useful, please show your support and give our GitHub repo a star ⭐️   
+This simple action helps our open-source project grow and reach more developers like you. 
+Thank you and happy coding!`;
+
 export function createInitialStepData(
   version: string,
   message: string
@@ -521,8 +528,10 @@ export class BuildService {
               gitOrganization
             );
 
-          const commitMessage =
-            commit.message && `Commit message: ${commit.message}.`;
+          const commitMessage = oldBuild
+            ? commit.message && `Commit message: ${commit.message}.`
+            : INITIAL_ONBOARDING_COMMIT_MESSAGE_BODY;
+
           const buildLinkHTML = `[${url}](${url})`;
 
           const createPullRequestMessage: CreatePrRequest.Value = {
@@ -537,7 +546,7 @@ export class BuildService {
             oldBuildId: oldBuild?.id,
             commit: {
               title: commitTitle,
-              body: `Amplication build # ${build.id}\n${commitMessage}\nBuild URL: ${buildLinkHTML}`,
+              body: `${commitMessage}\n\nAmplication build # ${build.id}\n\nBuild URL: ${buildLinkHTML}`,
             },
             gitResourceMeta: {
               adminUIPath: resourceInfo.settings.adminUISettings.adminUIPath,

--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -35,12 +35,7 @@ const USER_RESOURCE_ROLE = {
 };
 
 export const DEFAULT_ENVIRONMENT_NAME = "Sandbox environment";
-export const INITIAL_COMMIT_MESSAGE = `Congratulations on your first commit with Amplication! 
-We encourage you to continue exploring the many ways Amplication can supercharge your development. 
- 
-If you find Amplication useful, please show your support and give our GitHub repo a star ⭐️   
-This simple action helps our open-source project grow and reach more developers like you. 
-Thank you and happy coding!`;
+export const INITIAL_COMMIT_MESSAGE = "Initial Commit";
 
 export const INVALID_RESOURCE_ID = "Invalid resourceId";
 export const INVALID_DELETE_PROJECT_CONFIGURATION =


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #[issue-number]

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8809e75</samp>

### Summary
🎨🔥📝

<!--
1.  🎨 - This emoji is used for improving the format or structure of the code, such as indentation, spacing, or simplification. It can also be used for cosmetic changes that do not affect the functionality, such as changing colors or fonts. In this case, the change to the `INITIAL_COMMIT_MESSAGE` constant in the server service is a cosmetic change that makes the commit message more concise and consistent with the client component.
2. 🔥 - This emoji is used for removing code or files that are no longer needed or used. It can also be used for refactoring or cleaning up code that is redundant, obsolete, or deprecated. In this case, the removal of the unused constant `INITIAL_COMMIT_MESSAGE` in the client is a refactoring change that eliminates unnecessary code.
3. 📝 - This emoji is used for adding or updating documentation, comments, or annotations. It can also be used for writing or improving tests, examples, or tutorials. In this case, the addition of a constant for the initial commit message and the change to the commit body format in `BuildService` is a documentation change that enhances the readability and clarity of the commit history for the user.
-->
Simplified and standardized the initial commit message for code generation in the client and server. Changed the commit body format in `BuildService` to improve readability.

> _The code gen wizard had a mission_
> _To simplify the commit message vision_
> _So it removed a constant_
> _And changed the format_
> _To match the `ResourceService` decision_

### Walkthrough
*  Simplify the initial commit message for resources and builds to "Initial commit" ([link](https://github.com/amplication/amplication/pull/6181/files?diff=unified&w=0#diff-36bf54e6ad6252831ad5337401f235297f9ad594a974aa03cf986d594239ada1L20-L25), [link](https://github.com/amplication/amplication/pull/6181/files?diff=unified&w=0#diff-36bf54e6ad6252831ad5337401f235297f9ad594a974aa03cf986d594239ada1L113-R107), [link](https://github.com/amplication/amplication/pull/6181/files?diff=unified&w=0#diff-69e1f5c184f8ffa46def579dd2fb6e88ea5b228afc3ea64079b51134af116c80L38-R38))
*  Add a constant `INITIAL_ONBOARDING_COMMIT_MESSAGE_BODY` to store the long text for the initial commit message in `build.service.ts` ([link](https://github.com/amplication/amplication/pull/6181/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aR116-R122))
*  Use the `INITIAL_ONBOARDING_COMMIT_MESSAGE_BODY` for the first build and the user-provided message for subsequent builds in `build.service.ts` ([link](https://github.com/amplication/amplication/pull/6181/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aL524-R534))
*  Change the format of the commit body to put the commit message first and the build details in a new paragraph in `build.service.ts` ([link](https://github.com/amplication/amplication/pull/6181/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aL540-R549))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
