### PR TITLE
fix(client): get latest version by isLatest flag

### DIFF
--- a/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
@@ -218,7 +218,7 @@ const CreateServiceWizard: React.FC<Props> = ({
   );
 
   const authCoreVersion = pluginUseLatest
-    ? authCorePlugin?.versions[authCorePlugin?.versions.length - 1]
+    ? authCorePlugin?.versions.find((x) => x.isLatest)
     : authCorePlugin?.versions[0];
 
   const authJwtPlugin = pluginsVersionData?.plugins.find(
@@ -226,7 +226,7 @@ const CreateServiceWizard: React.FC<Props> = ({
   );
 
   const authJwtVersion = pluginUseLatest
-    ? authJwtPlugin?.versions[authJwtPlugin?.versions.length - 1]
+    ? authJwtPlugin?.versions.find((x) => x.isLatest)
     : authJwtPlugin?.versions[0];
 
   const AUTH_PLUGINS = [
@@ -314,7 +314,7 @@ const CreateServiceWizard: React.FC<Props> = ({
       );
 
       const dbLastVersion = pluginUseLatest
-        ? dbPlugin?.versions[dbPlugin?.versions.length - 1]
+        ? dbPlugin?.versions.find((x) => x.isLatest)
         : dbPlugin?.versions[0];
 
       const authCorePlugins = authType === "core" && AUTH_PLUGINS;


### PR DESCRIPTION
Close: #6336

## PR Details

Get  latest version by isLatest flag
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 850275c</samp>

### Summary
🐛🧙‍♂️🔌

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this pull request.
2.  🧙‍♂️ - This emoji represents a wizard, which is a fitting symbol for the create service wizard that is being fixed.
3.  🔌 - This emoji represents a plugin, which is the type of dependency that is being updated in the wizard.
-->
Fix bug in create service wizard that could select outdated plugin versions. Use `isLatest` property to filter the latest versions of `auth-core`, `auth-jwt`, and `db` plugins in `CreateServiceWizard.tsx`.

> _`create service` bug_
> _fixed with `isLatest` check_
> _autumn leaves outdated_

### Walkthrough
*  Fix bug in selecting latest version of auth-core plugin in create service wizard ([link](https://github.com/amplication/amplication/pull/6339/files?diff=unified&w=0#diff-5a8f852ecd706b64aada842f7e069be776805096dcc064c8172b93d0388e14cdL221-R221))
*  Apply same logic to select latest version of auth-jwt plugin in create service wizard ([link](https://github.com/amplication/amplication/pull/6339/files?diff=unified&w=0#diff-5a8f852ecd706b64aada842f7e069be776805096dcc064c8172b93d0388e14cdL229-R229))
*  Apply same logic to select latest version of db plugin in create service wizard ([link](https://github.com/amplication/amplication/pull/6339/files?diff=unified&w=0#diff-5a8f852ecd706b64aada842f7e069be776805096dcc064c8172b93d0388e14cdL317-R317))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

