### PR TITLE
fix(dsg): custom seed user fields

### DIFF
--- a/packages/data-service-generator/src/server/seed/create-seed.ts
+++ b/packages/data-service-generator/src/server/seed/create-seed.ts
@@ -93,19 +93,20 @@ export async function createSeed(): Promise<ModuleMap> {
   const outputFileName = "seed.ts";
 
   const userEntity = entities.find((entity) => entity.name === userEntityName);
-  const customProperties = createUserObjectCustomProperties(
-    userEntity as Entity
-  );
+  const customProperties =
+    userEntity && createUserObjectCustomProperties(userEntity as Entity);
 
   const template = await readFile(seedTemplatePath);
-  const seedingProperties = [
-    ...createDefaultAuthProperties({
-      userNameFieldName,
-      userPasswordFieldName,
-      userRolesFieldName,
-    }),
-    ...customProperties,
-  ];
+  const seedingProperties = customProperties
+    ? [
+        ...createDefaultAuthProperties({
+          userNameFieldName,
+          userPasswordFieldName,
+          userRolesFieldName,
+        }),
+        ...customProperties,
+      ]
+    : [];
   const templateMapping = {
     DATA: builders.objectExpression(seedingProperties),
   };


### PR DESCRIPTION
Close: #5851

## PR Details

Check if the user entity exists before adding his custom fields to the seed template. 

copilot:all

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

