### PR TITLE
feat(kafka): increase maxBytesPerPartition value to 10MB

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,6 +52,7 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_MESSAGE_MAX_BYTES: 10485760
       JMX_PORT: 9997
       KAFKA_JMX_OPTS: -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=kafka -Dcom.sun.management.jmxremote.rmi.port=9997
     healthcheck:

--- a/libs/util/kafka/src/lib/kafkaEnv.ts
+++ b/libs/util/kafka/src/lib/kafkaEnv.ts
@@ -68,4 +68,8 @@ export class KafkaEnvironmentVariables {
     const rebalanceTimeout = this.getConsumerSessionTimeout();
     return rebalanceTimeout * 2;
   }
+
+  getConsumerMaxBytesPerPartition(): number {
+    return 10485760;
+  }
 }

--- a/libs/util/nestjs/kafka/src/createNestjsKafkaConfig.ts
+++ b/libs/util/nestjs/kafka/src/createNestjsKafkaConfig.ts
@@ -15,6 +15,7 @@ export function createNestjsKafkaConfig(envSuffix = ""): KafkaOptions {
       sessionTimeout: kafkaEnv.getConsumerSessionTimeout(),
       rebalanceTimeout: kafkaEnv.getConsumerRebalanceTimeout(),
       heartbeatInterval: kafkaEnv.getConsumerHeartbeat(),
+      maxBytesPerPartition: kafkaEnv.getConsumerMaxBytesPerPartition(),
     };
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6446 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at da5c9e7</samp>

### Summary
🆕🗄️🐦

<!--
1.  🆕 - This emoji can be used to indicate that something new was added, such as a method or a property.
2.  🗄️ - This emoji can be used to indicate that something related to data or storage was modified, such as the maximum number of bytes a consumer can fetch from a partition.
3.  🐦 - This emoji can be used to indicate that something related to NestJS or Kafka was changed, since both of them use a bird as their logo. Alternatively, one could use 🐧 for Kafka, since it is based on the Linux mascot.
-->
Added a new configuration option for the NestJS Kafka consumer module to limit the maximum bytes per partition. Used a constant value from the `KafkaEnv` class in `libs/util/kafka/src/lib/kafkaEnv.ts` to set the default value for the option in `libs/util/nestjs/kafka/src/createNestjsKafkaConfig.ts`.

> _`KafkaEnv` knows_
> _consumer max bytes per_
> _partition: a constant_

### Walkthrough
*  Add `maxBytesPerPartition` property to `KafkaConfig` interface to configure the maximum number of bytes a consumer can fetch from a single partition ([link](https://github.com/amplication/amplication/pull/6448/files?diff=unified&w=0#diff-5961ee4f29a8b06f8ee6199c8b107272d33d1359a81297484b530f4d4f6f9ae6R18))
*  Implement `getConsumerMaxBytesPerPartition` method in `KafkaEnv` class to return the default value of 10485760 bytes ([link](https://github.com/amplication/amplication/pull/6448/files?diff=unified&w=0#diff-2e076e55bb11bb27f9304ad7436e9012a313a438914772b2a42e64da56e00770R71-R74))
*  Use `getConsumerMaxBytesPerPartition` method to set the `maxBytesPerPartition` property in `createNestjsKafkaConfig` function in `createNestjsKafkaConfig.ts` ([link](https://github.com/amplication/amplication/pull/6448/files?diff=unified&w=0#diff-5961ee4f29a8b06f8ee6199c8b107272d33d1359a81297484b530f4d4f6f9ae6R18))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
