### PR TITLE
feat(client): add latest plugin flag to install plugin flow

### DIFF
--- a/packages/amplication-client/src/Plugins/PluginsCatalogItem.tsx
+++ b/packages/amplication-client/src/Plugins/PluginsCatalogItem.tsx
@@ -16,6 +16,7 @@ import { Plugin, PluginVersion } from "./hooks/usePlugins";
 import { PluginLogo } from "./PluginLogo";
 import "./PluginsCatalogItem.scss";
 import { LATEST_VERSION_TAG } from "./constant";
+import { REACT_APP_PLUGIN_VERSION_USE_LATEST } from "../env";
 
 type Props = {
   plugin: Plugin;
@@ -27,6 +28,7 @@ type Props = {
   isDraggable?: boolean;
 };
 
+const pluginUseLatest = REACT_APP_PLUGIN_VERSION_USE_LATEST === "true";
 const CLASS_NAME = "plugins-catalog-item";
 
 function PluginsCatalogItem({
@@ -57,10 +59,13 @@ function PluginsCatalogItem({
   }, [onOrderChange, order, pluginInstallation]);
 
   const handleInstall = useCallback(() => {
-    // Get the "latest" version
-    const hardcodedLatestVersion = plugin.versions.find(
-      (version) => version.version === LATEST_VERSION_TAG
-    );
+    // Get the "latest" version or the first one by the env variable flag
+    const hardcodedLatestVersion = pluginUseLatest
+      ? plugin.versions.find(
+          (version) => version.version === LATEST_VERSION_TAG
+        )
+      : plugin.versions[0];
+
     onInstall && onInstall(plugin, hardcodedLatestVersion);
   }, [onInstall, plugin]);
 


### PR DESCRIPTION
Close: #5851 

## PR Details

Add latest version plugin flag to install plugin process
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at abafb37</samp>

### Summary
:sparkles::wrench::memo:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or enhancement, which is the option to install the latest or the first version of a plugin from the plugins catalog.
2.  :wrench: - This emoji represents the adjustment or improvement of an existing feature or functionality, which is the update of the `handleInstall` function to use the new option.
3.  :memo: - This emoji represents the documentation or explanation of the changes, which is the update of the README file to include the new environment variable.
-->
This pull request enhances the plugin installation feature by allowing users to choose between the latest or the first version of a plugin from the catalog, depending on an environment variable. It also modifies the `PluginsCatalogItem.tsx` file to implement this logic.

> _Sing, O Muse, of the crafty coder who devised_
> _A cunning option for the plugins catalog, to choose_
> _The latest or the first of versions, as he pleased,_
> _By setting `REACT_APP_PLUGIN_VERSION_USE_LATEST` to true or false._

### Walkthrough
*  Add environment variable to control plugin version selection ([link](https://github.com/amplication/amplication/pull/6294/files?diff=unified&w=0#diff-069de3b168a7ec6810b1453bcb08a63346d53aff23003da53f0ea774bd4324e1R19))
*  Define constant `pluginUseLatest` based on environment variable value ([link](https://github.com/amplication/amplication/pull/6294/files?diff=unified&w=0#diff-069de3b168a7ec6810b1453bcb08a63346d53aff23003da53f0ea774bd4324e1R31))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

