### PR TITLE
feat(server): model and field names collision

### DIFF
--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -442,9 +442,21 @@ export class EntityService {
     });
 
     try {
+      const existingEntities = await this.prisma.entity.findMany({
+        where: {
+          resourceId: resourceId,
+        },
+        select: {
+          name: true,
+        },
+      });
+
       //Step 1: Convert Prisma schema to import objects
       const { preparedEntitiesWithFields, log } =
-        this.schemaUtilsService.convertPrismaSchemaForImportObjects(file);
+        this.schemaUtilsService.convertPrismaSchemaForImportObjects(
+          file,
+          existingEntities
+        );
 
       //Step 2: Validate entities and fields
       const valid = await this.validateBeforeCreateBulkEntitiesAndFields(

--- a/packages/amplication-server/src/core/prismaSchemaUtils/prismaSchemaUtils.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaUtils/prismaSchemaUtils.service.ts
@@ -364,10 +364,10 @@ export class PrismaSchemaUtilsService {
     log,
   }: PrepareOperationIO): PrepareOperationIO {
     const schema = builder.getSchema();
-    const models = schema.list.filter(
+    const modelList = schema.list.filter(
       (item) => item.type === MODEL_TYPE_NAME
     ) as Model[];
-    models.map((model: Model) => {
+    modelList.map((model: Model) => {
       const modelAttributes = model.properties.filter(
         (prop) => prop.type === ATTRIBUTE_TYPE_NAME
       ) as ModelAttribute[];
@@ -379,9 +379,10 @@ export class PrismaSchemaUtilsService {
       const formattedModelName = formatModelName(model.name);
 
       if (formattedModelName !== model.name) {
-        const isFormattedModelNameAlreadyTaken = models.some(
-          (model) => model.name === formattedModelName
+        const isFormattedModelNameAlreadyTaken = modelList.some(
+          (modelFromList) => modelFromList.name === formattedModelName
         );
+
         const newModelName = isFormattedModelNameAlreadyTaken
           ? `${formattedModelName}Model`
           : formattedModelName;
@@ -430,12 +431,12 @@ export class PrismaSchemaUtilsService {
     const schema = builder.getSchema();
     const models = schema.list.filter((item) => item.type === MODEL_TYPE_NAME);
     models.map((model: Model) => {
-      const modelFields = model.properties.filter(
+      const modelFieldList = model.properties.filter(
         (property) =>
           property.type === FIELD_TYPE_NAME &&
           !property.attributes?.some((attr) => attr.name === ID_ATTRIBUTE_NAME)
       ) as Field[];
-      modelFields.map((field: Field) => {
+      modelFieldList.map((field: Field) => {
         // we don't want to rename field if it is a foreign key holder
         if (this.isFkFieldOfARelation(schema, model, field)) return builder;
         if (this.isOptionSetField(schema, field)) return builder;
@@ -452,9 +453,11 @@ export class PrismaSchemaUtilsService {
         const formattedFieldName = formatFieldName(field.name);
 
         if (formattedFieldName !== field.name) {
-          const isFormattedFieldNameAlreadyTaken = modelFields.some(
-            (field) => field.name === formattedFieldName
+          const isFormattedFieldNameAlreadyTaken = modelFieldList.some(
+            (fieldFromModelFieldList) =>
+              fieldFromModelFieldList.name === formattedFieldName
           );
+
           const newFieldName = isFormattedFieldNameAlreadyTaken
             ? `${formattedFieldName}Field`
             : formattedFieldName;

--- a/packages/amplication-server/src/core/prismaSchemaUtils/types.ts
+++ b/packages/amplication-server/src/core/prismaSchemaUtils/types.ts
@@ -6,8 +6,15 @@ export type PrepareOperation = (
   prepareOperationIO: PrepareOperationIO
 ) => PrepareOperationIO;
 
+export type PrepareOperationInput = {
+  inputSchema: string;
+  existingEntities: ExistingEntitySelect[];
+  log: ActionLog[];
+};
+
 export type PrepareOperationIO = {
   builder: ConcretePrismaSchemaBuilder;
+  existingEntities: ExistingEntitySelect[];
   mapper: Mapper;
   log: ActionLog[];
 };
@@ -27,4 +34,8 @@ export type MapperItem = {
 export type ConvertPrismaSchemaForImportObjectsResponse = {
   preparedEntitiesWithFields: CreateBulkEntitiesInput[];
   log: ActionLog[];
+};
+
+export type ExistingEntitySelect = {
+  name: string;
 };


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6402 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7db43f1</samp>

### Summary
🧮🚫🧵

<!--
1.  🧮 - This emoji represents the improved logic of casting types between Amplication and Prisma schemas.
2. 🚫 - This emoji represents the improved logic of avoiding name conflicts between Amplication and Prisma schemas.
3. 🧵 - This emoji represents the improved logic of using consistent variables throughout the code.
-->
This pull request enhances the Prisma schema generation service to handle different data types, prevent naming collisions, and improve readability. It modifies the `prismaSchemaUtils.service.ts` file to implement these changes.

> _To generate Prisma schema models_
> _From Amplication entities and fields_
> _We cast types and avoid conflicts_
> _With consistent variables and tricks_
> _And hope that our logic never yields_

### Walkthrough
*  Cast filter result to Model array to avoid type errors ([link](https://github.com/amplication/amplication/pull/6406/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L367-R369))
*  Handle model name conflicts by appending "Model" if needed and assign to variable ([link](https://github.com/amplication/amplication/pull/6406/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L380-R396), [link](https://github.com/amplication/amplication/pull/6406/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L398-R407))
*  Handle field name conflicts by appending "Field" if needed and assign to variable ([link](https://github.com/amplication/amplication/pull/6406/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L446-R469), [link](https://github.com/amplication/amplication/pull/6406/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L468-R484))
*  Rename fields variable to modelFields to avoid confusion ([link](https://github.com/amplication/amplication/pull/6406/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L424-R438))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
