### PR TITLE
Fix/6220 project settings specify plural

### DIFF
--- a/packages/amplication-client/src/Resource/resourceSettings/ProjectConfigurationSettingsPage.tsx
+++ b/packages/amplication-client/src/Resource/resourceSettings/ProjectConfigurationSettingsPage.tsx
@@ -26,7 +26,7 @@ const ProjectConfigurationSettingsPage: React.FC<{}> = () => {
           to={`/${currentWorkspace?.id}/${currentProject?.id}/${currentResource?.id}/settings/directories/update`}
           icon="settings"
         >
-          Base Directories
+          Base Directory
         </InnerTabLink>
       </div>
     </div>

--- a/packages/amplication-client/src/Resource/resourceSettings/ServiceSettingsPage.tsx
+++ b/packages/amplication-client/src/Resource/resourceSettings/ServiceSettingsPage.tsx
@@ -33,7 +33,7 @@ const ServiceSettingsPage: React.FC<{}> = () => {
           to={`/${currentWorkspace?.id}/${currentProject?.id}/${currentResource?.id}/settings/directories/update`}
           icon="settings"
         >
-          Base Directories
+          Base Directory
         </InnerTabLink>
       </div>
       <div>


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #[6220]

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6b12a3c</samp>

### Summary
📝🗂️🧹

<!--
1.  📝 - This emoji can be used to indicate that some text was edited or rewritten, which is the case for the inner tab link.
2.  🗂️ - This emoji can be used to indicate that something related to files or directories was changed, which is relevant for the base directory option and page.
3.  🧹 - This emoji can be used to indicate that some cleanup or simplification was done, which is the effect of using the singular form instead of the plural form.
-->
Changed the inner tab link text from "Base Directories" to "Base Directory" in `ProjectConfigurationSettingsPage.tsx` and `ServiceSettingsPage.tsx`. This improves the UI consistency and accuracy of the resource settings pages.

> _`Base Directory`_
> _One tab for one setting now_
> _Autumn of clutter_

### Walkthrough
* Change the text of the inner tab link for base directory settings from "Base Directories" to "Base Directory" in both resource and service settings pages ([link](https://github.com/amplication/amplication/pull/6261/files?diff=unified&w=0#diff-574e89b87cdcb7af07cb41463c97bed48f19dbd6adb62529033a7073fd9be638L29-R29), [link](https://github.com/amplication/amplication/pull/6261/files?diff=unified&w=0#diff-cdee9b4f9fa826aab9c55634b4b9c61f0adcb33b32ab45662aec1c2b639d0081L36-R36))



IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
