### PR TITLE
fix: enforce naming in the workspace settings

### DIFF
--- a/packages/amplication-client/src/Workspaces/WorkspaceForm.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceForm.tsx
@@ -95,7 +95,7 @@ function WorkspaceForm() {
             }}
           </Formik>
         )}
-        <label className={`${CLASS_NAME}__label`}>workspace ID </label>
+        <label className={`${CLASS_NAME}__label`}>Workspace ID </label>
         {currentWorkspace && <div>{currentWorkspace.id}</div>}
 
         <Snackbar open={Boolean(errorMessage)} message={errorMessage} />


### PR DESCRIPTION
…Workspace'

Close: #6242

## PR Details

The workspace setting page had a typo, `w` in `workspace ID` in small letters.
Now fixed to: **`Workplace ID`**

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
