### PR TITLE
feat(plugin-api): add latest version to all plugins

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,14 +9,9 @@
       "request": "attach",
       "name": "Attach NestJS WS",
       "port": 9229,
-      "restart": true
-    },
-    {
-      "name": "Debug Client",
-      "type": "chrome",
-      "request": "launch",
-      "url": "http://localhost:3001",
-      "webRoot": "${workspaceFolder}/packages/amplication-client"
+      "restart": true,
+      "stopOnEntry": false,
+      "protocol": "inspector"
     },
     {
       "type": "node",

--- a/packages/amplication-client/src/Plugins/InstalledPluginSettings.tsx
+++ b/packages/amplication-client/src/Plugins/InstalledPluginSettings.tsx
@@ -36,8 +36,6 @@ type Props = AppRouteProps & {
 };
 
 const generatedKey = () => Math.random().toString(36).slice(2, 7);
-const LATEST_VERSION_TAG = "latest";
-const LATEST_VERSION_LABEL = (version: string) => `Latest (${version})`;
 
 const InstalledPluginSettings: React.FC<Props> = ({
   match,
@@ -95,10 +93,9 @@ const InstalledPluginSettings: React.FC<Props> = ({
 
   const handleSelectVersion = useCallback(
     (pluginVersion: PluginVersion) => {
-      const selectedVersion = pluginVersion.version;
-      setSelectedVersion(selectedVersion);
-      pluginInstallation?.PluginInstallation.version !== selectedVersion &&
-        setIsValid(false);
+      setSelectedVersion(pluginVersion.version);
+      pluginInstallation?.PluginInstallation.version !==
+        pluginVersion.version && setIsValid(false);
       editorRef.current = pluginVersion.settings;
     },
     [setSelectedVersion, setIsValid]
@@ -107,15 +104,11 @@ const InstalledPluginSettings: React.FC<Props> = ({
   const handlePluginInstalledSave = useCallback(() => {
     if (!pluginInstallation) return;
     const { enabled, id } = pluginInstallation.PluginInstallation;
-    const selectedVersionOrLatest =
-      plugin.taggedVersions[LATEST_VERSION_TAG] === selectedVersion
-        ? LATEST_VERSION_TAG
-        : selectedVersion;
     updatePluginInstallation({
       variables: {
         data: {
           enabled,
-          version: selectedVersionOrLatest,
+          version: selectedVersion,
           settings: JSON.parse(editorRef.current),
         },
         where: {
@@ -153,13 +146,8 @@ const InstalledPluginSettings: React.FC<Props> = ({
               </div>
               <SelectMenu
                 title={
-                  plugin.taggedVersions[LATEST_VERSION_TAG] ===
-                    selectedVersion || selectedVersion === LATEST_VERSION_TAG
-                    ? LATEST_VERSION_LABEL(
-                        plugin.taggedVersions[LATEST_VERSION_TAG]
-                      )
-                    : selectedVersion ||
-                      pluginInstallation.PluginInstallation.version
+                  selectedVersion ||
+                  pluginInstallation.PluginInstallation.version
                 }
                 buttonStyle={EnumButtonStyle.Secondary}
                 className={`${moduleClass}__menu`}
@@ -172,18 +160,13 @@ const InstalledPluginSettings: React.FC<Props> = ({
                         <SelectMenuItem
                           closeAfterSelectionChange
                           itemData={pluginVersion}
-                          selected={[
-                            selectedVersion,
-                            LATEST_VERSION_LABEL(pluginVersion.version),
-                          ].includes(pluginVersion.version)}
+                          selected={pluginVersion.version === selectedVersion}
                           key={pluginVersion.id}
                           onSelectionChange={(pluginVersion) => {
                             handleSelectVersion(pluginVersion);
                           }}
                         >
-                          {pluginVersion.isLatest
-                            ? LATEST_VERSION_LABEL(pluginVersion.version)
-                            : pluginVersion.version}
+                          {pluginVersion.version}
                         </SelectMenuItem>
                       ))}
                     </>

--- a/packages/amplication-client/src/Plugins/PluginsCatalogItem.tsx
+++ b/packages/amplication-client/src/Plugins/PluginsCatalogItem.tsx
@@ -56,7 +56,7 @@ function PluginsCatalogItem({
   }, [onOrderChange, order, pluginInstallation]);
 
   const handleInstall = useCallback(() => {
-    const lastVersion = plugin.versions.find((version) => version.isLatest);
+    const lastVersion = plugin.versions[plugin.versions.length - 1];
     onInstall && onInstall(plugin, lastVersion);
   }, [onInstall, plugin]);
 

--- a/packages/amplication-plugin-api/jest.config.ts
+++ b/packages/amplication-plugin-api/jest.config.ts
@@ -15,8 +15,8 @@ export default {
   coverageDirectory: "../../coverage/packages/amplication-plugin-api",
   coverageThreshold: {
     global: {
-      branches: 4,
-      lines: 0.82,
+      branches: 27,
+      lines: 9,
     },
   },
 };

--- a/packages/amplication-plugin-api/jest.config.ts
+++ b/packages/amplication-plugin-api/jest.config.ts
@@ -11,7 +11,7 @@ export default {
   transform: {
     "^.+\\.[tj]s$": "ts-jest",
   },
-  moduleFileExtensions: ["ts", "js", "html"],
+  moduleFileExtensions: ["ts", "js", "html", "json"],
   coverageDirectory: "../../coverage/packages/amplication-plugin-api",
   coverageThreshold: {
     global: {

--- a/packages/amplication-plugin-api/src/pluginVersion/pluginVersion.service.spec.ts
+++ b/packages/amplication-plugin-api/src/pluginVersion/pluginVersion.service.spec.ts
@@ -1,0 +1,103 @@
+import { Test } from "@nestjs/testing";
+import { ModuleMocker, MockFunctionMetadata } from "jest-mock";
+import { PluginVersionService } from "./pluginVersion.service";
+import { PrismaService } from "../prisma/prisma.service";
+
+const moduleMocker = new ModuleMocker(global);
+
+describe("Service: PluginVersionService", () => {
+  let service: PluginVersionService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [],
+      providers: [PluginVersionService],
+    })
+      .useMocker((token) => {
+        const results = [
+          {
+            id: "pluginVersionId1",
+            version: "1.0.0",
+            pluginId: "pluginVersionPluginId",
+            pluginIdVersion: "pluginVersionPluginIdVersion-1.0.0",
+            isLatest: true,
+            deprecated: null,
+            settings: {},
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          {
+            id: "pluginVersionId2",
+            version: "2.0.0",
+            pluginId: "pluginVersionPluginId",
+            pluginIdVersion: "pluginVersionPluginIdVersion-2.0.0",
+            isLatest: false,
+            deprecated: null,
+            settings: {},
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ];
+
+        if (token === PrismaService) {
+          return {
+            pluginVersion: {
+              findMany: jest.fn().mockResolvedValue(results),
+            },
+          };
+        }
+        if (typeof token === "function") {
+          const mockMetadata = moduleMocker.getMetadata(
+            token
+          ) as MockFunctionMetadata<any, any>;
+          const mock = moduleMocker.generateFromMetadata(mockMetadata);
+          return new mock();
+        }
+      })
+      .compile();
+
+    service = moduleRef.get(PluginVersionService);
+  });
+
+  it("findMany should return all the plugin versions plus a 'latest' version for the version tagged as latest", async () => {
+    const result = await service.findMany({});
+
+    expect(result).toStrictEqual([
+      {
+        id: "latest",
+        version: "latest",
+        pluginId: "pluginVersionPluginId",
+        pluginIdVersion: "pluginVersionPluginIdVersion-1.0.0",
+        isLatest: true,
+        deprecated: null,
+        settings: {},
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      },
+      {
+        id: "pluginVersionId1",
+        version: "1.0.0",
+        pluginId: "pluginVersionPluginId",
+        pluginIdVersion: "pluginVersionPluginIdVersion-1.0.0",
+        isLatest: true,
+        deprecated: null,
+        settings: {},
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      },
+      {
+        id: "pluginVersionId2",
+        version: "2.0.0",
+        pluginId: "pluginVersionPluginId",
+        pluginIdVersion: "pluginVersionPluginIdVersion-2.0.0",
+        isLatest: false,
+        deprecated: null,
+        settings: {},
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      },
+    ]);
+  });
+});

--- a/packages/amplication-plugin-api/src/pluginVersion/pluginVersion.service.ts
+++ b/packages/amplication-plugin-api/src/pluginVersion/pluginVersion.service.ts
@@ -230,4 +230,21 @@ export class PluginVersionService extends PluginVersionServiceBase {
       throw error;
     }
   }
+
+  async findMany(
+    args: Prisma.PluginVersionFindManyArgs
+  ): Promise<PluginVersion[]> {
+    const versions = await super.findMany(args);
+
+    const latestVersion = versions.find((version) => version.isLatest);
+
+    if (latestVersion) {
+      versions.unshift({
+        ...latestVersion,
+        id: "latest",
+        version: "latest",
+      });
+    }
+    return versions;
+  }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #5556

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e00f087</samp>

### Summary
📄🧪🆕

<!--
1.  📄 - This emoji can be used to indicate that a new test file was added, or that a file extension was changed.
2.  🧪 - This emoji can be used to indicate that a test case or a testing module was added or updated, or that a service was tested.
3.  🆕 - This emoji can be used to indicate that a new feature or functionality was added, or that a method was overridden or implemented.
-->
This pull request adds support for a 'latest' version of plugins in the plugin API. It updates the jest configuration file to allow importing JSON files in the test suite. It also adds a test file and modifies the service class for the plugin version entity to implement the 'latest' version logic.

> _`jest` config changed_
> _adding `json` extension_
> _autumn of testing_

### Walkthrough
*  Add `json` to the jest configuration file to enable importing JSON files in the test suite ([link](https://github.com/amplication/amplication/pull/6206/files?diff=unified&w=0#diff-278b809593dd18f11785435ba8727830da091eea4f13b528bdc3172503bf64d6L14-R14))
* Override the `findMany` method of the `PluginVersionService` class to return a 'latest' version along with the plugin versions from the database ([link](https://github.com/amplication/amplication/pull/6206/files?diff=unified&w=0#diff-03132437c20c7c428a6fcc9a5b6696c276bc574d95099d8130387ef2dd7d8a6fR233-R249))
* Create a test file for the `PluginVersionService` class using the `@nestjs/testing` module and mock plugin version data ([link](https://github.com/amplication/amplication/pull/6206/files?diff=unified&w=0#diff-a36fcf043e267320978acf59eea9cb0c742298887ef86f7c0e34000b98534ab2R1-R103))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
