### PR TITLE
fix(git): branch recreation failing due to empty commits and missing relevant old commits

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -20,6 +20,10 @@ module.exports = {
     "!**/index.ts",
     "!**/*.mock.ts",
     "!**/*.module.ts",
+    "!**/*.interface.ts",
+    "!**/*.enum.ts",
+    "!**/*.constants.ts",
+    "!**/(*.|^)types.ts",
   ],
   coverageThreshold: {
     global: {

--- a/libs/util/git/jest.config.ts
+++ b/libs/util/git/jest.config.ts
@@ -15,8 +15,8 @@ export default {
   coverageDirectory: "../../../coverage/libs/util/git",
   coverageThreshold: {
     global: {
-      branches: 80,
-      lines: 40,
+      branches: 81,
+      lines: 43,
     },
   },
 };

--- a/libs/util/git/src/git-client.service.spec.ts
+++ b/libs/util/git/src/git-client.service.spec.ts
@@ -3,6 +3,8 @@ import { ILogger } from "@amplication/util/logging";
 import { GitCli } from "./providers/git-cli";
 import { GitFactory } from "./git-factory";
 import { GitProvider } from "./git-provider.interface";
+import { Bot, EnumGitProvider } from "./types";
+import { GitError } from "simple-git";
 
 jest.mock("./providers/git-cli");
 jest.mock("simple-git");
@@ -18,7 +20,12 @@ const logger: ILogger = {
   }),
 };
 
-const amplicationBotOrIntegrationApp = { id: "2", login: "amplication[bot]" };
+const amplicationBotOrIntegrationApp: Bot = {
+  id: "2",
+  login: "amplication[bot]",
+  gitAuthor: "amplication[bot] <abot@email.local>",
+};
+
 const amplicationGitUser = {
   name: "amplication[bot]",
   email: "bot@amplication.com",
@@ -27,41 +34,88 @@ const amplicationGitUserAuthor = `${amplicationGitUser.name} <${amplicationGitUs
 
 describe("GitClientService", () => {
   let service: GitClientService;
-  const mockedGitLog = jest.fn();
-  const mockedGitDiff = jest.fn();
+  const gitDiffMock = jest.fn();
+  const gitLogMock = jest.fn();
+  const cherryPickMock = jest.fn();
+  const cherryPickAbortMock = jest.fn();
 
-  const mockedGitCli: GitCli = {
+  const gitCliMock: GitCli = {
     gitAuthorUser: amplicationGitUserAuthor,
-    log: mockedGitLog,
+    log: gitLogMock,
     checkout: jest.fn(),
     reset: jest.fn(),
     push: jest.fn(),
     resetState: jest.fn(),
-    diff: mockedGitDiff,
+    diff: gitDiffMock,
+    cherryPick: cherryPickMock,
+    cherryPickAbort: cherryPickAbortMock,
   } as unknown as GitCli;
 
-  const mockedAmplicationBotIdentity = jest
-    .fn()
-    .mockResolvedValue(amplicationBotOrIntegrationApp);
+  const amplicationBotIdentityMock = jest.fn();
+  const initMock = jest.fn();
+  const getGitInstallationUrlMock = jest.fn();
+  const getCurrentOAuthUserMock = jest.fn();
+  const getOAuthTokensMock = jest.fn();
+  const refreshAccessTokenMock = jest.fn();
+  const getGitGroupsMock = jest.fn();
+  const getRepositoryMock = jest.fn();
+  const getRepositoriesMock = jest.fn();
+  const createRepositoryMock = jest.fn();
+  const deleteGitOrganizationMock = jest.fn();
+  const getOrganizationMock = jest.fn();
+  const getFileMock = jest.fn();
+  const createPullRequestFromFilesMock = jest.fn();
+  const getPullRequestMock = jest.fn();
+  const createPullRequestMock = jest.fn();
+  const getBranchMock = jest.fn();
+  const createBranchMock = jest.fn();
+  const getFirstCommitOnBranchMock = jest.fn();
+  const getCloneUrlMock = jest.fn();
+  const createPullRequestCommentMock = jest.fn();
+  const gitProviderMock: GitProvider = {
+    getAmplicationBotIdentity: amplicationBotIdentityMock,
+    init: initMock,
+    getGitInstallationUrl: getGitInstallationUrlMock,
+    getCurrentOAuthUser: getCurrentOAuthUserMock,
+    getOAuthTokens: getOAuthTokensMock,
+    refreshAccessToken: refreshAccessTokenMock,
+    getGitGroups: getGitGroupsMock,
+    getRepository: getRepositoryMock,
+    getRepositories: getRepositoriesMock,
+    createRepository: createRepositoryMock,
+    deleteGitOrganization: deleteGitOrganizationMock,
+    getOrganization: getOrganizationMock,
+    getFile: getFileMock,
+    createPullRequestFromFiles: createPullRequestFromFilesMock,
+    getPullRequest: getPullRequestMock,
+    createPullRequest: createPullRequestMock,
+    getBranch: getBranchMock,
+    createBranch: createBranchMock,
+    getFirstCommitOnBranch: getFirstCommitOnBranchMock,
+    getCloneUrl: getCloneUrlMock,
+    createPullRequestComment: createPullRequestCommentMock,
+    name: EnumGitProvider.Github,
+    domain: "",
+  };
 
   beforeEach(() => {
-    const mockedProvider: GitProvider = {
-      getAmplicationBotIdentity: mockedAmplicationBotIdentity,
-    } as unknown as GitProvider;
-
-    jest.spyOn(GitFactory, "getProvider").mockResolvedValue(mockedProvider);
-
+    jest.spyOn(GitFactory, "getProvider").mockResolvedValue(gitProviderMock);
     service = new GitClientService();
+
+    amplicationBotIdentityMock.mockResolvedValue(
+      amplicationBotOrIntegrationApp
+    );
 
     service.create(null, null, logger);
   });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   describe("when there are no commits from amplication <bot@amplication.com> and there are commits for amplication[bot] (or amplication provider integration)", () => {
     beforeEach(() => {
-      mockedGitLog.mockImplementation((author, maxCount) => {
+      gitLogMock.mockImplementation((author, maxCount) => {
         if (author === amplicationGitUserAuthor)
           return {
             all: [],
@@ -94,21 +148,21 @@ describe("GitClientService", () => {
     it("should return the diff of the latest commit of amplication[bot] (or amplication provider integration)", async () => {
       await service.preCommitProcess({
         branchName: "amplication",
-        gitCli: mockedGitCli,
+        gitCli: gitCliMock,
       });
 
-      expect(mockedGitLog).toBeCalledTimes(2);
-      expect(mockedGitDiff).toBeCalledWith("sghfsjfdsfd34234");
+      expect(gitLogMock).toBeCalledTimes(2);
+      expect(gitDiffMock).toBeCalledWith("sghfsjfdsfd34234");
     });
   });
 
   describe("when there is not amplication[bot] (or amplication provider integration)", () => {
     beforeEach(() => {
-      mockedAmplicationBotIdentity.mockResolvedValue(null);
+      amplicationBotIdentityMock.mockResolvedValue(null);
     });
 
     it("should return the diff of the latest commit of amplication <bot@amplication.com>", async () => {
-      mockedGitLog.mockResolvedValue({
+      gitLogMock.mockResolvedValue({
         all: [
           {
             hash: "sghfsjfdsfd34234",
@@ -131,22 +185,184 @@ describe("GitClientService", () => {
 
       await service.preCommitProcess({
         branchName: "amplication",
-        gitCli: mockedGitCli,
+        gitCli: gitCliMock,
       });
 
-      expect(mockedGitLog).toBeCalledTimes(1);
-      expect(mockedGitDiff).toBeCalledWith("sghfsjfdsfd34234");
+      expect(gitLogMock).toBeCalledTimes(1);
+      expect(gitDiffMock).toBeCalledWith("sghfsjfdsfd34234");
     });
 
     it("should not call the gitlog for author amplication[bot] (or amplication provider integration)", async () => {
       await service.preCommitProcess({
         branchName: "amplication",
-        gitCli: mockedGitCli,
+        gitCli: gitCliMock,
       });
 
-      expect(mockedGitLog).toHaveBeenCalledTimes(1);
+      expect(gitLogMock).toHaveBeenCalledTimes(1);
 
-      expect(mockedGitLog).toBeCalledWith(amplicationGitUserAuthor, 1);
+      expect(gitLogMock).toBeCalledWith(amplicationGitUserAuthor, 1);
+    });
+  });
+
+  describe("restoreAmplicationBranchIfNotExists", () => {
+    beforeEach(() => {
+      amplicationBotIdentityMock.mockResolvedValue(
+        amplicationBotOrIntegrationApp
+      );
+    });
+
+    describe("when the new branch does not exists", () => {
+      it("should create a new branch from the first commit with all the amplication authored commits from the default branch", async () => {
+        // Arrange
+        const args = {
+          branchName: "new-branch",
+          owner: "owner",
+          repositoryName: "repository",
+          gitCli: gitCliMock,
+          repositoryGroupName: "group",
+          defaultBranch: "default",
+        };
+        getBranchMock.mockResolvedValueOnce(null);
+
+        getFirstCommitOnBranchMock.mockResolvedValueOnce({
+          sha: "first-commit-sha",
+        });
+
+        createBranchMock.mockResolvedValueOnce({ name: "new-branch" });
+
+        gitLogMock.mockImplementation(async (author) => {
+          if (author === amplicationBotOrIntegrationApp.gitAuthor) {
+            return {
+              total: 2,
+              all: [{ hash: "commit-1" }, { hash: "commit-2" }],
+              latest: { hash: "commit-2" },
+            };
+          }
+          if (author === amplicationGitUserAuthor) {
+            return {
+              total: 1,
+              all: [{ hash: "commit-3" }],
+              latest: { hash: "commit-3" },
+            };
+          }
+        });
+
+        cherryPickMock.mockResolvedValue(undefined);
+
+        // Act
+        const result = await service.restoreAmplicationBranchIfNotExists(args);
+
+        // Assert the result
+        expect(result).toEqual({ name: "new-branch" });
+        expect(gitProviderMock.getBranch).toHaveBeenCalledWith(args);
+        expect(gitProviderMock.getFirstCommitOnBranch).toHaveBeenCalledWith({
+          owner: "owner",
+          repositoryName: "repository",
+          branchName: "default",
+          repositoryGroupName: "group",
+        });
+        expect(gitProviderMock.createBranch).toHaveBeenCalledWith({
+          owner: "owner",
+          branchName: "new-branch",
+          repositoryName: "repository",
+          repositoryGroupName: "group",
+          pointingSha: "first-commit-sha",
+        });
+        expect(gitLogMock).toHaveBeenNthCalledWith(
+          1,
+          amplicationBotOrIntegrationApp.gitAuthor,
+          -1
+        );
+        expect(gitLogMock).toHaveBeenNthCalledWith(
+          2,
+          amplicationGitUserAuthor,
+          -1
+        );
+        expect(cherryPickMock).toHaveBeenCalledTimes(3);
+      });
+
+      it("should skip empty commits when it creates a new branch from the first commit with all the amplication authored commits from the default branch", async () => {
+        // Arrange
+        const args = {
+          branchName: "new-branch",
+          owner: "owner",
+          repositoryName: "repository",
+          gitCli: gitCliMock,
+          repositoryGroupName: "group",
+          defaultBranch: "default",
+        };
+        const emptyCommitSha = "commit-2";
+        const successfullCommitShas = [];
+
+        getBranchMock.mockResolvedValueOnce(null);
+
+        getFirstCommitOnBranchMock.mockResolvedValueOnce({
+          sha: "first-commit-sha",
+        });
+
+        createBranchMock.mockResolvedValueOnce({ name: "new-branch" });
+
+        gitLogMock.mockImplementation(async (author) => {
+          if (author === amplicationBotOrIntegrationApp.gitAuthor) {
+            return {
+              total: 2,
+              all: [{ hash: emptyCommitSha }, { hash: "commit-1" }],
+              latest: { hash: emptyCommitSha },
+            };
+          }
+          if (author === amplicationGitUserAuthor) {
+            return {
+              total: 1,
+              all: [{ hash: "commit-3" }],
+              latest: { hash: "commit-3" },
+            };
+          }
+        });
+
+        cherryPickMock.mockImplementation(async (sha) => {
+          if (sha === emptyCommitSha) {
+            throw new GitError();
+          }
+          successfullCommitShas.push(sha);
+          return;
+        });
+
+        // Act
+        const result = await service.restoreAmplicationBranchIfNotExists(args);
+
+        // Assert the result
+        expect(result).toEqual({ name: "new-branch" });
+        expect(gitProviderMock.getBranch).toHaveBeenCalledWith(args);
+        expect(gitProviderMock.getFirstCommitOnBranch).toHaveBeenCalledTimes(1);
+        expect(gitProviderMock.createBranch).toHaveBeenCalledTimes(1);
+        expect(gitLogMock).toHaveBeenCalledTimes(2);
+        expect(cherryPickMock).toHaveBeenCalledTimes(3);
+        expect(cherryPickAbortMock).toHaveBeenCalledTimes(1);
+        expect(successfullCommitShas).toEqual(["commit-1", "commit-3"]);
+      });
+    });
+
+    it("should return an existing branch without creating a new one", async () => {
+      const args = {
+        branchName: "existing-branch",
+        owner: "owner",
+        repositoryName: "repository",
+        gitCli: gitCliMock,
+        repositoryGroupName: "group",
+        defaultBranch: "default",
+      };
+
+      getBranchMock.mockResolvedValue({
+        name: "existing-branch",
+      });
+
+      const result = await service.restoreAmplicationBranchIfNotExists(args);
+
+      expect(result).toEqual({ name: "existing-branch" });
+      expect(gitProviderMock.getBranch).toHaveBeenCalledWith(args);
+      expect(gitProviderMock.getFirstCommitOnBranch).not.toHaveBeenCalled();
+      expect(gitProviderMock.createBranch).not.toHaveBeenCalled();
+      expect(gitLogMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/util/git/src/providers/git-cli.ts
+++ b/libs/util/git/src/providers/git-cli.ts
@@ -76,6 +76,10 @@ export class GitCli {
     ]);
   }
 
+  async cherryPickAbort() {
+    await this.git.raw(["cherry-pick", "--abort"]);
+  }
+
   /**
    * Checkout to branch if exists, otherwise create new branch
    * @param branchName name of the branch to checkout

--- a/libs/util/git/src/providers/git-cli.ts
+++ b/libs/util/git/src/providers/git-cli.ts
@@ -1,4 +1,10 @@
-import { CleanOptions, ResetMode, simpleGit, SimpleGit } from "simple-git";
+import {
+  CleanOptions,
+  LogResult,
+  ResetMode,
+  simpleGit,
+  SimpleGit,
+} from "simple-git";
 import { UpdateFile } from "../types";
 import { mkdir, writeFile, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
@@ -184,12 +190,19 @@ export class GitCli {
    * @param author Author of commits returned by the log
    * @param maxCount Limit the number of commits to output. Negative numbers denote no upper limit
    */
-  async log(author: string, maxCount?: number) {
-    const authorEscaped = author.replaceAll("[", "\\[").replaceAll("]", "\\]");
+  async log(authors: string[], maxCount?: number): Promise<LogResult> {
+    const author = authors.join("|");
+    const authorEscaped = author
+      .replaceAll("[", "\\[")
+      .replaceAll("]", "\\]")
+      .replaceAll("+", "\\+");
+
+    const authorsRegex = `'^(${authorEscaped})$'`;
 
     maxCount = maxCount ?? -1;
     return this.git.log({
-      "--author": authorEscaped,
+      "--perl-regexp": "",
+      "--author": authorsRegex,
       "--max-count": maxCount,
     });
   }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6451 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

Fixing the branch recreation by:
- handles repositories with amplication authored empty commits
- fix logic around git log that was missing relevant commits in the process 

Regex test:
<img width="985" alt="image" src="https://github.com/amplication/amplication/assets/2861984/e6cb06db-51b8-4b13-811c-35bfd2808b6a">



<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f66944a</samp>

### Summary
🧪🛠️🌟

<!--
1.  🧪 - This emoji represents testing, experimentation, or scientific work. It can be used to indicate that the changes involve adding or improving tests, or using a test-driven approach to development. It is suitable for the first and the third changes, which focus on increasing the test coverage and quality of the git client service and its dependencies.
2.  🛠️ - This emoji represents tools, fixing, or construction. It can be used to indicate that the changes involve refactoring, improving, or enhancing some existing code or functionality. It is suitable for the second and the fourth changes, which focus on updating the coverage threshold, handling errors, simplifying logic, and making methods public in the git client service and the git cli class.
3.  🌟 - This emoji represents stars, sparkles, or shining. It can be used to indicate that the changes involve adding or improving some new or exciting features, or making something more attractive or appealing. It is suitable for the fifth change, which focuses on enhancing the git cli class and its interface to support cherry-picking and logging commits by multiple authors, which are useful and desirable features for the git client service.
-->
This pull request enhances the util/git library by adding more features and tests to the GitClientService and GitCli classes, and by improving the error handling and the filtering logic of the git operations. It also updates the jest configuration to ignore some files from the coverage report and to increase the coverage threshold.

> _Sing, O Muse, of the valiant deeds of the Amplication team_
> _Who, with skill and wisdom, improved their code and tests supreme_
> _They added and updated files, to jest they gave commands_
> _To ignore what needs no scrutiny, and raise the coverage standards_

### Walkthrough
*  Simplify and improve the gitLog method to accept and filter by multiple authors ([link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-7030ed1d7460a9345852066fcdbb545162d9aa94cf278b82f9d0e5eebe1a9600L330-R339), [link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-299340b9a106b410204f30fd8481219507e7c5329f5e2d83126a6cb8e7e43f12L183-R205), [link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL64-R136), [link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL97-R147), [link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL107-R157), [link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL134-R184), [link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-7030ed1d7460a9345852066fcdbb545162d9aa94cf278b82f9d0e5eebe1a9600L371-R369), [link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-7030ed1d7460a9345852066fcdbb545162d9aa94cf278b82f9d0e5eebe1a9600L380-L399), [link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-7030ed1d7460a9345852066fcdbb545162d9aa94cf278b82f9d0e5eebe1a9600L466-R441))
*  Add error handling and logging to the cherryPickCommits method using the GitError class ([link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-7030ed1d7460a9345852066fcdbb545162d9aa94cf278b82f9d0e5eebe1a9600L40-R40), [link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-7030ed1d7460a9345852066fcdbb545162d9aa94cf278b82f9d0e5eebe1a9600L488-R475), [link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-299340b9a106b410204f30fd8481219507e7c5329f5e2d83126a6cb8e7e43f12R85-R88))
*  Make the restoreAmplicationBranchIfNotExists method public and add more test cases for it ([link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-7030ed1d7460a9345852066fcdbb545162d9aa94cf278b82f9d0e5eebe1a9600L428-R403), [link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL144-R337))
*  Add the gitAuthor property to the amplicationBotOrIntegrationApp object and use it in the gitLog method ([link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL21-R28))
*  Refactor the `git-client.service.spec.ts` file to use more descriptive and consistent names for the mocks and add more imports ([link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aR6-R7), [link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL30-R111))
*  Update the coverage threshold for the util/git library in `jest.config.ts` ([link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-51391ca3053c92c35199312b6ec54cbfb6f75cd774a6d36aa1b938e7625c6b1cL18-R19))
*  Add some file patterns to the jest coverage ignore list in `jest.preset.js` ([link](https://github.com/amplication/amplication/pull/6452/files?diff=unified&w=0#diff-4a3dfd1441f8f6e290336bb5ca65bd4e7f3f53b9583de0f5845449170b214d58R23-R26))




## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
