### PR TITLE
feat(server):keep analytics session for server side events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
         "nest-morgan": "^2.0.0",
         "nest-winston": "^1.7.0",
         "nestjs-paginate": "^4.13.0",
+        "nestjs-request-context": "^2.1.0",
         "node-fetch": "^2.6.7",
         "node-jose": "^2.2.0",
         "octokit": "^1.8.1",
@@ -43610,6 +43611,14 @@
         "express": "^4.18.2",
         "fastify": "^4.14.0",
         "typeorm": "^0.3.12"
+      }
+    },
+    "node_modules/nestjs-request-context": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nestjs-request-context/-/nestjs-request-context-2.1.0.tgz",
+      "integrity": "sha512-XSZ4CGjgVetyP0q6TSgu+urpUhS8hlY4UxDenPioqEhwpiLCjYFnWrp8NSJctn6NdON5d45LLKz/TN/5ZppL9w==",
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.5"
       }
     },
     "node_modules/new-github-issue-url": {
@@ -90408,6 +90417,12 @@
       "requires": {
         "lodash": "^4.17.21"
       }
+    },
+    "nestjs-request-context": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nestjs-request-context/-/nestjs-request-context-2.1.0.tgz",
+      "integrity": "sha512-XSZ4CGjgVetyP0q6TSgu+urpUhS8hlY4UxDenPioqEhwpiLCjYFnWrp8NSJctn6NdON5d45LLKz/TN/5ZppL9w==",
+      "requires": {}
     },
     "new-github-issue-url": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "nest-morgan": "^2.0.0",
     "nest-winston": "^1.7.0",
     "nestjs-paginate": "^4.13.0",
+    "nestjs-request-context": "^2.1.0",
     "node-fetch": "^2.6.7",
     "node-jose": "^2.2.0",
     "octokit": "^1.8.1",

--- a/packages/amplication-client/src/index.tsx
+++ b/packages/amplication-client/src/index.tsx
@@ -16,6 +16,10 @@ import "./index.scss";
 import App from "./App";
 import { REACT_APP_DATA_SOURCE, REACT_APP_PLUGIN_API_DATA_SOURCE } from "./env";
 import { QueryClient, QueryClientProvider } from "react-query";
+import {
+  getSessionId,
+  ANALYTICS_SESSION_ID_HEADER_KEY,
+} from "./util/analytics";
 
 const queryClient = new QueryClient();
 
@@ -41,6 +45,7 @@ const authLink = setContext((_, { headers }) => {
     headers: {
       ...headers,
       authorization: token ? `Bearer ${token}` : "",
+      [ANALYTICS_SESSION_ID_HEADER_KEY]: getSessionId(),
     },
   };
 });

--- a/packages/amplication-client/src/util/analytics.ts
+++ b/packages/amplication-client/src/util/analytics.ts
@@ -8,6 +8,9 @@ export interface Event {
   [key: string]: unknown;
 }
 
+const ANALYTICS_SESSION_ID_KEY = "analytics_session_id";
+export const ANALYTICS_SESSION_ID_HEADER_KEY = "analytics-session-id";
+
 const MISSING_EVENT_NAME = "MISSING_EVENT_NAME";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 //@ts-ignore
@@ -74,4 +77,8 @@ export function page(name?: string, props?: EventProps) {
     const analytics = window.analytics;
     analytics.page(name, props);
   }
+}
+
+export function getSessionId(): string | null {
+  return localStorage.getItem(ANALYTICS_SESSION_ID_KEY);
 }

--- a/packages/amplication-server/src/app.module.ts
+++ b/packages/amplication-server/src/app.module.ts
@@ -19,6 +19,8 @@ import { SERVICE_NAME } from "./constants";
 import { ApolloDriver, ApolloDriverConfig } from "@nestjs/apollo";
 import { Logger } from "@amplication/util/logging";
 import { TracingModule } from "@amplication/util/nestjs/tracing";
+import { AnalyticsSessionIdInterceptor } from "./interceptors/analytics-session-id.interceptor";
+import { RequestContextModule } from "nestjs-request-context";
 
 @Module({
   imports: [
@@ -59,12 +61,17 @@ import { TracingModule } from "@amplication/util/nestjs/tracing";
     }),
     HealthModule,
     CoreModule,
+    RequestContextModule,
   ],
   controllers: [],
   providers: [
     {
       provide: APP_INTERCEPTOR,
       useClass: InjectContextInterceptor,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: AnalyticsSessionIdInterceptor,
     },
   ],
 })

--- a/packages/amplication-server/src/interceptors/analytics-session-id.interceptor.ts
+++ b/packages/amplication-server/src/interceptors/analytics-session-id.interceptor.ts
@@ -1,0 +1,24 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from "@nestjs/common";
+import { GqlExecutionContext } from "@nestjs/graphql";
+
+export const INJECT_CONTEXT_VALUE = "injectContextValue";
+
+const ANALYTICS_SESSION_ID_HEADER_KEY = "analytics-session-id";
+
+@Injectable()
+export class AnalyticsSessionIdInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler) {
+    const graphqlContext = GqlExecutionContext.create(context);
+    const { req } = graphqlContext.getContext();
+
+    const analyticsSessionId = req.headers[ANALYTICS_SESSION_ID_HEADER_KEY];
+    req.analyticsSessionId = analyticsSessionId;
+
+    return next.handle();
+  }
+}

--- a/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
+++ b/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, Inject } from "@nestjs/common";
 import Analytics from "analytics-node";
 import { SegmentAnalyticsOptions } from "./segmentAnalytics.interfaces";
+import { RequestContext } from "nestjs-request-context";
+
+import { AuthUser } from "../../core/auth/auth.service";
 
 export enum EnumEventType {
   Signup = "Signup",
@@ -40,6 +43,9 @@ export type TrackData = {
     | undefined;
   context?: {
     traits?: IdentifyData;
+    amplication?: {
+      analyticsSessionId?: string;
+    };
   };
 };
 
@@ -69,12 +75,21 @@ export class SegmentAnalyticsService {
 
   public async track(data: TrackData): Promise<void> {
     if (!this.analytics) return;
+
+    const req = RequestContext.currentContext.req;
+    const analyticsSessionId = req.analyticsSessionId;
+
     this.analytics.track({
       ...data,
       properties: {
         ...data.properties,
         source: "amplication-server",
       },
-    });
+      context: {
+        amplication: {
+          analyticsSessionId: analyticsSessionId,
+        },
+      },
+    } as TrackData);
   }
 }

--- a/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
+++ b/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
@@ -3,8 +3,6 @@ import Analytics from "analytics-node";
 import { SegmentAnalyticsOptions } from "./segmentAnalytics.interfaces";
 import { RequestContext } from "nestjs-request-context";
 
-import { AuthUser } from "../../core/auth/auth.service";
-
 export enum EnumEventType {
   Signup = "Signup",
   WorkspacePlanUpgradeRequest = "WorkspacePlanUpgradeRequest",


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: https://github.com/amplication/private-issues/issues/16

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ea6377c</samp>

### Summary
📊🛠️🔗

<!--
1.  📊 - This emoji represents analytics, data, and charts, and can be used to indicate the addition of analytics functionality to the GraphQL client and the SegmentAnalyticsService.
2.  🛠️ - This emoji represents tools, construction, and fixing, and can be used to indicate the improvement of the analytics module and the creation of the custom interceptor and the request context module.
3.  🔗 - This emoji represents links, connections, and relationships, and can be used to indicate the extraction and setting of the analytics session id header and the use of the request object in the services and providers.
-->
This pull request adds and improves analytics functionality for the client and server packages. It uses the analytics session id header to track user events across requests and sessions, and integrates with the Segment analytics service. It also adds a new dependency on the `nestjs-request-context` package and creates a new interceptor for the analytics session id.

> _We track your every move with GraphQL_
> _We extract the session id from the header_
> _We send it to the Segment of doom_
> _We are the analytics interceptor_

### Walkthrough
*  Add a dependency on the nestjs-request-context package to access the request object in any NestJS service or provider ([link](https://github.com/amplication/amplication/pull/6435/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R124))
*  Import functions to get and set the analytics session id header for the GraphQL client ([link](https://github.com/amplication/amplication/pull/6435/files?diff=unified&w=0#diff-bbe88b0b875d8555a7f5d15f4ad1b5bc61587cec1f1d91bec1efee44bc35fb98R19-R22))
*  Attach the analytics session id header to the GraphQL requests using the authLink middleware ([link](https://github.com/amplication/amplication/pull/6435/files?diff=unified&w=0#diff-bbe88b0b875d8555a7f5d15f4ad1b5bc61587cec1f1d91bec1efee44bc35fb98R48))
*  Define constants for the analytics session id key for the local storage and the header ([link](https://github.com/amplication/amplication/pull/6435/files?diff=unified&w=0#diff-07750f951d970ece6646dc7b22c8344ca2ee26f8e5a7dc6c00e1f010b617f828R11-R13))
*  Add a function to get the analytics session id from the local storage or null ([link](https://github.com/amplication/amplication/pull/6435/files?diff=unified&w=0#diff-07750f951d970ece6646dc7b22c8344ca2ee26f8e5a7dc6c00e1f010b617f828R81-R84))
*  Import and register the AnalyticsSessionIdInterceptor and the RequestContextModule to intercept the GraphQL requests and set the analytics session id on the request object ([link](https://github.com/amplication/amplication/pull/6435/files?diff=unified&w=0#diff-4e72dc01e875c6474e7255d4778cb9acef369010c0ae3f813255eeee5fabcc24R22-R23), [link](https://github.com/amplication/amplication/pull/6435/files?diff=unified&w=0#diff-4e72dc01e875c6474e7255d4778cb9acef369010c0ae3f813255eeee5fabcc24R64), [link](https://github.com/amplication/amplication/pull/6435/files?diff=unified&w=0#diff-4e72dc01e875c6474e7255d4778cb9acef369010c0ae3f813255eeee5fabcc24R72-R75))
*  Implement the AnalyticsSessionIdInterceptor in `analytics-session-id.interceptor.ts` to extract the analytics session id from the request headers and set it on the request object ([link](https://github.com/amplication/amplication/pull/6435/files?diff=unified&w=0#diff-7583a094a4c148544c9848fff662f8ec8cecb3601211c16774924a09e38da7f6R1-R24))
*  Import the RequestContext and the AuthUser types to access the request object and the authenticated user in the SegmentAnalyticsService ([link](https://github.com/amplication/amplication/pull/6435/files?diff=unified&w=0#diff-18685efac1e573e80e4297b774d6d17dae8ccbbcde9db01faa86aa7740526745L4-R7))
*  Add a new property to the TrackData interface to include the analytics session id in the data sent to the Segment analytics service ([link](https://github.com/amplication/amplication/pull/6435/files?diff=unified&w=0#diff-18685efac1e573e80e4297b774d6d17dae8ccbbcde9db01faa86aa7740526745R46-R48))
*  Get the current request object and the analytics session id from it in the SegmentAnalyticsService ([link](https://github.com/amplication/amplication/pull/6435/files?diff=unified&w=0#diff-18685efac1e573e80e4297b774d6d17dae8ccbbcde9db01faa86aa7740526745R78-R81))
*  Add the analytics session id to the context property of the data sent to the Segment analytics service using the amplication namespace ([link](https://github.com/amplication/amplication/pull/6435/files?diff=unified&w=0#diff-18685efac1e573e80e4297b774d6d17dae8ccbbcde9db01faa86aa7740526745L78-R93))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
