### PR TITLE
feat(client): open create github repo for personal github connections

### DIFF
--- a/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/RepositoryActions.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/RepositoryActions.tsx
@@ -11,6 +11,7 @@ import "../../AuthResourceWithGit.scss";
 import { GitOrganizationFromGitRepository } from "../../SyncWithGithubPage";
 import GithubSyncDetails from "./GithubSyncDetails";
 import "./RepositoryActions.scss";
+import { EnumGitProvider } from "@amplication/code-gen-types/models";
 type Props = {
   onCreateRepository: () => void;
   onSelectRepository: () => void;
@@ -67,6 +68,26 @@ export default function RepositoryActions({
                       </Button>
                     </div>
                   )}
+                  {selectedGitOrganization.type ===
+                    EnumGitOrganizationType.User &&
+                    selectedGitOrganization.provider ===
+                      EnumGitProvider.Github && (
+                      <div className={`${CLASS_NAME}__action`}>
+                        <a
+                          href={`https://github.com/new?&owner=${selectedGitOrganization.name}`}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          <Button
+                            type="button"
+                            buttonStyle={EnumButtonStyle.Primary}
+                            icon="plus"
+                          >
+                            Create repository
+                          </Button>
+                        </a>
+                      </div>
+                    )}
                 </>
               )}
             </div>

--- a/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/WizardRepositoryActions.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/WizardRepositoryActions.tsx
@@ -12,6 +12,7 @@ import { GitRepositorySelected } from "../../dialogs/GitRepos/GithubRepos";
 import { GitOrganizationFromGitRepository } from "../../SyncWithGithubPage";
 import "./RepositoryActions.scss";
 import WizardGithubSyncDetails from "./WizardGithubSyncDetails";
+import { EnumGitProvider } from "@amplication/code-gen-types/models";
 type Props = {
   onCreateRepository: () => void;
   onSelectRepository: () => void;
@@ -69,6 +70,25 @@ export default function WizardRepositoryActions({
                       </Button>
                     </div>
                   )}
+                  {selectedGitOrganization.type ===
+                    EnumGitOrganizationType.User &&
+                    selectedGitOrganization.provider ===
+                      EnumGitProvider.Github && (
+                      <div className={`${CLASS_NAME}__action`}>
+                        <a
+                          href={`https://github.com/new?&owner=${selectedGitOrganization.name}`}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          <Button
+                            type="button"
+                            buttonStyle={EnumButtonStyle.Primary}
+                          >
+                            Create repository
+                          </Button>
+                        </a>
+                      </div>
+                    )}
                 </>
               )}
             </div>

--- a/packages/amplication-client/src/Resource/git/dialogs/GitRepos/GithubRepos.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitRepos/GithubRepos.tsx
@@ -237,6 +237,22 @@ function GitRepos({
               Create repository
             </Button>
           )}
+          {gitOrganization.type === EnumGitOrganizationType.User &&
+            gitOrganization.provider === EnumGitProvider.Github && (
+              <a
+                href={`https://github.com/new?&owner=${gitOrganization.name}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <Button
+                  className={`${CLASS_NAME}__header-create`}
+                  buttonStyle={EnumButtonStyle.Outline}
+                  type="button"
+                >
+                  Create repository
+                </Button>
+              </a>
+            )}
         </div>
       </div>
       {networkStatus !== NetworkStatus.refetch && // hide data if refetch


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #5854 
## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b15951e</samp>

### Summary
:sparkles::recycle::hammer:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature, which is creating GitHub repositories from the UI.
2. :recycle: - This emoji represents the refactoring of existing code, which is importing the `EnumGitProvider` type and using it to handle different git providers.
3. :hammer: - This emoji represents the improvement of an existing feature, which is adding support for GitLab as a git provider.
-->
This pull request adds support for GitLab as a git provider in the Amplication UI, allowing users to create and select GitLab repositories from the wizard and the dialog components. It uses the `EnumGitProvider` type to handle different git providers in the code.

> _`EnumGitProvider` is the key to the gate_
> _Choose your destiny, GitHub or GitLab_
> _Create and import, unleash your code_
> _Amplication wizard, the ultimate mode_

### Walkthrough
*  Add buttons to create new GitHub repositories from the UI ([link](https://github.com/amplication/amplication/pull/6265/files?diff=unified&w=0#diff-98edde0eb0fdf9420d94d090382c7ba88e7b6305bc88626ce46443ee7f4fc624R71-R90), [link](https://github.com/amplication/amplication/pull/6265/files?diff=unified&w=0#diff-bcd30b54c52fad42717cabcf1e530071f65bfdb8b215fe51e33abf56a494a56bR73-R91), [link](https://github.com/amplication/amplication/pull/6265/files?diff=unified&w=0#diff-94eef013532e791bf0bdb669febc1b7aacdaa3a94041dd8a09bf359461a94a89R240-R255))
  - Import `EnumGitProvider` type from `code-gen-types` package to check the git provider ([link](https://github.com/amplication/amplication/pull/6265/files?diff=unified&w=0#diff-98edde0eb0fdf9420d94d090382c7ba88e7b6305bc88626ce46443ee7f4fc624R14), [link](https://github.com/amplication/amplication/pull/6265/files?diff=unified&w=0#diff-bcd30b54c52fad42717cabcf1e530071f65bfdb8b215fe51e33abf56a494a56bR15))
    - In `RepositoryActions.tsx`, the button is styled as a secondary action and has a GitHub icon ([link](https://github.com/amplication/amplication/pull/6265/files?diff=unified&w=0#diff-98edde0eb0fdf9420d94d090382c7ba88e7b6305bc88626ce46443ee7f4fc624R71-R90))
    - In `WizardRepositoryActions.tsx`, the button is styled as a primary action and has no icon ([link](https://github.com/amplication/amplication/pull/6265/files?diff=unified&w=0#diff-bcd30b54c52fad42717cabcf1e530071f65bfdb8b215fe51e33abf56a494a56bR73-R91))
    - In `GithubRepos.tsx`, the button is styled as a link and is positioned above the repository list ([link](https://github.com/amplication/amplication/pull/6265/files?diff=unified&w=0#diff-94eef013532e791bf0bdb669febc1b7aacdaa3a94041dd8a09bf359461a94a89R240-R255))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
