### PR TITLE
feat(server): log entity provider

### DIFF
--- a/packages/amplication-server/src/core/account/account.service.spec.ts
+++ b/packages/amplication-server/src/core/account/account.service.spec.ts
@@ -2,6 +2,7 @@ import { PrismaService, Account } from "../../prisma";
 import { Test, TestingModule } from "@nestjs/testing";
 import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { AccountService } from "./account.service";
+import { IDENTITY_PROVIDER_MANUAL } from "../auth/auth.service";
 
 const EXAMPLE_ACCOUNT_ID = "ExampleAccountId",
   EXAMPLE_EMAIL = "example@email.com",
@@ -85,7 +86,9 @@ describe("AccountService", () => {
         password: EXAMPLE_PASSWORD,
       },
     };
-    expect(await service.createAccount(args)).toEqual(EXAMPLE_ACCOUNT);
+    expect(await service.createAccount(args, IDENTITY_PROVIDER_MANUAL)).toEqual(
+      EXAMPLE_ACCOUNT
+    );
     expect(prismaAccountCreateMock).toBeCalledTimes(1);
     expect(prismaAccountCreateMock).toBeCalledWith(args);
     expect(segmentAnalyticsIdentifyMock).toBeCalledTimes(1);

--- a/packages/amplication-server/src/core/account/account.service.ts
+++ b/packages/amplication-server/src/core/account/account.service.ts
@@ -14,7 +14,10 @@ export class AccountService {
     private analytics: SegmentAnalyticsService
   ) {}
 
-  async createAccount(args: Prisma.AccountCreateArgs): Promise<Account> {
+  async createAccount(
+    args: Prisma.AccountCreateArgs,
+    identityProvider: string
+  ): Promise<Account> {
     const account = await this.prisma.account.create(args);
 
     const userData: IdentifyData = {
@@ -30,6 +33,9 @@ export class AccountService {
     await this.analytics.track({
       userId: account.id,
       event: EnumEventType.Signup,
+      properties: {
+        identityProvider,
+      },
       context: {
         traits: userData,
       },

--- a/packages/amplication-server/src/core/auth/auth.service.spec.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.spec.ts
@@ -12,7 +12,11 @@ import { Role } from "../../enums/Role";
 import { AccountService } from "../account/account.service";
 import { PasswordService } from "../account/password.service";
 import { UserService } from "../user/user.service";
-import { AuthService, AuthUser } from "./auth.service";
+import {
+  AuthService,
+  AuthUser,
+  IDENTITY_PROVIDER_MANUAL,
+} from "./auth.service";
 import { WorkspaceService } from "../workspace/workspace.service";
 import { EnumTokenType } from "./dto";
 import { ProjectService } from "../project/project.service";
@@ -246,14 +250,17 @@ describe("AuthService", () => {
     });
     expect(result).toBe(EXAMPLE_TOKEN);
     expect(createAccountMock).toHaveBeenCalledTimes(1);
-    expect(createAccountMock).toHaveBeenCalledWith({
-      data: {
-        email: EXAMPLE_ACCOUNT.email,
-        password: EXAMPLE_HASHED_PASSWORD,
-        firstName: EXAMPLE_ACCOUNT.firstName,
-        lastName: EXAMPLE_ACCOUNT.lastName,
+    expect(createAccountMock).toHaveBeenCalledWith(
+      {
+        data: {
+          email: EXAMPLE_ACCOUNT.email,
+          password: EXAMPLE_HASHED_PASSWORD,
+          firstName: EXAMPLE_ACCOUNT.firstName,
+          lastName: EXAMPLE_ACCOUNT.lastName,
+        },
       },
-    });
+      IDENTITY_PROVIDER_MANUAL
+    );
     expect(setCurrentUserMock).toHaveBeenCalledTimes(1);
     expect(setCurrentUserMock).toHaveBeenCalledWith(
       EXAMPLE_ACCOUNT.id,

--- a/packages/amplication-server/src/core/auth/auth.service.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.ts
@@ -32,7 +32,7 @@ const TOKEN_PREVIEW_LENGTH = 8;
 const TOKEN_EXPIRY_DAYS = 30;
 export const IDENTITY_PROVIDER_GITHUB = "GitHub";
 export const IDENTITY_PROVIDER_SSO = "SSO";
-export const IDENTITY_PROVIDER_MANUAL = "Manuel";
+export const IDENTITY_PROVIDER_MANUAL = "Manual";
 
 const AUTH_USER_INCLUDE = {
   account: true,

--- a/packages/amplication-server/src/core/auth/auth.service.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.ts
@@ -30,6 +30,9 @@ export type AuthUser = User & {
 
 const TOKEN_PREVIEW_LENGTH = 8;
 const TOKEN_EXPIRY_DAYS = 30;
+const IDENTITY_PROVIDER_GITHUB = "GitHub";
+const IDENTITY_PROVIDER_SSO = "SSO";
+const IDENTITY_PROVIDER_MANUAL = "Manuel";
 
 const AUTH_USER_INCLUDE = {
   account: true,
@@ -61,15 +64,18 @@ export class AuthService {
     payload: GitHubProfile,
     email: string
   ): Promise<AuthUser> {
-    const account = await this.accountService.createAccount({
-      data: {
-        email,
-        firstName: email,
-        lastName: "",
-        password: "",
-        githubId: payload.id,
+    const account = await this.accountService.createAccount(
+      {
+        data: {
+          email,
+          firstName: email,
+          lastName: "",
+          password: "",
+          githubId: payload.id,
+        },
       },
-    });
+      IDENTITY_PROVIDER_GITHUB
+    );
 
     const user = await this.bootstrapUser(account, payload.id);
 
@@ -93,15 +99,18 @@ export class AuthService {
   }
 
   async createUser(profile: AuthProfile): Promise<AuthUser> {
-    const account = await this.accountService.createAccount({
-      data: {
-        email: profile.email,
-        firstName: profile.given_name || profile.nickname || profile.email,
-        lastName: profile.family_name,
-        password: "",
-        githubId: profile.sub,
+    const account = await this.accountService.createAccount(
+      {
+        data: {
+          email: profile.email,
+          firstName: profile.given_name || profile.nickname || profile.email,
+          lastName: profile.family_name,
+          password: "",
+          githubId: profile.sub,
+        },
       },
-    });
+      IDENTITY_PROVIDER_SSO
+    );
 
     const user = await this.bootstrapUser(account, profile.sub);
 
@@ -126,14 +135,17 @@ export class AuthService {
       payload.password
     );
 
-    const account = await this.accountService.createAccount({
-      data: {
-        email: payload.email,
-        firstName: payload.firstName,
-        lastName: payload.lastName,
-        password: hashedPassword,
+    const account = await this.accountService.createAccount(
+      {
+        data: {
+          email: payload.email,
+          firstName: payload.firstName,
+          lastName: payload.lastName,
+          password: hashedPassword,
+        },
       },
-    });
+      IDENTITY_PROVIDER_MANUAL
+    );
 
     const user = await this.bootstrapUser(account, payload.workspaceName);
 

--- a/packages/amplication-server/src/core/auth/auth.service.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.ts
@@ -30,9 +30,9 @@ export type AuthUser = User & {
 
 const TOKEN_PREVIEW_LENGTH = 8;
 const TOKEN_EXPIRY_DAYS = 30;
-const IDENTITY_PROVIDER_GITHUB = "GitHub";
-const IDENTITY_PROVIDER_SSO = "SSO";
-const IDENTITY_PROVIDER_MANUAL = "Manuel";
+export const IDENTITY_PROVIDER_GITHUB = "GitHub";
+export const IDENTITY_PROVIDER_SSO = "SSO";
+export const IDENTITY_PROVIDER_MANUAL = "Manuel";
 
 const AUTH_USER_INCLUDE = {
   account: true,


### PR DESCRIPTION


Close: https://github.com/amplication/private-issues/issues/17

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 72401ab</samp>

### Summary
:sparkles::passport_control::card_file_box:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, which is the support for different identity providers in account creation.
2.  :passport_control: This emoji represents the concept of identity, authentication, or authorization, which is relevant to the `identityProvider` parameter and the account data.
3.  :card_file_box: This emoji represents the storage or organization of data, which is what the `createAccount` method does with the account data.
-->
The pull request adds support for different identity providers in account creation and authentication. It modifies the `createAccount` method of the `AccountService` class and the `auth.service.ts` file to use constants for the identity providers. This enhances the flexibility and clarity of the code.

> _We're sailing on the digital sea, with accounts of every kind_
> _We need to know the `identityProvider`, so we don't get left behind_
> _So heave away, me hearties, and pass the parameter in_
> _We'll call the `createAccount` method and let the fun begin_

### Walkthrough
*  Add `identityProvider` parameter to `createAccount` method of `AccountService` class to store the source of account creation ([link](https://github.com/amplication/amplication/pull/6331/files?diff=unified&w=0#diff-ceb7aeeb9ff4e40183c2c4389f985f46db0218fcfd73b25a9f1d5133ef669d1cL17-R20), [link](https://github.com/amplication/amplication/pull/6331/files?diff=unified&w=0#diff-ceb7aeeb9ff4e40183c2c4389f985f46db0218fcfd73b25a9f1d5133ef669d1cR36-R38))
*  Use constants for the possible values of `identityProvider` in `AuthService` class ([link](https://github.com/amplication/amplication/pull/6331/files?diff=unified&w=0#diff-368a0067447ce7f9a858f275793696cb4a7fc7111e2c14caba62cfb5febf3eddR33-R35))
*  Pass the appropriate `identityProvider` constant to `createAccount` method in `githubLogin`, `createUser`, and `register` methods of `AuthService` class, depending on whether the account was created from GitHub, SSO, or manual registration ([link](https://github.com/amplication/amplication/pull/6331/files?diff=unified&w=0#diff-368a0067447ce7f9a858f275793696cb4a7fc7111e2c14caba62cfb5febf3eddL64-R78), [link](https://github.com/amplication/amplication/pull/6331/files?diff=unified&w=0#diff-368a0067447ce7f9a858f275793696cb4a7fc7111e2c14caba62cfb5febf3eddL96-R113), [link](https://github.com/amplication/amplication/pull/6331/files?diff=unified&w=0#diff-368a0067447ce7f9a858f275793696cb4a7fc7111e2c14caba62cfb5febf3eddL129-R148))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
