### PR TITLE
feat(git): add support for get file in aws codecommit provider

### DIFF
--- a/libs/util/git/src/git-client.service.ts
+++ b/libs/util/git/src/git-client.service.ts
@@ -497,8 +497,8 @@ export class GitClientService {
         if (!file) {
           return "";
         }
-        const { content, htmlUrl, name } = file;
-        this.logger.info(`Got ${name} file ${htmlUrl}`);
+        const { content, path, name } = file;
+        this.logger.info(`Got ${name} file ${path}`);
         return content;
       } catch (error) {
         this.logger.warn(

--- a/libs/util/git/src/providers/bitbucket/bitbucket.service.spec.ts
+++ b/libs/util/git/src/providers/bitbucket/bitbucket.service.spec.ts
@@ -147,7 +147,6 @@ describe("bitbucket.service", () => {
         content: await (
           await spyOnGetFileRequest.mock.results[0].value
         ).toString("utf-8"),
-        htmlUrl: mockedGetFileResponse.commit.links.html.href,
         name: parse(mockedGetFileResponse.path).name,
         path: mockedGetFileResponse.path,
       };

--- a/libs/util/git/src/providers/bitbucket/bitbucket.service.ts
+++ b/libs/util/git/src/providers/bitbucket/bitbucket.service.ts
@@ -351,7 +351,6 @@ export class BitBucketService implements GitProvider {
 
     return {
       content: fileBufferResponse.toString("utf-8"),
-      htmlUrl: gitFileResponse.commit.links.html.href,
       name: parse(gitFileResponse.path).name,
       path: gitFileResponse.path,
     };

--- a/libs/util/git/src/providers/github/github.service.ts
+++ b/libs/util/git/src/providers/github/github.service.ts
@@ -335,7 +335,6 @@ export class GithubService implements GitProvider {
 
         const file: GitFile = {
           content: buff.toString("utf-8"),
-          htmlUrl: item.html_url,
           name: item.name,
           path: item.path,
         };

--- a/libs/util/git/src/types.ts
+++ b/libs/util/git/src/types.ts
@@ -173,7 +173,6 @@ export interface GitFile {
   name: string | null;
   path: string | null;
   content: string;
-  htmlUrl: string | null;
 }
 
 export interface GitResourceMeta {

--- a/libs/util/git/tests/providers/git.constants.ts
+++ b/libs/util/git/tests/providers/git.constants.ts
@@ -14,7 +14,6 @@ export const GIT_HUB_FILE: GitFile = {
   name: "exampleGithubFileName",
   path: "examplePath",
   content: "exampleContent",
-  htmlUrl: "exampleHtmlUrl",
 };
 
 export const TEST_GIT_REMOTE_ORGANIZATION: RemoteGitOrganization = {


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6351 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9084c34</samp>

### Summary
🚚🧪🆕

<!--
1.  🚚 - This emoji represents the removal of the `htmlUrl` property from the `GitFile` interface and the related changes in the service classes and the test files. It conveys the idea of moving or deleting something that is not needed anymore.
2.  🧪 - This emoji represents the addition of tests for the `getFile` method of the `AwsCodeCommitService` class. It conveys the idea of testing or experimenting with something new or improved.
3.  🆕 - This emoji represents the addition of the `getFile` method to the `AwsCodeCommitService` class and the dummy `uninstall` method. It conveys the idea of creating or introducing something new or updated.
-->
Added a new method to fetch files from AWS CodeCommit repositories and simplified the `GitFile` interface by removing the unused `htmlUrl` property. Updated the existing git providers and tests to reflect the interface change.

> _We don't need the `htmlUrl` to unleash our code_
> _We simplify the `GitFile` interface and lighten our load_
> _We use the `path` property to access the files we need_
> _We support AWS CodeCommit and make our service complete_

### Walkthrough
*  Remove `htmlUrl` property from `GitFile` interface and update all git providers to omit it from the returned file objects ([link](https://github.com/amplication/amplication/pull/6449/files?diff=unified&w=0#diff-32aa29da64da9b56bdccbd8c64390608dd92173a29efa2ccdd76128047fe4eb0L176), [link](https://github.com/amplication/amplication/pull/6449/files?diff=unified&w=0#diff-6a4ff7a4b369c728d4774674867790601df7f5b0bced14ab8026f83e90082e5eL150), [link](https://github.com/amplication/amplication/pull/6449/files?diff=unified&w=0#diff-56ef914963af52878160ed7c5190fba1204419b6c2b525819d6846f6b0824f5aL354), [link](https://github.com/amplication/amplication/pull/6449/files?diff=unified&w=0#diff-7825d1b6180f809d60624f1acd8e9ee0f7acfcab132ec45ce7480e4252b1120bL338), [link](https://github.com/amplication/amplication/pull/6449/files?diff=unified&w=0#diff-e07021f3dce5ca6754ed905528113320b7f43e5e391e693b2b531aa480ae20c5L17), [link](https://github.com/amplication/amplication/pull/6449/files?diff=unified&w=0#diff-7030ed1d7460a9345852066fcdbb545162d9aa94cf278b82f9d0e5eebe1a9600L513-R514))
* Implement `getFile` method for `AwsCodeCommitService` class using `GetFileCommand` and `parse` function, and add dummy implementation for `uninstall` method ([link](https://github.com/amplication/amplication/pull/6449/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aL34-R39), [link](https://github.com/amplication/amplication/pull/6449/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aR200-R202), [link](https://github.com/amplication/amplication/pull/6449/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aL211-R236))
* Add `describe` block for testing `getFile` method of `AwsCodeCommitService` class using `awsClientMock` and `getFileArgs` variables ([link](https://github.com/amplication/amplication/pull/6449/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486R17), [link](https://github.com/amplication/amplication/pull/6449/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L347-R412))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
