### PR TITLE
#6240 - Changed Second discord link in WelcomePage

### DIFF
--- a/packages/amplication-client/src/Layout/WelcomePage.tsx
+++ b/packages/amplication-client/src/Layout/WelcomePage.tsx
@@ -100,7 +100,7 @@ function WelcomePage({
         <div className={`${CLASS_NAME}__form__open-source-message`}>
           {openSourceMessage}
           <a
-            href="https://discord.gg/Z2CG3rUFnu"
+            href="https://amplication.com/discord"
             target="discord"
             className="discord-button"
           >


### PR DESCRIPTION
closes #6240 
#### Changed second discord link from https://discord.gg/Z2CG3rUFnu to https://amplication.com/discord in Welcome Page. 