### PR TITLE
test(git): add tests for git cli class

### DIFF
--- a/libs/util/git/src/providers/git-cli.spec.ts
+++ b/libs/util/git/src/providers/git-cli.spec.ts
@@ -1,0 +1,199 @@
+import * as simpleGit from "simple-git";
+
+import { GitCli } from "./git-cli";
+import { MockedLogger } from "@amplication/util/logging/test-utils";
+import { UpdateFile } from "../types";
+
+const gitFetchMock = jest.fn();
+const gitBranchMock = jest.fn();
+const gitCheckoutLocalBranchMock = jest.fn();
+const gitCheckoutMock = jest.fn();
+const gitStatusMock = jest.fn();
+const gitCommitMock = jest.fn();
+const gitPushMock = jest.fn();
+
+jest.mock("simple-git");
+jest.mock("node:fs/promises");
+
+const simpleGitMocked = simpleGit as jest.Mocked<typeof simpleGit>;
+
+describe("GitCli", () => {
+  let gitCli: GitCli;
+
+  beforeEach(() => {
+    simpleGitMocked.simpleGit.mockReturnValue({
+      fetch: gitFetchMock,
+      branch: gitBranchMock,
+      checkoutLocalBranch: gitCheckoutLocalBranchMock,
+      checkout: gitCheckoutMock,
+      status: gitStatusMock,
+      commit: gitCommitMock,
+      push: gitPushMock,
+      add: jest.fn(),
+    } as unknown as simpleGit.SimpleGit);
+
+    gitCli = new GitCli(MockedLogger, {
+      originUrl: "http://example.com",
+      repositoryDir: "repository-dir",
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  describe("checkout", () => {
+    it("should checkout a local branch if remote branch does not exist", async () => {
+      gitFetchMock.mockResolvedValue(undefined);
+      gitBranchMock.mockResolvedValue({ all: [] });
+
+      const branchName = "my-branch";
+
+      await gitCli.checkout(branchName);
+
+      expect(gitFetchMock).toHaveBeenCalledTimes(1);
+      expect(gitBranchMock).toHaveBeenCalledTimes(1);
+      expect(gitCheckoutLocalBranchMock).toHaveBeenCalledWith(branchName);
+      expect(gitCheckoutMock).not.toHaveBeenCalled();
+    });
+
+    it("should checkout a remote branch if it exists", async () => {
+      gitFetchMock.mockResolvedValue(undefined);
+      gitBranchMock.mockResolvedValue({ all: ["origin/my-branch"] });
+
+      const branchName = "my-branch";
+      await gitCli.checkout(branchName);
+
+      expect(gitFetchMock).toHaveBeenCalledTimes(1);
+      expect(gitBranchMock).toHaveBeenCalledTimes(1);
+      expect(gitCheckoutLocalBranchMock).not.toHaveBeenCalled();
+      expect(gitCheckoutMock).toHaveBeenCalledWith(branchName);
+    });
+
+    it("should always perform a fetch before checking the remote branch existence", async () => {
+      gitFetchMock.mockResolvedValue(undefined);
+      gitBranchMock.mockResolvedValue({ all: ["origin/my-branch"] });
+
+      const branchName = "my-branch";
+      await gitCli.checkout(branchName);
+
+      expect(gitFetchMock).toHaveBeenCalledTimes(1);
+      expect(gitBranchMock).toHaveBeenCalledTimes(1);
+      expect(gitCheckoutLocalBranchMock).not.toHaveBeenCalled();
+      expect(gitCheckoutMock).toHaveBeenCalledWith(branchName);
+    });
+  });
+
+  describe("commit", () => {
+    beforeEach(() => {
+      gitFetchMock.mockResolvedValue(undefined);
+      gitBranchMock.mockResolvedValue({ all: ["origin/main"] });
+    });
+
+    it("should commit changes and return the commit SHA", async () => {
+      // Mock the necessary functions
+      gitCheckoutMock.mockResolvedValueOnce(undefined);
+      gitStatusMock.mockResolvedValueOnce({
+        staged: ["file1.txt"],
+        renamed: [],
+      });
+      gitCommitMock.mockResolvedValueOnce({ commit: "abcd1234" });
+      gitPushMock.mockResolvedValueOnce(undefined);
+
+      const branchName = "main";
+      const message = "Commit message";
+      const files: UpdateFile[] = [
+        {
+          path: "file1.txt",
+          content: "File content",
+          deleted: false,
+          skipIfExists: false,
+        },
+      ];
+
+      const result = await gitCli.commit(branchName, message, files);
+
+      expect(gitCheckoutMock).toHaveBeenCalledWith(branchName);
+      expect(gitStatusMock).toHaveBeenCalled();
+      expect(gitCommitMock).toHaveBeenCalledWith(message);
+      expect(gitPushMock).toHaveBeenCalled();
+      expect(result).toBe("abcd1234");
+    });
+
+    it("should log a warning and return an empty string if no changes to commit", async () => {
+      // Mock the necessary functions
+      gitCheckoutMock.mockResolvedValueOnce(undefined);
+      gitStatusMock.mockResolvedValueOnce({
+        staged: [],
+        renamed: [],
+      });
+
+      const branchName = "main";
+      const message = "Commit message";
+      const files: UpdateFile[] = [];
+
+      const result = await gitCli.commit(branchName, message, files);
+
+      expect(gitCheckoutMock).toHaveBeenCalledWith(branchName);
+      expect(gitStatusMock).toHaveBeenCalled();
+      expect(gitCommitMock).not.toHaveBeenCalled();
+      expect(gitPushMock).not.toHaveBeenCalled();
+      expect(result).toBe("");
+      expect(gitCli["logger"].warn).toHaveBeenCalled();
+    });
+
+    it("should handle file deletions", async () => {
+      // Mock the necessary functions
+      gitCheckoutMock.mockResolvedValueOnce(undefined);
+      gitStatusMock.mockResolvedValueOnce({
+        staged: ["file1.txt"],
+        renamed: [],
+      });
+      gitCommitMock.mockResolvedValueOnce({ commit: "abcd1234" });
+      gitPushMock.mockResolvedValueOnce(undefined);
+
+      const branchName = "main";
+      const message = "Commit message";
+      const files: UpdateFile[] = [
+        { path: "file1.txt", deleted: true, content: "", skipIfExists: false },
+      ];
+
+      const result = await gitCli.commit(branchName, message, files);
+
+      expect(gitCheckoutMock).toHaveBeenCalledWith(branchName);
+      expect(gitStatusMock).toHaveBeenCalled();
+      expect(gitCommitMock).toHaveBeenCalledWith(message);
+      expect(gitPushMock).toHaveBeenCalled();
+      expect(result).toBe("abcd1234");
+    });
+
+    it("should handle file creation and skipping if already exists", async () => {
+      // Mock the necessary functions
+      gitCheckoutMock.mockResolvedValueOnce(undefined);
+      gitStatusMock.mockResolvedValueOnce({
+        staged: ["file1.txt"],
+        renamed: [],
+      });
+      gitCommitMock.mockResolvedValueOnce({ commit: "abcd1234" });
+      gitPushMock.mockResolvedValueOnce(undefined);
+
+      const branchName = "main";
+      const message = "Commit message";
+      const files: UpdateFile[] = [
+        {
+          path: "file1.txt",
+          content: "File content",
+          skipIfExists: true,
+          deleted: false,
+        },
+      ];
+
+      const result = await gitCli.commit(branchName, message, files);
+
+      expect(gitCheckoutMock).toHaveBeenCalledWith(branchName);
+      expect(gitStatusMock).toHaveBeenCalled();
+      expect(gitCommitMock).toHaveBeenCalledWith(message);
+      expect(gitPushMock).toHaveBeenCalled();
+      expect(result).toBe("abcd1234");
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6471 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ecfba04</samp>

### Summary
:test_tube::memo::sparkles:

<!--
1.  :test_tube: This emoji represents testing, which is the main focus of this change. The `git-cli.spec.ts` file contains unit tests that verify the functionality and edge cases of the `GitCli` class. The emoji conveys the idea of experimentation, validation, and quality assurance.
2.  :memo: This emoji represents writing, which is another aspect of this change. The `GitCli` class is used to write and commit code to a git repository, and the tests document the expected behavior and outcomes of this process. The emoji conveys the idea of documentation, communication, and expression.
3.  :sparkles: This emoji represents new features, which is the final aspect of this change. The `GitCli` class is a new addition to the project that enables generating and committing code to a git repository. The tests also cover new scenarios and use cases that were not previously supported. The emoji conveys the idea of innovation, creativity, and enhancement.
-->
Add unit tests for `GitCli` class. The tests verify the functionality of the `checkout` and `commit` methods using jest mocks. The tests improve the test coverage and reliability of the `GitCli` class.

> _`GitCli` wrapper_
> _Mocking `simple-git` and `fs`_
> _Autumn tests harvest_

### Walkthrough
*  Add unit tests for the `GitCli` class ([link](https://github.com/amplication/amplication/pull/6475/files?diff=unified&w=0#diff-cc01eeb1204c726afa88830582a99ff9316b9d28ffab7d4d3cdc1cfb1ec3763aR1-R199))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
