### PR TITLE
Fix/6243 incorrect naming of GitHub

### DIFF
--- a/packages/amplication-client/src/Resource/constants.ts
+++ b/packages/amplication-client/src/Resource/constants.ts
@@ -3,6 +3,7 @@ import * as models from "../models";
 import { EnumAuthProviderType } from "../models";
 import { DefineUser } from "./create-resource/CreateServiceWizard";
 import { TemplateSettings } from "./create-resource/wizardResourceSchema";
+import { EnumGitProvider } from "../models";
 
 export const serviceSettingsFieldsInitValues = {
   generateAdminUI: true,
@@ -188,4 +189,11 @@ export const resourceThemeMap: {
     icon: "queue",
     color: "#8DD9B9",
   },
+};
+
+export const PROVIDERS_DISPLAY_NAME: {
+  [key in EnumGitProvider]: string;
+} = {
+  [EnumGitProvider.Github]: "GitHub",
+  [EnumGitProvider.Bitbucket]: "Bitbucket",
 };

--- a/packages/amplication-client/src/Resource/git/dialogs/GitDialogsContainer.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitDialogsContainer.tsx
@@ -10,6 +10,7 @@ import GitRepos, {
 import { GitOrganizationFromGitRepository } from "../SyncWithGithubPage";
 import "./GitDialogsContainer.scss";
 import { useCallback } from "react";
+import { PROVIDERS_DISPLAY_NAME } from "../../constants";
 
 type Props = {
   gitOrganization: GitOrganizationFromGitRepository;
@@ -52,12 +53,14 @@ export default function GitDialogsContainer({
     openCreateNewRepo();
   }, [closeSelectRepoDialog, openCreateNewRepo]);
 
+  const providerDisplayName = PROVIDERS_DISPLAY_NAME[gitProvider];
+
   return (
     <div>
       <Dialog
         className="select-repo-dialog"
         isOpen={isSelectRepositoryOpen}
-        title={`Select ${gitProvider} repository`}
+        title={`Select ${providerDisplayName} repository`}
         onDismiss={onSelectGitRepositoryDialogClose}
       >
         <GitRepos


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6243 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

The word "GitHub" was incorrectly spelled as "Github" on the "Select GitHub Repository" dialog.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at da660da</samp>

### Summary
🎨🌟🚚

<!--
1.  🎨 - This emoji represents improving the user interface or the appearance of something, which is what the second change does by showing the display name of the git provider instead of the internal value.
2.  🌟 - This emoji represents adding a new feature or enhancing an existing one, which is what the first change does by adding a constant to show the names of different Git providers in the UI.
3.  🚚 - This emoji represents moving or renaming files or code, which is what the first change also does by using an existing enum type to ensure consistency and avoid duplication.
-->
Improved the UI of the Select Repository Dialog by using display names for Git providers. Added a constant and an enum type to ensure consistency and readability of the Git provider values in `constants.ts` and `GitDialogsContainer.tsx`.

> _To make the UI more refined_
> _They used a constant to assign_
> _The display name of `GitProvider`_
> _Instead of the value that's prior_
> _And thus the dialog was redesigned_

### Walkthrough
*  Import `EnumGitProvider` type from `models` module to use in `constants.ts` ([link](https://github.com/amplication/amplication/pull/6292/files?diff=unified&w=0#diff-efbbf399b1e1187d531eea679ac8af971cfd9d6a41ed137aff50e5f8763f51e4R6))
* Define `PROVIDERS_DISPLAY_NAME` constant as a mapping from `EnumGitProvider` values to display names in `constants.ts` ([link](https://github.com/amplication/amplication/pull/6292/files?diff=unified&w=0#diff-efbbf399b1e1187d531eea679ac8af971cfd9d6a41ed137aff50e5f8763f51e4R193-R199))
* Import `PROVIDERS_DISPLAY_NAME` constant from `constants` module to use in `GitDialogsContainer` component in `GitDialogsContainer.tsx` ([link](https://github.com/amplication/amplication/pull/6292/files?diff=unified&w=0#diff-305aa5a8e8ac7a7b73a0b3132c4102a0f3512993f97fc93998a57fedce0bb195R13))
* Assign `providerDisplayName` variable the display name of the selected `gitProvider` using `PROVIDERS_DISPLAY_NAME` constant in `GitDialogsContainer` component in `GitDialogsContainer.tsx` ([link](https://github.com/amplication/amplication/pull/6292/files?diff=unified&w=0#diff-305aa5a8e8ac7a7b73a0b3132c4102a0f3512993f97fc93998a57fedce0bb195R56-R57))
* Update `title` prop of `SelectRepositoryDialog` component to use `providerDisplayName` variable instead of `gitProvider` value in `GitDialogsContainer` component in `GitDialogsContainer.tsx` ([link](https://github.com/amplication/amplication/pull/6292/files?diff=unified&w=0#diff-305aa5a8e8ac7a7b73a0b3132c4102a0f3512993f97fc93998a57fedce0bb195L60-R63))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
