### PR TITLE
fix(server): id field and attribute on model

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaUtils/constants.ts
+++ b/packages/amplication-server/src/core/prismaSchemaUtils/constants.ts
@@ -6,6 +6,7 @@ export const ATTRIBUTE_TYPE_NAME = "attribute";
 export const MAP_ATTRIBUTE_NAME = "map";
 
 export const DEFAULT_ATTRIBUTE_NAME = "default";
+export const UNIQUE_ATTRIBUTE_NAME = "unique";
 export const UPDATED_AT_ATTRIBUTE_NAME = "updatedAt";
 export const ID_ATTRIBUTE_NAME = "id";
 export const RELATION_ATTRIBUTE_NAME = "relation";


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Part of: #5413 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 67e0ed4</samp>

### Summary
🔒🆔🛠️

<!--
1.  🔒 - This emoji represents the concept of uniqueness and security, which is related to the `unique` attribute and the `id` field.
2.  🆔 - This emoji represents the concept of identity and identification, which is related to the `id` field and the `@id` attribute.
3.  🛠️ - This emoji represents the concept of tools and utilities, which is related to the `PrismaSchemaUtilsService` class and its functionality.
-->
This pull request enhances the `PrismaSchemaUtilsService` class to automatically add an `id` field to every model in the Prisma schema, and to adjust the existing keys accordingly. This ensures compatibility with Prisma's requirements and avoids potential conflicts or errors.

> _To mark fields as unique in Prisma_
> _We define a constant for the schema_
> _But every model needs an `id`_
> _Or else Prisma will forbid_
> _So we add one and rename `@@id` to `@@unique`a_

### Walkthrough
*  Ensure every model has an `id` field with the `@id` attribute by adding a new method `prepareModelIdAttribute` and invoking it in the `prepareSchema` method of the `PrismaSchemaUtilsService` class ([link](https://github.com/amplication/amplication/pull/6467/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911R68), [link](https://github.com/amplication/amplication/pull/6467/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911R78), [link](https://github.com/amplication/amplication/pull/6467/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911R572-R630))
  * Rename the `@@id` attribute to `@@unique` for models with composite keys, using the constant `UNIQUE_ATTRIBUTE_NAME` imported from `constants.ts` ([link](https://github.com/amplication/amplication/pull/6467/files?diff=unified&w=0#diff-b5be81781d293f79ac5277d34d4c5556e3401b3159d7d89722e68d518248b36bR9), [link](https://github.com/amplication/amplication/pull/6467/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911R572-R630))
  * Add an `id` field with the `@id` attribute to models with composite keys, using the `builder` object to modify the schema ([link](https://github.com/amplication/amplication/pull/6467/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911R572-R630))
  * Push warning messages to the `log` array to inform the user about the changes made to the schema ([link](https://github.com/amplication/amplication/pull/6467/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911R572-R630))
* Add an empty line for formatting purposes ([link](https://github.com/amplication/amplication/pull/6467/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911R653))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
