### PR TITLE
Revert "fix(git): avoid failures for empty commits on default branch during `amplication` branch creation"

### DIFF
--- a/libs/util/git/src/providers/git-cli.ts
+++ b/libs/util/git/src/providers/git-cli.ts
@@ -67,9 +67,6 @@ export class GitCli {
     await this.git.raw([
       "cherry-pick",
       "-m 1",
-      // --ff --allow-empty will allow cherry-pick to succeed even if the commit is empty (e.g. only metadata changes)
-      "--allow-empty",
-      "--ff",
       "--strategy=ort",
       "-X",
       "theirs",


### PR DESCRIPTION
Reverts amplication/amplication#6428