### PR TITLE
feat(git): add support for branches actions in aws codecommit provider

### DIFF
--- a/libs/util/git/jest.config.ts
+++ b/libs/util/git/jest.config.ts
@@ -15,8 +15,8 @@ export default {
   coverageDirectory: "../../../coverage/libs/util/git",
   coverageThreshold: {
     global: {
-      branches: 78,
-      lines: 43,
+      branches: 80,
+      lines: 50,
     },
   },
 };

--- a/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
@@ -765,9 +765,9 @@ describe("AwsCodeCommit", () => {
       );
     });
   });
-  it("should throw an error when calling getAmplicationBotIdentity()", async () => {
-    await expect(gitProvider.getAmplicationBotIdentity()).rejects.toThrowError(
-      "Method not implemented."
-    );
+
+  it("should return null getAmplicationBotIdentity()", async () => {
+    const res = await gitProvider.getAmplicationBotIdentity();
+    expect(res).toBeNull();
   });
 });

--- a/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
@@ -1,5 +1,4 @@
 import {
-  CreateBranchArgs,
   CreatePullRequestFromFilesArgs,
   EnumGitOrganizationType,
   GetBranchArgs,

--- a/libs/util/git/src/providers/aws/aws-code-commit.service.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.ts
@@ -387,6 +387,6 @@ export class AwsCodeCommitService implements GitProvider {
   }
 
   async getAmplicationBotIdentity(): Promise<Bot | null> {
-    throw NotImplementedError;
+    return null;
   }
 }

--- a/libs/util/git/src/providers/aws/aws-code-commit.service.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.ts
@@ -31,6 +31,7 @@ import {
   BranchDoesNotExistException,
   CodeCommitClient,
   CreatePullRequestCommand,
+  CreateBranchCommand,
   CreateRepositoryCommand,
   GetBranchCommand,
   GetFileCommand,
@@ -376,7 +377,23 @@ export class AwsCodeCommitService implements GitProvider {
   }
 
   async createBranch(args: CreateBranchArgs): Promise<Branch> {
-    throw NotImplementedError;
+    const command = new CreateBranchCommand({
+      branchName: args.branchName,
+      commitId: args.pointingSha,
+      repositoryName: args.repositoryName,
+    });
+    try {
+      await this.awsClient.send(command);
+
+      return {
+        name: args.branchName,
+        sha: args.pointingSha,
+      };
+    } catch (error) {
+      this.logger.error(error.message, error, { args });
+
+      throw error;
+    }
   }
 
   async getFirstCommitOnBranch(args: GetBranchArgs): Promise<Commit | null> {


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6351 
## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ed5f7ea</samp>

### Summary
🧪🌿🤖

<!--
1.  🧪 for adding and updating tests
2.  🌿 for creating branches
3.  🤖 for working with the Amplication bot identity
-->
Added branch support and improved bot identity handling for AWS CodeCommit provider. Implemented and tested `getBranch` and `createBranch` methods in `AwsCodeCommitService`. Changed `getAmplicationBotIdentity` to return null instead of throwing an error. Updated `aws-code-commit.service.spec.ts` to reflect these changes.

> _We are the branch creators, we defy the code of doom_
> _We invoke the AWS power, we unleash the CodeCommit boom_
> _We don't need a bot identity, we are the masters of null_
> _We are the branch creators, we make the code submit to our will_

### Walkthrough
*  Implement `getBranch` and `createBranch` methods for `AwsCodeCommitService` class, using AWS CodeCommit commands and handling possible exceptions or results ([link](https://github.com/amplication/amplication/pull/6480/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aL252-R301), [link](https://github.com/amplication/amplication/pull/6480/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aL295-R339))
* Add imports for AWS CodeCommit commands and exceptions in `aws-code-commit.service.ts` and `aws-code-commit.service.spec.ts` files ([link](https://github.com/amplication/amplication/pull/6480/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aL31-R35), [link](https://github.com/amplication/amplication/pull/6480/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L14-R18))
* Add tests for `getBranch` and `createBranch` methods in `aws-code-commit.service.spec.ts` file, mocking AWS CodeCommit client and checking expected results or errors ([link](https://github.com/amplication/amplication/pull/6480/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L444-R550))
* Change `getAmplicationBotIdentity` method to return null instead of throwing error, as it is not implemented for AWS CodeCommit provider ([link](https://github.com/amplication/amplication/pull/6480/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aL295-R339), [link](https://github.com/amplication/amplication/pull/6480/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L546-R637))
* Add blank lines before `getBranch` and `createBranch` methods for readability and consistency ([link](https://github.com/amplication/amplication/pull/6480/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aR245), [link](https://github.com/amplication/amplication/pull/6480/files?diff=unified&w=0#diff-79b256dbe34679386e43a1af887c0d3a77531fcf3f7b69683a0dffe258c7262aR251))
* Remove unused `GetFileArgs` import from `aws-code-commit.service.spec.ts` file ([link](https://github.com/amplication/amplication/pull/6480/files?diff=unified&w=0#diff-0187c463cbbf3cb74e5c005c9691d0584432bec13114b641714134e483c23486L7))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
