### PR TITLE
fix(server): add workspace Id to the event

### DIFF
--- a/packages/amplication-server/src/core/workspace/workspace.service.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.service.ts
@@ -273,6 +273,9 @@ export class WorkspaceService {
     await this.analytics.track({
       userId: account.id,
       event: EnumEventType.InvitationAcceptance,
+      properties: {
+        workspaceId: invitation.workspaceId,
+      },
     });
 
     return workspace;


### PR DESCRIPTION

Close: https://github.com/amplication/private-issues/issues/19

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ba55ea7</samp>

### Summary
📧🆔👥

<!--
1.  📧 - This emoji represents the email functionality that is involved in this change. It is a common symbol for email and communication, and it indicates that the change affects how emails are sent and formatted.
2.  🆔 - This emoji represents the `workspaceId` property that is added to the `properties` object. It is a symbol for identification and uniqueness, and it indicates that the change involves passing a specific identifier for the workspace that the user is inviting others to join.
3.  👥 - This emoji represents the collaboration and invitation feature that this change is part of. It is a symbol for groups and teamwork, and it indicates that the change enables users to share their workspaces with other users.
-->
This change modifies the analytics event to pass the `workspaceId` with the payload

> _Invite to workspace_
> _`sendEmail` with `workspaceId`_
> _Autumn leaves fall fast_

### Walkthrough
*  Add `workspaceId` to email properties ([link](https://github.com/amplication/amplication/pull/6432/files?diff=unified&w=0#diff-459b39603b99f959572cd0bf1bde2c4acdb355140d351c2ef545663706a01b0dR276-R278))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
