### PR TITLE
fix(git): cherry-pick abort command order

### DIFF
--- a/libs/util/git/src/git-client.service.ts
+++ b/libs/util/git/src/git-client.service.ts
@@ -469,8 +469,8 @@ export class GitClientService {
             `Failed to cherry pick commit ${commit.hash} on branch ${branchName}`,
             error
           );
-          await gitCli.resetState();
           await gitCli.cherryPickAbort();
+          await gitCli.resetState();
           continue;
         }
       }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: https://github.com/amplication/amplication/issues/6451

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 17c5c1d</samp>

### Summary
🐛🚚🍒

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change. It indicates that the previous code had a flaw or error that was corrected by this change.
2.  🚚 - This emoji represents moving or swapping something, which is what this change does with the order of the two git commands. It indicates that the previous order was not optimal or caused problems, and that the new order is more suitable or reliable.
3.  🍒 - This emoji represents cherry-picking, which is the git operation that this change affects. It indicates that the change is related to the logic or functionality of cherry-picking commits from one branch to another.
-->
Swapped the order of `gitCli.resetState()` and `gitCli.cherryPickAbort()` in `git-client.service.ts` to fix a bug in merging remote changes. This change prevents a possible conflict between the two commands when a cherry-pick operation fails.

> _`mergeRemoteChanges`_
> _Swaps two commands for bug fix_
> _Autumn leaves conflict_

### Walkthrough
*  Swap the order of `gitCli.resetState()` and `gitCli.cherryPickAbort()` to avoid a potential conflict between the two commands when cherry-picking fails ([link](https://github.com/amplication/amplication/pull/6468/files?diff=unified&w=0#diff-7030ed1d7460a9345852066fcdbb545162d9aa94cf278b82f9d0e5eebe1a9600L472-R473)). This fixes a bug that caused the GitClientService to sometimes fail to merge changes from the remote branch into the local branch. The change affects the `mergeRemoteChanges` method in `git-client.service.ts`.



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
