### PR TITLE
feat(git) add support for repositories actions in aws codecommit provider

### DIFF
--- a/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
@@ -3,11 +3,9 @@ import {
   CreateBranchArgs,
   CreatePullRequestCommentArgs,
   CreatePullRequestFromFilesArgs,
-  CreateRepositoryArgs,
   EnumGitOrganizationType,
   GetBranchArgs,
   GetFileArgs,
-  GetRepositoriesArgs,
   GitProviderCreatePullRequestArgs,
   GitProviderGetPullRequestArgs,
 } from "../../types";
@@ -20,6 +18,8 @@ import {
   ListRepositoriesCommand,
 } from "@aws-sdk/client-codecommit";
 import { mockClient } from "aws-sdk-client-mock";
+
+const awsClientMock = mockClient(CodeCommitClient);
 
 describe("AwsCodeCommit", () => {
   let gitProvider: AwsCodeCommitService;
@@ -39,6 +39,8 @@ describe("AwsCodeCommit", () => {
       },
       MockedLogger
     );
+
+    awsClientMock.reset();
   });
 
   it("should throw an error when calling init()", async () => {
@@ -78,7 +80,6 @@ describe("AwsCodeCommit", () => {
   });
 
   describe("getRepository", () => {
-    const awsClientMock = mockClient(CodeCommitClient);
     let getRepositoryArgs;
 
     beforeEach(() => {
@@ -97,9 +98,10 @@ describe("AwsCodeCommit", () => {
         repositoryName: "example-repo",
         cloneUrlHttp: "https://github.com/example/example-repo.git",
       };
+
       awsClientMock
         .on(GetRepositoryCommand, {
-          repositoryName: "example-repo",
+          repositoryName: getRepositoryArgs.repositoryName,
         })
         .resolves({
           repositoryMetadata,
@@ -124,7 +126,7 @@ describe("AwsCodeCommit", () => {
       const repositoryMetadata = {};
       awsClientMock
         .on(GetRepositoryCommand, {
-          repositoryName: "example-repo",
+          repositoryName: getRepositoryArgs.repositoryName,
         })
         .resolves({
           repositoryMetadata,
@@ -137,7 +139,6 @@ describe("AwsCodeCommit", () => {
   });
 
   describe("getRepositories", () => {
-    const awsClientMock = mockClient(CodeCommitClient);
     let getRepositoriesArgs;
 
     beforeEach(() => {
@@ -273,7 +274,6 @@ describe("AwsCodeCommit", () => {
   });
 
   describe("createRepository", () => {
-    const awsClientMock = mockClient(CodeCommitClient);
     let createRepositoryArgs;
 
     beforeEach(() => {

--- a/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
@@ -4,6 +4,7 @@ import {
   CreatePullRequestCommentArgs,
   CreatePullRequestFromFilesArgs,
   CreateRepositoryArgs,
+  EnumGitOrganizationType,
   GetBranchArgs,
   GetFileArgs,
   GetRepositoriesArgs,
@@ -336,10 +337,16 @@ describe("AwsCodeCommit", () => {
     );
   });
 
-  it("should throw an error when calling getOrganization()", async () => {
-    await expect(gitProvider.getOrganization()).rejects.toThrowError(
-      "Method not implemented."
-    );
+  describe("getOrganization", () => {
+    it("should return an hardcoded aws codecommit organisation", async () => {
+      const result = await gitProvider.getOrganization();
+
+      expect(result).toEqual({
+        name: "AWS CodeCommit",
+        type: EnumGitOrganizationType.User,
+        useGroupingForRepositories: false,
+      });
+    });
   });
 
   it("should throw an error when calling getFile()", async () => {

--- a/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
@@ -331,10 +331,9 @@ describe("AwsCodeCommit", () => {
     });
   });
 
-  it("should throw an error when calling deleteGitOrganization()", async () => {
-    await expect(gitProvider.deleteGitOrganization()).rejects.toThrowError(
-      "Method not implemented."
-    );
+  it("should return always true when calling deleteGitOrganization() since there is nothing to uninstall/delete when an organisation is deleted in AWS CodeCommit.", async () => {
+    const result = await gitProvider.deleteGitOrganization();
+    expect(result).toBe(true);
   });
 
   describe("getOrganization", () => {

--- a/libs/util/git/src/providers/aws/aws-code-commit.service.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.ts
@@ -27,6 +27,7 @@ import {
   AwsCodeCommitProviderOrganizationProperties,
 } from "../../types";
 import { CodeCommitClient } from "@aws-sdk/client-codecommit";
+import { NotImplementedError } from "../../utils/custom-error";
 
 export class AwsCodeCommitService implements GitProvider {
   public readonly name = EnumGitProvider.AwsCodeCommit;
@@ -61,80 +62,80 @@ export class AwsCodeCommitService implements GitProvider {
   }
 
   async init(): Promise<void> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async getGitInstallationUrl(amplicationWorkspaceId: string): Promise<string> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async getCurrentOAuthUser(accessToken: string): Promise<CurrentUser> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async getOAuthTokens(authorizationCode: string): Promise<OAuthTokens> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async refreshAccessToken(): Promise<OAuthTokens> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async getGitGroups(): Promise<PaginatedGitGroup> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async getRepository(
     getRepositoryArgs: GetRepositoryArgs
   ): Promise<RemoteGitRepository> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async getRepositories(
     getRepositoriesArgs: GetRepositoriesArgs
   ): Promise<RemoteGitRepos> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async createRepository(
     createRepositoryArgs: CreateRepositoryArgs
   ): Promise<RemoteGitRepository | null> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async deleteGitOrganization(): Promise<boolean> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async getOrganization(): Promise<RemoteGitOrganization> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async getFile(file: GetFileArgs): Promise<GitFile | null> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async createPullRequestFromFiles(
     createPullRequestFromFilesArgs: CreatePullRequestFromFilesArgs
   ): Promise<string> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async getPullRequest(
     getPullRequestArgs: GitProviderGetPullRequestArgs
   ): Promise<PullRequest | null> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async createPullRequest(
     createPullRequestArgs: GitProviderCreatePullRequestArgs
   ): Promise<PullRequest> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async getBranch(args: GetBranchArgs): Promise<Branch | null> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async createBranch(args: CreateBranchArgs): Promise<Branch> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async getFirstCommitOnBranch(args: GetBranchArgs): Promise<Commit | null> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async getCloneUrl(args: CloneUrlArgs): Promise<string> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async createPullRequestComment(
     args: CreatePullRequestCommentArgs
   ): Promise<void> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
   async getAmplicationBotIdentity(): Promise<Bot | null> {
-    throw new Error("Method not implemented.");
+    throw NotImplementedError;
   }
 }

--- a/libs/util/git/src/providers/aws/aws-code-commit.service.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.ts
@@ -199,7 +199,8 @@ export class AwsCodeCommitService implements GitProvider {
   }
 
   async deleteGitOrganization(): Promise<boolean> {
-    throw NotImplementedError;
+    // There is nothing to uninstall/delete when an organisation is deleted in AWS CodeCommit.
+    return true;
   }
 
   async getOrganization(): Promise<RemoteGitOrganization> {

--- a/libs/util/git/src/providers/aws/aws-code-commit.service.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.ts
@@ -25,6 +25,7 @@ import {
   CreatePullRequestCommentArgs,
   Bot,
   AwsCodeCommitProviderOrganizationProperties,
+  EnumGitOrganizationType,
 } from "../../types";
 import {
   BatchGetRepositoriesCommand,
@@ -200,9 +201,15 @@ export class AwsCodeCommitService implements GitProvider {
   async deleteGitOrganization(): Promise<boolean> {
     throw NotImplementedError;
   }
+
   async getOrganization(): Promise<RemoteGitOrganization> {
-    throw NotImplementedError;
+    return {
+      name: "AWS CodeCommit",
+      type: EnumGitOrganizationType.User,
+      useGroupingForRepositories: false,
+    };
   }
+
   async getFile(file: GetFileArgs): Promise<GitFile | null> {
     throw NotImplementedError;
   }

--- a/libs/util/git/src/utils/custom-error.ts
+++ b/libs/util/git/src/utils/custom-error.ts
@@ -1,5 +1,5 @@
 const DEFAULT_CUSTOM_ERROR = "Custom Error";
-const NOT_IMPLEMENTED_ERROR = "Not Implemented";
+const NOT_IMPLEMENTED_ERROR = "Method not implemented.";
 
 export class CustomError extends Error {
   constructor(message: string, private options: Record<string, unknown> = {}) {

--- a/package.json
+++ b/package.json
@@ -259,6 +259,7 @@
     "@types/yargs": "^17.0.24",
     "@typescript-eslint/eslint-plugin": "^5.60.1",
     "@typescript-eslint/parser": "^5.39.0",
+    "aws-sdk-client-mock": "^3.0.0",
     "babel-jest": "^28.1.0",
     "base-64": "^1.0.0",
     "copy-webpack-plugin": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "dependencies": {
-    "@amplication/opentelemetry-nestjs": "^4.2.0",
+    "@amplication/opentelemetry-nestjs": "^4.2.1",
     "@amplication/react-compound-timer": "^2.1.0",
     "@amplication/react-diff-viewer-continued": "^3.4.3",
     "@apollo/client": "^3.7.1",


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6351 

## PR Details

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ceba0bc</samp>

### Summary
🔄🧪✨

<!--
1.  🔄 for changing the constant value to match the standard error message.
2.  🧪 for adding a new dependency for testing and updating the unit tests.
3.  ✨ for implementing some methods of the service class and adding new functionality.
-->
This pull request adds functionality and tests for working with AWS CodeCommit repositories and organizations in the `AwsCodeCommitService` class, and updates the `NOT_IMPLEMENTED_ERROR` message to match TypeScript conventions. It also adds the `aws-sdk-client-mock` dependency for testing.

> _We mock the CodeCommitClient with our skill_
> _We test the AwsCodeCommitService with our will_
> _We implement the methods of doom_
> _We face the `NOT_IMPLEMENTED_ERROR` of gloom_

### Walkthrough
* Implement the `getRepository`, `getRepositories`, `createRepository`, `deleteGitOrganization`, and `getOrganization` methods of the `AwsCodeCommitService` class using the `CodeCommitClient` commands and the `isRequiredValid` helper method ([link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aL63-R250), [link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L16-R23), [link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L6-R8))
  * Import the `CodeCommitClient` and its commands from `@aws-sdk/client-codecommit` in `aws-code-commit.service.ts` and `aws-code-commit.service.spec.ts` ([link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aL28-R37), [link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L16-R23))
  * Return the expected types of `RemoteGitRepository`, `RemoteGitRepos`, `RemoteGitOrganization`, or `boolean`, or throw errors if the repository metadata is not valid or the method is not implemented ([link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aL63-R250))
  * Use the `EnumGitOrganizationType` type from `../../types` to represent the AWS account ID as the organization type in `getOrganization` ([link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L6-R8))
  * Throw a `NotImplementedError` from `../../utils/custom-error` in `deleteGitOrganization` ([link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aL63-R250), [link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aL28-R37))
* Add multiple test cases for each method of the `AwsCodeCommitService` class using the `awsClientMock` to mock the responses of the `CodeCommitClient` commands and assert the expected results or errors ([link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L73-R348))
  * Import the `mockClient` function from `aws-sdk-client-mock` in `aws-code-commit.service.spec.ts` and create a mock instance of the `CodeCommitClient` ([link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L16-R23))
  * Reset the mock client after each test case using the `afterEach` hook ([link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486R42-R43))
  * Use the `isRequiredValid` helper method to check the validity of the repository metadata objects returned by the commands ([link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L73-R348))
* Change the `NOT_IMPLEMENTED_ERROR` constant to "Method not implemented." in `custom-error.ts` to match the standard error message for unimplemented methods in TypeScript ([link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-a7393bc8827ef57ee19c3c93e1ca04fee4453699d8a245f7e7e79def02358960L2-R2))
* Add the `aws-sdk-client-mock` dependency to the `package.json` file to enable mocking the `CodeCommitClient` for testing purposes ([link](https://github.com/amplication/amplication/pull/6447/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R262))



## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
