### PR TITLE
fix routes to handle wrong paths [Fixes #4424]

### DIFF
--- a/packages/amplication-client/src/routes/appRoutes.tsx
+++ b/packages/amplication-client/src/routes/appRoutes.tsx
@@ -1,6 +1,5 @@
 import { ComponentType, lazy, LazyExoticComponent } from "react";
 import resourceRoutes from "./resourceRoutes";
-import NotFoundPage from "../404/NotFoundPage";
 
 export interface RouteDef {
   path: string;

--- a/packages/amplication-client/src/routes/appRoutes.tsx
+++ b/packages/amplication-client/src/routes/appRoutes.tsx
@@ -183,7 +183,7 @@ export const Routes: RouteDef[] = [
       // Fallback route for wrong paths
   {
     path: "*",
-    Component: NotFoundPage,
+    Component: lazy(() => import("../404/NotFoundPage")),
     exactPath: false,
     isAnalytics: false,
   },

--- a/packages/amplication-client/src/routes/appRoutes.tsx
+++ b/packages/amplication-client/src/routes/appRoutes.tsx
@@ -1,5 +1,6 @@
 import { ComponentType, lazy, LazyExoticComponent } from "react";
 import resourceRoutes from "./resourceRoutes";
+import NotFoundPage from "../404/NotFoundPage";
 
 export interface RouteDef {
   path: string;
@@ -178,5 +179,12 @@ export const Routes: RouteDef[] = [
     routeTrackType: "signup",
     exactPath: true,
     isAnalytics: true,
+  },
+      // Fallback route for wrong paths
+  {
+    path: "*",
+    Component: NotFoundPage,
+    exactPath: false,
+    isAnalytics: false,
   },
 ];

--- a/packages/amplication-client/src/routes/resourceEntitiesRoutes.tsx
+++ b/packages/amplication-client/src/routes/resourceEntitiesRoutes.tsx
@@ -1,5 +1,4 @@
 import { lazy } from "react";
-import NotFoundPage from "../404/NotFoundPage";
 
 const resourceEntitiesRoutes = [
   {
@@ -41,7 +40,7 @@ const resourceEntitiesRoutes = [
       // Fallback route for wrong paths
   {
     path: "*",
-    Component: NotFoundPage,
+    Component: lazy(() => import("../404/NotFoundPage")),
     exactPath: false,
     isAnalytics: false,
   },

--- a/packages/amplication-client/src/routes/resourceEntitiesRoutes.tsx
+++ b/packages/amplication-client/src/routes/resourceEntitiesRoutes.tsx
@@ -1,4 +1,5 @@
 import { lazy } from "react";
+import NotFoundPage from "../404/NotFoundPage";
 
 const resourceEntitiesRoutes = [
   {
@@ -36,6 +37,13 @@ const resourceEntitiesRoutes = [
         isAnalytics: true,
       },
     ],
+  },
+      // Fallback route for wrong paths
+  {
+    path: "*",
+    Component: NotFoundPage,
+    exactPath: false,
+    isAnalytics: false,
   },
 ];
 

--- a/packages/amplication-client/src/routes/resourceRoutes.tsx
+++ b/packages/amplication-client/src/routes/resourceRoutes.tsx
@@ -1,7 +1,6 @@
 import { lazy } from "react";
 import resourceEntitiesRoutes from "./resourceEntitiesRoutes";
 import resourceSettingsRoutes from "./resourceSettingsRoutes";
-import NotFoundPage from "../404/NotFoundPage";
 
 const resourceRoutes = [
   {
@@ -169,7 +168,7 @@ const resourceRoutes = [
     // Fallback route for wrong paths
   {
     path: "*",
-    Component: NotFoundPage,
+    Component: lazy(() => import("../404/NotFoundPage")),
     exactPath: false,
     isAnalytics: false,
   },

--- a/packages/amplication-client/src/routes/resourceRoutes.tsx
+++ b/packages/amplication-client/src/routes/resourceRoutes.tsx
@@ -1,6 +1,7 @@
 import { lazy } from "react";
 import resourceEntitiesRoutes from "./resourceEntitiesRoutes";
 import resourceSettingsRoutes from "./resourceSettingsRoutes";
+import NotFoundPage from "../404/NotFoundPage";
 
 const resourceRoutes = [
   {
@@ -164,6 +165,13 @@ const resourceRoutes = [
         isAnalytics: true,
       },
     ],
+  },
+    // Fallback route for wrong paths
+  {
+    path: "*",
+    Component: NotFoundPage,
+    exactPath: false,
+    isAnalytics: false,
   },
 ];
 

--- a/packages/amplication-client/src/routes/resourceSettingsRoutes.tsx
+++ b/packages/amplication-client/src/routes/resourceSettingsRoutes.tsx
@@ -1,5 +1,4 @@
 import { lazy } from "react";
-import NotFoundPage from "../404/NotFoundPage";
 
 const resourceSettingsRoutes = [
   {
@@ -45,7 +44,7 @@ const resourceSettingsRoutes = [
       // Fallback route for wrong paths
   {
     path: "*",
-    Component: NotFoundPage,
+    Component: lazy(() => import("../404/NotFoundPage")),
     exactPath: false,
     isAnalytics: false,
   },

--- a/packages/amplication-client/src/routes/resourceSettingsRoutes.tsx
+++ b/packages/amplication-client/src/routes/resourceSettingsRoutes.tsx
@@ -1,4 +1,5 @@
 import { lazy } from "react";
+import NotFoundPage from "../404/NotFoundPage";
 
 const resourceSettingsRoutes = [
   {
@@ -40,6 +41,13 @@ const resourceSettingsRoutes = [
     exactPath: true,
     routes: [],
     isAnalytics: true,
+  },
+      // Fallback route for wrong paths
+  {
+    path: "*",
+    Component: NotFoundPage,
+    exactPath: false,
+    isAnalytics: false,
   },
 ];
 


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #4424 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

This PR resolves the issue where the routes where not being redirected to the 404 page on modifying them to something which doeesn't exist in react router.

Amplication uses regex patterns to handle the patterns so the minimum length of all those patterns is supposed to be more than 20 according to ```([A-Za-z0-9-]{20,})```

Now, all the unhandled routes would be directed to ```NotFoundPage```


## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
