### PR TITLE
feat(git): add support for getCloneUrl in aws codecommit provider

### DIFF
--- a/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
@@ -430,7 +430,7 @@ describe("AwsCodeCommit", () => {
       ${"username"}   | ${"password"}    | ${"https://username:password@example.com/repo.git"}
       ${"user/name?"} | ${"/:pass?word"} | ${"https://user%2Fname%3F:%2F%3Apass%3Fword@example.com/repo.git"}
     `(
-      "should return the authenticated clone URL when repository exists",
+      "should return the authenticated clone URL when repository exists for username '$username' and password '$password'",
       async ({ username, password, expectedCloneUrl }) => {
         awsClientMock
           .on(GetRepositoryCommand, {

--- a/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
@@ -1,5 +1,4 @@
 import {
-  CloneUrlArgs,
   CreateBranchArgs,
   CreatePullRequestCommentArgs,
   CreatePullRequestFromFilesArgs,
@@ -411,13 +410,70 @@ describe("AwsCodeCommit", () => {
     );
   });
 
-  it("should throw an error when calling getCloneUrl()", async () => {
-    const args = <CloneUrlArgs>{
-      /* provide appropriate arguments */
-    };
-    await expect(gitProvider.getCloneUrl(args)).rejects.toThrowError(
-      "Method not implemented."
+  describe("getCloneUrl", () => {
+    let getCloneUrlArgs;
+
+    beforeEach(() => {
+      getCloneUrlArgs = {
+        repositoryName: "example-repo",
+      };
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it.each`
+      username        | password         | expectedCloneUrl
+      ${null}         | ${null}          | ${"https://example.com/repo.git"}
+      ${""}           | ${""}            | ${"https://example.com/repo.git"}
+      ${"username"}   | ${"password"}    | ${"https://username:password@example.com/repo.git"}
+      ${"user/name?"} | ${"/:pass?word"} | ${"https://user%2Fname%3F:%2F%3Apass%3Fword@example.com/repo.git"}
+    `(
+      "should return the authenticated clone URL when repository exists",
+      async ({ username, password, expectedCloneUrl }) => {
+        awsClientMock
+          .on(GetRepositoryCommand, {
+            repositoryName: getCloneUrlArgs.repositoryName,
+          })
+          .resolves({
+            repositoryMetadata: {
+              cloneUrlHttp: "https://example.com/repo.git",
+            },
+          });
+
+        gitProvider = new AwsCodeCommitService(
+          {
+            gitCredentials: {
+              username,
+              password,
+            },
+            sdkCredentials: {
+              accessKeyId: "accessKeyId",
+              accessKeySecret: "accessKeySecret",
+              region: "region",
+            },
+          },
+          MockedLogger
+        );
+
+        const result = await gitProvider.getCloneUrl(getCloneUrlArgs);
+
+        expect(result).toBe(expectedCloneUrl);
+      }
     );
+
+    it("should throw an error when repository does not exist", async () => {
+      awsClientMock
+        .on(GetRepositoryCommand, {
+          repositoryName: getCloneUrlArgs.repositoryName,
+        })
+        .resolves({});
+
+      await expect(gitProvider.getCloneUrl(getCloneUrlArgs)).rejects.toThrow(
+        `Repository ${getCloneUrlArgs.repositoryName} not found`
+      );
+    });
   });
 
   it("should throw an error when calling createPullRequestComment()", async () => {


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6351 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ba33b7c</samp>

### Summary
🧪🛠️🔥

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the refactoring and expansion of the test suite for the `getCloneUrl` method.
2.  🛠️ - This emoji represents tools, construction, or repair, and can be used to indicate the implementation of the `getCloneUrl` method for the AWS CodeCommit provider, which is a core functionality of the service.
3.  🔥 - This emoji represents fire, burning, or deletion, and can be used to indicate the removal of unused imports from the service and test files, which is a minor cleanup task.
-->
Added support for AWS CodeCommit as a git provider, by creating a service class and a test suite for fetching repository clone URLs. Refactored some imports and types in the `libs/util/git` module.

> _We mock the client of the cloud_
> _We test the clone URL with blood_
> _We fetch the repo with our code_
> _We purge the import of the old_

### Walkthrough
* Implement `getCloneUrl` method in `aws-code-commit.service.ts` to fetch repository metadata and return clone URL with encoded credentials ([link](https://github.com/amplication/amplication/pull/6450/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aL241-R267))
* Remove unused import of `BatchGetRepositoriesCommand` from `aws-code-commit.service.ts` ([link](https://github.com/amplication/amplication/pull/6450/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aL31))
* Replace single test case for `getCloneUrl` method in `aws-code-commit.service.spec.ts` with multiple test cases using mock AWS client and different credential combinations ([link](https://github.com/amplication/amplication/pull/6450/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L414-R476))
* Remove unused import of `CloneUrlArgs` from `aws-code-commit.service.spec.ts` ([link](https://github.com/amplication/amplication/pull/6450/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L2))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
