### PR TITLE
fix(dsg): add `type-fest` as dependency 

### DIFF
--- a/packages/data-service-generator/src/server/package-json/package.json
+++ b/packages/data-service-generator/src/server/package-json/package.json
@@ -41,6 +41,7 @@
     "reflect-metadata": "0.1.13",
     "swagger-ui-express": "4.3.0",
     "ts-node": "10.9.1",
+    "type-fest": "0.13.1",
     "validator": "^13.9.0"
   },
   "devDependencies": {
@@ -57,7 +58,6 @@
     "prisma": "4.6.1",
     "supertest": "4.0.2",
     "ts-jest": "27.0.3",
-    "type-fest": "0.11.0",
     "typescript": "4.2.3"
   },
   "jest": {

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -3014,6 +3014,7 @@ services:
     \\"reflect-metadata\\": \\"0.1.13\\",
     \\"swagger-ui-express\\": \\"4.3.0\\",
     \\"ts-node\\": \\"10.9.1\\",
+    \\"type-fest\\": \\"0.13.1\\",
     \\"validator\\": \\"^13.9.0\\"
   },
   \\"devDependencies\\": {
@@ -3030,7 +3031,6 @@ services:
     \\"prisma\\": \\"4.6.1\\",
     \\"supertest\\": \\"4.0.2\\",
     \\"ts-jest\\": \\"27.0.3\\",
-    \\"type-fest\\": \\"0.11.0\\",
     \\"typescript\\": \\"4.2.3\\"
   },
   \\"jest\\": {

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -3014,6 +3014,7 @@ services:
     \\"reflect-metadata\\": \\"0.1.13\\",
     \\"swagger-ui-express\\": \\"4.3.0\\",
     \\"ts-node\\": \\"10.9.1\\",
+    \\"type-fest\\": \\"0.13.1\\",
     \\"validator\\": \\"^13.9.0\\"
   },
   \\"devDependencies\\": {
@@ -3030,7 +3031,6 @@ services:
     \\"prisma\\": \\"4.6.1\\",
     \\"supertest\\": \\"4.0.2\\",
     \\"ts-jest\\": \\"27.0.3\\",
-    \\"type-fest\\": \\"0.11.0\\",
     \\"typescript\\": \\"4.2.3\\"
   },
   \\"jest\\": {

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -3014,6 +3014,7 @@ services:
     \\"reflect-metadata\\": \\"0.1.13\\",
     \\"swagger-ui-express\\": \\"4.3.0\\",
     \\"ts-node\\": \\"10.9.1\\",
+    \\"type-fest\\": \\"0.13.1\\",
     \\"validator\\": \\"^13.9.0\\"
   },
   \\"devDependencies\\": {
@@ -3030,7 +3031,6 @@ services:
     \\"prisma\\": \\"4.6.1\\",
     \\"supertest\\": \\"4.0.2\\",
     \\"ts-jest\\": \\"27.0.3\\",
-    \\"type-fest\\": \\"0.11.0\\",
     \\"typescript\\": \\"4.2.3\\"
   },
   \\"jest\\": {

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -3014,6 +3014,7 @@ services:
     \\"reflect-metadata\\": \\"0.1.13\\",
     \\"swagger-ui-express\\": \\"4.3.0\\",
     \\"ts-node\\": \\"10.9.1\\",
+    \\"type-fest\\": \\"0.13.1\\",
     \\"validator\\": \\"^13.9.0\\"
   },
   \\"devDependencies\\": {
@@ -3030,7 +3031,6 @@ services:
     \\"prisma\\": \\"4.6.1\\",
     \\"supertest\\": \\"4.0.2\\",
     \\"ts-jest\\": \\"27.0.3\\",
-    \\"type-fest\\": \\"0.11.0\\",
     \\"typescript\\": \\"4.2.3\\"
   },
   \\"jest\\": {

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -3014,6 +3014,7 @@ services:
     \\"reflect-metadata\\": \\"0.1.13\\",
     \\"swagger-ui-express\\": \\"4.3.0\\",
     \\"ts-node\\": \\"10.9.1\\",
+    \\"type-fest\\": \\"0.13.1\\",
     \\"validator\\": \\"^13.9.0\\"
   },
   \\"devDependencies\\": {
@@ -3030,7 +3031,6 @@ services:
     \\"prisma\\": \\"4.6.1\\",
     \\"supertest\\": \\"4.0.2\\",
     \\"ts-jest\\": \\"27.0.3\\",
-    \\"type-fest\\": \\"0.11.0\\",
     \\"typescript\\": \\"4.2.3\\"
   },
   \\"jest\\": {

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -3014,6 +3014,7 @@ services:
     \\"reflect-metadata\\": \\"0.1.13\\",
     \\"swagger-ui-express\\": \\"4.3.0\\",
     \\"ts-node\\": \\"10.9.1\\",
+    \\"type-fest\\": \\"0.13.1\\",
     \\"validator\\": \\"^13.9.0\\"
   },
   \\"devDependencies\\": {
@@ -3030,7 +3031,6 @@ services:
     \\"prisma\\": \\"4.6.1\\",
     \\"supertest\\": \\"4.0.2\\",
     \\"ts-jest\\": \\"27.0.3\\",
-    \\"type-fest\\": \\"0.11.0\\",
     \\"typescript\\": \\"4.2.3\\"
   },
   \\"jest\\": {


### PR DESCRIPTION
Close: #6121 

## PR Details

This solution represent a temporary solution until we refactor the DSG to understand difference between `imports` and `imports types`. 
Types, i.e. types from `type-fest` like `JsonValue`, should be imported as `import type {} from ""` to avoid needing the dependency at runtime. 
This pr configure `type-fest` as dependency  instead of devDependency to unblock any user that run the service installing only the production dependencies
 

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
