### PR TITLE
feat(server): build errors BI

### DIFF
--- a/packages/amplication-server/src/core/build/build.controller.ts
+++ b/packages/amplication-server/src/core/build/build.controller.ts
@@ -8,7 +8,7 @@ import { ActionService } from "../action/action.service";
 import { EnumActionStepStatus } from "../action/dto";
 import { ReplyResultMessage } from "./dto/ReplyResultMessage";
 import { ReplyStatusEnum } from "./dto/ReplyStatusEnum";
-import { ACTION_LOG_LEVEL, BuildService } from "./build.service";
+import { BuildService } from "./build.service";
 import {
   CanUserAccessBuild,
   CodeGenerationFailure,
@@ -104,11 +104,6 @@ export class BuildController {
   @EventPattern(EnvironmentVariables.instance.get(Env.DSG_LOG_TOPIC, true))
   async onDsgLog(@Payload() message: CodeGenerationLog.Value): Promise<void> {
     const logEntry = plainToInstance(CodeGenerationLog.Value, message);
-    const step = await this.buildService.getGenerateCodeStep(logEntry.buildId);
-    await this.actionService.logByStepId(
-      step.id,
-      ACTION_LOG_LEVEL[logEntry.level],
-      logEntry.message
-    );
+    await this.buildService.onDsgLog(logEntry);
   }
 }

--- a/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
+++ b/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
@@ -21,6 +21,7 @@ export enum EnumEventType {
   DemoRepoCreate = "CreateDemoRepo",
   InvitationAcceptance = "invitationAcceptance",
   GitSyncError = "gitSyncError",
+  CodeGenerationError = "codeGenerationError",
 }
 
 export type IdentifyData = {

--- a/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
+++ b/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
@@ -20,6 +20,7 @@ export enum EnumEventType {
   PluginUpdate = "updatePlugin",
   DemoRepoCreate = "CreateDemoRepo",
   InvitationAcceptance = "invitationAcceptance",
+  GitSyncError = "gitSyncError",
 }
 
 export type IdentifyData = {


### PR DESCRIPTION

Close: https://github.com/amplication/private-issues/issues/10

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aa42bce</samp>

### Summary
📈🐛🛠️

<!--
1.  📈 - This emoji represents the addition of analytics tracking for git sync and code generation errors, which can help monitor and improve the performance and reliability of these features.
2.  🐛 - This emoji represents the removal of unused import and code duplication in `build.controller`, which can help fix potential bugs and improve code quality and readability.
3.  🛠️ - This emoji represents the updates to the imports and the constructor of `build.service`, which can help ensure the proper dependencies and injection of the `SegmentAnalyticsService` and the `CodeGenerationLog` type.
-->
This pull request improves the error handling and logging of the build process, by adding analytics tracking for git sync and code generation errors, and refactoring some code to avoid duplication and unused imports. It affects the files `build.controller.ts`, `build.service.ts`, and `segmentAnalytics.service.ts`.

> _To track errors in git sync and code gen_
> _We added some events to `EnumEventType` then_
> _We used `SegmentAnalyticsService`_
> _And `CodeGenerationLog` with ease_
> _And refactored `build.controller` to clean up the pen_

### Walkthrough
*  Add `SegmentAnalyticsService` to `build.service` and use it to track analytics events for git sync and code generation errors ([link](https://github.com/amplication/amplication/pull/6434/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aR51-R54),[link](https://github.com/amplication/amplication/pull/6434/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aL195-R201),[link](https://github.com/amplication/amplication/pull/6434/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aL454-R513),[link](https://github.com/amplication/amplication/pull/6434/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aL437-R452),[link](https://github.com/amplication/amplication/pull/6434/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aL454-R513))
*  Remove unused import of `ACTION_LOG_LEVEL` from `build.controller` ([link](https://github.com/amplication/amplication/pull/6434/files?diff=unified&w=0#diff-d5c5677256d985fd177eb124cf83fff2f5a963d813363cfcbd21208d957233f7L11-R11))
*  Simplify `onDsgLog` method in `build.controller` to delegate to `onDsgLog` method in `build.service` ([link](https://github.com/amplication/amplication/pull/6434/files?diff=unified&w=0#diff-d5c5677256d985fd177eb124cf83fff2f5a963d813363cfcbd21208d957233f7L107-R107),[link](https://github.com/amplication/amplication/pull/6434/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aL454-R513))
*  Add import of `CodeGenerationLog` to `build.service` and use it to type the log message from the code generation process ([link](https://github.com/amplication/amplication/pull/6434/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aR43),[link](https://github.com/amplication/amplication/pull/6434/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aL454-R513))
*  Extend `EnumEventType` in `segmentAnalytics.service` to include new events for git sync and code generation errors ([link](https://github.com/amplication/amplication/pull/6434/files?diff=unified&w=0#diff-18685efac1e573e80e4297b774d6d17dae8ccbbcde9db01faa86aa7740526745R23-R24))




## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
