### PR TITLE
fix(client): default plugin installation to latest version

### DIFF
--- a/packages/amplication-client/src/Plugins/PluginsCatalogItem.tsx
+++ b/packages/amplication-client/src/Plugins/PluginsCatalogItem.tsx
@@ -15,6 +15,7 @@ import { AppContext } from "../context/appContext";
 import { Plugin, PluginVersion } from "./hooks/usePlugins";
 import { PluginLogo } from "./PluginLogo";
 import "./PluginsCatalogItem.scss";
+import { LATEST_VERSION_TAG } from "./constant";
 
 type Props = {
   plugin: Plugin;
@@ -56,8 +57,11 @@ function PluginsCatalogItem({
   }, [onOrderChange, order, pluginInstallation]);
 
   const handleInstall = useCallback(() => {
-    const lastVersion = plugin.versions[plugin.versions.length - 1];
-    onInstall && onInstall(plugin, lastVersion);
+    // Get the "latest" version
+    const hardcodedLatestVersion = plugin.versions.find(
+      (version) => version.version === LATEST_VERSION_TAG
+    );
+    onInstall && onInstall(plugin, hardcodedLatestVersion);
   }, [onInstall, plugin]);
 
   const handleEnableStateChange = useCallback(() => {

--- a/packages/amplication-client/src/Plugins/constant.ts
+++ b/packages/amplication-client/src/Plugins/constant.ts
@@ -1,0 +1,1 @@
+export const LATEST_VERSION_TAG = "latest";

--- a/packages/amplication-client/src/Plugins/hooks/usePlugins.ts
+++ b/packages/amplication-client/src/Plugins/hooks/usePlugins.ts
@@ -12,6 +12,7 @@ import * as models from "../../models";
 import { keyBy } from "lodash";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { AppContext } from "../../context/appContext";
+import { LATEST_VERSION_TAG } from "../constant";
 
 export type PluginVersion = {
   version: string;
@@ -41,8 +42,6 @@ export type OnPluginDropped = (
   dragItem: models.PluginInstallation,
   hoverItem: models.PluginInstallation
 ) => void;
-
-const LASTEST_VERSION_TAG = "latest";
 
 const setPluginOrderMap = (pluginOrder: models.PluginOrderItem[]) => {
   return pluginOrder.reduce(
@@ -144,8 +143,8 @@ const usePlugins = (resourceId: string, pluginInstallationId?: string) => {
             versions: [
               {
                 ...latestVersion,
-                id: `${latestVersion.id}-${LASTEST_VERSION_TAG}`,
-                version: LASTEST_VERSION_TAG,
+                id: `${latestVersion.id}-${LATEST_VERSION_TAG}`,
+                version: LATEST_VERSION_TAG,
               },
               ...plugin.versions,
             ],


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6136 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bb0de3b</samp>

### Summary
🆕📝🛠️

<!--
1.  🆕 for adding a new constant
2. 📝 for fixing a spelling error and importing a constant
3. 🛠️ for updating the plugin installation logic
-->
This pull request refactors the plugin installation logic to use a constant tag for the latest version of a plugin. This improves the readability, maintainability, reliability, and consistency of the `usePlugins` hook and the `PluginsCatalogItem.tsx` component.

> _To install plugins with ease and grace_
> _We added a constant to our base_
> _`LATEST_VERSION_TAG`_
> _Is the name of the flag_
> _That we use in the `handleInstall` case_

### Walkthrough
*  Add `LATEST_VERSION_TAG` constant to `constant.ts` file ([link](https://github.com/amplication/amplication/pull/6226/files?diff=unified&w=0#diff-6f6a956d995e3908dbfa8d7805874fccd5bcf96266dd92bcb51a8b4f8296d856R1))
*  Use `LATEST_VERSION_TAG` constant in `usePlugins` hook to identify and install the latest version of a plugin ([link](https://github.com/amplication/amplication/pull/6226/files?diff=unified&w=0#diff-c3e9a5f0c039d20b925e8e91b4cbf497a62b30afb763eefd2dbcddee60f3c31bR15), [link](https://github.com/amplication/amplication/pull/6226/files?diff=unified&w=0#diff-c3e9a5f0c039d20b925e8e91b4cbf497a62b30afb763eefd2dbcddee60f3c31bL147-R147))
*  Remove redundant and misspelled `LASTEST_VERSION_TAG` constant from `usePlugins` hook ([link](https://github.com/amplication/amplication/pull/6226/files?diff=unified&w=0#diff-c3e9a5f0c039d20b925e8e91b4cbf497a62b30afb763eefd2dbcddee60f3c31bL45-L46))
*  Use `LATEST_VERSION_TAG` constant in `PluginsCatalogItem` component to install the latest version of a plugin ([link](https://github.com/amplication/amplication/pull/6226/files?diff=unified&w=0#diff-069de3b168a7ec6810b1453bcb08a63346d53aff23003da53f0ea774bd4324e1R18), [link](https://github.com/amplication/amplication/pull/6226/files?diff=unified&w=0#diff-069de3b168a7ec6810b1453bcb08a63346d53aff23003da53f0ea774bd4324e1L59-R64))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
