### PR TITLE
fix(amplication): models and graphql schema

### DIFF
--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -302,7 +302,7 @@ export type CreateGitRepositoryInput = {
   groupName?: InputMaybe<Scalars['String']>;
   isPublic: Scalars['Boolean'];
   name: Scalars['String'];
-  resourceId: Scalars['String'];
+  resourceId?: InputMaybe<Scalars['String']>;
 };
 
 export type DateTimeFilter = {
@@ -861,6 +861,7 @@ export type Mutation = {
   commit?: Maybe<Commit>;
   completeGitOAuth2Flow: GitOrganization;
   completeInvitation: Auth;
+  connectGitRepository: Resource;
   connectResourceGitRepository: Resource;
   connectResourceToProjectRepository: Resource;
   createApiToken: ApiToken;
@@ -869,14 +870,13 @@ export type Mutation = {
   createDefaultRelatedField: EntityField;
   createEntityField: EntityField;
   createEntityFieldByDisplayName: EntityField;
-  createGitRepository: Resource;
   createMessageBroker: Resource;
   createOneEntity: Entity;
   /** Only for GitHub integrations */
   createOrganization: GitOrganization;
   createPluginInstallation: PluginInstallation;
   createProject: Project;
-  createRemoteGitRepository: Scalars['Boolean'];
+  createRemoteGitRepository: RemoteGitRepository;
   createResourceRole: ResourceRole;
   createService: Resource;
   createServiceTopics: ServiceTopics;
@@ -952,6 +952,11 @@ export type MutationCompleteInvitationArgs = {
 };
 
 
+export type MutationConnectGitRepositoryArgs = {
+  data: CreateGitRepositoryInput;
+};
+
+
 export type MutationConnectResourceGitRepositoryArgs = {
   data: ConnectGitRepositoryInput;
 };
@@ -993,11 +998,6 @@ export type MutationCreateEntityFieldArgs = {
 
 export type MutationCreateEntityFieldByDisplayNameArgs = {
   data: EntityFieldCreateByDisplayNameInput;
-};
-
-
-export type MutationCreateGitRepositoryArgs = {
-  data: CreateGitRepositoryInput;
 };
 
 

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -302,7 +302,7 @@ export type CreateGitRepositoryInput = {
   groupName?: InputMaybe<Scalars['String']>;
   isPublic: Scalars['Boolean'];
   name: Scalars['String'];
-  resourceId: Scalars['String'];
+  resourceId?: InputMaybe<Scalars['String']>;
 };
 
 export type DateTimeFilter = {
@@ -861,6 +861,7 @@ export type Mutation = {
   commit?: Maybe<Commit>;
   completeGitOAuth2Flow: GitOrganization;
   completeInvitation: Auth;
+  connectGitRepository: Resource;
   connectResourceGitRepository: Resource;
   connectResourceToProjectRepository: Resource;
   createApiToken: ApiToken;
@@ -869,14 +870,13 @@ export type Mutation = {
   createDefaultRelatedField: EntityField;
   createEntityField: EntityField;
   createEntityFieldByDisplayName: EntityField;
-  createGitRepository: Resource;
   createMessageBroker: Resource;
   createOneEntity: Entity;
   /** Only for GitHub integrations */
   createOrganization: GitOrganization;
   createPluginInstallation: PluginInstallation;
   createProject: Project;
-  createRemoteGitRepository: Scalars['Boolean'];
+  createRemoteGitRepository: RemoteGitRepository;
   createResourceRole: ResourceRole;
   createService: Resource;
   createServiceTopics: ServiceTopics;
@@ -952,6 +952,11 @@ export type MutationCompleteInvitationArgs = {
 };
 
 
+export type MutationConnectGitRepositoryArgs = {
+  data: CreateGitRepositoryInput;
+};
+
+
 export type MutationConnectResourceGitRepositoryArgs = {
   data: ConnectGitRepositoryInput;
 };
@@ -993,11 +998,6 @@ export type MutationCreateEntityFieldArgs = {
 
 export type MutationCreateEntityFieldByDisplayNameArgs = {
   data: EntityFieldCreateByDisplayNameInput;
-};
-
-
-export type MutationCreateGitRepositoryArgs = {
-  data: CreateGitRepositoryInput;
 };
 
 

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -302,7 +302,7 @@ export type CreateGitRepositoryInput = {
   groupName?: InputMaybe<Scalars['String']>;
   isPublic: Scalars['Boolean'];
   name: Scalars['String'];
-  resourceId: Scalars['String'];
+  resourceId?: InputMaybe<Scalars['String']>;
 };
 
 export type DateTimeFilter = {
@@ -861,6 +861,7 @@ export type Mutation = {
   commit?: Maybe<Commit>;
   completeGitOAuth2Flow: GitOrganization;
   completeInvitation: Auth;
+  connectGitRepository: Resource;
   connectResourceGitRepository: Resource;
   connectResourceToProjectRepository: Resource;
   createApiToken: ApiToken;
@@ -869,14 +870,13 @@ export type Mutation = {
   createDefaultRelatedField: EntityField;
   createEntityField: EntityField;
   createEntityFieldByDisplayName: EntityField;
-  createGitRepository: Resource;
   createMessageBroker: Resource;
   createOneEntity: Entity;
   /** Only for GitHub integrations */
   createOrganization: GitOrganization;
   createPluginInstallation: PluginInstallation;
   createProject: Project;
-  createRemoteGitRepository: Scalars['Boolean'];
+  createRemoteGitRepository: RemoteGitRepository;
   createResourceRole: ResourceRole;
   createService: Resource;
   createServiceTopics: ServiceTopics;
@@ -952,6 +952,11 @@ export type MutationCompleteInvitationArgs = {
 };
 
 
+export type MutationConnectGitRepositoryArgs = {
+  data: CreateGitRepositoryInput;
+};
+
+
 export type MutationConnectResourceGitRepositoryArgs = {
   data: ConnectGitRepositoryInput;
 };
@@ -993,11 +998,6 @@ export type MutationCreateEntityFieldArgs = {
 
 export type MutationCreateEntityFieldByDisplayNameArgs = {
   data: EntityFieldCreateByDisplayNameInput;
-};
-
-
-export type MutationCreateGitRepositoryArgs = {
-  data: CreateGitRepositoryInput;
 };
 
 

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -302,7 +302,7 @@ export type CreateGitRepositoryInput = {
   groupName?: InputMaybe<Scalars['String']>;
   isPublic: Scalars['Boolean'];
   name: Scalars['String'];
-  resourceId: Scalars['String'];
+  resourceId?: InputMaybe<Scalars['String']>;
 };
 
 export type DateTimeFilter = {
@@ -861,6 +861,7 @@ export type Mutation = {
   commit?: Maybe<Commit>;
   completeGitOAuth2Flow: GitOrganization;
   completeInvitation: Auth;
+  connectGitRepository: Resource;
   connectResourceGitRepository: Resource;
   connectResourceToProjectRepository: Resource;
   createApiToken: ApiToken;
@@ -869,14 +870,13 @@ export type Mutation = {
   createDefaultRelatedField: EntityField;
   createEntityField: EntityField;
   createEntityFieldByDisplayName: EntityField;
-  createGitRepository: Resource;
   createMessageBroker: Resource;
   createOneEntity: Entity;
   /** Only for GitHub integrations */
   createOrganization: GitOrganization;
   createPluginInstallation: PluginInstallation;
   createProject: Project;
-  createRemoteGitRepository: Scalars['Boolean'];
+  createRemoteGitRepository: RemoteGitRepository;
   createResourceRole: ResourceRole;
   createService: Resource;
   createServiceTopics: ServiceTopics;
@@ -952,6 +952,11 @@ export type MutationCompleteInvitationArgs = {
 };
 
 
+export type MutationConnectGitRepositoryArgs = {
+  data: CreateGitRepositoryInput;
+};
+
+
 export type MutationConnectResourceGitRepositoryArgs = {
   data: ConnectGitRepositoryInput;
 };
@@ -993,11 +998,6 @@ export type MutationCreateEntityFieldArgs = {
 
 export type MutationCreateEntityFieldByDisplayNameArgs = {
   data: EntityFieldCreateByDisplayNameInput;
-};
-
-
-export type MutationCreateGitRepositoryArgs = {
-  data: CreateGitRepositoryInput;
 };
 
 

--- a/packages/amplication-server/src/core/git/git.resolver.ts
+++ b/packages/amplication-server/src/core/git/git.resolver.ts
@@ -18,7 +18,10 @@ import { DeleteGitRepositoryArgs } from "./dto/args/DeleteGitRepositoryArgs";
 import { GetGitInstallationUrlArgs } from "./dto/args/GetGitInstallationUrlArgs";
 import { RemoteGitRepositoriesFindManyArgs } from "./dto/args/RemoteGitRepositoriesFindManyArgs";
 import { GitOrganizationFindManyArgs } from "./dto/args/GitOrganizationFindManyArgs";
-import { RemoteGitRepos } from "./dto/objects/RemoteGitRepository";
+import {
+  RemoteGitRepos,
+  RemoteGitRepository,
+} from "./dto/objects/RemoteGitRepository";
 import { GitProviderService } from "./git.provider.service";
 import { DisconnectGitRepositoryArgs } from "./dto/args/DisconnectGitRepositoryArgs";
 import { ConnectToProjectGitRepositoryArgs } from "./dto/args/ConnectToProjectGitRepositoryArgs";
@@ -28,7 +31,6 @@ import { GitGroupArgs } from "./dto/args/GitGroupArgs";
 import { PaginatedGitGroup } from "./dto/objects/PaginatedGitGroup";
 import { User } from "../../models";
 import { UserEntity } from "../../decorators/user.decorator";
-import { RemoteGitRepository } from "@amplication/git-utils";
 
 @UseFilters(GqlResolverExceptionsFilter)
 @UseGuards(GqlAuthGuard)
@@ -45,7 +47,7 @@ export class GitResolver {
     return this.gitService.connectGitRepository(args.data);
   }
 
-  @Mutation(() => Boolean)
+  @Mutation(() => RemoteGitRepository)
   @AuthorizeContext(
     AuthorizableOriginParameter.GitOrganizationId,
     "data.gitOrganizationId"

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -1149,6 +1149,7 @@ type Mutation {
   updatePluginInstallation(data: PluginInstallationUpdateInput!, where: WhereUniqueInput!): PluginInstallation!
   deletePluginInstallation(where: WhereUniqueInput!): PluginInstallation!
   setPluginOrder(data: PluginSetOrderInput!, where: WhereUniqueInput!): PluginOrder
+  updateProjectConfigurationSettings(data: ProjectConfigurationSettingsUpdateInput!, where: WhereUniqueInput!): ProjectConfigurationSettings
   connectGitRepository(data: CreateGitRepositoryInput!): Resource!
   createRemoteGitRepository(data: CreateGitRepositoryBaseInput!): RemoteGitRepository!
   connectResourceGitRepository(data: ConnectGitRepositoryInput!): Resource!
@@ -1504,7 +1505,7 @@ input CreateGitRepositoryInput {
   gitOrganizationId: String!
   gitProvider: EnumGitProvider!
   gitOrganizationType: EnumGitOrganizationType!
-  resourceId: String!
+  resourceId: String
 }
 
 input CreateGitRepositoryBaseInput {

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -302,7 +302,7 @@ export type CreateGitRepositoryInput = {
   groupName?: InputMaybe<Scalars['String']>;
   isPublic: Scalars['Boolean'];
   name: Scalars['String'];
-  resourceId: Scalars['String'];
+  resourceId?: InputMaybe<Scalars['String']>;
 };
 
 export type DateTimeFilter = {
@@ -861,6 +861,7 @@ export type Mutation = {
   commit?: Maybe<Commit>;
   completeGitOAuth2Flow: GitOrganization;
   completeInvitation: Auth;
+  connectGitRepository: Resource;
   connectResourceGitRepository: Resource;
   connectResourceToProjectRepository: Resource;
   createApiToken: ApiToken;
@@ -869,14 +870,13 @@ export type Mutation = {
   createDefaultRelatedField: EntityField;
   createEntityField: EntityField;
   createEntityFieldByDisplayName: EntityField;
-  createGitRepository: Resource;
   createMessageBroker: Resource;
   createOneEntity: Entity;
   /** Only for GitHub integrations */
   createOrganization: GitOrganization;
   createPluginInstallation: PluginInstallation;
   createProject: Project;
-  createRemoteGitRepository: Scalars['Boolean'];
+  createRemoteGitRepository: RemoteGitRepository;
   createResourceRole: ResourceRole;
   createService: Resource;
   createServiceTopics: ServiceTopics;
@@ -952,6 +952,11 @@ export type MutationCompleteInvitationArgs = {
 };
 
 
+export type MutationConnectGitRepositoryArgs = {
+  data: CreateGitRepositoryInput;
+};
+
+
 export type MutationConnectResourceGitRepositoryArgs = {
   data: ConnectGitRepositoryInput;
 };
@@ -993,11 +998,6 @@ export type MutationCreateEntityFieldArgs = {
 
 export type MutationCreateEntityFieldByDisplayNameArgs = {
   data: EntityFieldCreateByDisplayNameInput;
-};
-
-
-export type MutationCreateGitRepositoryArgs = {
-  data: CreateGitRepositoryInput;
 };
 
 


### PR DESCRIPTION
Close: #6340 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0ffeb58</samp>

### Summary
🌐🛠️📝

<!--
1.  🌐 - This emoji represents the feature of connecting an existing git repository to a project, which involves interacting with external web services and platforms.
2.  🛠️ - This emoji represents the changes that improve the consistency and usability of the git integration feature, which involve fixing and enhancing the existing functionality and tools.
3.  📝 - This emoji represents the changes that enable more flexibility and control over project settings and git integration, which involve adding and modifying input types and mutations.
-->
This pull request adds and updates types and mutations in several packages to support connecting an existing git repository to a project and creating and updating git repositories and pull requests with more options and metadata. It also improves the consistency and usability of the git integration feature and fixes some minor issues in the data service generator models.

> _Oh we're the coders of the sea, and we work with git and types_
> _We create and update repos, with mutations and inputs_
> _We heave and ho and pull the code, and we make it nice and neat_
> _We sing this shanty as we go, to the rhythm of our feet_

### Walkthrough
*  Make the `resourceId` field optional in the `CreateGitRepositoryInput` type to allow connecting an existing git repository to a project ([link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-8e34f7703a0b39fa5e612bb39ad750167d90a6b75df578f54f35a9348dd0a509L305-R305), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-b9ccc53c48e521fb7c98b07ad7f4761ba0ea91eb649e157d159b065ac2487c1dL305-R305), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-3860f234d2c5629bf7aeb4e7439fe3b357be4e00c08a9f008b56d3610bb017c0L305-R305), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-6137baa91c68c17d5e3716428198a16a3cb5cdd263e22998503daa29c86a296eL305-R305), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75L1507-R1508), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-a54fca1e77b31822272d37bef66289ad466ba9d835ac76a5474a6808d4bcaaabL305-R305))
* Add the `connectGitRepository` mutation to the `Mutation` type to connect an existing git repository to a project ([link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-8e34f7703a0b39fa5e612bb39ad750167d90a6b75df578f54f35a9348dd0a509R864), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-b9ccc53c48e521fb7c98b07ad7f4761ba0ea91eb649e157d159b065ac2487c1dR864), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-3860f234d2c5629bf7aeb4e7439fe3b357be4e00c08a9f008b56d3610bb017c0R864), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-6137baa91c68c17d5e3716428198a16a3cb5cdd263e22998503daa29c86a296eR864), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-a54fca1e77b31822272d37bef66289ad466ba9d835ac76a5474a6808d4bcaaabR864))
* Remove the `createGitRepository` mutation from the `Mutation` type and replace it with the `createRemoteGitRepository` mutation, which returns a `RemoteGitRepository` object instead of a `Resource` object ([link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-8e34f7703a0b39fa5e612bb39ad750167d90a6b75df578f54f35a9348dd0a509L872), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-8e34f7703a0b39fa5e612bb39ad750167d90a6b75df578f54f35a9348dd0a509L879-R879), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-8e34f7703a0b39fa5e612bb39ad750167d90a6b75df578f54f35a9348dd0a509L999-L1003), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-b9ccc53c48e521fb7c98b07ad7f4761ba0ea91eb649e157d159b065ac2487c1dL872), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-b9ccc53c48e521fb7c98b07ad7f4761ba0ea91eb649e157d159b065ac2487c1dL879-R879), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-b9ccc53c48e521fb7c98b07ad7f4761ba0ea91eb649e157d159b065ac2487c1dL999-L1003), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-3860f234d2c5629bf7aeb4e7439fe3b357be4e00c08a9f008b56d3610bb017c0L872), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-3860f234d2c5629bf7aeb4e7439fe3b357be4e00c08a9f008b56d3610bb017c0L879-R879), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-3860f234d2c5629bf7aeb4e7439fe3b357be4e00c08a9f008b56d3610bb017c0L999-L1003), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-6137baa91c68c17d5e3716428198a16a3cb5cdd263e22998503daa29c86a296eL872), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-6137baa91c68c17d5e3716428198a16a3cb5cdd263e22998503daa29c86a296eL879-R879), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-6137baa91c68c17d5e3716428198a16a3cb5cdd263e22998503daa29c86a296eL999-L1003), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-a54fca1e77b31822272d37bef66289ad466ba9d835ac76a5474a6808d4bcaaabL872), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-a54fca1e77b31822272d37bef66289ad466ba9d835ac76a5474a6808d4bcaaabL879-R879), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-a54fca1e77b31822272d37bef66289ad466ba9d835ac76a5474a6808d4bcaaabL999-L1003))
* Change the `createRemoteGitRepository` mutation in the `GitResolver` class in `packages/amplication-server/src/core/git/git.resolver.ts` to return a `RemoteGitRepository` object instead of a `Boolean` value and import the `RemoteGitRepository` type from `./dto/objects/RemoteGitRepository` instead of `@amplication/git-utils` ([link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-01d226ac86a8c9aa7fbcf553978f106d6e2e8b565ec56d190d60477293b61678L21-R24), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-01d226ac86a8c9aa7fbcf553978f106d6e2e8b565ec56d190d60477293b61678L31), [link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-01d226ac86a8c9aa7fbcf553978f106d6e2e8b565ec56d190d60477293b61678L48-R50))
* Add the `updateProjectConfigurationSettings` mutation to the `Mutation` type in `packages/amplication-server/src/schema.graphql` to update the configuration settings of a project ([link](https://github.com/amplication/amplication/pull/6341/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75R1152))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
