### PR TITLE
fix(server): enum option set filter out map

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaUtils/constants.ts
+++ b/packages/amplication-server/src/core/prismaSchemaUtils/constants.ts
@@ -1,6 +1,7 @@
 export const MODEL_TYPE_NAME = "model";
 export const FIELD_TYPE_NAME = "field";
 export const ENUM_TYPE_NAME = "enum";
+export const ENUMERATOR_TYPE_NAME = "enumerator";
 export const ATTRIBUTE_TYPE_NAME = "attribute";
 export const MAP_ATTRIBUTE_NAME = "map";
 

--- a/packages/amplication-server/src/core/prismaSchemaUtils/prismaSchemaUtils.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaUtils/prismaSchemaUtils.service.ts
@@ -1264,16 +1264,19 @@ export class PrismaSchemaUtilsService {
     const enumerators = enumOfTheField.enumerators as Enumerator[];
     let optionSetObj;
 
-    for (let i = 0; i < enumerators.length - 1; i++) {
+    for (let i = 0; i < enumerators.length; i++) {
       // if the current item is a map attribute, skip it and don't add it to the enumOptions array
       if (
         (enumerators[i] as unknown as Attribute).type === ATTRIBUTE_TYPE_NAME &&
         enumerators[i].name === MAP_ATTRIBUTE_NAME
       ) {
-        break;
-        // if the current item is an enumerator and the next item is a map attribute, add the enumerator to the enumOptions array
-      } else if (
+        continue;
+      }
+
+      // if the current item is an enumerator and the next item is exists and it is a map attribute, add the enumerator to the enumOptions array
+      if (
         enumerators[i].type === ENUMERATOR_TYPE_NAME &&
+        enumerators[i + 1] &&
         (enumerators[i + 1] as unknown as Attribute).type ===
           ATTRIBUTE_TYPE_NAME &&
         enumerators[i + 1].name === MAP_ATTRIBUTE_NAME

--- a/packages/amplication-server/src/core/prismaSchemaUtils/prismaSchemaUtils.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaUtils/prismaSchemaUtils.service.ts
@@ -58,6 +58,7 @@ import {
 } from "../entity/entity.service";
 import {
   ATTRIBUTE_TYPE_NAME,
+  ENUMERATOR_TYPE_NAME,
   ENUM_TYPE_NAME,
   FIELD_TYPE_NAME,
   ID_ATTRIBUTE_NAME,
@@ -1259,14 +1260,14 @@ export class PrismaSchemaUtilsService {
       throw new Error(`Enum ${field.name} not found`);
     }
 
-    const enumOptions = enumOfTheField.enumerators.map(
-      (enumerator: Enumerator) => {
+    const enumOptions = enumOfTheField.enumerators
+      .filter((item) => item.type === ENUMERATOR_TYPE_NAME)
+      .map((enumerator: Enumerator) => {
         return {
           label: enumerator.name,
           value: enumerator.name,
         };
-      }
-    );
+      });
 
     const properties = <types.OptionSet>{
       options: enumOptions,


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Part of: #5413 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8447b4e</samp>

### Summary
🆕🔧🎉

<!--
1.  🆕 for adding a new constant
2.  🔧 for fixing or improving the functionality of the method
3.  🎉 for adding support for a new feature or enhancement
-->
This pull request adds support for different types of enumerators in the database schema. It introduces a constant for the enumerator type name in `constants.ts` and uses it to filter the enum options in `prismaSchemaUtils.service.ts`.

> _To support different enum types_
> _We added a constant that pipes_
> _The type name to `getPropertiesOfField`_
> _Which filters the options to yield_
> _Only the enums that match our types_

### Walkthrough
*  Filter out invalid enum options based on type name ([link](https://github.com/amplication/amplication/pull/6455/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L1262-R1270), [link](https://github.com/amplication/amplication/pull/6455/files?diff=unified&w=0#diff-b5be81781d293f79ac5277d34d4c5556e3401b3159d7d89722e68d518248b36bR4), [link](https://github.com/amplication/amplication/pull/6455/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911R61))
  - Import `ENUMERATOR_TYPE_NAME` constant from `constants.ts` in `prismaSchemaUtils.service.ts` ([link](https://github.com/amplication/amplication/pull/6455/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911R61))
  - Use the constant to filter the `enumOptions` array in `getPropertiesOfField` method of `PrismaSchemaUtilsService` class ([link](https://github.com/amplication/amplication/pull/6455/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L1262-R1270))
  - Only include the enumerators that have the type name equal to the constant, and ignore any other enumerators with different type names ([link](https://github.com/amplication/amplication/pull/6455/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L1262-R1270), [link](https://github.com/amplication/amplication/pull/6455/files?diff=unified&w=0#diff-b5be81781d293f79ac5277d34d4c5556e3401b3159d7d89722e68d518248b36bR4))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
