### PR TITLE
chore(deps-dev): bump @graphql-codegen/cli from 3.0.2 to 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "@babel/core": "7.12.13",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "7.12.13",
-    "@graphql-codegen/cli": "3.2.2",
+    "@graphql-codegen/cli": "4.0.1",
     "@graphql-codegen/typescript": "4.0.1",
     "@lcov-viewer/cli": "^1.3.0",
     "@nestjs/cli": "^9.5.0",

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -3,131 +3,133 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
   /** A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format. */
-  DateTime: any;
+  DateTime: { input: any; output: any; }
   /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
-  JSONObject: any;
+  JSONObject: { input: any; output: any; }
   /** The `Upload` scalar type represents a file upload. */
-  Upload: any;
+  Upload: { input: any; output: any; }
 };
 
 export type Account = {
-  createdAt: Scalars['DateTime'];
-  email: Scalars['String'];
-  firstName: Scalars['String'];
-  githubId?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  lastName: Scalars['String'];
-  password: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  email: Scalars['String']['output'];
+  firstName: Scalars['String']['output'];
+  githubId?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  lastName: Scalars['String']['output'];
+  password: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type Action = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   steps?: Maybe<Array<ActionStep>>;
 };
 
 export type ActionLog = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   level: EnumActionLogLevel;
-  message: Scalars['String'];
-  meta: Scalars['JSONObject'];
+  message: Scalars['String']['output'];
+  meta: Scalars['JSONObject']['output'];
 };
 
 export type ActionStep = {
-  completedAt?: Maybe<Scalars['DateTime']>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  completedAt?: Maybe<Scalars['DateTime']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   logs?: Maybe<Array<ActionLog>>;
-  message: Scalars['String'];
-  name: Scalars['String'];
+  message: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   status: EnumActionStepStatus;
 };
 
 export type AdminUiSettings = {
-  adminUIPath: Scalars['String'];
-  generateAdminUI: Scalars['Boolean'];
+  adminUIPath: Scalars['String']['output'];
+  generateAdminUI: Scalars['Boolean']['output'];
 };
 
 export type AdminUiSettingsUpdateInput = {
-  adminUIPath?: InputMaybe<Scalars['String']>;
-  generateAdminUI?: InputMaybe<Scalars['Boolean']>;
+  adminUIPath?: InputMaybe<Scalars['String']['input']>;
+  generateAdminUI?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ApiToken = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  lastAccessAt: Scalars['DateTime'];
-  name: Scalars['String'];
-  previewChars: Scalars['String'];
-  token?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  userId: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  lastAccessAt: Scalars['DateTime']['output'];
+  name: Scalars['String']['output'];
+  previewChars: Scalars['String']['output'];
+  token?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  userId: Scalars['String']['output'];
 };
 
 export type ApiTokenCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type Auth = {
   /** JWT Bearer token */
-  token: Scalars['String'];
+  token: Scalars['String']['output'];
 };
 
 export type AuthorizeResourceWithGitResult = {
-  url: Scalars['String'];
+  url: Scalars['String']['output'];
 };
 
 export type Block = {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  lockedAt?: Maybe<Scalars['DateTime']>;
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedByUser: Array<User>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   parentBlock?: Maybe<Block>;
   resource?: Maybe<Resource>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber?: Maybe<Scalars['Float']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber?: Maybe<Scalars['Float']['output']>;
   versions?: Maybe<Array<BlockVersion>>;
 };
 
 
 export type BlockVersionsArgs = {
   orderBy?: InputMaybe<BlockVersionOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BlockVersionWhereInput>;
 };
 
 export type BlockInputOutput = {
   dataType?: Maybe<EnumDataType>;
-  dataTypeEntityName?: Maybe<Scalars['String']>;
-  description: Scalars['String'];
-  includeAllPropertiesByDefault?: Maybe<Scalars['Boolean']>;
-  isList?: Maybe<Scalars['Boolean']>;
-  name: Scalars['String'];
+  dataTypeEntityName?: Maybe<Scalars['String']['output']>;
+  description: Scalars['String']['output'];
+  includeAllPropertiesByDefault?: Maybe<Scalars['Boolean']['output']>;
+  isList?: Maybe<Scalars['Boolean']['output']>;
+  name: Scalars['String']['output'];
   propertyList?: Maybe<Array<PropertySelector>>;
 };
 
 export type BlockInputOutputInput = {
   dataType?: InputMaybe<EnumDataType>;
-  dataTypeEntityName?: InputMaybe<Scalars['String']>;
-  description: Scalars['String'];
-  includeAllPropertiesByDefault?: InputMaybe<Scalars['Boolean']>;
-  isList?: InputMaybe<Scalars['Boolean']>;
-  name: Scalars['String'];
+  dataTypeEntityName?: InputMaybe<Scalars['String']['input']>;
+  description: Scalars['String']['input'];
+  includeAllPropertiesByDefault?: InputMaybe<Scalars['Boolean']['input']>;
+  isList?: InputMaybe<Scalars['Boolean']['input']>;
+  name: Scalars['String']['input'];
   propertyList?: InputMaybe<Array<PropertySelectorInput>>;
 };
 
@@ -143,13 +145,13 @@ export type BlockOrderByInput = {
 export type BlockVersion = {
   block: Block;
   commit?: Maybe<Commit>;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  settings?: Maybe<Scalars['JSONObject']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Int'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  settings?: Maybe<Scalars['JSONObject']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 export type BlockVersionOrderByInput = {
@@ -181,30 +183,30 @@ export type BlockWhereInput = {
 };
 
 export type BooleanFilter = {
-  equals?: InputMaybe<Scalars['Boolean']>;
-  not?: InputMaybe<Scalars['Boolean']>;
+  equals?: InputMaybe<Scalars['Boolean']['input']>;
+  not?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type Build = {
   action?: Maybe<Action>;
-  actionId: Scalars['String'];
-  archiveURI: Scalars['String'];
+  actionId: Scalars['String']['output'];
+  archiveURI: Scalars['String']['output'];
   commit: Commit;
-  commitId: Scalars['String'];
-  createdAt: Scalars['DateTime'];
+  commitId: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
   createdBy: User;
-  id: Scalars['String'];
-  message: Scalars['String'];
+  id: Scalars['String']['output'];
+  message: Scalars['String']['output'];
   resource?: Maybe<Resource>;
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['output'];
   status?: Maybe<EnumBuildStatus>;
-  userId: Scalars['String'];
-  version: Scalars['String'];
+  userId: Scalars['String']['output'];
+  version: Scalars['String']['output'];
 };
 
 export type BuildCreateInput = {
   commit: WhereParentIdInput;
-  message: Scalars['String'];
+  message: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
@@ -228,30 +230,30 @@ export type BuildWhereInput = {
 };
 
 export type ChangePasswordInput = {
-  newPassword: Scalars['String'];
-  oldPassword: Scalars['String'];
+  newPassword: Scalars['String']['input'];
+  oldPassword: Scalars['String']['input'];
 };
 
 export type Commit = {
   builds?: Maybe<Array<Build>>;
   changes?: Maybe<Array<PendingChange>>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  message: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  message: Scalars['String']['output'];
   user?: Maybe<User>;
-  userId: Scalars['String'];
+  userId: Scalars['String']['output'];
 };
 
 
 export type CommitBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
 export type CommitCreateInput = {
-  message: Scalars['String'];
+  message: Scalars['String']['input'];
   project: WhereParentIdInput;
 };
 
@@ -270,24 +272,24 @@ export type CommitWhereInput = {
 };
 
 export type CommitWhereUniqueInput = {
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CompleteInvitationInput = {
-  token: Scalars['String'];
+  token: Scalars['String']['input'];
 };
 
 export type ConnectGitRepositoryInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isOverrideGitRepository?: InputMaybe<Scalars['Boolean']>;
-  name: Scalars['String'];
-  resourceId: Scalars['String'];
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isOverrideGitRepository?: InputMaybe<Scalars['Boolean']['input']>;
+  name: Scalars['String']['input'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type CreateEntitiesFromPrismaSchemaInput = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type CreateEntitiesFromPrismaSchemaResponse = {
@@ -296,128 +298,128 @@ export type CreateEntitiesFromPrismaSchemaResponse = {
 };
 
 export type CreateGitRepositoryBaseInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isPublic: Scalars['Boolean'];
-  name: Scalars['String'];
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isPublic: Scalars['Boolean']['input'];
+  name: Scalars['String']['input'];
 };
 
 export type CreateGitRepositoryInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isPublic: Scalars['Boolean'];
-  name: Scalars['String'];
-  resourceId?: InputMaybe<Scalars['String']>;
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isPublic: Scalars['Boolean']['input'];
+  name: Scalars['String']['input'];
+  resourceId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type DateTimeFilter = {
-  equals?: InputMaybe<Scalars['DateTime']>;
-  gt?: InputMaybe<Scalars['DateTime']>;
-  gte?: InputMaybe<Scalars['DateTime']>;
-  in?: InputMaybe<Array<Scalars['DateTime']>>;
-  lt?: InputMaybe<Scalars['DateTime']>;
-  lte?: InputMaybe<Scalars['DateTime']>;
-  not?: InputMaybe<Scalars['DateTime']>;
-  notIn?: InputMaybe<Array<Scalars['DateTime']>>;
+  equals?: InputMaybe<Scalars['DateTime']['input']>;
+  gt?: InputMaybe<Scalars['DateTime']['input']>;
+  gte?: InputMaybe<Scalars['DateTime']['input']>;
+  in?: InputMaybe<Array<Scalars['DateTime']['input']>>;
+  lt?: InputMaybe<Scalars['DateTime']['input']>;
+  lte?: InputMaybe<Scalars['DateTime']['input']>;
+  not?: InputMaybe<Scalars['DateTime']['input']>;
+  notIn?: InputMaybe<Array<Scalars['DateTime']['input']>>;
 };
 
 export type DefaultEntitiesInput = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type Entity = {
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
   fields?: Maybe<Array<EntityField>>;
-  id: Scalars['String'];
-  lockedAt?: Maybe<Scalars['DateTime']>;
+  id: Scalars['String']['output'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedByUser?: Maybe<User>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
   permissions?: Maybe<Array<EntityPermission>>;
-  pluralDisplayName: Scalars['String'];
+  pluralDisplayName: Scalars['String']['output'];
   resource?: Maybe<Resource>;
-  resourceId: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  resourceId: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
   versions?: Maybe<Array<EntityVersion>>;
 };
 
 
 export type EntityFieldsArgs = {
   orderBy?: InputMaybe<EntityFieldOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityFieldWhereInput>;
 };
 
 
 export type EntityVersionsArgs = {
   orderBy?: InputMaybe<EntityVersionOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityVersionWhereInput>;
 };
 
 export type EntityAddPermissionFieldInput = {
   action: EnumEntityAction;
   entity: WhereParentIdInput;
-  fieldName: Scalars['String'];
+  fieldName: Scalars['String']['input'];
 };
 
 export type EntityCreateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
   /** allow creating the id for the entity when using import prisma schema because we need it for the relation */
-  id?: InputMaybe<Scalars['String']>;
-  name: Scalars['String'];
-  pluralDisplayName: Scalars['String'];
+  id?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  pluralDisplayName: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
 export type EntityField = {
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
   dataType: EnumDataType;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
-  permanentId: Scalars['String'];
-  position?: Maybe<Scalars['Int']>;
-  properties?: Maybe<Scalars['JSONObject']>;
-  required: Scalars['Boolean'];
-  searchable: Scalars['Boolean'];
-  unique: Scalars['Boolean'];
-  updatedAt: Scalars['DateTime'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  permanentId: Scalars['String']['output'];
+  position?: Maybe<Scalars['Int']['output']>;
+  properties?: Maybe<Scalars['JSONObject']['output']>;
+  required: Scalars['Boolean']['output'];
+  searchable: Scalars['Boolean']['output'];
+  unique: Scalars['Boolean']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type EntityFieldCreateByDisplayNameInput = {
   dataType?: InputMaybe<EnumDataType>;
-  displayName: Scalars['String'];
+  displayName: Scalars['String']['input'];
   entity: WhereParentIdInput;
 };
 
 export type EntityFieldCreateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
   dataType: EnumDataType;
-  description: Scalars['String'];
-  displayName: Scalars['String'];
+  description: Scalars['String']['input'];
+  displayName: Scalars['String']['input'];
   entity: WhereParentIdInput;
-  name: Scalars['String'];
-  position?: InputMaybe<Scalars['Int']>;
-  properties: Scalars['JSONObject'];
-  required: Scalars['Boolean'];
-  searchable: Scalars['Boolean'];
-  unique: Scalars['Boolean'];
+  name: Scalars['String']['input'];
+  position?: InputMaybe<Scalars['Int']['input']>;
+  properties: Scalars['JSONObject']['input'];
+  required: Scalars['Boolean']['input'];
+  searchable: Scalars['Boolean']['input'];
+  unique: Scalars['Boolean']['input'];
 };
 
 export type EntityFieldFilter = {
@@ -443,16 +445,16 @@ export type EntityFieldOrderByInput = {
 };
 
 export type EntityFieldUpdateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
   dataType?: InputMaybe<EnumDataType>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  position?: InputMaybe<Scalars['Int']>;
-  properties?: InputMaybe<Scalars['JSONObject']>;
-  required?: InputMaybe<Scalars['Boolean']>;
-  searchable?: InputMaybe<Scalars['Boolean']>;
-  unique?: InputMaybe<Scalars['Boolean']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  position?: InputMaybe<Scalars['Int']['input']>;
+  properties?: InputMaybe<Scalars['JSONObject']['input']>;
+  required?: InputMaybe<Scalars['Boolean']['input']>;
+  searchable?: InputMaybe<Scalars['Boolean']['input']>;
+  unique?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type EntityFieldWhereInput = {
@@ -484,44 +486,44 @@ export type EntityOrderByInput = {
 export type EntityPermission = {
   action: EnumEntityAction;
   entityVersion?: Maybe<EntityVersion>;
-  entityVersionId: Scalars['String'];
-  id: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   permissionFields?: Maybe<Array<EntityPermissionField>>;
   permissionRoles?: Maybe<Array<EntityPermissionRole>>;
   type: EnumEntityPermissionType;
 };
 
 export type EntityPermissionField = {
-  entityVersionId: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
   field: EntityField;
-  fieldPermanentId: Scalars['String'];
-  id: Scalars['String'];
+  fieldPermanentId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   permission?: Maybe<EntityPermission>;
-  permissionId: Scalars['String'];
+  permissionId: Scalars['String']['output'];
   permissionRoles?: Maybe<Array<EntityPermissionRole>>;
 };
 
 export type EntityPermissionFieldWhereUniqueInput = {
   action: EnumEntityAction;
-  entityId: Scalars['String'];
-  fieldPermanentId: Scalars['String'];
+  entityId: Scalars['String']['input'];
+  fieldPermanentId: Scalars['String']['input'];
 };
 
 export type EntityPermissionRole = {
   action: EnumEntityAction;
   entityPermission?: Maybe<EntityPermission>;
-  entityVersionId: Scalars['String'];
-  id: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   resourceRole: ResourceRole;
-  resourceRoleId: Scalars['String'];
+  resourceRoleId: Scalars['String']['output'];
 };
 
 export type EntityUpdateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  pluralDisplayName?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  pluralDisplayName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type EntityUpdatePermissionFieldRolesInput = {
@@ -544,26 +546,26 @@ export type EntityUpdatePermissionRolesInput = {
 
 export type EntityVersion = {
   commit?: Maybe<Commit>;
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
   entity: Entity;
-  entityId: Scalars['String'];
+  entityId: Scalars['String']['output'];
   fields: Array<EntityField>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   permissions?: Maybe<Array<EntityPermission>>;
-  pluralDisplayName: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Int'];
+  pluralDisplayName: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 
 export type EntityVersionFieldsArgs = {
   orderBy?: InputMaybe<EntityFieldOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityFieldWhereInput>;
 };
 
@@ -753,14 +755,14 @@ export enum EnumWorkspaceMemberType {
 }
 
 export type Environment = {
-  address: Scalars['String'];
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  address: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   resource: Resource;
-  resourceId: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  resourceId: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type GitGetInstallationUrlInput = {
@@ -769,103 +771,103 @@ export type GitGetInstallationUrlInput = {
 
 /** Group of Repositories */
 export type GitGroup = {
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
 };
 
 export type GitGroupInput = {
-  organizationId: Scalars['String'];
+  organizationId: Scalars['String']['input'];
 };
 
 export type GitOAuth2FlowInput = {
-  code: Scalars['String'];
+  code: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
 };
 
 export type GitOrganization = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  installationId: Scalars['String'];
-  name: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  installationId: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   provider: EnumGitProvider;
   type: EnumGitOrganizationType;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   /** Defines if a git organisation needs defined repository groups */
-  useGroupingForRepositories: Scalars['Boolean'];
+  useGroupingForRepositories: Scalars['Boolean']['output'];
 };
 
 export type GitOrganizationCreateInput = {
   gitProvider: EnumGitProvider;
-  installationId: Scalars['String'];
+  installationId: Scalars['String']['input'];
 };
 
 export type GitOrganizationWhereInput = {
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type GitRepository = {
-  createdAt?: Maybe<Scalars['DateTime']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
   gitOrganization: GitOrganization;
-  gitOrganizationId: Scalars['String'];
-  groupName?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
-  updatedAt?: Maybe<Scalars['DateTime']>;
+  gitOrganizationId: Scalars['String']['output'];
+  groupName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
 };
 
 export type IBlock = {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type IntFilter = {
-  equals?: InputMaybe<Scalars['Int']>;
-  gt?: InputMaybe<Scalars['Int']>;
-  gte?: InputMaybe<Scalars['Int']>;
-  in?: InputMaybe<Array<Scalars['Int']>>;
-  lt?: InputMaybe<Scalars['Int']>;
-  lte?: InputMaybe<Scalars['Int']>;
-  not?: InputMaybe<Scalars['Int']>;
-  notIn?: InputMaybe<Array<Scalars['Int']>>;
+  equals?: InputMaybe<Scalars['Int']['input']>;
+  gt?: InputMaybe<Scalars['Int']['input']>;
+  gte?: InputMaybe<Scalars['Int']['input']>;
+  in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  lt?: InputMaybe<Scalars['Int']['input']>;
+  lte?: InputMaybe<Scalars['Int']['input']>;
+  not?: InputMaybe<Scalars['Int']['input']>;
+  notIn?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 export type Invitation = {
-  createdAt: Scalars['DateTime'];
-  email: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  email: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   invitedByUser?: Maybe<User>;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   workspace?: Maybe<Workspace>;
 };
 
 export type InviteUserInput = {
-  email: Scalars['String'];
+  email: Scalars['String']['input'];
 };
 
 export type LoginInput = {
-  email: Scalars['String'];
-  password: Scalars['String'];
+  email: Scalars['String']['input'];
+  password: Scalars['String']['input'];
 };
 
 export type MessagePattern = {
-  topicId: Scalars['String'];
+  topicId: Scalars['String']['output'];
   type: EnumMessagePatternConnectionOptions;
 };
 
 export type MessagePatternCreateInput = {
-  topicId: Scalars['String'];
+  topicId: Scalars['String']['input'];
   type: EnumMessagePatternConnectionOptions;
 };
 
@@ -902,7 +904,7 @@ export type Mutation = {
   deleteEntity?: Maybe<Entity>;
   deleteEntityField: EntityField;
   deleteEntityPermissionField: EntityPermissionField;
-  deleteGitOrganization: Scalars['Boolean'];
+  deleteGitOrganization: Scalars['Boolean']['output'];
   deleteGitRepository: Resource;
   deletePluginInstallation: PluginInstallation;
   deleteProject?: Maybe<Project>;
@@ -912,7 +914,7 @@ export type Mutation = {
   deleteTopic: Topic;
   deleteUser?: Maybe<User>;
   deleteWorkspace?: Maybe<Workspace>;
-  discardPendingChanges?: Maybe<Scalars['Boolean']>;
+  discardPendingChanges?: Maybe<Scalars['Boolean']['output']>;
   disconnectResourceGitRepository: Resource;
   getGitResourceInstallationUrl: AuthorizeResourceWithGitResult;
   inviteUser?: Maybe<Invitation>;
@@ -978,7 +980,7 @@ export type MutationConnectResourceGitRepositoryArgs = {
 
 
 export type MutationConnectResourceToProjectRepositoryArgs = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 
@@ -998,24 +1000,24 @@ export type MutationCreateDefaultEntitiesArgs = {
 
 
 export type MutationCreateDefaultRelatedFieldArgs = {
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
   where: WhereUniqueInput;
 };
 
 
 export type MutationCreateEntitiesFromPrismaSchemaArgs = {
   data: CreateEntitiesFromPrismaSchemaInput;
-  file: Scalars['Upload'];
+  file: Scalars['Upload']['input'];
 };
 
 
 export type MutationCreateEntityFieldArgs = {
   data: EntityFieldCreateInput;
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1105,13 +1107,13 @@ export type MutationDeleteEntityPermissionFieldArgs = {
 
 
 export type MutationDeleteGitOrganizationArgs = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
 };
 
 
 export type MutationDeleteGitRepositoryArgs = {
-  gitRepositoryId: Scalars['String'];
+  gitRepositoryId: Scalars['String']['input'];
 };
 
 
@@ -1161,7 +1163,7 @@ export type MutationDiscardPendingChangesArgs = {
 
 
 export type MutationDisconnectResourceGitRepositoryArgs = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 
@@ -1229,9 +1231,9 @@ export type MutationUpdateEntityArgs = {
 
 export type MutationUpdateEntityFieldArgs = {
   data: EntityFieldUpdateInput;
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
   where: WhereUniqueInput;
 };
 
@@ -1309,25 +1311,25 @@ export type MutationUpdateWorkspaceArgs = {
 export type PaginatedGitGroup = {
   groups?: Maybe<Array<GitGroup>>;
   /** Page number */
-  page: Scalars['Float'];
+  page: Scalars['Float']['output'];
   /** Number of groups per page */
-  pageSize: Scalars['Float'];
+  pageSize: Scalars['Float']['output'];
   /** Total number of groups */
-  total: Scalars['Float'];
+  total: Scalars['Float']['output'];
 };
 
 export type Pagination = {
-  page: Scalars['Float'];
-  perPage: Scalars['Float'];
+  page: Scalars['Float']['output'];
+  perPage: Scalars['Float']['output'];
 };
 
 export type PendingChange = {
   action: EnumPendingChangeAction;
   origin: PendingChangeOrigin;
-  originId: Scalars['String'];
+  originId: Scalars['String']['output'];
   originType: EnumPendingChangeOriginType;
   resource: Resource;
-  versionNumber: Scalars['Int'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 export type PendingChangeOrigin = Block | Entity;
@@ -1342,39 +1344,39 @@ export type PendingChangesFindInput = {
 
 export type PluginInstallation = IBlock & {
   blockType: EnumBlockType;
-  configurations?: Maybe<Scalars['JSONObject']>;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
-  id: Scalars['String'];
+  configurations?: Maybe<Scalars['JSONObject']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  enabled: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  npm: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  npm: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  pluginId: Scalars['String'];
-  resourceId?: Maybe<Scalars['String']>;
-  settings?: Maybe<Scalars['JSONObject']>;
-  updatedAt: Scalars['DateTime'];
-  version: Scalars['String'];
-  versionNumber: Scalars['Float'];
+  pluginId: Scalars['String']['output'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  settings?: Maybe<Scalars['JSONObject']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  version: Scalars['String']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type PluginInstallationCreateInput = {
-  configurations?: InputMaybe<Scalars['JSONObject']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
+  configurations?: InputMaybe<Scalars['JSONObject']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  enabled: Scalars['Boolean']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  npm: Scalars['String'];
+  npm: Scalars['String']['input'];
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
-  pluginId: Scalars['String'];
+  pluginId: Scalars['String']['input'];
   resource: WhereParentIdInput;
-  settings?: InputMaybe<Scalars['JSONObject']>;
-  version: Scalars['String'];
+  settings?: InputMaybe<Scalars['JSONObject']['input']>;
+  version: Scalars['String']['input'];
 };
 
 export type PluginInstallationOrderByInput = {
@@ -1387,12 +1389,12 @@ export type PluginInstallationOrderByInput = {
 };
 
 export type PluginInstallationUpdateInput = {
-  configurations?: InputMaybe<Scalars['JSONObject']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  enabled: Scalars['Boolean'];
-  settings?: InputMaybe<Scalars['JSONObject']>;
-  version: Scalars['String'];
+  configurations?: InputMaybe<Scalars['JSONObject']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  enabled: Scalars['Boolean']['input'];
+  settings?: InputMaybe<Scalars['JSONObject']['input']>;
+  version: Scalars['String']['input'];
 };
 
 export type PluginInstallationWhereInput = {
@@ -1411,65 +1413,65 @@ export type PluginInstallationsCreateInput = {
 
 export type PluginOrder = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   order: Array<PluginOrderItem>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type PluginOrderItem = {
-  order: Scalars['Int'];
-  pluginId: Scalars['String'];
+  order: Scalars['Int']['output'];
+  pluginId: Scalars['String']['output'];
 };
 
 export type PluginSetOrderInput = {
-  order: Scalars['Int'];
+  order: Scalars['Int']['input'];
 };
 
 export type Project = {
-  createdAt: Scalars['DateTime'];
-  demoRepoName?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  demoRepoName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   resources?: Maybe<Array<Resource>>;
-  updatedAt: Scalars['DateTime'];
-  useDemoRepo: Scalars['Boolean'];
+  updatedAt: Scalars['DateTime']['output'];
+  useDemoRepo: Scalars['Boolean']['output'];
 };
 
 export type ProjectConfigurationSettings = IBlock & {
-  baseDirectory: Scalars['String'];
+  baseDirectory: Scalars['String']['output'];
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ProjectConfigurationSettingsUpdateInput = {
-  baseDirectory?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
+  baseDirectory?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ProjectCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type ProjectOrderByInput = {
@@ -1479,38 +1481,38 @@ export type ProjectOrderByInput = {
 };
 
 export type ProjectUpdateInput = {
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ProjectWhereInput = {
   deletedAt?: InputMaybe<DateTimeFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   resources?: InputMaybe<ResourceListRelationFilter>;
 };
 
 export type PropertySelector = {
-  include: Scalars['Boolean'];
-  propertyName: Scalars['String'];
+  include: Scalars['Boolean']['output'];
+  propertyName: Scalars['String']['output'];
 };
 
 export type PropertySelectorInput = {
-  include: Scalars['Boolean'];
-  propertyName: Scalars['String'];
+  include: Scalars['Boolean']['input'];
+  propertyName: Scalars['String']['input'];
 };
 
 export type ProvisionSubscriptionInput = {
-  billingPeriod: Scalars['String'];
-  cancelUrl?: InputMaybe<Scalars['String']>;
-  intentionType: Scalars['String'];
-  planId: Scalars['String'];
-  successUrl?: InputMaybe<Scalars['String']>;
-  workspaceId: Scalars['String'];
+  billingPeriod: Scalars['String']['input'];
+  cancelUrl?: InputMaybe<Scalars['String']['input']>;
+  intentionType: Scalars['String']['input'];
+  planId: Scalars['String']['input'];
+  successUrl?: InputMaybe<Scalars['String']['input']>;
+  workspaceId: Scalars['String']['input'];
 };
 
 export type ProvisionSubscriptionResult = {
-  checkoutUrl?: Maybe<Scalars['String']>;
-  provisionStatus: Scalars['String'];
+  checkoutUrl?: Maybe<Scalars['String']['output']>;
+  provisionStatus: Scalars['String']['output'];
 };
 
 export type Query = {
@@ -1561,8 +1563,8 @@ export type QueryPluginInstallationArgs = {
 
 export type QueryPluginInstallationsArgs = {
   orderBy?: InputMaybe<PluginInstallationOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<PluginInstallationWhereInput>;
 };
 
@@ -1574,8 +1576,8 @@ export type QueryServiceTopicsArgs = {
 
 export type QueryServiceTopicsListArgs = {
   orderBy?: InputMaybe<ServiceTopicsOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ServiceTopicsWhereInput>;
 };
 
@@ -1587,8 +1589,8 @@ export type QueryTopicArgs = {
 
 export type QueryTopicsArgs = {
   orderBy?: InputMaybe<TopicOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<TopicWhereInput>;
 };
 
@@ -1605,8 +1607,8 @@ export type QueryBlockArgs = {
 
 export type QueryBlocksArgs = {
   orderBy?: InputMaybe<BlockOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BlockWhereInput>;
 };
 
@@ -1618,8 +1620,8 @@ export type QueryBuildArgs = {
 
 export type QueryBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
@@ -1632,16 +1634,16 @@ export type QueryCommitArgs = {
 export type QueryCommitsArgs = {
   cursor?: InputMaybe<CommitWhereUniqueInput>;
   orderBy?: InputMaybe<CommitOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<CommitWhereInput>;
 };
 
 
 export type QueryEntitiesArgs = {
   orderBy?: InputMaybe<EntityOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityWhereInput>;
 };
 
@@ -1662,8 +1664,8 @@ export type QueryGitOrganizationArgs = {
 
 
 export type QueryGitOrganizationsArgs = {
-  skip?: InputMaybe<Scalars['Float']>;
-  take?: InputMaybe<Scalars['Float']>;
+  skip?: InputMaybe<Scalars['Float']['input']>;
+  take?: InputMaybe<Scalars['Float']['input']>;
   where?: InputMaybe<GitOrganizationWhereInput>;
 };
 
@@ -1695,8 +1697,8 @@ export type QueryProjectConfigurationSettingsArgs = {
 
 export type QueryProjectsArgs = {
   orderBy?: InputMaybe<ProjectOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ProjectWhereInput>;
 };
 
@@ -1712,23 +1714,23 @@ export type QueryResourceArgs = {
 
 
 export type QueryResourceRoleArgs = {
-  version?: InputMaybe<Scalars['Float']>;
+  version?: InputMaybe<Scalars['Float']['input']>;
   where: WhereUniqueInput;
 };
 
 
 export type QueryResourceRolesArgs = {
   orderBy?: InputMaybe<ResourceRoleOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ResourceRoleWhereInput>;
 };
 
 
 export type QueryResourcesArgs = {
   orderBy?: InputMaybe<Array<ResourceOrderByInput>>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ResourceWhereInput>;
 };
 
@@ -1750,68 +1752,68 @@ export enum QueryMode {
 export type RemoteGitRepos = {
   pagination: Pagination;
   repos: Array<RemoteGitRepository>;
-  total: Scalars['Float'];
+  total: Scalars['Float']['output'];
 };
 
 export type RemoteGitRepositoriesWhereUniqueInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
-  groupName?: InputMaybe<Scalars['String']>;
+  groupName?: InputMaybe<Scalars['String']['input']>;
   /** The page number. One-based indexing */
-  page?: Scalars['Float'];
+  page?: Scalars['Float']['input'];
   /** The number of items to return per page */
-  perPage?: Scalars['Float'];
+  perPage?: Scalars['Float']['input'];
 };
 
 export type RemoteGitRepository = {
-  admin: Scalars['Boolean'];
-  defaultBranch: Scalars['String'];
-  fullName: Scalars['String'];
-  groupName?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
-  private: Scalars['Boolean'];
-  url: Scalars['String'];
+  admin: Scalars['Boolean']['output'];
+  defaultBranch: Scalars['String']['output'];
+  fullName: Scalars['String']['output'];
+  groupName?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  private: Scalars['Boolean']['output'];
+  url: Scalars['String']['output'];
 };
 
 export type Resource = {
   builds: Array<Build>;
-  createdAt: Scalars['DateTime'];
-  description: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description: Scalars['String']['output'];
   entities: Array<Entity>;
   environments: Array<Environment>;
   gitRepository?: Maybe<GitRepository>;
-  gitRepositoryId?: Maybe<Scalars['String']>;
-  gitRepositoryOverride: Scalars['Boolean'];
-  githubLastMessage?: Maybe<Scalars['String']>;
-  githubLastSync?: Maybe<Scalars['DateTime']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  gitRepositoryId?: Maybe<Scalars['String']['output']>;
+  gitRepositoryOverride: Scalars['Boolean']['output'];
+  githubLastMessage?: Maybe<Scalars['String']['output']>;
+  githubLastSync?: Maybe<Scalars['DateTime']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   project?: Maybe<Project>;
-  projectId?: Maybe<Scalars['String']>;
+  projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 
 export type ResourceBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
 
 export type ResourceEntitiesArgs = {
   orderBy?: InputMaybe<EntityOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityWhereInput>;
 };
 
 export type ResourceCreateInput = {
-  description: Scalars['String'];
+  description: Scalars['String']['input'];
   gitRepository?: InputMaybe<ConnectGitRepositoryInput>;
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
   project: WhereParentIdInput;
   resourceType: EnumResourceType;
   serviceSettings?: InputMaybe<ServiceSettingsUpdateInput>;
@@ -1819,25 +1821,25 @@ export type ResourceCreateInput = {
 
 export type ResourceCreateWithEntitiesEntityInput = {
   fields: Array<ResourceCreateWithEntitiesFieldInput>;
-  name: Scalars['String'];
-  relationsToEntityIndex?: InputMaybe<Array<Scalars['Int']>>;
+  name: Scalars['String']['input'];
+  relationsToEntityIndex?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 export type ResourceCreateWithEntitiesFieldInput = {
   dataType?: InputMaybe<EnumDataType>;
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type ResourceCreateWithEntitiesInput = {
-  authType: Scalars['String'];
-  commitMessage: Scalars['String'];
-  connectToDemoRepo: Scalars['Boolean'];
-  dbType: Scalars['String'];
+  authType: Scalars['String']['input'];
+  commitMessage: Scalars['String']['input'];
+  connectToDemoRepo: Scalars['Boolean']['input'];
+  dbType: Scalars['String']['input'];
   entities: Array<ResourceCreateWithEntitiesEntityInput>;
   plugins?: InputMaybe<PluginInstallationsCreateInput>;
-  repoType: Scalars['String'];
+  repoType: Scalars['String']['input'];
   resource: ResourceCreateInput;
-  wizardType: Scalars['String'];
+  wizardType: Scalars['String']['input'];
 };
 
 export type ResourceCreateWithEntitiesResult = {
@@ -1861,18 +1863,18 @@ export type ResourceOrderByInput = {
 };
 
 export type ResourceRole = {
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type ResourceRoleCreateInput = {
-  description: Scalars['String'];
-  displayName: Scalars['String'];
-  name: Scalars['String'];
+  description: Scalars['String']['input'];
+  displayName: Scalars['String']['input'];
+  name: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
@@ -1886,34 +1888,34 @@ export type ResourceRoleOrderByInput = {
 };
 
 export type ResourceRoleUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceRoleWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   resource?: InputMaybe<WhereUniqueInput>;
   updatedAt?: InputMaybe<DateTimeFilter>;
 };
 
 export type ResourceUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  gitRepositoryOverride?: InputMaybe<Scalars['Boolean']>;
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  gitRepositoryOverride?: InputMaybe<Scalars['Boolean']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
   description?: InputMaybe<StringFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   project?: InputMaybe<ProjectWhereInput>;
-  projectId?: InputMaybe<Scalars['String']>;
+  projectId?: InputMaybe<Scalars['String']['input']>;
   resourceType?: InputMaybe<EnumResourceTypeFilter>;
   updatedAt?: InputMaybe<DateTimeFilter>;
 };
@@ -1926,69 +1928,69 @@ export enum Role {
 }
 
 export type ServerSettings = {
-  generateGraphQL: Scalars['Boolean'];
-  generateRestApi: Scalars['Boolean'];
-  serverPath: Scalars['String'];
+  generateGraphQL: Scalars['Boolean']['output'];
+  generateRestApi: Scalars['Boolean']['output'];
+  serverPath: Scalars['String']['output'];
 };
 
 export type ServerSettingsUpdateInput = {
-  generateGraphQL?: InputMaybe<Scalars['Boolean']>;
-  generateRestApi?: InputMaybe<Scalars['Boolean']>;
-  serverPath?: InputMaybe<Scalars['String']>;
+  generateGraphQL?: InputMaybe<Scalars['Boolean']['input']>;
+  generateRestApi?: InputMaybe<Scalars['Boolean']['input']>;
+  serverPath?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ServiceSettings = IBlock & {
   adminUISettings: AdminUiSettings;
   authProvider: EnumAuthProviderType;
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
+  resourceId?: Maybe<Scalars['String']['output']>;
   serverSettings: ServerSettings;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ServiceSettingsUpdateInput = {
   adminUISettings: AdminUiSettingsUpdateInput;
   authProvider: EnumAuthProviderType;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
   serverSettings: ServerSettingsUpdateInput;
 };
 
 export type ServiceTopics = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  enabled: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  messageBrokerId: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  messageBrokerId: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
   patterns: Array<MessagePattern>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ServiceTopicsCreateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  enabled: Scalars['Boolean']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  messageBrokerId: Scalars['String'];
+  messageBrokerId: Scalars['String']['input'];
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
   patterns?: InputMaybe<Array<MessagePatternCreateInput>>;
@@ -2005,10 +2007,10 @@ export type ServiceTopicsOrderByInput = {
 };
 
 export type ServiceTopicsUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  enabled: Scalars['Boolean'];
-  messageBrokerId: Scalars['String'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  enabled: Scalars['Boolean']['input'];
+  messageBrokerId: Scalars['String']['input'];
   patterns?: InputMaybe<Array<MessagePatternCreateInput>>;
 };
 
@@ -2023,11 +2025,11 @@ export type ServiceTopicsWhereInput = {
 };
 
 export type SignupInput = {
-  email: Scalars['String'];
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  password: Scalars['String'];
-  workspaceName: Scalars['String'];
+  email: Scalars['String']['input'];
+  firstName: Scalars['String']['input'];
+  lastName: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+  workspaceName: Scalars['String']['input'];
 };
 
 export enum SortOrder {
@@ -2036,57 +2038,57 @@ export enum SortOrder {
 }
 
 export type StringFilter = {
-  contains?: InputMaybe<Scalars['String']>;
-  endsWith?: InputMaybe<Scalars['String']>;
-  equals?: InputMaybe<Scalars['String']>;
-  gt?: InputMaybe<Scalars['String']>;
-  gte?: InputMaybe<Scalars['String']>;
-  in?: InputMaybe<Array<Scalars['String']>>;
-  lt?: InputMaybe<Scalars['String']>;
-  lte?: InputMaybe<Scalars['String']>;
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
   mode?: InputMaybe<QueryMode>;
-  not?: InputMaybe<Scalars['String']>;
-  notIn?: InputMaybe<Array<Scalars['String']>>;
-  startsWith?: InputMaybe<Scalars['String']>;
+  not?: InputMaybe<Scalars['String']['input']>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Subscription = {
-  cancelUrl?: Maybe<Scalars['String']>;
-  cancellationEffectiveDate?: Maybe<Scalars['DateTime']>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  nextBillDate?: Maybe<Scalars['DateTime']>;
-  price?: Maybe<Scalars['Float']>;
+  cancelUrl?: Maybe<Scalars['String']['output']>;
+  cancellationEffectiveDate?: Maybe<Scalars['DateTime']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  nextBillDate?: Maybe<Scalars['DateTime']['output']>;
+  price?: Maybe<Scalars['Float']['output']>;
   status: EnumSubscriptionStatus;
   subscriptionPlan: EnumSubscriptionPlan;
-  updateUrl?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
+  updateUrl?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
   workspace?: Maybe<Workspace>;
-  workspaceId: Scalars['String'];
+  workspaceId: Scalars['String']['output'];
 };
 
 export type Topic = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type TopicCreateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
   resource: WhereParentIdInput;
@@ -2102,9 +2104,9 @@ export type TopicOrderByInput = {
 };
 
 export type TopicUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicWhereInput = {
@@ -2118,25 +2120,25 @@ export type TopicWhereInput = {
 };
 
 export type UpdateAccountInput = {
-  firstName?: InputMaybe<Scalars['String']>;
-  lastName?: InputMaybe<Scalars['String']>;
+  firstName?: InputMaybe<Scalars['String']['input']>;
+  lastName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type User = {
   account?: Maybe<Account>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  isOwner: Scalars['Boolean'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  isOwner: Scalars['Boolean']['output'];
+  updatedAt: Scalars['DateTime']['output'];
   userRoles?: Maybe<Array<UserRole>>;
   workspace?: Maybe<Workspace>;
 };
 
 export type UserRole = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   role: Role;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type WhereParentIdInput = {
@@ -2144,22 +2146,22 @@ export type WhereParentIdInput = {
 };
 
 export type WhereUniqueInput = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type Workspace = {
-  createdAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
   gitOrganizations?: Maybe<Array<GitOrganization>>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   projects: Array<Project>;
   subscription?: Maybe<Subscription>;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   users: Array<User>;
 };
 
 export type WorkspaceCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type WorkspaceMember = {
@@ -2170,5 +2172,5 @@ export type WorkspaceMember = {
 export type WorkspaceMemberType = Invitation | User;
 
 export type WorkspaceUpdateInput = {
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -3,131 +3,133 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
   /** A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format. */
-  DateTime: any;
+  DateTime: { input: any; output: any; }
   /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
-  JSONObject: any;
+  JSONObject: { input: any; output: any; }
   /** The `Upload` scalar type represents a file upload. */
-  Upload: any;
+  Upload: { input: any; output: any; }
 };
 
 export type Account = {
-  createdAt: Scalars['DateTime'];
-  email: Scalars['String'];
-  firstName: Scalars['String'];
-  githubId?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  lastName: Scalars['String'];
-  password: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  email: Scalars['String']['output'];
+  firstName: Scalars['String']['output'];
+  githubId?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  lastName: Scalars['String']['output'];
+  password: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type Action = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   steps?: Maybe<Array<ActionStep>>;
 };
 
 export type ActionLog = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   level: EnumActionLogLevel;
-  message: Scalars['String'];
-  meta: Scalars['JSONObject'];
+  message: Scalars['String']['output'];
+  meta: Scalars['JSONObject']['output'];
 };
 
 export type ActionStep = {
-  completedAt?: Maybe<Scalars['DateTime']>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  completedAt?: Maybe<Scalars['DateTime']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   logs?: Maybe<Array<ActionLog>>;
-  message: Scalars['String'];
-  name: Scalars['String'];
+  message: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   status: EnumActionStepStatus;
 };
 
 export type AdminUiSettings = {
-  adminUIPath: Scalars['String'];
-  generateAdminUI: Scalars['Boolean'];
+  adminUIPath: Scalars['String']['output'];
+  generateAdminUI: Scalars['Boolean']['output'];
 };
 
 export type AdminUiSettingsUpdateInput = {
-  adminUIPath?: InputMaybe<Scalars['String']>;
-  generateAdminUI?: InputMaybe<Scalars['Boolean']>;
+  adminUIPath?: InputMaybe<Scalars['String']['input']>;
+  generateAdminUI?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ApiToken = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  lastAccessAt: Scalars['DateTime'];
-  name: Scalars['String'];
-  previewChars: Scalars['String'];
-  token?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  userId: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  lastAccessAt: Scalars['DateTime']['output'];
+  name: Scalars['String']['output'];
+  previewChars: Scalars['String']['output'];
+  token?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  userId: Scalars['String']['output'];
 };
 
 export type ApiTokenCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type Auth = {
   /** JWT Bearer token */
-  token: Scalars['String'];
+  token: Scalars['String']['output'];
 };
 
 export type AuthorizeResourceWithGitResult = {
-  url: Scalars['String'];
+  url: Scalars['String']['output'];
 };
 
 export type Block = {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  lockedAt?: Maybe<Scalars['DateTime']>;
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedByUser: Array<User>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   parentBlock?: Maybe<Block>;
   resource?: Maybe<Resource>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber?: Maybe<Scalars['Float']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber?: Maybe<Scalars['Float']['output']>;
   versions?: Maybe<Array<BlockVersion>>;
 };
 
 
 export type BlockVersionsArgs = {
   orderBy?: InputMaybe<BlockVersionOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BlockVersionWhereInput>;
 };
 
 export type BlockInputOutput = {
   dataType?: Maybe<EnumDataType>;
-  dataTypeEntityName?: Maybe<Scalars['String']>;
-  description: Scalars['String'];
-  includeAllPropertiesByDefault?: Maybe<Scalars['Boolean']>;
-  isList?: Maybe<Scalars['Boolean']>;
-  name: Scalars['String'];
+  dataTypeEntityName?: Maybe<Scalars['String']['output']>;
+  description: Scalars['String']['output'];
+  includeAllPropertiesByDefault?: Maybe<Scalars['Boolean']['output']>;
+  isList?: Maybe<Scalars['Boolean']['output']>;
+  name: Scalars['String']['output'];
   propertyList?: Maybe<Array<PropertySelector>>;
 };
 
 export type BlockInputOutputInput = {
   dataType?: InputMaybe<EnumDataType>;
-  dataTypeEntityName?: InputMaybe<Scalars['String']>;
-  description: Scalars['String'];
-  includeAllPropertiesByDefault?: InputMaybe<Scalars['Boolean']>;
-  isList?: InputMaybe<Scalars['Boolean']>;
-  name: Scalars['String'];
+  dataTypeEntityName?: InputMaybe<Scalars['String']['input']>;
+  description: Scalars['String']['input'];
+  includeAllPropertiesByDefault?: InputMaybe<Scalars['Boolean']['input']>;
+  isList?: InputMaybe<Scalars['Boolean']['input']>;
+  name: Scalars['String']['input'];
   propertyList?: InputMaybe<Array<PropertySelectorInput>>;
 };
 
@@ -143,13 +145,13 @@ export type BlockOrderByInput = {
 export type BlockVersion = {
   block: Block;
   commit?: Maybe<Commit>;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  settings?: Maybe<Scalars['JSONObject']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Int'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  settings?: Maybe<Scalars['JSONObject']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 export type BlockVersionOrderByInput = {
@@ -181,30 +183,30 @@ export type BlockWhereInput = {
 };
 
 export type BooleanFilter = {
-  equals?: InputMaybe<Scalars['Boolean']>;
-  not?: InputMaybe<Scalars['Boolean']>;
+  equals?: InputMaybe<Scalars['Boolean']['input']>;
+  not?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type Build = {
   action?: Maybe<Action>;
-  actionId: Scalars['String'];
-  archiveURI: Scalars['String'];
+  actionId: Scalars['String']['output'];
+  archiveURI: Scalars['String']['output'];
   commit: Commit;
-  commitId: Scalars['String'];
-  createdAt: Scalars['DateTime'];
+  commitId: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
   createdBy: User;
-  id: Scalars['String'];
-  message: Scalars['String'];
+  id: Scalars['String']['output'];
+  message: Scalars['String']['output'];
   resource?: Maybe<Resource>;
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['output'];
   status?: Maybe<EnumBuildStatus>;
-  userId: Scalars['String'];
-  version: Scalars['String'];
+  userId: Scalars['String']['output'];
+  version: Scalars['String']['output'];
 };
 
 export type BuildCreateInput = {
   commit: WhereParentIdInput;
-  message: Scalars['String'];
+  message: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
@@ -228,30 +230,30 @@ export type BuildWhereInput = {
 };
 
 export type ChangePasswordInput = {
-  newPassword: Scalars['String'];
-  oldPassword: Scalars['String'];
+  newPassword: Scalars['String']['input'];
+  oldPassword: Scalars['String']['input'];
 };
 
 export type Commit = {
   builds?: Maybe<Array<Build>>;
   changes?: Maybe<Array<PendingChange>>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  message: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  message: Scalars['String']['output'];
   user?: Maybe<User>;
-  userId: Scalars['String'];
+  userId: Scalars['String']['output'];
 };
 
 
 export type CommitBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
 export type CommitCreateInput = {
-  message: Scalars['String'];
+  message: Scalars['String']['input'];
   project: WhereParentIdInput;
 };
 
@@ -270,24 +272,24 @@ export type CommitWhereInput = {
 };
 
 export type CommitWhereUniqueInput = {
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CompleteInvitationInput = {
-  token: Scalars['String'];
+  token: Scalars['String']['input'];
 };
 
 export type ConnectGitRepositoryInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isOverrideGitRepository?: InputMaybe<Scalars['Boolean']>;
-  name: Scalars['String'];
-  resourceId: Scalars['String'];
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isOverrideGitRepository?: InputMaybe<Scalars['Boolean']['input']>;
+  name: Scalars['String']['input'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type CreateEntitiesFromPrismaSchemaInput = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type CreateEntitiesFromPrismaSchemaResponse = {
@@ -296,128 +298,128 @@ export type CreateEntitiesFromPrismaSchemaResponse = {
 };
 
 export type CreateGitRepositoryBaseInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isPublic: Scalars['Boolean'];
-  name: Scalars['String'];
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isPublic: Scalars['Boolean']['input'];
+  name: Scalars['String']['input'];
 };
 
 export type CreateGitRepositoryInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isPublic: Scalars['Boolean'];
-  name: Scalars['String'];
-  resourceId?: InputMaybe<Scalars['String']>;
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isPublic: Scalars['Boolean']['input'];
+  name: Scalars['String']['input'];
+  resourceId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type DateTimeFilter = {
-  equals?: InputMaybe<Scalars['DateTime']>;
-  gt?: InputMaybe<Scalars['DateTime']>;
-  gte?: InputMaybe<Scalars['DateTime']>;
-  in?: InputMaybe<Array<Scalars['DateTime']>>;
-  lt?: InputMaybe<Scalars['DateTime']>;
-  lte?: InputMaybe<Scalars['DateTime']>;
-  not?: InputMaybe<Scalars['DateTime']>;
-  notIn?: InputMaybe<Array<Scalars['DateTime']>>;
+  equals?: InputMaybe<Scalars['DateTime']['input']>;
+  gt?: InputMaybe<Scalars['DateTime']['input']>;
+  gte?: InputMaybe<Scalars['DateTime']['input']>;
+  in?: InputMaybe<Array<Scalars['DateTime']['input']>>;
+  lt?: InputMaybe<Scalars['DateTime']['input']>;
+  lte?: InputMaybe<Scalars['DateTime']['input']>;
+  not?: InputMaybe<Scalars['DateTime']['input']>;
+  notIn?: InputMaybe<Array<Scalars['DateTime']['input']>>;
 };
 
 export type DefaultEntitiesInput = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type Entity = {
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
   fields?: Maybe<Array<EntityField>>;
-  id: Scalars['String'];
-  lockedAt?: Maybe<Scalars['DateTime']>;
+  id: Scalars['String']['output'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedByUser?: Maybe<User>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
   permissions?: Maybe<Array<EntityPermission>>;
-  pluralDisplayName: Scalars['String'];
+  pluralDisplayName: Scalars['String']['output'];
   resource?: Maybe<Resource>;
-  resourceId: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  resourceId: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
   versions?: Maybe<Array<EntityVersion>>;
 };
 
 
 export type EntityFieldsArgs = {
   orderBy?: InputMaybe<EntityFieldOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityFieldWhereInput>;
 };
 
 
 export type EntityVersionsArgs = {
   orderBy?: InputMaybe<EntityVersionOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityVersionWhereInput>;
 };
 
 export type EntityAddPermissionFieldInput = {
   action: EnumEntityAction;
   entity: WhereParentIdInput;
-  fieldName: Scalars['String'];
+  fieldName: Scalars['String']['input'];
 };
 
 export type EntityCreateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
   /** allow creating the id for the entity when using import prisma schema because we need it for the relation */
-  id?: InputMaybe<Scalars['String']>;
-  name: Scalars['String'];
-  pluralDisplayName: Scalars['String'];
+  id?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  pluralDisplayName: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
 export type EntityField = {
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
   dataType: EnumDataType;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
-  permanentId: Scalars['String'];
-  position?: Maybe<Scalars['Int']>;
-  properties?: Maybe<Scalars['JSONObject']>;
-  required: Scalars['Boolean'];
-  searchable: Scalars['Boolean'];
-  unique: Scalars['Boolean'];
-  updatedAt: Scalars['DateTime'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  permanentId: Scalars['String']['output'];
+  position?: Maybe<Scalars['Int']['output']>;
+  properties?: Maybe<Scalars['JSONObject']['output']>;
+  required: Scalars['Boolean']['output'];
+  searchable: Scalars['Boolean']['output'];
+  unique: Scalars['Boolean']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type EntityFieldCreateByDisplayNameInput = {
   dataType?: InputMaybe<EnumDataType>;
-  displayName: Scalars['String'];
+  displayName: Scalars['String']['input'];
   entity: WhereParentIdInput;
 };
 
 export type EntityFieldCreateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
   dataType: EnumDataType;
-  description: Scalars['String'];
-  displayName: Scalars['String'];
+  description: Scalars['String']['input'];
+  displayName: Scalars['String']['input'];
   entity: WhereParentIdInput;
-  name: Scalars['String'];
-  position?: InputMaybe<Scalars['Int']>;
-  properties: Scalars['JSONObject'];
-  required: Scalars['Boolean'];
-  searchable: Scalars['Boolean'];
-  unique: Scalars['Boolean'];
+  name: Scalars['String']['input'];
+  position?: InputMaybe<Scalars['Int']['input']>;
+  properties: Scalars['JSONObject']['input'];
+  required: Scalars['Boolean']['input'];
+  searchable: Scalars['Boolean']['input'];
+  unique: Scalars['Boolean']['input'];
 };
 
 export type EntityFieldFilter = {
@@ -443,16 +445,16 @@ export type EntityFieldOrderByInput = {
 };
 
 export type EntityFieldUpdateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
   dataType?: InputMaybe<EnumDataType>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  position?: InputMaybe<Scalars['Int']>;
-  properties?: InputMaybe<Scalars['JSONObject']>;
-  required?: InputMaybe<Scalars['Boolean']>;
-  searchable?: InputMaybe<Scalars['Boolean']>;
-  unique?: InputMaybe<Scalars['Boolean']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  position?: InputMaybe<Scalars['Int']['input']>;
+  properties?: InputMaybe<Scalars['JSONObject']['input']>;
+  required?: InputMaybe<Scalars['Boolean']['input']>;
+  searchable?: InputMaybe<Scalars['Boolean']['input']>;
+  unique?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type EntityFieldWhereInput = {
@@ -484,44 +486,44 @@ export type EntityOrderByInput = {
 export type EntityPermission = {
   action: EnumEntityAction;
   entityVersion?: Maybe<EntityVersion>;
-  entityVersionId: Scalars['String'];
-  id: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   permissionFields?: Maybe<Array<EntityPermissionField>>;
   permissionRoles?: Maybe<Array<EntityPermissionRole>>;
   type: EnumEntityPermissionType;
 };
 
 export type EntityPermissionField = {
-  entityVersionId: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
   field: EntityField;
-  fieldPermanentId: Scalars['String'];
-  id: Scalars['String'];
+  fieldPermanentId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   permission?: Maybe<EntityPermission>;
-  permissionId: Scalars['String'];
+  permissionId: Scalars['String']['output'];
   permissionRoles?: Maybe<Array<EntityPermissionRole>>;
 };
 
 export type EntityPermissionFieldWhereUniqueInput = {
   action: EnumEntityAction;
-  entityId: Scalars['String'];
-  fieldPermanentId: Scalars['String'];
+  entityId: Scalars['String']['input'];
+  fieldPermanentId: Scalars['String']['input'];
 };
 
 export type EntityPermissionRole = {
   action: EnumEntityAction;
   entityPermission?: Maybe<EntityPermission>;
-  entityVersionId: Scalars['String'];
-  id: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   resourceRole: ResourceRole;
-  resourceRoleId: Scalars['String'];
+  resourceRoleId: Scalars['String']['output'];
 };
 
 export type EntityUpdateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  pluralDisplayName?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  pluralDisplayName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type EntityUpdatePermissionFieldRolesInput = {
@@ -544,26 +546,26 @@ export type EntityUpdatePermissionRolesInput = {
 
 export type EntityVersion = {
   commit?: Maybe<Commit>;
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
   entity: Entity;
-  entityId: Scalars['String'];
+  entityId: Scalars['String']['output'];
   fields: Array<EntityField>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   permissions?: Maybe<Array<EntityPermission>>;
-  pluralDisplayName: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Int'];
+  pluralDisplayName: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 
 export type EntityVersionFieldsArgs = {
   orderBy?: InputMaybe<EntityFieldOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityFieldWhereInput>;
 };
 
@@ -753,14 +755,14 @@ export enum EnumWorkspaceMemberType {
 }
 
 export type Environment = {
-  address: Scalars['String'];
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  address: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   resource: Resource;
-  resourceId: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  resourceId: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type GitGetInstallationUrlInput = {
@@ -769,103 +771,103 @@ export type GitGetInstallationUrlInput = {
 
 /** Group of Repositories */
 export type GitGroup = {
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
 };
 
 export type GitGroupInput = {
-  organizationId: Scalars['String'];
+  organizationId: Scalars['String']['input'];
 };
 
 export type GitOAuth2FlowInput = {
-  code: Scalars['String'];
+  code: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
 };
 
 export type GitOrganization = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  installationId: Scalars['String'];
-  name: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  installationId: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   provider: EnumGitProvider;
   type: EnumGitOrganizationType;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   /** Defines if a git organisation needs defined repository groups */
-  useGroupingForRepositories: Scalars['Boolean'];
+  useGroupingForRepositories: Scalars['Boolean']['output'];
 };
 
 export type GitOrganizationCreateInput = {
   gitProvider: EnumGitProvider;
-  installationId: Scalars['String'];
+  installationId: Scalars['String']['input'];
 };
 
 export type GitOrganizationWhereInput = {
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type GitRepository = {
-  createdAt?: Maybe<Scalars['DateTime']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
   gitOrganization: GitOrganization;
-  gitOrganizationId: Scalars['String'];
-  groupName?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
-  updatedAt?: Maybe<Scalars['DateTime']>;
+  gitOrganizationId: Scalars['String']['output'];
+  groupName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
 };
 
 export type IBlock = {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type IntFilter = {
-  equals?: InputMaybe<Scalars['Int']>;
-  gt?: InputMaybe<Scalars['Int']>;
-  gte?: InputMaybe<Scalars['Int']>;
-  in?: InputMaybe<Array<Scalars['Int']>>;
-  lt?: InputMaybe<Scalars['Int']>;
-  lte?: InputMaybe<Scalars['Int']>;
-  not?: InputMaybe<Scalars['Int']>;
-  notIn?: InputMaybe<Array<Scalars['Int']>>;
+  equals?: InputMaybe<Scalars['Int']['input']>;
+  gt?: InputMaybe<Scalars['Int']['input']>;
+  gte?: InputMaybe<Scalars['Int']['input']>;
+  in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  lt?: InputMaybe<Scalars['Int']['input']>;
+  lte?: InputMaybe<Scalars['Int']['input']>;
+  not?: InputMaybe<Scalars['Int']['input']>;
+  notIn?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 export type Invitation = {
-  createdAt: Scalars['DateTime'];
-  email: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  email: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   invitedByUser?: Maybe<User>;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   workspace?: Maybe<Workspace>;
 };
 
 export type InviteUserInput = {
-  email: Scalars['String'];
+  email: Scalars['String']['input'];
 };
 
 export type LoginInput = {
-  email: Scalars['String'];
-  password: Scalars['String'];
+  email: Scalars['String']['input'];
+  password: Scalars['String']['input'];
 };
 
 export type MessagePattern = {
-  topicId: Scalars['String'];
+  topicId: Scalars['String']['output'];
   type: EnumMessagePatternConnectionOptions;
 };
 
 export type MessagePatternCreateInput = {
-  topicId: Scalars['String'];
+  topicId: Scalars['String']['input'];
   type: EnumMessagePatternConnectionOptions;
 };
 
@@ -902,7 +904,7 @@ export type Mutation = {
   deleteEntity?: Maybe<Entity>;
   deleteEntityField: EntityField;
   deleteEntityPermissionField: EntityPermissionField;
-  deleteGitOrganization: Scalars['Boolean'];
+  deleteGitOrganization: Scalars['Boolean']['output'];
   deleteGitRepository: Resource;
   deletePluginInstallation: PluginInstallation;
   deleteProject?: Maybe<Project>;
@@ -912,7 +914,7 @@ export type Mutation = {
   deleteTopic: Topic;
   deleteUser?: Maybe<User>;
   deleteWorkspace?: Maybe<Workspace>;
-  discardPendingChanges?: Maybe<Scalars['Boolean']>;
+  discardPendingChanges?: Maybe<Scalars['Boolean']['output']>;
   disconnectResourceGitRepository: Resource;
   getGitResourceInstallationUrl: AuthorizeResourceWithGitResult;
   inviteUser?: Maybe<Invitation>;
@@ -978,7 +980,7 @@ export type MutationConnectResourceGitRepositoryArgs = {
 
 
 export type MutationConnectResourceToProjectRepositoryArgs = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 
@@ -998,24 +1000,24 @@ export type MutationCreateDefaultEntitiesArgs = {
 
 
 export type MutationCreateDefaultRelatedFieldArgs = {
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
   where: WhereUniqueInput;
 };
 
 
 export type MutationCreateEntitiesFromPrismaSchemaArgs = {
   data: CreateEntitiesFromPrismaSchemaInput;
-  file: Scalars['Upload'];
+  file: Scalars['Upload']['input'];
 };
 
 
 export type MutationCreateEntityFieldArgs = {
   data: EntityFieldCreateInput;
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1105,13 +1107,13 @@ export type MutationDeleteEntityPermissionFieldArgs = {
 
 
 export type MutationDeleteGitOrganizationArgs = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
 };
 
 
 export type MutationDeleteGitRepositoryArgs = {
-  gitRepositoryId: Scalars['String'];
+  gitRepositoryId: Scalars['String']['input'];
 };
 
 
@@ -1161,7 +1163,7 @@ export type MutationDiscardPendingChangesArgs = {
 
 
 export type MutationDisconnectResourceGitRepositoryArgs = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 
@@ -1229,9 +1231,9 @@ export type MutationUpdateEntityArgs = {
 
 export type MutationUpdateEntityFieldArgs = {
   data: EntityFieldUpdateInput;
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
   where: WhereUniqueInput;
 };
 
@@ -1309,25 +1311,25 @@ export type MutationUpdateWorkspaceArgs = {
 export type PaginatedGitGroup = {
   groups?: Maybe<Array<GitGroup>>;
   /** Page number */
-  page: Scalars['Float'];
+  page: Scalars['Float']['output'];
   /** Number of groups per page */
-  pageSize: Scalars['Float'];
+  pageSize: Scalars['Float']['output'];
   /** Total number of groups */
-  total: Scalars['Float'];
+  total: Scalars['Float']['output'];
 };
 
 export type Pagination = {
-  page: Scalars['Float'];
-  perPage: Scalars['Float'];
+  page: Scalars['Float']['output'];
+  perPage: Scalars['Float']['output'];
 };
 
 export type PendingChange = {
   action: EnumPendingChangeAction;
   origin: PendingChangeOrigin;
-  originId: Scalars['String'];
+  originId: Scalars['String']['output'];
   originType: EnumPendingChangeOriginType;
   resource: Resource;
-  versionNumber: Scalars['Int'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 export type PendingChangeOrigin = Block | Entity;
@@ -1342,39 +1344,39 @@ export type PendingChangesFindInput = {
 
 export type PluginInstallation = IBlock & {
   blockType: EnumBlockType;
-  configurations?: Maybe<Scalars['JSONObject']>;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
-  id: Scalars['String'];
+  configurations?: Maybe<Scalars['JSONObject']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  enabled: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  npm: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  npm: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  pluginId: Scalars['String'];
-  resourceId?: Maybe<Scalars['String']>;
-  settings?: Maybe<Scalars['JSONObject']>;
-  updatedAt: Scalars['DateTime'];
-  version: Scalars['String'];
-  versionNumber: Scalars['Float'];
+  pluginId: Scalars['String']['output'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  settings?: Maybe<Scalars['JSONObject']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  version: Scalars['String']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type PluginInstallationCreateInput = {
-  configurations?: InputMaybe<Scalars['JSONObject']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
+  configurations?: InputMaybe<Scalars['JSONObject']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  enabled: Scalars['Boolean']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  npm: Scalars['String'];
+  npm: Scalars['String']['input'];
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
-  pluginId: Scalars['String'];
+  pluginId: Scalars['String']['input'];
   resource: WhereParentIdInput;
-  settings?: InputMaybe<Scalars['JSONObject']>;
-  version: Scalars['String'];
+  settings?: InputMaybe<Scalars['JSONObject']['input']>;
+  version: Scalars['String']['input'];
 };
 
 export type PluginInstallationOrderByInput = {
@@ -1387,12 +1389,12 @@ export type PluginInstallationOrderByInput = {
 };
 
 export type PluginInstallationUpdateInput = {
-  configurations?: InputMaybe<Scalars['JSONObject']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  enabled: Scalars['Boolean'];
-  settings?: InputMaybe<Scalars['JSONObject']>;
-  version: Scalars['String'];
+  configurations?: InputMaybe<Scalars['JSONObject']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  enabled: Scalars['Boolean']['input'];
+  settings?: InputMaybe<Scalars['JSONObject']['input']>;
+  version: Scalars['String']['input'];
 };
 
 export type PluginInstallationWhereInput = {
@@ -1411,65 +1413,65 @@ export type PluginInstallationsCreateInput = {
 
 export type PluginOrder = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   order: Array<PluginOrderItem>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type PluginOrderItem = {
-  order: Scalars['Int'];
-  pluginId: Scalars['String'];
+  order: Scalars['Int']['output'];
+  pluginId: Scalars['String']['output'];
 };
 
 export type PluginSetOrderInput = {
-  order: Scalars['Int'];
+  order: Scalars['Int']['input'];
 };
 
 export type Project = {
-  createdAt: Scalars['DateTime'];
-  demoRepoName?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  demoRepoName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   resources?: Maybe<Array<Resource>>;
-  updatedAt: Scalars['DateTime'];
-  useDemoRepo: Scalars['Boolean'];
+  updatedAt: Scalars['DateTime']['output'];
+  useDemoRepo: Scalars['Boolean']['output'];
 };
 
 export type ProjectConfigurationSettings = IBlock & {
-  baseDirectory: Scalars['String'];
+  baseDirectory: Scalars['String']['output'];
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ProjectConfigurationSettingsUpdateInput = {
-  baseDirectory?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
+  baseDirectory?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ProjectCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type ProjectOrderByInput = {
@@ -1479,38 +1481,38 @@ export type ProjectOrderByInput = {
 };
 
 export type ProjectUpdateInput = {
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ProjectWhereInput = {
   deletedAt?: InputMaybe<DateTimeFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   resources?: InputMaybe<ResourceListRelationFilter>;
 };
 
 export type PropertySelector = {
-  include: Scalars['Boolean'];
-  propertyName: Scalars['String'];
+  include: Scalars['Boolean']['output'];
+  propertyName: Scalars['String']['output'];
 };
 
 export type PropertySelectorInput = {
-  include: Scalars['Boolean'];
-  propertyName: Scalars['String'];
+  include: Scalars['Boolean']['input'];
+  propertyName: Scalars['String']['input'];
 };
 
 export type ProvisionSubscriptionInput = {
-  billingPeriod: Scalars['String'];
-  cancelUrl?: InputMaybe<Scalars['String']>;
-  intentionType: Scalars['String'];
-  planId: Scalars['String'];
-  successUrl?: InputMaybe<Scalars['String']>;
-  workspaceId: Scalars['String'];
+  billingPeriod: Scalars['String']['input'];
+  cancelUrl?: InputMaybe<Scalars['String']['input']>;
+  intentionType: Scalars['String']['input'];
+  planId: Scalars['String']['input'];
+  successUrl?: InputMaybe<Scalars['String']['input']>;
+  workspaceId: Scalars['String']['input'];
 };
 
 export type ProvisionSubscriptionResult = {
-  checkoutUrl?: Maybe<Scalars['String']>;
-  provisionStatus: Scalars['String'];
+  checkoutUrl?: Maybe<Scalars['String']['output']>;
+  provisionStatus: Scalars['String']['output'];
 };
 
 export type Query = {
@@ -1561,8 +1563,8 @@ export type QueryPluginInstallationArgs = {
 
 export type QueryPluginInstallationsArgs = {
   orderBy?: InputMaybe<PluginInstallationOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<PluginInstallationWhereInput>;
 };
 
@@ -1574,8 +1576,8 @@ export type QueryServiceTopicsArgs = {
 
 export type QueryServiceTopicsListArgs = {
   orderBy?: InputMaybe<ServiceTopicsOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ServiceTopicsWhereInput>;
 };
 
@@ -1587,8 +1589,8 @@ export type QueryTopicArgs = {
 
 export type QueryTopicsArgs = {
   orderBy?: InputMaybe<TopicOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<TopicWhereInput>;
 };
 
@@ -1605,8 +1607,8 @@ export type QueryBlockArgs = {
 
 export type QueryBlocksArgs = {
   orderBy?: InputMaybe<BlockOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BlockWhereInput>;
 };
 
@@ -1618,8 +1620,8 @@ export type QueryBuildArgs = {
 
 export type QueryBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
@@ -1632,16 +1634,16 @@ export type QueryCommitArgs = {
 export type QueryCommitsArgs = {
   cursor?: InputMaybe<CommitWhereUniqueInput>;
   orderBy?: InputMaybe<CommitOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<CommitWhereInput>;
 };
 
 
 export type QueryEntitiesArgs = {
   orderBy?: InputMaybe<EntityOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityWhereInput>;
 };
 
@@ -1662,8 +1664,8 @@ export type QueryGitOrganizationArgs = {
 
 
 export type QueryGitOrganizationsArgs = {
-  skip?: InputMaybe<Scalars['Float']>;
-  take?: InputMaybe<Scalars['Float']>;
+  skip?: InputMaybe<Scalars['Float']['input']>;
+  take?: InputMaybe<Scalars['Float']['input']>;
   where?: InputMaybe<GitOrganizationWhereInput>;
 };
 
@@ -1695,8 +1697,8 @@ export type QueryProjectConfigurationSettingsArgs = {
 
 export type QueryProjectsArgs = {
   orderBy?: InputMaybe<ProjectOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ProjectWhereInput>;
 };
 
@@ -1712,23 +1714,23 @@ export type QueryResourceArgs = {
 
 
 export type QueryResourceRoleArgs = {
-  version?: InputMaybe<Scalars['Float']>;
+  version?: InputMaybe<Scalars['Float']['input']>;
   where: WhereUniqueInput;
 };
 
 
 export type QueryResourceRolesArgs = {
   orderBy?: InputMaybe<ResourceRoleOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ResourceRoleWhereInput>;
 };
 
 
 export type QueryResourcesArgs = {
   orderBy?: InputMaybe<Array<ResourceOrderByInput>>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ResourceWhereInput>;
 };
 
@@ -1750,68 +1752,68 @@ export enum QueryMode {
 export type RemoteGitRepos = {
   pagination: Pagination;
   repos: Array<RemoteGitRepository>;
-  total: Scalars['Float'];
+  total: Scalars['Float']['output'];
 };
 
 export type RemoteGitRepositoriesWhereUniqueInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
-  groupName?: InputMaybe<Scalars['String']>;
+  groupName?: InputMaybe<Scalars['String']['input']>;
   /** The page number. One-based indexing */
-  page?: Scalars['Float'];
+  page?: Scalars['Float']['input'];
   /** The number of items to return per page */
-  perPage?: Scalars['Float'];
+  perPage?: Scalars['Float']['input'];
 };
 
 export type RemoteGitRepository = {
-  admin: Scalars['Boolean'];
-  defaultBranch: Scalars['String'];
-  fullName: Scalars['String'];
-  groupName?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
-  private: Scalars['Boolean'];
-  url: Scalars['String'];
+  admin: Scalars['Boolean']['output'];
+  defaultBranch: Scalars['String']['output'];
+  fullName: Scalars['String']['output'];
+  groupName?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  private: Scalars['Boolean']['output'];
+  url: Scalars['String']['output'];
 };
 
 export type Resource = {
   builds: Array<Build>;
-  createdAt: Scalars['DateTime'];
-  description: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description: Scalars['String']['output'];
   entities: Array<Entity>;
   environments: Array<Environment>;
   gitRepository?: Maybe<GitRepository>;
-  gitRepositoryId?: Maybe<Scalars['String']>;
-  gitRepositoryOverride: Scalars['Boolean'];
-  githubLastMessage?: Maybe<Scalars['String']>;
-  githubLastSync?: Maybe<Scalars['DateTime']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  gitRepositoryId?: Maybe<Scalars['String']['output']>;
+  gitRepositoryOverride: Scalars['Boolean']['output'];
+  githubLastMessage?: Maybe<Scalars['String']['output']>;
+  githubLastSync?: Maybe<Scalars['DateTime']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   project?: Maybe<Project>;
-  projectId?: Maybe<Scalars['String']>;
+  projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 
 export type ResourceBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
 
 export type ResourceEntitiesArgs = {
   orderBy?: InputMaybe<EntityOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityWhereInput>;
 };
 
 export type ResourceCreateInput = {
-  description: Scalars['String'];
+  description: Scalars['String']['input'];
   gitRepository?: InputMaybe<ConnectGitRepositoryInput>;
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
   project: WhereParentIdInput;
   resourceType: EnumResourceType;
   serviceSettings?: InputMaybe<ServiceSettingsUpdateInput>;
@@ -1819,25 +1821,25 @@ export type ResourceCreateInput = {
 
 export type ResourceCreateWithEntitiesEntityInput = {
   fields: Array<ResourceCreateWithEntitiesFieldInput>;
-  name: Scalars['String'];
-  relationsToEntityIndex?: InputMaybe<Array<Scalars['Int']>>;
+  name: Scalars['String']['input'];
+  relationsToEntityIndex?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 export type ResourceCreateWithEntitiesFieldInput = {
   dataType?: InputMaybe<EnumDataType>;
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type ResourceCreateWithEntitiesInput = {
-  authType: Scalars['String'];
-  commitMessage: Scalars['String'];
-  connectToDemoRepo: Scalars['Boolean'];
-  dbType: Scalars['String'];
+  authType: Scalars['String']['input'];
+  commitMessage: Scalars['String']['input'];
+  connectToDemoRepo: Scalars['Boolean']['input'];
+  dbType: Scalars['String']['input'];
   entities: Array<ResourceCreateWithEntitiesEntityInput>;
   plugins?: InputMaybe<PluginInstallationsCreateInput>;
-  repoType: Scalars['String'];
+  repoType: Scalars['String']['input'];
   resource: ResourceCreateInput;
-  wizardType: Scalars['String'];
+  wizardType: Scalars['String']['input'];
 };
 
 export type ResourceCreateWithEntitiesResult = {
@@ -1861,18 +1863,18 @@ export type ResourceOrderByInput = {
 };
 
 export type ResourceRole = {
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type ResourceRoleCreateInput = {
-  description: Scalars['String'];
-  displayName: Scalars['String'];
-  name: Scalars['String'];
+  description: Scalars['String']['input'];
+  displayName: Scalars['String']['input'];
+  name: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
@@ -1886,34 +1888,34 @@ export type ResourceRoleOrderByInput = {
 };
 
 export type ResourceRoleUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceRoleWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   resource?: InputMaybe<WhereUniqueInput>;
   updatedAt?: InputMaybe<DateTimeFilter>;
 };
 
 export type ResourceUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  gitRepositoryOverride?: InputMaybe<Scalars['Boolean']>;
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  gitRepositoryOverride?: InputMaybe<Scalars['Boolean']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
   description?: InputMaybe<StringFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   project?: InputMaybe<ProjectWhereInput>;
-  projectId?: InputMaybe<Scalars['String']>;
+  projectId?: InputMaybe<Scalars['String']['input']>;
   resourceType?: InputMaybe<EnumResourceTypeFilter>;
   updatedAt?: InputMaybe<DateTimeFilter>;
 };
@@ -1926,69 +1928,69 @@ export enum Role {
 }
 
 export type ServerSettings = {
-  generateGraphQL: Scalars['Boolean'];
-  generateRestApi: Scalars['Boolean'];
-  serverPath: Scalars['String'];
+  generateGraphQL: Scalars['Boolean']['output'];
+  generateRestApi: Scalars['Boolean']['output'];
+  serverPath: Scalars['String']['output'];
 };
 
 export type ServerSettingsUpdateInput = {
-  generateGraphQL?: InputMaybe<Scalars['Boolean']>;
-  generateRestApi?: InputMaybe<Scalars['Boolean']>;
-  serverPath?: InputMaybe<Scalars['String']>;
+  generateGraphQL?: InputMaybe<Scalars['Boolean']['input']>;
+  generateRestApi?: InputMaybe<Scalars['Boolean']['input']>;
+  serverPath?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ServiceSettings = IBlock & {
   adminUISettings: AdminUiSettings;
   authProvider: EnumAuthProviderType;
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
+  resourceId?: Maybe<Scalars['String']['output']>;
   serverSettings: ServerSettings;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ServiceSettingsUpdateInput = {
   adminUISettings: AdminUiSettingsUpdateInput;
   authProvider: EnumAuthProviderType;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
   serverSettings: ServerSettingsUpdateInput;
 };
 
 export type ServiceTopics = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  enabled: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  messageBrokerId: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  messageBrokerId: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
   patterns: Array<MessagePattern>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ServiceTopicsCreateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  enabled: Scalars['Boolean']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  messageBrokerId: Scalars['String'];
+  messageBrokerId: Scalars['String']['input'];
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
   patterns?: InputMaybe<Array<MessagePatternCreateInput>>;
@@ -2005,10 +2007,10 @@ export type ServiceTopicsOrderByInput = {
 };
 
 export type ServiceTopicsUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  enabled: Scalars['Boolean'];
-  messageBrokerId: Scalars['String'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  enabled: Scalars['Boolean']['input'];
+  messageBrokerId: Scalars['String']['input'];
   patterns?: InputMaybe<Array<MessagePatternCreateInput>>;
 };
 
@@ -2023,11 +2025,11 @@ export type ServiceTopicsWhereInput = {
 };
 
 export type SignupInput = {
-  email: Scalars['String'];
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  password: Scalars['String'];
-  workspaceName: Scalars['String'];
+  email: Scalars['String']['input'];
+  firstName: Scalars['String']['input'];
+  lastName: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+  workspaceName: Scalars['String']['input'];
 };
 
 export enum SortOrder {
@@ -2036,57 +2038,57 @@ export enum SortOrder {
 }
 
 export type StringFilter = {
-  contains?: InputMaybe<Scalars['String']>;
-  endsWith?: InputMaybe<Scalars['String']>;
-  equals?: InputMaybe<Scalars['String']>;
-  gt?: InputMaybe<Scalars['String']>;
-  gte?: InputMaybe<Scalars['String']>;
-  in?: InputMaybe<Array<Scalars['String']>>;
-  lt?: InputMaybe<Scalars['String']>;
-  lte?: InputMaybe<Scalars['String']>;
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
   mode?: InputMaybe<QueryMode>;
-  not?: InputMaybe<Scalars['String']>;
-  notIn?: InputMaybe<Array<Scalars['String']>>;
-  startsWith?: InputMaybe<Scalars['String']>;
+  not?: InputMaybe<Scalars['String']['input']>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Subscription = {
-  cancelUrl?: Maybe<Scalars['String']>;
-  cancellationEffectiveDate?: Maybe<Scalars['DateTime']>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  nextBillDate?: Maybe<Scalars['DateTime']>;
-  price?: Maybe<Scalars['Float']>;
+  cancelUrl?: Maybe<Scalars['String']['output']>;
+  cancellationEffectiveDate?: Maybe<Scalars['DateTime']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  nextBillDate?: Maybe<Scalars['DateTime']['output']>;
+  price?: Maybe<Scalars['Float']['output']>;
   status: EnumSubscriptionStatus;
   subscriptionPlan: EnumSubscriptionPlan;
-  updateUrl?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
+  updateUrl?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
   workspace?: Maybe<Workspace>;
-  workspaceId: Scalars['String'];
+  workspaceId: Scalars['String']['output'];
 };
 
 export type Topic = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type TopicCreateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
   resource: WhereParentIdInput;
@@ -2102,9 +2104,9 @@ export type TopicOrderByInput = {
 };
 
 export type TopicUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicWhereInput = {
@@ -2118,25 +2120,25 @@ export type TopicWhereInput = {
 };
 
 export type UpdateAccountInput = {
-  firstName?: InputMaybe<Scalars['String']>;
-  lastName?: InputMaybe<Scalars['String']>;
+  firstName?: InputMaybe<Scalars['String']['input']>;
+  lastName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type User = {
   account?: Maybe<Account>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  isOwner: Scalars['Boolean'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  isOwner: Scalars['Boolean']['output'];
+  updatedAt: Scalars['DateTime']['output'];
   userRoles?: Maybe<Array<UserRole>>;
   workspace?: Maybe<Workspace>;
 };
 
 export type UserRole = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   role: Role;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type WhereParentIdInput = {
@@ -2144,22 +2146,22 @@ export type WhereParentIdInput = {
 };
 
 export type WhereUniqueInput = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type Workspace = {
-  createdAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
   gitOrganizations?: Maybe<Array<GitOrganization>>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   projects: Array<Project>;
   subscription?: Maybe<Subscription>;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   users: Array<User>;
 };
 
 export type WorkspaceCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type WorkspaceMember = {
@@ -2170,5 +2172,5 @@ export type WorkspaceMember = {
 export type WorkspaceMemberType = Invitation | User;
 
 export type WorkspaceUpdateInput = {
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -3,131 +3,133 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
   /** A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format. */
-  DateTime: any;
+  DateTime: { input: any; output: any; }
   /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
-  JSONObject: any;
+  JSONObject: { input: any; output: any; }
   /** The `Upload` scalar type represents a file upload. */
-  Upload: any;
+  Upload: { input: any; output: any; }
 };
 
 export type Account = {
-  createdAt: Scalars['DateTime'];
-  email: Scalars['String'];
-  firstName: Scalars['String'];
-  githubId?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  lastName: Scalars['String'];
-  password: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  email: Scalars['String']['output'];
+  firstName: Scalars['String']['output'];
+  githubId?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  lastName: Scalars['String']['output'];
+  password: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type Action = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   steps?: Maybe<Array<ActionStep>>;
 };
 
 export type ActionLog = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   level: EnumActionLogLevel;
-  message: Scalars['String'];
-  meta: Scalars['JSONObject'];
+  message: Scalars['String']['output'];
+  meta: Scalars['JSONObject']['output'];
 };
 
 export type ActionStep = {
-  completedAt?: Maybe<Scalars['DateTime']>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  completedAt?: Maybe<Scalars['DateTime']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   logs?: Maybe<Array<ActionLog>>;
-  message: Scalars['String'];
-  name: Scalars['String'];
+  message: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   status: EnumActionStepStatus;
 };
 
 export type AdminUiSettings = {
-  adminUIPath: Scalars['String'];
-  generateAdminUI: Scalars['Boolean'];
+  adminUIPath: Scalars['String']['output'];
+  generateAdminUI: Scalars['Boolean']['output'];
 };
 
 export type AdminUiSettingsUpdateInput = {
-  adminUIPath?: InputMaybe<Scalars['String']>;
-  generateAdminUI?: InputMaybe<Scalars['Boolean']>;
+  adminUIPath?: InputMaybe<Scalars['String']['input']>;
+  generateAdminUI?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ApiToken = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  lastAccessAt: Scalars['DateTime'];
-  name: Scalars['String'];
-  previewChars: Scalars['String'];
-  token?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  userId: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  lastAccessAt: Scalars['DateTime']['output'];
+  name: Scalars['String']['output'];
+  previewChars: Scalars['String']['output'];
+  token?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  userId: Scalars['String']['output'];
 };
 
 export type ApiTokenCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type Auth = {
   /** JWT Bearer token */
-  token: Scalars['String'];
+  token: Scalars['String']['output'];
 };
 
 export type AuthorizeResourceWithGitResult = {
-  url: Scalars['String'];
+  url: Scalars['String']['output'];
 };
 
 export type Block = {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  lockedAt?: Maybe<Scalars['DateTime']>;
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedByUser: Array<User>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   parentBlock?: Maybe<Block>;
   resource?: Maybe<Resource>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber?: Maybe<Scalars['Float']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber?: Maybe<Scalars['Float']['output']>;
   versions?: Maybe<Array<BlockVersion>>;
 };
 
 
 export type BlockVersionsArgs = {
   orderBy?: InputMaybe<BlockVersionOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BlockVersionWhereInput>;
 };
 
 export type BlockInputOutput = {
   dataType?: Maybe<EnumDataType>;
-  dataTypeEntityName?: Maybe<Scalars['String']>;
-  description: Scalars['String'];
-  includeAllPropertiesByDefault?: Maybe<Scalars['Boolean']>;
-  isList?: Maybe<Scalars['Boolean']>;
-  name: Scalars['String'];
+  dataTypeEntityName?: Maybe<Scalars['String']['output']>;
+  description: Scalars['String']['output'];
+  includeAllPropertiesByDefault?: Maybe<Scalars['Boolean']['output']>;
+  isList?: Maybe<Scalars['Boolean']['output']>;
+  name: Scalars['String']['output'];
   propertyList?: Maybe<Array<PropertySelector>>;
 };
 
 export type BlockInputOutputInput = {
   dataType?: InputMaybe<EnumDataType>;
-  dataTypeEntityName?: InputMaybe<Scalars['String']>;
-  description: Scalars['String'];
-  includeAllPropertiesByDefault?: InputMaybe<Scalars['Boolean']>;
-  isList?: InputMaybe<Scalars['Boolean']>;
-  name: Scalars['String'];
+  dataTypeEntityName?: InputMaybe<Scalars['String']['input']>;
+  description: Scalars['String']['input'];
+  includeAllPropertiesByDefault?: InputMaybe<Scalars['Boolean']['input']>;
+  isList?: InputMaybe<Scalars['Boolean']['input']>;
+  name: Scalars['String']['input'];
   propertyList?: InputMaybe<Array<PropertySelectorInput>>;
 };
 
@@ -143,13 +145,13 @@ export type BlockOrderByInput = {
 export type BlockVersion = {
   block: Block;
   commit?: Maybe<Commit>;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  settings?: Maybe<Scalars['JSONObject']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Int'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  settings?: Maybe<Scalars['JSONObject']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 export type BlockVersionOrderByInput = {
@@ -181,30 +183,30 @@ export type BlockWhereInput = {
 };
 
 export type BooleanFilter = {
-  equals?: InputMaybe<Scalars['Boolean']>;
-  not?: InputMaybe<Scalars['Boolean']>;
+  equals?: InputMaybe<Scalars['Boolean']['input']>;
+  not?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type Build = {
   action?: Maybe<Action>;
-  actionId: Scalars['String'];
-  archiveURI: Scalars['String'];
+  actionId: Scalars['String']['output'];
+  archiveURI: Scalars['String']['output'];
   commit: Commit;
-  commitId: Scalars['String'];
-  createdAt: Scalars['DateTime'];
+  commitId: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
   createdBy: User;
-  id: Scalars['String'];
-  message: Scalars['String'];
+  id: Scalars['String']['output'];
+  message: Scalars['String']['output'];
   resource?: Maybe<Resource>;
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['output'];
   status?: Maybe<EnumBuildStatus>;
-  userId: Scalars['String'];
-  version: Scalars['String'];
+  userId: Scalars['String']['output'];
+  version: Scalars['String']['output'];
 };
 
 export type BuildCreateInput = {
   commit: WhereParentIdInput;
-  message: Scalars['String'];
+  message: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
@@ -228,30 +230,30 @@ export type BuildWhereInput = {
 };
 
 export type ChangePasswordInput = {
-  newPassword: Scalars['String'];
-  oldPassword: Scalars['String'];
+  newPassword: Scalars['String']['input'];
+  oldPassword: Scalars['String']['input'];
 };
 
 export type Commit = {
   builds?: Maybe<Array<Build>>;
   changes?: Maybe<Array<PendingChange>>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  message: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  message: Scalars['String']['output'];
   user?: Maybe<User>;
-  userId: Scalars['String'];
+  userId: Scalars['String']['output'];
 };
 
 
 export type CommitBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
 export type CommitCreateInput = {
-  message: Scalars['String'];
+  message: Scalars['String']['input'];
   project: WhereParentIdInput;
 };
 
@@ -270,24 +272,24 @@ export type CommitWhereInput = {
 };
 
 export type CommitWhereUniqueInput = {
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CompleteInvitationInput = {
-  token: Scalars['String'];
+  token: Scalars['String']['input'];
 };
 
 export type ConnectGitRepositoryInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isOverrideGitRepository?: InputMaybe<Scalars['Boolean']>;
-  name: Scalars['String'];
-  resourceId: Scalars['String'];
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isOverrideGitRepository?: InputMaybe<Scalars['Boolean']['input']>;
+  name: Scalars['String']['input'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type CreateEntitiesFromPrismaSchemaInput = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type CreateEntitiesFromPrismaSchemaResponse = {
@@ -296,128 +298,128 @@ export type CreateEntitiesFromPrismaSchemaResponse = {
 };
 
 export type CreateGitRepositoryBaseInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isPublic: Scalars['Boolean'];
-  name: Scalars['String'];
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isPublic: Scalars['Boolean']['input'];
+  name: Scalars['String']['input'];
 };
 
 export type CreateGitRepositoryInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isPublic: Scalars['Boolean'];
-  name: Scalars['String'];
-  resourceId?: InputMaybe<Scalars['String']>;
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isPublic: Scalars['Boolean']['input'];
+  name: Scalars['String']['input'];
+  resourceId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type DateTimeFilter = {
-  equals?: InputMaybe<Scalars['DateTime']>;
-  gt?: InputMaybe<Scalars['DateTime']>;
-  gte?: InputMaybe<Scalars['DateTime']>;
-  in?: InputMaybe<Array<Scalars['DateTime']>>;
-  lt?: InputMaybe<Scalars['DateTime']>;
-  lte?: InputMaybe<Scalars['DateTime']>;
-  not?: InputMaybe<Scalars['DateTime']>;
-  notIn?: InputMaybe<Array<Scalars['DateTime']>>;
+  equals?: InputMaybe<Scalars['DateTime']['input']>;
+  gt?: InputMaybe<Scalars['DateTime']['input']>;
+  gte?: InputMaybe<Scalars['DateTime']['input']>;
+  in?: InputMaybe<Array<Scalars['DateTime']['input']>>;
+  lt?: InputMaybe<Scalars['DateTime']['input']>;
+  lte?: InputMaybe<Scalars['DateTime']['input']>;
+  not?: InputMaybe<Scalars['DateTime']['input']>;
+  notIn?: InputMaybe<Array<Scalars['DateTime']['input']>>;
 };
 
 export type DefaultEntitiesInput = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type Entity = {
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
   fields?: Maybe<Array<EntityField>>;
-  id: Scalars['String'];
-  lockedAt?: Maybe<Scalars['DateTime']>;
+  id: Scalars['String']['output'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedByUser?: Maybe<User>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
   permissions?: Maybe<Array<EntityPermission>>;
-  pluralDisplayName: Scalars['String'];
+  pluralDisplayName: Scalars['String']['output'];
   resource?: Maybe<Resource>;
-  resourceId: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  resourceId: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
   versions?: Maybe<Array<EntityVersion>>;
 };
 
 
 export type EntityFieldsArgs = {
   orderBy?: InputMaybe<EntityFieldOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityFieldWhereInput>;
 };
 
 
 export type EntityVersionsArgs = {
   orderBy?: InputMaybe<EntityVersionOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityVersionWhereInput>;
 };
 
 export type EntityAddPermissionFieldInput = {
   action: EnumEntityAction;
   entity: WhereParentIdInput;
-  fieldName: Scalars['String'];
+  fieldName: Scalars['String']['input'];
 };
 
 export type EntityCreateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
   /** allow creating the id for the entity when using import prisma schema because we need it for the relation */
-  id?: InputMaybe<Scalars['String']>;
-  name: Scalars['String'];
-  pluralDisplayName: Scalars['String'];
+  id?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  pluralDisplayName: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
 export type EntityField = {
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
   dataType: EnumDataType;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
-  permanentId: Scalars['String'];
-  position?: Maybe<Scalars['Int']>;
-  properties?: Maybe<Scalars['JSONObject']>;
-  required: Scalars['Boolean'];
-  searchable: Scalars['Boolean'];
-  unique: Scalars['Boolean'];
-  updatedAt: Scalars['DateTime'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  permanentId: Scalars['String']['output'];
+  position?: Maybe<Scalars['Int']['output']>;
+  properties?: Maybe<Scalars['JSONObject']['output']>;
+  required: Scalars['Boolean']['output'];
+  searchable: Scalars['Boolean']['output'];
+  unique: Scalars['Boolean']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type EntityFieldCreateByDisplayNameInput = {
   dataType?: InputMaybe<EnumDataType>;
-  displayName: Scalars['String'];
+  displayName: Scalars['String']['input'];
   entity: WhereParentIdInput;
 };
 
 export type EntityFieldCreateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
   dataType: EnumDataType;
-  description: Scalars['String'];
-  displayName: Scalars['String'];
+  description: Scalars['String']['input'];
+  displayName: Scalars['String']['input'];
   entity: WhereParentIdInput;
-  name: Scalars['String'];
-  position?: InputMaybe<Scalars['Int']>;
-  properties: Scalars['JSONObject'];
-  required: Scalars['Boolean'];
-  searchable: Scalars['Boolean'];
-  unique: Scalars['Boolean'];
+  name: Scalars['String']['input'];
+  position?: InputMaybe<Scalars['Int']['input']>;
+  properties: Scalars['JSONObject']['input'];
+  required: Scalars['Boolean']['input'];
+  searchable: Scalars['Boolean']['input'];
+  unique: Scalars['Boolean']['input'];
 };
 
 export type EntityFieldFilter = {
@@ -443,16 +445,16 @@ export type EntityFieldOrderByInput = {
 };
 
 export type EntityFieldUpdateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
   dataType?: InputMaybe<EnumDataType>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  position?: InputMaybe<Scalars['Int']>;
-  properties?: InputMaybe<Scalars['JSONObject']>;
-  required?: InputMaybe<Scalars['Boolean']>;
-  searchable?: InputMaybe<Scalars['Boolean']>;
-  unique?: InputMaybe<Scalars['Boolean']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  position?: InputMaybe<Scalars['Int']['input']>;
+  properties?: InputMaybe<Scalars['JSONObject']['input']>;
+  required?: InputMaybe<Scalars['Boolean']['input']>;
+  searchable?: InputMaybe<Scalars['Boolean']['input']>;
+  unique?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type EntityFieldWhereInput = {
@@ -484,44 +486,44 @@ export type EntityOrderByInput = {
 export type EntityPermission = {
   action: EnumEntityAction;
   entityVersion?: Maybe<EntityVersion>;
-  entityVersionId: Scalars['String'];
-  id: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   permissionFields?: Maybe<Array<EntityPermissionField>>;
   permissionRoles?: Maybe<Array<EntityPermissionRole>>;
   type: EnumEntityPermissionType;
 };
 
 export type EntityPermissionField = {
-  entityVersionId: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
   field: EntityField;
-  fieldPermanentId: Scalars['String'];
-  id: Scalars['String'];
+  fieldPermanentId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   permission?: Maybe<EntityPermission>;
-  permissionId: Scalars['String'];
+  permissionId: Scalars['String']['output'];
   permissionRoles?: Maybe<Array<EntityPermissionRole>>;
 };
 
 export type EntityPermissionFieldWhereUniqueInput = {
   action: EnumEntityAction;
-  entityId: Scalars['String'];
-  fieldPermanentId: Scalars['String'];
+  entityId: Scalars['String']['input'];
+  fieldPermanentId: Scalars['String']['input'];
 };
 
 export type EntityPermissionRole = {
   action: EnumEntityAction;
   entityPermission?: Maybe<EntityPermission>;
-  entityVersionId: Scalars['String'];
-  id: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   resourceRole: ResourceRole;
-  resourceRoleId: Scalars['String'];
+  resourceRoleId: Scalars['String']['output'];
 };
 
 export type EntityUpdateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  pluralDisplayName?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  pluralDisplayName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type EntityUpdatePermissionFieldRolesInput = {
@@ -544,26 +546,26 @@ export type EntityUpdatePermissionRolesInput = {
 
 export type EntityVersion = {
   commit?: Maybe<Commit>;
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
   entity: Entity;
-  entityId: Scalars['String'];
+  entityId: Scalars['String']['output'];
   fields: Array<EntityField>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   permissions?: Maybe<Array<EntityPermission>>;
-  pluralDisplayName: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Int'];
+  pluralDisplayName: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 
 export type EntityVersionFieldsArgs = {
   orderBy?: InputMaybe<EntityFieldOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityFieldWhereInput>;
 };
 
@@ -753,14 +755,14 @@ export enum EnumWorkspaceMemberType {
 }
 
 export type Environment = {
-  address: Scalars['String'];
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  address: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   resource: Resource;
-  resourceId: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  resourceId: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type GitGetInstallationUrlInput = {
@@ -769,103 +771,103 @@ export type GitGetInstallationUrlInput = {
 
 /** Group of Repositories */
 export type GitGroup = {
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
 };
 
 export type GitGroupInput = {
-  organizationId: Scalars['String'];
+  organizationId: Scalars['String']['input'];
 };
 
 export type GitOAuth2FlowInput = {
-  code: Scalars['String'];
+  code: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
 };
 
 export type GitOrganization = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  installationId: Scalars['String'];
-  name: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  installationId: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   provider: EnumGitProvider;
   type: EnumGitOrganizationType;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   /** Defines if a git organisation needs defined repository groups */
-  useGroupingForRepositories: Scalars['Boolean'];
+  useGroupingForRepositories: Scalars['Boolean']['output'];
 };
 
 export type GitOrganizationCreateInput = {
   gitProvider: EnumGitProvider;
-  installationId: Scalars['String'];
+  installationId: Scalars['String']['input'];
 };
 
 export type GitOrganizationWhereInput = {
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type GitRepository = {
-  createdAt?: Maybe<Scalars['DateTime']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
   gitOrganization: GitOrganization;
-  gitOrganizationId: Scalars['String'];
-  groupName?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
-  updatedAt?: Maybe<Scalars['DateTime']>;
+  gitOrganizationId: Scalars['String']['output'];
+  groupName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
 };
 
 export type IBlock = {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type IntFilter = {
-  equals?: InputMaybe<Scalars['Int']>;
-  gt?: InputMaybe<Scalars['Int']>;
-  gte?: InputMaybe<Scalars['Int']>;
-  in?: InputMaybe<Array<Scalars['Int']>>;
-  lt?: InputMaybe<Scalars['Int']>;
-  lte?: InputMaybe<Scalars['Int']>;
-  not?: InputMaybe<Scalars['Int']>;
-  notIn?: InputMaybe<Array<Scalars['Int']>>;
+  equals?: InputMaybe<Scalars['Int']['input']>;
+  gt?: InputMaybe<Scalars['Int']['input']>;
+  gte?: InputMaybe<Scalars['Int']['input']>;
+  in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  lt?: InputMaybe<Scalars['Int']['input']>;
+  lte?: InputMaybe<Scalars['Int']['input']>;
+  not?: InputMaybe<Scalars['Int']['input']>;
+  notIn?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 export type Invitation = {
-  createdAt: Scalars['DateTime'];
-  email: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  email: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   invitedByUser?: Maybe<User>;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   workspace?: Maybe<Workspace>;
 };
 
 export type InviteUserInput = {
-  email: Scalars['String'];
+  email: Scalars['String']['input'];
 };
 
 export type LoginInput = {
-  email: Scalars['String'];
-  password: Scalars['String'];
+  email: Scalars['String']['input'];
+  password: Scalars['String']['input'];
 };
 
 export type MessagePattern = {
-  topicId: Scalars['String'];
+  topicId: Scalars['String']['output'];
   type: EnumMessagePatternConnectionOptions;
 };
 
 export type MessagePatternCreateInput = {
-  topicId: Scalars['String'];
+  topicId: Scalars['String']['input'];
   type: EnumMessagePatternConnectionOptions;
 };
 
@@ -902,7 +904,7 @@ export type Mutation = {
   deleteEntity?: Maybe<Entity>;
   deleteEntityField: EntityField;
   deleteEntityPermissionField: EntityPermissionField;
-  deleteGitOrganization: Scalars['Boolean'];
+  deleteGitOrganization: Scalars['Boolean']['output'];
   deleteGitRepository: Resource;
   deletePluginInstallation: PluginInstallation;
   deleteProject?: Maybe<Project>;
@@ -912,7 +914,7 @@ export type Mutation = {
   deleteTopic: Topic;
   deleteUser?: Maybe<User>;
   deleteWorkspace?: Maybe<Workspace>;
-  discardPendingChanges?: Maybe<Scalars['Boolean']>;
+  discardPendingChanges?: Maybe<Scalars['Boolean']['output']>;
   disconnectResourceGitRepository: Resource;
   getGitResourceInstallationUrl: AuthorizeResourceWithGitResult;
   inviteUser?: Maybe<Invitation>;
@@ -978,7 +980,7 @@ export type MutationConnectResourceGitRepositoryArgs = {
 
 
 export type MutationConnectResourceToProjectRepositoryArgs = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 
@@ -998,24 +1000,24 @@ export type MutationCreateDefaultEntitiesArgs = {
 
 
 export type MutationCreateDefaultRelatedFieldArgs = {
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
   where: WhereUniqueInput;
 };
 
 
 export type MutationCreateEntitiesFromPrismaSchemaArgs = {
   data: CreateEntitiesFromPrismaSchemaInput;
-  file: Scalars['Upload'];
+  file: Scalars['Upload']['input'];
 };
 
 
 export type MutationCreateEntityFieldArgs = {
   data: EntityFieldCreateInput;
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1105,13 +1107,13 @@ export type MutationDeleteEntityPermissionFieldArgs = {
 
 
 export type MutationDeleteGitOrganizationArgs = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
 };
 
 
 export type MutationDeleteGitRepositoryArgs = {
-  gitRepositoryId: Scalars['String'];
+  gitRepositoryId: Scalars['String']['input'];
 };
 
 
@@ -1161,7 +1163,7 @@ export type MutationDiscardPendingChangesArgs = {
 
 
 export type MutationDisconnectResourceGitRepositoryArgs = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 
@@ -1229,9 +1231,9 @@ export type MutationUpdateEntityArgs = {
 
 export type MutationUpdateEntityFieldArgs = {
   data: EntityFieldUpdateInput;
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
   where: WhereUniqueInput;
 };
 
@@ -1309,25 +1311,25 @@ export type MutationUpdateWorkspaceArgs = {
 export type PaginatedGitGroup = {
   groups?: Maybe<Array<GitGroup>>;
   /** Page number */
-  page: Scalars['Float'];
+  page: Scalars['Float']['output'];
   /** Number of groups per page */
-  pageSize: Scalars['Float'];
+  pageSize: Scalars['Float']['output'];
   /** Total number of groups */
-  total: Scalars['Float'];
+  total: Scalars['Float']['output'];
 };
 
 export type Pagination = {
-  page: Scalars['Float'];
-  perPage: Scalars['Float'];
+  page: Scalars['Float']['output'];
+  perPage: Scalars['Float']['output'];
 };
 
 export type PendingChange = {
   action: EnumPendingChangeAction;
   origin: PendingChangeOrigin;
-  originId: Scalars['String'];
+  originId: Scalars['String']['output'];
   originType: EnumPendingChangeOriginType;
   resource: Resource;
-  versionNumber: Scalars['Int'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 export type PendingChangeOrigin = Block | Entity;
@@ -1342,39 +1344,39 @@ export type PendingChangesFindInput = {
 
 export type PluginInstallation = IBlock & {
   blockType: EnumBlockType;
-  configurations?: Maybe<Scalars['JSONObject']>;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
-  id: Scalars['String'];
+  configurations?: Maybe<Scalars['JSONObject']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  enabled: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  npm: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  npm: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  pluginId: Scalars['String'];
-  resourceId?: Maybe<Scalars['String']>;
-  settings?: Maybe<Scalars['JSONObject']>;
-  updatedAt: Scalars['DateTime'];
-  version: Scalars['String'];
-  versionNumber: Scalars['Float'];
+  pluginId: Scalars['String']['output'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  settings?: Maybe<Scalars['JSONObject']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  version: Scalars['String']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type PluginInstallationCreateInput = {
-  configurations?: InputMaybe<Scalars['JSONObject']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
+  configurations?: InputMaybe<Scalars['JSONObject']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  enabled: Scalars['Boolean']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  npm: Scalars['String'];
+  npm: Scalars['String']['input'];
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
-  pluginId: Scalars['String'];
+  pluginId: Scalars['String']['input'];
   resource: WhereParentIdInput;
-  settings?: InputMaybe<Scalars['JSONObject']>;
-  version: Scalars['String'];
+  settings?: InputMaybe<Scalars['JSONObject']['input']>;
+  version: Scalars['String']['input'];
 };
 
 export type PluginInstallationOrderByInput = {
@@ -1387,12 +1389,12 @@ export type PluginInstallationOrderByInput = {
 };
 
 export type PluginInstallationUpdateInput = {
-  configurations?: InputMaybe<Scalars['JSONObject']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  enabled: Scalars['Boolean'];
-  settings?: InputMaybe<Scalars['JSONObject']>;
-  version: Scalars['String'];
+  configurations?: InputMaybe<Scalars['JSONObject']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  enabled: Scalars['Boolean']['input'];
+  settings?: InputMaybe<Scalars['JSONObject']['input']>;
+  version: Scalars['String']['input'];
 };
 
 export type PluginInstallationWhereInput = {
@@ -1411,65 +1413,65 @@ export type PluginInstallationsCreateInput = {
 
 export type PluginOrder = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   order: Array<PluginOrderItem>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type PluginOrderItem = {
-  order: Scalars['Int'];
-  pluginId: Scalars['String'];
+  order: Scalars['Int']['output'];
+  pluginId: Scalars['String']['output'];
 };
 
 export type PluginSetOrderInput = {
-  order: Scalars['Int'];
+  order: Scalars['Int']['input'];
 };
 
 export type Project = {
-  createdAt: Scalars['DateTime'];
-  demoRepoName?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  demoRepoName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   resources?: Maybe<Array<Resource>>;
-  updatedAt: Scalars['DateTime'];
-  useDemoRepo: Scalars['Boolean'];
+  updatedAt: Scalars['DateTime']['output'];
+  useDemoRepo: Scalars['Boolean']['output'];
 };
 
 export type ProjectConfigurationSettings = IBlock & {
-  baseDirectory: Scalars['String'];
+  baseDirectory: Scalars['String']['output'];
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ProjectConfigurationSettingsUpdateInput = {
-  baseDirectory?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
+  baseDirectory?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ProjectCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type ProjectOrderByInput = {
@@ -1479,38 +1481,38 @@ export type ProjectOrderByInput = {
 };
 
 export type ProjectUpdateInput = {
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ProjectWhereInput = {
   deletedAt?: InputMaybe<DateTimeFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   resources?: InputMaybe<ResourceListRelationFilter>;
 };
 
 export type PropertySelector = {
-  include: Scalars['Boolean'];
-  propertyName: Scalars['String'];
+  include: Scalars['Boolean']['output'];
+  propertyName: Scalars['String']['output'];
 };
 
 export type PropertySelectorInput = {
-  include: Scalars['Boolean'];
-  propertyName: Scalars['String'];
+  include: Scalars['Boolean']['input'];
+  propertyName: Scalars['String']['input'];
 };
 
 export type ProvisionSubscriptionInput = {
-  billingPeriod: Scalars['String'];
-  cancelUrl?: InputMaybe<Scalars['String']>;
-  intentionType: Scalars['String'];
-  planId: Scalars['String'];
-  successUrl?: InputMaybe<Scalars['String']>;
-  workspaceId: Scalars['String'];
+  billingPeriod: Scalars['String']['input'];
+  cancelUrl?: InputMaybe<Scalars['String']['input']>;
+  intentionType: Scalars['String']['input'];
+  planId: Scalars['String']['input'];
+  successUrl?: InputMaybe<Scalars['String']['input']>;
+  workspaceId: Scalars['String']['input'];
 };
 
 export type ProvisionSubscriptionResult = {
-  checkoutUrl?: Maybe<Scalars['String']>;
-  provisionStatus: Scalars['String'];
+  checkoutUrl?: Maybe<Scalars['String']['output']>;
+  provisionStatus: Scalars['String']['output'];
 };
 
 export type Query = {
@@ -1561,8 +1563,8 @@ export type QueryPluginInstallationArgs = {
 
 export type QueryPluginInstallationsArgs = {
   orderBy?: InputMaybe<PluginInstallationOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<PluginInstallationWhereInput>;
 };
 
@@ -1574,8 +1576,8 @@ export type QueryServiceTopicsArgs = {
 
 export type QueryServiceTopicsListArgs = {
   orderBy?: InputMaybe<ServiceTopicsOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ServiceTopicsWhereInput>;
 };
 
@@ -1587,8 +1589,8 @@ export type QueryTopicArgs = {
 
 export type QueryTopicsArgs = {
   orderBy?: InputMaybe<TopicOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<TopicWhereInput>;
 };
 
@@ -1605,8 +1607,8 @@ export type QueryBlockArgs = {
 
 export type QueryBlocksArgs = {
   orderBy?: InputMaybe<BlockOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BlockWhereInput>;
 };
 
@@ -1618,8 +1620,8 @@ export type QueryBuildArgs = {
 
 export type QueryBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
@@ -1632,16 +1634,16 @@ export type QueryCommitArgs = {
 export type QueryCommitsArgs = {
   cursor?: InputMaybe<CommitWhereUniqueInput>;
   orderBy?: InputMaybe<CommitOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<CommitWhereInput>;
 };
 
 
 export type QueryEntitiesArgs = {
   orderBy?: InputMaybe<EntityOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityWhereInput>;
 };
 
@@ -1662,8 +1664,8 @@ export type QueryGitOrganizationArgs = {
 
 
 export type QueryGitOrganizationsArgs = {
-  skip?: InputMaybe<Scalars['Float']>;
-  take?: InputMaybe<Scalars['Float']>;
+  skip?: InputMaybe<Scalars['Float']['input']>;
+  take?: InputMaybe<Scalars['Float']['input']>;
   where?: InputMaybe<GitOrganizationWhereInput>;
 };
 
@@ -1695,8 +1697,8 @@ export type QueryProjectConfigurationSettingsArgs = {
 
 export type QueryProjectsArgs = {
   orderBy?: InputMaybe<ProjectOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ProjectWhereInput>;
 };
 
@@ -1712,23 +1714,23 @@ export type QueryResourceArgs = {
 
 
 export type QueryResourceRoleArgs = {
-  version?: InputMaybe<Scalars['Float']>;
+  version?: InputMaybe<Scalars['Float']['input']>;
   where: WhereUniqueInput;
 };
 
 
 export type QueryResourceRolesArgs = {
   orderBy?: InputMaybe<ResourceRoleOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ResourceRoleWhereInput>;
 };
 
 
 export type QueryResourcesArgs = {
   orderBy?: InputMaybe<Array<ResourceOrderByInput>>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ResourceWhereInput>;
 };
 
@@ -1750,68 +1752,68 @@ export enum QueryMode {
 export type RemoteGitRepos = {
   pagination: Pagination;
   repos: Array<RemoteGitRepository>;
-  total: Scalars['Float'];
+  total: Scalars['Float']['output'];
 };
 
 export type RemoteGitRepositoriesWhereUniqueInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
-  groupName?: InputMaybe<Scalars['String']>;
+  groupName?: InputMaybe<Scalars['String']['input']>;
   /** The page number. One-based indexing */
-  page?: Scalars['Float'];
+  page?: Scalars['Float']['input'];
   /** The number of items to return per page */
-  perPage?: Scalars['Float'];
+  perPage?: Scalars['Float']['input'];
 };
 
 export type RemoteGitRepository = {
-  admin: Scalars['Boolean'];
-  defaultBranch: Scalars['String'];
-  fullName: Scalars['String'];
-  groupName?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
-  private: Scalars['Boolean'];
-  url: Scalars['String'];
+  admin: Scalars['Boolean']['output'];
+  defaultBranch: Scalars['String']['output'];
+  fullName: Scalars['String']['output'];
+  groupName?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  private: Scalars['Boolean']['output'];
+  url: Scalars['String']['output'];
 };
 
 export type Resource = {
   builds: Array<Build>;
-  createdAt: Scalars['DateTime'];
-  description: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description: Scalars['String']['output'];
   entities: Array<Entity>;
   environments: Array<Environment>;
   gitRepository?: Maybe<GitRepository>;
-  gitRepositoryId?: Maybe<Scalars['String']>;
-  gitRepositoryOverride: Scalars['Boolean'];
-  githubLastMessage?: Maybe<Scalars['String']>;
-  githubLastSync?: Maybe<Scalars['DateTime']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  gitRepositoryId?: Maybe<Scalars['String']['output']>;
+  gitRepositoryOverride: Scalars['Boolean']['output'];
+  githubLastMessage?: Maybe<Scalars['String']['output']>;
+  githubLastSync?: Maybe<Scalars['DateTime']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   project?: Maybe<Project>;
-  projectId?: Maybe<Scalars['String']>;
+  projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 
 export type ResourceBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
 
 export type ResourceEntitiesArgs = {
   orderBy?: InputMaybe<EntityOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityWhereInput>;
 };
 
 export type ResourceCreateInput = {
-  description: Scalars['String'];
+  description: Scalars['String']['input'];
   gitRepository?: InputMaybe<ConnectGitRepositoryInput>;
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
   project: WhereParentIdInput;
   resourceType: EnumResourceType;
   serviceSettings?: InputMaybe<ServiceSettingsUpdateInput>;
@@ -1819,25 +1821,25 @@ export type ResourceCreateInput = {
 
 export type ResourceCreateWithEntitiesEntityInput = {
   fields: Array<ResourceCreateWithEntitiesFieldInput>;
-  name: Scalars['String'];
-  relationsToEntityIndex?: InputMaybe<Array<Scalars['Int']>>;
+  name: Scalars['String']['input'];
+  relationsToEntityIndex?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 export type ResourceCreateWithEntitiesFieldInput = {
   dataType?: InputMaybe<EnumDataType>;
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type ResourceCreateWithEntitiesInput = {
-  authType: Scalars['String'];
-  commitMessage: Scalars['String'];
-  connectToDemoRepo: Scalars['Boolean'];
-  dbType: Scalars['String'];
+  authType: Scalars['String']['input'];
+  commitMessage: Scalars['String']['input'];
+  connectToDemoRepo: Scalars['Boolean']['input'];
+  dbType: Scalars['String']['input'];
   entities: Array<ResourceCreateWithEntitiesEntityInput>;
   plugins?: InputMaybe<PluginInstallationsCreateInput>;
-  repoType: Scalars['String'];
+  repoType: Scalars['String']['input'];
   resource: ResourceCreateInput;
-  wizardType: Scalars['String'];
+  wizardType: Scalars['String']['input'];
 };
 
 export type ResourceCreateWithEntitiesResult = {
@@ -1861,18 +1863,18 @@ export type ResourceOrderByInput = {
 };
 
 export type ResourceRole = {
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type ResourceRoleCreateInput = {
-  description: Scalars['String'];
-  displayName: Scalars['String'];
-  name: Scalars['String'];
+  description: Scalars['String']['input'];
+  displayName: Scalars['String']['input'];
+  name: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
@@ -1886,34 +1888,34 @@ export type ResourceRoleOrderByInput = {
 };
 
 export type ResourceRoleUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceRoleWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   resource?: InputMaybe<WhereUniqueInput>;
   updatedAt?: InputMaybe<DateTimeFilter>;
 };
 
 export type ResourceUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  gitRepositoryOverride?: InputMaybe<Scalars['Boolean']>;
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  gitRepositoryOverride?: InputMaybe<Scalars['Boolean']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
   description?: InputMaybe<StringFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   project?: InputMaybe<ProjectWhereInput>;
-  projectId?: InputMaybe<Scalars['String']>;
+  projectId?: InputMaybe<Scalars['String']['input']>;
   resourceType?: InputMaybe<EnumResourceTypeFilter>;
   updatedAt?: InputMaybe<DateTimeFilter>;
 };
@@ -1926,69 +1928,69 @@ export enum Role {
 }
 
 export type ServerSettings = {
-  generateGraphQL: Scalars['Boolean'];
-  generateRestApi: Scalars['Boolean'];
-  serverPath: Scalars['String'];
+  generateGraphQL: Scalars['Boolean']['output'];
+  generateRestApi: Scalars['Boolean']['output'];
+  serverPath: Scalars['String']['output'];
 };
 
 export type ServerSettingsUpdateInput = {
-  generateGraphQL?: InputMaybe<Scalars['Boolean']>;
-  generateRestApi?: InputMaybe<Scalars['Boolean']>;
-  serverPath?: InputMaybe<Scalars['String']>;
+  generateGraphQL?: InputMaybe<Scalars['Boolean']['input']>;
+  generateRestApi?: InputMaybe<Scalars['Boolean']['input']>;
+  serverPath?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ServiceSettings = IBlock & {
   adminUISettings: AdminUiSettings;
   authProvider: EnumAuthProviderType;
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
+  resourceId?: Maybe<Scalars['String']['output']>;
   serverSettings: ServerSettings;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ServiceSettingsUpdateInput = {
   adminUISettings: AdminUiSettingsUpdateInput;
   authProvider: EnumAuthProviderType;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
   serverSettings: ServerSettingsUpdateInput;
 };
 
 export type ServiceTopics = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  enabled: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  messageBrokerId: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  messageBrokerId: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
   patterns: Array<MessagePattern>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ServiceTopicsCreateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  enabled: Scalars['Boolean']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  messageBrokerId: Scalars['String'];
+  messageBrokerId: Scalars['String']['input'];
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
   patterns?: InputMaybe<Array<MessagePatternCreateInput>>;
@@ -2005,10 +2007,10 @@ export type ServiceTopicsOrderByInput = {
 };
 
 export type ServiceTopicsUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  enabled: Scalars['Boolean'];
-  messageBrokerId: Scalars['String'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  enabled: Scalars['Boolean']['input'];
+  messageBrokerId: Scalars['String']['input'];
   patterns?: InputMaybe<Array<MessagePatternCreateInput>>;
 };
 
@@ -2023,11 +2025,11 @@ export type ServiceTopicsWhereInput = {
 };
 
 export type SignupInput = {
-  email: Scalars['String'];
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  password: Scalars['String'];
-  workspaceName: Scalars['String'];
+  email: Scalars['String']['input'];
+  firstName: Scalars['String']['input'];
+  lastName: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+  workspaceName: Scalars['String']['input'];
 };
 
 export enum SortOrder {
@@ -2036,57 +2038,57 @@ export enum SortOrder {
 }
 
 export type StringFilter = {
-  contains?: InputMaybe<Scalars['String']>;
-  endsWith?: InputMaybe<Scalars['String']>;
-  equals?: InputMaybe<Scalars['String']>;
-  gt?: InputMaybe<Scalars['String']>;
-  gte?: InputMaybe<Scalars['String']>;
-  in?: InputMaybe<Array<Scalars['String']>>;
-  lt?: InputMaybe<Scalars['String']>;
-  lte?: InputMaybe<Scalars['String']>;
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
   mode?: InputMaybe<QueryMode>;
-  not?: InputMaybe<Scalars['String']>;
-  notIn?: InputMaybe<Array<Scalars['String']>>;
-  startsWith?: InputMaybe<Scalars['String']>;
+  not?: InputMaybe<Scalars['String']['input']>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Subscription = {
-  cancelUrl?: Maybe<Scalars['String']>;
-  cancellationEffectiveDate?: Maybe<Scalars['DateTime']>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  nextBillDate?: Maybe<Scalars['DateTime']>;
-  price?: Maybe<Scalars['Float']>;
+  cancelUrl?: Maybe<Scalars['String']['output']>;
+  cancellationEffectiveDate?: Maybe<Scalars['DateTime']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  nextBillDate?: Maybe<Scalars['DateTime']['output']>;
+  price?: Maybe<Scalars['Float']['output']>;
   status: EnumSubscriptionStatus;
   subscriptionPlan: EnumSubscriptionPlan;
-  updateUrl?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
+  updateUrl?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
   workspace?: Maybe<Workspace>;
-  workspaceId: Scalars['String'];
+  workspaceId: Scalars['String']['output'];
 };
 
 export type Topic = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type TopicCreateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
   resource: WhereParentIdInput;
@@ -2102,9 +2104,9 @@ export type TopicOrderByInput = {
 };
 
 export type TopicUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicWhereInput = {
@@ -2118,25 +2120,25 @@ export type TopicWhereInput = {
 };
 
 export type UpdateAccountInput = {
-  firstName?: InputMaybe<Scalars['String']>;
-  lastName?: InputMaybe<Scalars['String']>;
+  firstName?: InputMaybe<Scalars['String']['input']>;
+  lastName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type User = {
   account?: Maybe<Account>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  isOwner: Scalars['Boolean'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  isOwner: Scalars['Boolean']['output'];
+  updatedAt: Scalars['DateTime']['output'];
   userRoles?: Maybe<Array<UserRole>>;
   workspace?: Maybe<Workspace>;
 };
 
 export type UserRole = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   role: Role;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type WhereParentIdInput = {
@@ -2144,22 +2146,22 @@ export type WhereParentIdInput = {
 };
 
 export type WhereUniqueInput = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type Workspace = {
-  createdAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
   gitOrganizations?: Maybe<Array<GitOrganization>>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   projects: Array<Project>;
   subscription?: Maybe<Subscription>;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   users: Array<User>;
 };
 
 export type WorkspaceCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type WorkspaceMember = {
@@ -2170,5 +2172,5 @@ export type WorkspaceMember = {
 export type WorkspaceMemberType = Invitation | User;
 
 export type WorkspaceUpdateInput = {
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -3,131 +3,133 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
   /** A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format. */
-  DateTime: any;
+  DateTime: { input: any; output: any; }
   /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
-  JSONObject: any;
+  JSONObject: { input: any; output: any; }
   /** The `Upload` scalar type represents a file upload. */
-  Upload: any;
+  Upload: { input: any; output: any; }
 };
 
 export type Account = {
-  createdAt: Scalars['DateTime'];
-  email: Scalars['String'];
-  firstName: Scalars['String'];
-  githubId?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  lastName: Scalars['String'];
-  password: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  email: Scalars['String']['output'];
+  firstName: Scalars['String']['output'];
+  githubId?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  lastName: Scalars['String']['output'];
+  password: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type Action = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   steps?: Maybe<Array<ActionStep>>;
 };
 
 export type ActionLog = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   level: EnumActionLogLevel;
-  message: Scalars['String'];
-  meta: Scalars['JSONObject'];
+  message: Scalars['String']['output'];
+  meta: Scalars['JSONObject']['output'];
 };
 
 export type ActionStep = {
-  completedAt?: Maybe<Scalars['DateTime']>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  completedAt?: Maybe<Scalars['DateTime']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   logs?: Maybe<Array<ActionLog>>;
-  message: Scalars['String'];
-  name: Scalars['String'];
+  message: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   status: EnumActionStepStatus;
 };
 
 export type AdminUiSettings = {
-  adminUIPath: Scalars['String'];
-  generateAdminUI: Scalars['Boolean'];
+  adminUIPath: Scalars['String']['output'];
+  generateAdminUI: Scalars['Boolean']['output'];
 };
 
 export type AdminUiSettingsUpdateInput = {
-  adminUIPath?: InputMaybe<Scalars['String']>;
-  generateAdminUI?: InputMaybe<Scalars['Boolean']>;
+  adminUIPath?: InputMaybe<Scalars['String']['input']>;
+  generateAdminUI?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ApiToken = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  lastAccessAt: Scalars['DateTime'];
-  name: Scalars['String'];
-  previewChars: Scalars['String'];
-  token?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  userId: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  lastAccessAt: Scalars['DateTime']['output'];
+  name: Scalars['String']['output'];
+  previewChars: Scalars['String']['output'];
+  token?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  userId: Scalars['String']['output'];
 };
 
 export type ApiTokenCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type Auth = {
   /** JWT Bearer token */
-  token: Scalars['String'];
+  token: Scalars['String']['output'];
 };
 
 export type AuthorizeResourceWithGitResult = {
-  url: Scalars['String'];
+  url: Scalars['String']['output'];
 };
 
 export type Block = {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  lockedAt?: Maybe<Scalars['DateTime']>;
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedByUser: Array<User>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   parentBlock?: Maybe<Block>;
   resource?: Maybe<Resource>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber?: Maybe<Scalars['Float']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber?: Maybe<Scalars['Float']['output']>;
   versions?: Maybe<Array<BlockVersion>>;
 };
 
 
 export type BlockVersionsArgs = {
   orderBy?: InputMaybe<BlockVersionOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BlockVersionWhereInput>;
 };
 
 export type BlockInputOutput = {
   dataType?: Maybe<EnumDataType>;
-  dataTypeEntityName?: Maybe<Scalars['String']>;
-  description: Scalars['String'];
-  includeAllPropertiesByDefault?: Maybe<Scalars['Boolean']>;
-  isList?: Maybe<Scalars['Boolean']>;
-  name: Scalars['String'];
+  dataTypeEntityName?: Maybe<Scalars['String']['output']>;
+  description: Scalars['String']['output'];
+  includeAllPropertiesByDefault?: Maybe<Scalars['Boolean']['output']>;
+  isList?: Maybe<Scalars['Boolean']['output']>;
+  name: Scalars['String']['output'];
   propertyList?: Maybe<Array<PropertySelector>>;
 };
 
 export type BlockInputOutputInput = {
   dataType?: InputMaybe<EnumDataType>;
-  dataTypeEntityName?: InputMaybe<Scalars['String']>;
-  description: Scalars['String'];
-  includeAllPropertiesByDefault?: InputMaybe<Scalars['Boolean']>;
-  isList?: InputMaybe<Scalars['Boolean']>;
-  name: Scalars['String'];
+  dataTypeEntityName?: InputMaybe<Scalars['String']['input']>;
+  description: Scalars['String']['input'];
+  includeAllPropertiesByDefault?: InputMaybe<Scalars['Boolean']['input']>;
+  isList?: InputMaybe<Scalars['Boolean']['input']>;
+  name: Scalars['String']['input'];
   propertyList?: InputMaybe<Array<PropertySelectorInput>>;
 };
 
@@ -143,13 +145,13 @@ export type BlockOrderByInput = {
 export type BlockVersion = {
   block: Block;
   commit?: Maybe<Commit>;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  settings?: Maybe<Scalars['JSONObject']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Int'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  settings?: Maybe<Scalars['JSONObject']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 export type BlockVersionOrderByInput = {
@@ -181,30 +183,30 @@ export type BlockWhereInput = {
 };
 
 export type BooleanFilter = {
-  equals?: InputMaybe<Scalars['Boolean']>;
-  not?: InputMaybe<Scalars['Boolean']>;
+  equals?: InputMaybe<Scalars['Boolean']['input']>;
+  not?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type Build = {
   action?: Maybe<Action>;
-  actionId: Scalars['String'];
-  archiveURI: Scalars['String'];
+  actionId: Scalars['String']['output'];
+  archiveURI: Scalars['String']['output'];
   commit: Commit;
-  commitId: Scalars['String'];
-  createdAt: Scalars['DateTime'];
+  commitId: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
   createdBy: User;
-  id: Scalars['String'];
-  message: Scalars['String'];
+  id: Scalars['String']['output'];
+  message: Scalars['String']['output'];
   resource?: Maybe<Resource>;
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['output'];
   status?: Maybe<EnumBuildStatus>;
-  userId: Scalars['String'];
-  version: Scalars['String'];
+  userId: Scalars['String']['output'];
+  version: Scalars['String']['output'];
 };
 
 export type BuildCreateInput = {
   commit: WhereParentIdInput;
-  message: Scalars['String'];
+  message: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
@@ -228,30 +230,30 @@ export type BuildWhereInput = {
 };
 
 export type ChangePasswordInput = {
-  newPassword: Scalars['String'];
-  oldPassword: Scalars['String'];
+  newPassword: Scalars['String']['input'];
+  oldPassword: Scalars['String']['input'];
 };
 
 export type Commit = {
   builds?: Maybe<Array<Build>>;
   changes?: Maybe<Array<PendingChange>>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  message: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  message: Scalars['String']['output'];
   user?: Maybe<User>;
-  userId: Scalars['String'];
+  userId: Scalars['String']['output'];
 };
 
 
 export type CommitBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
 export type CommitCreateInput = {
-  message: Scalars['String'];
+  message: Scalars['String']['input'];
   project: WhereParentIdInput;
 };
 
@@ -270,24 +272,24 @@ export type CommitWhereInput = {
 };
 
 export type CommitWhereUniqueInput = {
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CompleteInvitationInput = {
-  token: Scalars['String'];
+  token: Scalars['String']['input'];
 };
 
 export type ConnectGitRepositoryInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isOverrideGitRepository?: InputMaybe<Scalars['Boolean']>;
-  name: Scalars['String'];
-  resourceId: Scalars['String'];
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isOverrideGitRepository?: InputMaybe<Scalars['Boolean']['input']>;
+  name: Scalars['String']['input'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type CreateEntitiesFromPrismaSchemaInput = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type CreateEntitiesFromPrismaSchemaResponse = {
@@ -296,128 +298,128 @@ export type CreateEntitiesFromPrismaSchemaResponse = {
 };
 
 export type CreateGitRepositoryBaseInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isPublic: Scalars['Boolean'];
-  name: Scalars['String'];
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isPublic: Scalars['Boolean']['input'];
+  name: Scalars['String']['input'];
 };
 
 export type CreateGitRepositoryInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isPublic: Scalars['Boolean'];
-  name: Scalars['String'];
-  resourceId?: InputMaybe<Scalars['String']>;
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isPublic: Scalars['Boolean']['input'];
+  name: Scalars['String']['input'];
+  resourceId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type DateTimeFilter = {
-  equals?: InputMaybe<Scalars['DateTime']>;
-  gt?: InputMaybe<Scalars['DateTime']>;
-  gte?: InputMaybe<Scalars['DateTime']>;
-  in?: InputMaybe<Array<Scalars['DateTime']>>;
-  lt?: InputMaybe<Scalars['DateTime']>;
-  lte?: InputMaybe<Scalars['DateTime']>;
-  not?: InputMaybe<Scalars['DateTime']>;
-  notIn?: InputMaybe<Array<Scalars['DateTime']>>;
+  equals?: InputMaybe<Scalars['DateTime']['input']>;
+  gt?: InputMaybe<Scalars['DateTime']['input']>;
+  gte?: InputMaybe<Scalars['DateTime']['input']>;
+  in?: InputMaybe<Array<Scalars['DateTime']['input']>>;
+  lt?: InputMaybe<Scalars['DateTime']['input']>;
+  lte?: InputMaybe<Scalars['DateTime']['input']>;
+  not?: InputMaybe<Scalars['DateTime']['input']>;
+  notIn?: InputMaybe<Array<Scalars['DateTime']['input']>>;
 };
 
 export type DefaultEntitiesInput = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type Entity = {
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
   fields?: Maybe<Array<EntityField>>;
-  id: Scalars['String'];
-  lockedAt?: Maybe<Scalars['DateTime']>;
+  id: Scalars['String']['output'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedByUser?: Maybe<User>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
   permissions?: Maybe<Array<EntityPermission>>;
-  pluralDisplayName: Scalars['String'];
+  pluralDisplayName: Scalars['String']['output'];
   resource?: Maybe<Resource>;
-  resourceId: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  resourceId: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
   versions?: Maybe<Array<EntityVersion>>;
 };
 
 
 export type EntityFieldsArgs = {
   orderBy?: InputMaybe<EntityFieldOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityFieldWhereInput>;
 };
 
 
 export type EntityVersionsArgs = {
   orderBy?: InputMaybe<EntityVersionOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityVersionWhereInput>;
 };
 
 export type EntityAddPermissionFieldInput = {
   action: EnumEntityAction;
   entity: WhereParentIdInput;
-  fieldName: Scalars['String'];
+  fieldName: Scalars['String']['input'];
 };
 
 export type EntityCreateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
   /** allow creating the id for the entity when using import prisma schema because we need it for the relation */
-  id?: InputMaybe<Scalars['String']>;
-  name: Scalars['String'];
-  pluralDisplayName: Scalars['String'];
+  id?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  pluralDisplayName: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
 export type EntityField = {
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
   dataType: EnumDataType;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
-  permanentId: Scalars['String'];
-  position?: Maybe<Scalars['Int']>;
-  properties?: Maybe<Scalars['JSONObject']>;
-  required: Scalars['Boolean'];
-  searchable: Scalars['Boolean'];
-  unique: Scalars['Boolean'];
-  updatedAt: Scalars['DateTime'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  permanentId: Scalars['String']['output'];
+  position?: Maybe<Scalars['Int']['output']>;
+  properties?: Maybe<Scalars['JSONObject']['output']>;
+  required: Scalars['Boolean']['output'];
+  searchable: Scalars['Boolean']['output'];
+  unique: Scalars['Boolean']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type EntityFieldCreateByDisplayNameInput = {
   dataType?: InputMaybe<EnumDataType>;
-  displayName: Scalars['String'];
+  displayName: Scalars['String']['input'];
   entity: WhereParentIdInput;
 };
 
 export type EntityFieldCreateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
   dataType: EnumDataType;
-  description: Scalars['String'];
-  displayName: Scalars['String'];
+  description: Scalars['String']['input'];
+  displayName: Scalars['String']['input'];
   entity: WhereParentIdInput;
-  name: Scalars['String'];
-  position?: InputMaybe<Scalars['Int']>;
-  properties: Scalars['JSONObject'];
-  required: Scalars['Boolean'];
-  searchable: Scalars['Boolean'];
-  unique: Scalars['Boolean'];
+  name: Scalars['String']['input'];
+  position?: InputMaybe<Scalars['Int']['input']>;
+  properties: Scalars['JSONObject']['input'];
+  required: Scalars['Boolean']['input'];
+  searchable: Scalars['Boolean']['input'];
+  unique: Scalars['Boolean']['input'];
 };
 
 export type EntityFieldFilter = {
@@ -443,16 +445,16 @@ export type EntityFieldOrderByInput = {
 };
 
 export type EntityFieldUpdateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
   dataType?: InputMaybe<EnumDataType>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  position?: InputMaybe<Scalars['Int']>;
-  properties?: InputMaybe<Scalars['JSONObject']>;
-  required?: InputMaybe<Scalars['Boolean']>;
-  searchable?: InputMaybe<Scalars['Boolean']>;
-  unique?: InputMaybe<Scalars['Boolean']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  position?: InputMaybe<Scalars['Int']['input']>;
+  properties?: InputMaybe<Scalars['JSONObject']['input']>;
+  required?: InputMaybe<Scalars['Boolean']['input']>;
+  searchable?: InputMaybe<Scalars['Boolean']['input']>;
+  unique?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type EntityFieldWhereInput = {
@@ -484,44 +486,44 @@ export type EntityOrderByInput = {
 export type EntityPermission = {
   action: EnumEntityAction;
   entityVersion?: Maybe<EntityVersion>;
-  entityVersionId: Scalars['String'];
-  id: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   permissionFields?: Maybe<Array<EntityPermissionField>>;
   permissionRoles?: Maybe<Array<EntityPermissionRole>>;
   type: EnumEntityPermissionType;
 };
 
 export type EntityPermissionField = {
-  entityVersionId: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
   field: EntityField;
-  fieldPermanentId: Scalars['String'];
-  id: Scalars['String'];
+  fieldPermanentId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   permission?: Maybe<EntityPermission>;
-  permissionId: Scalars['String'];
+  permissionId: Scalars['String']['output'];
   permissionRoles?: Maybe<Array<EntityPermissionRole>>;
 };
 
 export type EntityPermissionFieldWhereUniqueInput = {
   action: EnumEntityAction;
-  entityId: Scalars['String'];
-  fieldPermanentId: Scalars['String'];
+  entityId: Scalars['String']['input'];
+  fieldPermanentId: Scalars['String']['input'];
 };
 
 export type EntityPermissionRole = {
   action: EnumEntityAction;
   entityPermission?: Maybe<EntityPermission>;
-  entityVersionId: Scalars['String'];
-  id: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   resourceRole: ResourceRole;
-  resourceRoleId: Scalars['String'];
+  resourceRoleId: Scalars['String']['output'];
 };
 
 export type EntityUpdateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  pluralDisplayName?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  pluralDisplayName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type EntityUpdatePermissionFieldRolesInput = {
@@ -544,26 +546,26 @@ export type EntityUpdatePermissionRolesInput = {
 
 export type EntityVersion = {
   commit?: Maybe<Commit>;
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
   entity: Entity;
-  entityId: Scalars['String'];
+  entityId: Scalars['String']['output'];
   fields: Array<EntityField>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   permissions?: Maybe<Array<EntityPermission>>;
-  pluralDisplayName: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Int'];
+  pluralDisplayName: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 
 export type EntityVersionFieldsArgs = {
   orderBy?: InputMaybe<EntityFieldOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityFieldWhereInput>;
 };
 
@@ -753,14 +755,14 @@ export enum EnumWorkspaceMemberType {
 }
 
 export type Environment = {
-  address: Scalars['String'];
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  address: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   resource: Resource;
-  resourceId: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  resourceId: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type GitGetInstallationUrlInput = {
@@ -769,103 +771,103 @@ export type GitGetInstallationUrlInput = {
 
 /** Group of Repositories */
 export type GitGroup = {
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
 };
 
 export type GitGroupInput = {
-  organizationId: Scalars['String'];
+  organizationId: Scalars['String']['input'];
 };
 
 export type GitOAuth2FlowInput = {
-  code: Scalars['String'];
+  code: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
 };
 
 export type GitOrganization = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  installationId: Scalars['String'];
-  name: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  installationId: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   provider: EnumGitProvider;
   type: EnumGitOrganizationType;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   /** Defines if a git organisation needs defined repository groups */
-  useGroupingForRepositories: Scalars['Boolean'];
+  useGroupingForRepositories: Scalars['Boolean']['output'];
 };
 
 export type GitOrganizationCreateInput = {
   gitProvider: EnumGitProvider;
-  installationId: Scalars['String'];
+  installationId: Scalars['String']['input'];
 };
 
 export type GitOrganizationWhereInput = {
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type GitRepository = {
-  createdAt?: Maybe<Scalars['DateTime']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
   gitOrganization: GitOrganization;
-  gitOrganizationId: Scalars['String'];
-  groupName?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
-  updatedAt?: Maybe<Scalars['DateTime']>;
+  gitOrganizationId: Scalars['String']['output'];
+  groupName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
 };
 
 export type IBlock = {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type IntFilter = {
-  equals?: InputMaybe<Scalars['Int']>;
-  gt?: InputMaybe<Scalars['Int']>;
-  gte?: InputMaybe<Scalars['Int']>;
-  in?: InputMaybe<Array<Scalars['Int']>>;
-  lt?: InputMaybe<Scalars['Int']>;
-  lte?: InputMaybe<Scalars['Int']>;
-  not?: InputMaybe<Scalars['Int']>;
-  notIn?: InputMaybe<Array<Scalars['Int']>>;
+  equals?: InputMaybe<Scalars['Int']['input']>;
+  gt?: InputMaybe<Scalars['Int']['input']>;
+  gte?: InputMaybe<Scalars['Int']['input']>;
+  in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  lt?: InputMaybe<Scalars['Int']['input']>;
+  lte?: InputMaybe<Scalars['Int']['input']>;
+  not?: InputMaybe<Scalars['Int']['input']>;
+  notIn?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 export type Invitation = {
-  createdAt: Scalars['DateTime'];
-  email: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  email: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   invitedByUser?: Maybe<User>;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   workspace?: Maybe<Workspace>;
 };
 
 export type InviteUserInput = {
-  email: Scalars['String'];
+  email: Scalars['String']['input'];
 };
 
 export type LoginInput = {
-  email: Scalars['String'];
-  password: Scalars['String'];
+  email: Scalars['String']['input'];
+  password: Scalars['String']['input'];
 };
 
 export type MessagePattern = {
-  topicId: Scalars['String'];
+  topicId: Scalars['String']['output'];
   type: EnumMessagePatternConnectionOptions;
 };
 
 export type MessagePatternCreateInput = {
-  topicId: Scalars['String'];
+  topicId: Scalars['String']['input'];
   type: EnumMessagePatternConnectionOptions;
 };
 
@@ -902,7 +904,7 @@ export type Mutation = {
   deleteEntity?: Maybe<Entity>;
   deleteEntityField: EntityField;
   deleteEntityPermissionField: EntityPermissionField;
-  deleteGitOrganization: Scalars['Boolean'];
+  deleteGitOrganization: Scalars['Boolean']['output'];
   deleteGitRepository: Resource;
   deletePluginInstallation: PluginInstallation;
   deleteProject?: Maybe<Project>;
@@ -912,7 +914,7 @@ export type Mutation = {
   deleteTopic: Topic;
   deleteUser?: Maybe<User>;
   deleteWorkspace?: Maybe<Workspace>;
-  discardPendingChanges?: Maybe<Scalars['Boolean']>;
+  discardPendingChanges?: Maybe<Scalars['Boolean']['output']>;
   disconnectResourceGitRepository: Resource;
   getGitResourceInstallationUrl: AuthorizeResourceWithGitResult;
   inviteUser?: Maybe<Invitation>;
@@ -978,7 +980,7 @@ export type MutationConnectResourceGitRepositoryArgs = {
 
 
 export type MutationConnectResourceToProjectRepositoryArgs = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 
@@ -998,24 +1000,24 @@ export type MutationCreateDefaultEntitiesArgs = {
 
 
 export type MutationCreateDefaultRelatedFieldArgs = {
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
   where: WhereUniqueInput;
 };
 
 
 export type MutationCreateEntitiesFromPrismaSchemaArgs = {
   data: CreateEntitiesFromPrismaSchemaInput;
-  file: Scalars['Upload'];
+  file: Scalars['Upload']['input'];
 };
 
 
 export type MutationCreateEntityFieldArgs = {
   data: EntityFieldCreateInput;
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1105,13 +1107,13 @@ export type MutationDeleteEntityPermissionFieldArgs = {
 
 
 export type MutationDeleteGitOrganizationArgs = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
 };
 
 
 export type MutationDeleteGitRepositoryArgs = {
-  gitRepositoryId: Scalars['String'];
+  gitRepositoryId: Scalars['String']['input'];
 };
 
 
@@ -1161,7 +1163,7 @@ export type MutationDiscardPendingChangesArgs = {
 
 
 export type MutationDisconnectResourceGitRepositoryArgs = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 
@@ -1229,9 +1231,9 @@ export type MutationUpdateEntityArgs = {
 
 export type MutationUpdateEntityFieldArgs = {
   data: EntityFieldUpdateInput;
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
   where: WhereUniqueInput;
 };
 
@@ -1309,25 +1311,25 @@ export type MutationUpdateWorkspaceArgs = {
 export type PaginatedGitGroup = {
   groups?: Maybe<Array<GitGroup>>;
   /** Page number */
-  page: Scalars['Float'];
+  page: Scalars['Float']['output'];
   /** Number of groups per page */
-  pageSize: Scalars['Float'];
+  pageSize: Scalars['Float']['output'];
   /** Total number of groups */
-  total: Scalars['Float'];
+  total: Scalars['Float']['output'];
 };
 
 export type Pagination = {
-  page: Scalars['Float'];
-  perPage: Scalars['Float'];
+  page: Scalars['Float']['output'];
+  perPage: Scalars['Float']['output'];
 };
 
 export type PendingChange = {
   action: EnumPendingChangeAction;
   origin: PendingChangeOrigin;
-  originId: Scalars['String'];
+  originId: Scalars['String']['output'];
   originType: EnumPendingChangeOriginType;
   resource: Resource;
-  versionNumber: Scalars['Int'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 export type PendingChangeOrigin = Block | Entity;
@@ -1342,39 +1344,39 @@ export type PendingChangesFindInput = {
 
 export type PluginInstallation = IBlock & {
   blockType: EnumBlockType;
-  configurations?: Maybe<Scalars['JSONObject']>;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
-  id: Scalars['String'];
+  configurations?: Maybe<Scalars['JSONObject']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  enabled: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  npm: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  npm: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  pluginId: Scalars['String'];
-  resourceId?: Maybe<Scalars['String']>;
-  settings?: Maybe<Scalars['JSONObject']>;
-  updatedAt: Scalars['DateTime'];
-  version: Scalars['String'];
-  versionNumber: Scalars['Float'];
+  pluginId: Scalars['String']['output'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  settings?: Maybe<Scalars['JSONObject']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  version: Scalars['String']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type PluginInstallationCreateInput = {
-  configurations?: InputMaybe<Scalars['JSONObject']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
+  configurations?: InputMaybe<Scalars['JSONObject']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  enabled: Scalars['Boolean']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  npm: Scalars['String'];
+  npm: Scalars['String']['input'];
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
-  pluginId: Scalars['String'];
+  pluginId: Scalars['String']['input'];
   resource: WhereParentIdInput;
-  settings?: InputMaybe<Scalars['JSONObject']>;
-  version: Scalars['String'];
+  settings?: InputMaybe<Scalars['JSONObject']['input']>;
+  version: Scalars['String']['input'];
 };
 
 export type PluginInstallationOrderByInput = {
@@ -1387,12 +1389,12 @@ export type PluginInstallationOrderByInput = {
 };
 
 export type PluginInstallationUpdateInput = {
-  configurations?: InputMaybe<Scalars['JSONObject']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  enabled: Scalars['Boolean'];
-  settings?: InputMaybe<Scalars['JSONObject']>;
-  version: Scalars['String'];
+  configurations?: InputMaybe<Scalars['JSONObject']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  enabled: Scalars['Boolean']['input'];
+  settings?: InputMaybe<Scalars['JSONObject']['input']>;
+  version: Scalars['String']['input'];
 };
 
 export type PluginInstallationWhereInput = {
@@ -1411,65 +1413,65 @@ export type PluginInstallationsCreateInput = {
 
 export type PluginOrder = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   order: Array<PluginOrderItem>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type PluginOrderItem = {
-  order: Scalars['Int'];
-  pluginId: Scalars['String'];
+  order: Scalars['Int']['output'];
+  pluginId: Scalars['String']['output'];
 };
 
 export type PluginSetOrderInput = {
-  order: Scalars['Int'];
+  order: Scalars['Int']['input'];
 };
 
 export type Project = {
-  createdAt: Scalars['DateTime'];
-  demoRepoName?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  demoRepoName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   resources?: Maybe<Array<Resource>>;
-  updatedAt: Scalars['DateTime'];
-  useDemoRepo: Scalars['Boolean'];
+  updatedAt: Scalars['DateTime']['output'];
+  useDemoRepo: Scalars['Boolean']['output'];
 };
 
 export type ProjectConfigurationSettings = IBlock & {
-  baseDirectory: Scalars['String'];
+  baseDirectory: Scalars['String']['output'];
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ProjectConfigurationSettingsUpdateInput = {
-  baseDirectory?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
+  baseDirectory?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ProjectCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type ProjectOrderByInput = {
@@ -1479,38 +1481,38 @@ export type ProjectOrderByInput = {
 };
 
 export type ProjectUpdateInput = {
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ProjectWhereInput = {
   deletedAt?: InputMaybe<DateTimeFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   resources?: InputMaybe<ResourceListRelationFilter>;
 };
 
 export type PropertySelector = {
-  include: Scalars['Boolean'];
-  propertyName: Scalars['String'];
+  include: Scalars['Boolean']['output'];
+  propertyName: Scalars['String']['output'];
 };
 
 export type PropertySelectorInput = {
-  include: Scalars['Boolean'];
-  propertyName: Scalars['String'];
+  include: Scalars['Boolean']['input'];
+  propertyName: Scalars['String']['input'];
 };
 
 export type ProvisionSubscriptionInput = {
-  billingPeriod: Scalars['String'];
-  cancelUrl?: InputMaybe<Scalars['String']>;
-  intentionType: Scalars['String'];
-  planId: Scalars['String'];
-  successUrl?: InputMaybe<Scalars['String']>;
-  workspaceId: Scalars['String'];
+  billingPeriod: Scalars['String']['input'];
+  cancelUrl?: InputMaybe<Scalars['String']['input']>;
+  intentionType: Scalars['String']['input'];
+  planId: Scalars['String']['input'];
+  successUrl?: InputMaybe<Scalars['String']['input']>;
+  workspaceId: Scalars['String']['input'];
 };
 
 export type ProvisionSubscriptionResult = {
-  checkoutUrl?: Maybe<Scalars['String']>;
-  provisionStatus: Scalars['String'];
+  checkoutUrl?: Maybe<Scalars['String']['output']>;
+  provisionStatus: Scalars['String']['output'];
 };
 
 export type Query = {
@@ -1561,8 +1563,8 @@ export type QueryPluginInstallationArgs = {
 
 export type QueryPluginInstallationsArgs = {
   orderBy?: InputMaybe<PluginInstallationOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<PluginInstallationWhereInput>;
 };
 
@@ -1574,8 +1576,8 @@ export type QueryServiceTopicsArgs = {
 
 export type QueryServiceTopicsListArgs = {
   orderBy?: InputMaybe<ServiceTopicsOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ServiceTopicsWhereInput>;
 };
 
@@ -1587,8 +1589,8 @@ export type QueryTopicArgs = {
 
 export type QueryTopicsArgs = {
   orderBy?: InputMaybe<TopicOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<TopicWhereInput>;
 };
 
@@ -1605,8 +1607,8 @@ export type QueryBlockArgs = {
 
 export type QueryBlocksArgs = {
   orderBy?: InputMaybe<BlockOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BlockWhereInput>;
 };
 
@@ -1618,8 +1620,8 @@ export type QueryBuildArgs = {
 
 export type QueryBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
@@ -1632,16 +1634,16 @@ export type QueryCommitArgs = {
 export type QueryCommitsArgs = {
   cursor?: InputMaybe<CommitWhereUniqueInput>;
   orderBy?: InputMaybe<CommitOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<CommitWhereInput>;
 };
 
 
 export type QueryEntitiesArgs = {
   orderBy?: InputMaybe<EntityOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityWhereInput>;
 };
 
@@ -1662,8 +1664,8 @@ export type QueryGitOrganizationArgs = {
 
 
 export type QueryGitOrganizationsArgs = {
-  skip?: InputMaybe<Scalars['Float']>;
-  take?: InputMaybe<Scalars['Float']>;
+  skip?: InputMaybe<Scalars['Float']['input']>;
+  take?: InputMaybe<Scalars['Float']['input']>;
   where?: InputMaybe<GitOrganizationWhereInput>;
 };
 
@@ -1695,8 +1697,8 @@ export type QueryProjectConfigurationSettingsArgs = {
 
 export type QueryProjectsArgs = {
   orderBy?: InputMaybe<ProjectOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ProjectWhereInput>;
 };
 
@@ -1712,23 +1714,23 @@ export type QueryResourceArgs = {
 
 
 export type QueryResourceRoleArgs = {
-  version?: InputMaybe<Scalars['Float']>;
+  version?: InputMaybe<Scalars['Float']['input']>;
   where: WhereUniqueInput;
 };
 
 
 export type QueryResourceRolesArgs = {
   orderBy?: InputMaybe<ResourceRoleOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ResourceRoleWhereInput>;
 };
 
 
 export type QueryResourcesArgs = {
   orderBy?: InputMaybe<Array<ResourceOrderByInput>>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ResourceWhereInput>;
 };
 
@@ -1750,68 +1752,68 @@ export enum QueryMode {
 export type RemoteGitRepos = {
   pagination: Pagination;
   repos: Array<RemoteGitRepository>;
-  total: Scalars['Float'];
+  total: Scalars['Float']['output'];
 };
 
 export type RemoteGitRepositoriesWhereUniqueInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
-  groupName?: InputMaybe<Scalars['String']>;
+  groupName?: InputMaybe<Scalars['String']['input']>;
   /** The page number. One-based indexing */
-  page?: Scalars['Float'];
+  page?: Scalars['Float']['input'];
   /** The number of items to return per page */
-  perPage?: Scalars['Float'];
+  perPage?: Scalars['Float']['input'];
 };
 
 export type RemoteGitRepository = {
-  admin: Scalars['Boolean'];
-  defaultBranch: Scalars['String'];
-  fullName: Scalars['String'];
-  groupName?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
-  private: Scalars['Boolean'];
-  url: Scalars['String'];
+  admin: Scalars['Boolean']['output'];
+  defaultBranch: Scalars['String']['output'];
+  fullName: Scalars['String']['output'];
+  groupName?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  private: Scalars['Boolean']['output'];
+  url: Scalars['String']['output'];
 };
 
 export type Resource = {
   builds: Array<Build>;
-  createdAt: Scalars['DateTime'];
-  description: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description: Scalars['String']['output'];
   entities: Array<Entity>;
   environments: Array<Environment>;
   gitRepository?: Maybe<GitRepository>;
-  gitRepositoryId?: Maybe<Scalars['String']>;
-  gitRepositoryOverride: Scalars['Boolean'];
-  githubLastMessage?: Maybe<Scalars['String']>;
-  githubLastSync?: Maybe<Scalars['DateTime']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  gitRepositoryId?: Maybe<Scalars['String']['output']>;
+  gitRepositoryOverride: Scalars['Boolean']['output'];
+  githubLastMessage?: Maybe<Scalars['String']['output']>;
+  githubLastSync?: Maybe<Scalars['DateTime']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   project?: Maybe<Project>;
-  projectId?: Maybe<Scalars['String']>;
+  projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 
 export type ResourceBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
 
 export type ResourceEntitiesArgs = {
   orderBy?: InputMaybe<EntityOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityWhereInput>;
 };
 
 export type ResourceCreateInput = {
-  description: Scalars['String'];
+  description: Scalars['String']['input'];
   gitRepository?: InputMaybe<ConnectGitRepositoryInput>;
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
   project: WhereParentIdInput;
   resourceType: EnumResourceType;
   serviceSettings?: InputMaybe<ServiceSettingsUpdateInput>;
@@ -1819,25 +1821,25 @@ export type ResourceCreateInput = {
 
 export type ResourceCreateWithEntitiesEntityInput = {
   fields: Array<ResourceCreateWithEntitiesFieldInput>;
-  name: Scalars['String'];
-  relationsToEntityIndex?: InputMaybe<Array<Scalars['Int']>>;
+  name: Scalars['String']['input'];
+  relationsToEntityIndex?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 export type ResourceCreateWithEntitiesFieldInput = {
   dataType?: InputMaybe<EnumDataType>;
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type ResourceCreateWithEntitiesInput = {
-  authType: Scalars['String'];
-  commitMessage: Scalars['String'];
-  connectToDemoRepo: Scalars['Boolean'];
-  dbType: Scalars['String'];
+  authType: Scalars['String']['input'];
+  commitMessage: Scalars['String']['input'];
+  connectToDemoRepo: Scalars['Boolean']['input'];
+  dbType: Scalars['String']['input'];
   entities: Array<ResourceCreateWithEntitiesEntityInput>;
   plugins?: InputMaybe<PluginInstallationsCreateInput>;
-  repoType: Scalars['String'];
+  repoType: Scalars['String']['input'];
   resource: ResourceCreateInput;
-  wizardType: Scalars['String'];
+  wizardType: Scalars['String']['input'];
 };
 
 export type ResourceCreateWithEntitiesResult = {
@@ -1861,18 +1863,18 @@ export type ResourceOrderByInput = {
 };
 
 export type ResourceRole = {
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type ResourceRoleCreateInput = {
-  description: Scalars['String'];
-  displayName: Scalars['String'];
-  name: Scalars['String'];
+  description: Scalars['String']['input'];
+  displayName: Scalars['String']['input'];
+  name: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
@@ -1886,34 +1888,34 @@ export type ResourceRoleOrderByInput = {
 };
 
 export type ResourceRoleUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceRoleWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   resource?: InputMaybe<WhereUniqueInput>;
   updatedAt?: InputMaybe<DateTimeFilter>;
 };
 
 export type ResourceUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  gitRepositoryOverride?: InputMaybe<Scalars['Boolean']>;
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  gitRepositoryOverride?: InputMaybe<Scalars['Boolean']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
   description?: InputMaybe<StringFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   project?: InputMaybe<ProjectWhereInput>;
-  projectId?: InputMaybe<Scalars['String']>;
+  projectId?: InputMaybe<Scalars['String']['input']>;
   resourceType?: InputMaybe<EnumResourceTypeFilter>;
   updatedAt?: InputMaybe<DateTimeFilter>;
 };
@@ -1926,69 +1928,69 @@ export enum Role {
 }
 
 export type ServerSettings = {
-  generateGraphQL: Scalars['Boolean'];
-  generateRestApi: Scalars['Boolean'];
-  serverPath: Scalars['String'];
+  generateGraphQL: Scalars['Boolean']['output'];
+  generateRestApi: Scalars['Boolean']['output'];
+  serverPath: Scalars['String']['output'];
 };
 
 export type ServerSettingsUpdateInput = {
-  generateGraphQL?: InputMaybe<Scalars['Boolean']>;
-  generateRestApi?: InputMaybe<Scalars['Boolean']>;
-  serverPath?: InputMaybe<Scalars['String']>;
+  generateGraphQL?: InputMaybe<Scalars['Boolean']['input']>;
+  generateRestApi?: InputMaybe<Scalars['Boolean']['input']>;
+  serverPath?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ServiceSettings = IBlock & {
   adminUISettings: AdminUiSettings;
   authProvider: EnumAuthProviderType;
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
+  resourceId?: Maybe<Scalars['String']['output']>;
   serverSettings: ServerSettings;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ServiceSettingsUpdateInput = {
   adminUISettings: AdminUiSettingsUpdateInput;
   authProvider: EnumAuthProviderType;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
   serverSettings: ServerSettingsUpdateInput;
 };
 
 export type ServiceTopics = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  enabled: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  messageBrokerId: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  messageBrokerId: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
   patterns: Array<MessagePattern>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ServiceTopicsCreateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  enabled: Scalars['Boolean']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  messageBrokerId: Scalars['String'];
+  messageBrokerId: Scalars['String']['input'];
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
   patterns?: InputMaybe<Array<MessagePatternCreateInput>>;
@@ -2005,10 +2007,10 @@ export type ServiceTopicsOrderByInput = {
 };
 
 export type ServiceTopicsUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  enabled: Scalars['Boolean'];
-  messageBrokerId: Scalars['String'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  enabled: Scalars['Boolean']['input'];
+  messageBrokerId: Scalars['String']['input'];
   patterns?: InputMaybe<Array<MessagePatternCreateInput>>;
 };
 
@@ -2023,11 +2025,11 @@ export type ServiceTopicsWhereInput = {
 };
 
 export type SignupInput = {
-  email: Scalars['String'];
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  password: Scalars['String'];
-  workspaceName: Scalars['String'];
+  email: Scalars['String']['input'];
+  firstName: Scalars['String']['input'];
+  lastName: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+  workspaceName: Scalars['String']['input'];
 };
 
 export enum SortOrder {
@@ -2036,57 +2038,57 @@ export enum SortOrder {
 }
 
 export type StringFilter = {
-  contains?: InputMaybe<Scalars['String']>;
-  endsWith?: InputMaybe<Scalars['String']>;
-  equals?: InputMaybe<Scalars['String']>;
-  gt?: InputMaybe<Scalars['String']>;
-  gte?: InputMaybe<Scalars['String']>;
-  in?: InputMaybe<Array<Scalars['String']>>;
-  lt?: InputMaybe<Scalars['String']>;
-  lte?: InputMaybe<Scalars['String']>;
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
   mode?: InputMaybe<QueryMode>;
-  not?: InputMaybe<Scalars['String']>;
-  notIn?: InputMaybe<Array<Scalars['String']>>;
-  startsWith?: InputMaybe<Scalars['String']>;
+  not?: InputMaybe<Scalars['String']['input']>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Subscription = {
-  cancelUrl?: Maybe<Scalars['String']>;
-  cancellationEffectiveDate?: Maybe<Scalars['DateTime']>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  nextBillDate?: Maybe<Scalars['DateTime']>;
-  price?: Maybe<Scalars['Float']>;
+  cancelUrl?: Maybe<Scalars['String']['output']>;
+  cancellationEffectiveDate?: Maybe<Scalars['DateTime']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  nextBillDate?: Maybe<Scalars['DateTime']['output']>;
+  price?: Maybe<Scalars['Float']['output']>;
   status: EnumSubscriptionStatus;
   subscriptionPlan: EnumSubscriptionPlan;
-  updateUrl?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
+  updateUrl?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
   workspace?: Maybe<Workspace>;
-  workspaceId: Scalars['String'];
+  workspaceId: Scalars['String']['output'];
 };
 
 export type Topic = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type TopicCreateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
   resource: WhereParentIdInput;
@@ -2102,9 +2104,9 @@ export type TopicOrderByInput = {
 };
 
 export type TopicUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicWhereInput = {
@@ -2118,25 +2120,25 @@ export type TopicWhereInput = {
 };
 
 export type UpdateAccountInput = {
-  firstName?: InputMaybe<Scalars['String']>;
-  lastName?: InputMaybe<Scalars['String']>;
+  firstName?: InputMaybe<Scalars['String']['input']>;
+  lastName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type User = {
   account?: Maybe<Account>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  isOwner: Scalars['Boolean'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  isOwner: Scalars['Boolean']['output'];
+  updatedAt: Scalars['DateTime']['output'];
   userRoles?: Maybe<Array<UserRole>>;
   workspace?: Maybe<Workspace>;
 };
 
 export type UserRole = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   role: Role;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type WhereParentIdInput = {
@@ -2144,22 +2146,22 @@ export type WhereParentIdInput = {
 };
 
 export type WhereUniqueInput = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type Workspace = {
-  createdAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
   gitOrganizations?: Maybe<Array<GitOrganization>>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   projects: Array<Project>;
   subscription?: Maybe<Subscription>;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   users: Array<User>;
 };
 
 export type WorkspaceCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type WorkspaceMember = {
@@ -2170,5 +2172,5 @@ export type WorkspaceMember = {
 export type WorkspaceMemberType = Invitation | User;
 
 export type WorkspaceUpdateInput = {
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -3,131 +3,133 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
   /** A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format. */
-  DateTime: any;
+  DateTime: { input: any; output: any; }
   /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
-  JSONObject: any;
+  JSONObject: { input: any; output: any; }
   /** The `Upload` scalar type represents a file upload. */
-  Upload: any;
+  Upload: { input: any; output: any; }
 };
 
 export type Account = {
-  createdAt: Scalars['DateTime'];
-  email: Scalars['String'];
-  firstName: Scalars['String'];
-  githubId?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  lastName: Scalars['String'];
-  password: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  email: Scalars['String']['output'];
+  firstName: Scalars['String']['output'];
+  githubId?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  lastName: Scalars['String']['output'];
+  password: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type Action = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   steps?: Maybe<Array<ActionStep>>;
 };
 
 export type ActionLog = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   level: EnumActionLogLevel;
-  message: Scalars['String'];
-  meta: Scalars['JSONObject'];
+  message: Scalars['String']['output'];
+  meta: Scalars['JSONObject']['output'];
 };
 
 export type ActionStep = {
-  completedAt?: Maybe<Scalars['DateTime']>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  completedAt?: Maybe<Scalars['DateTime']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   logs?: Maybe<Array<ActionLog>>;
-  message: Scalars['String'];
-  name: Scalars['String'];
+  message: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   status: EnumActionStepStatus;
 };
 
 export type AdminUiSettings = {
-  adminUIPath: Scalars['String'];
-  generateAdminUI: Scalars['Boolean'];
+  adminUIPath: Scalars['String']['output'];
+  generateAdminUI: Scalars['Boolean']['output'];
 };
 
 export type AdminUiSettingsUpdateInput = {
-  adminUIPath?: InputMaybe<Scalars['String']>;
-  generateAdminUI?: InputMaybe<Scalars['Boolean']>;
+  adminUIPath?: InputMaybe<Scalars['String']['input']>;
+  generateAdminUI?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ApiToken = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  lastAccessAt: Scalars['DateTime'];
-  name: Scalars['String'];
-  previewChars: Scalars['String'];
-  token?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  userId: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  lastAccessAt: Scalars['DateTime']['output'];
+  name: Scalars['String']['output'];
+  previewChars: Scalars['String']['output'];
+  token?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  userId: Scalars['String']['output'];
 };
 
 export type ApiTokenCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type Auth = {
   /** JWT Bearer token */
-  token: Scalars['String'];
+  token: Scalars['String']['output'];
 };
 
 export type AuthorizeResourceWithGitResult = {
-  url: Scalars['String'];
+  url: Scalars['String']['output'];
 };
 
 export type Block = {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  lockedAt?: Maybe<Scalars['DateTime']>;
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedByUser: Array<User>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   parentBlock?: Maybe<Block>;
   resource?: Maybe<Resource>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber?: Maybe<Scalars['Float']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber?: Maybe<Scalars['Float']['output']>;
   versions?: Maybe<Array<BlockVersion>>;
 };
 
 
 export type BlockVersionsArgs = {
   orderBy?: InputMaybe<BlockVersionOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BlockVersionWhereInput>;
 };
 
 export type BlockInputOutput = {
   dataType?: Maybe<EnumDataType>;
-  dataTypeEntityName?: Maybe<Scalars['String']>;
-  description: Scalars['String'];
-  includeAllPropertiesByDefault?: Maybe<Scalars['Boolean']>;
-  isList?: Maybe<Scalars['Boolean']>;
-  name: Scalars['String'];
+  dataTypeEntityName?: Maybe<Scalars['String']['output']>;
+  description: Scalars['String']['output'];
+  includeAllPropertiesByDefault?: Maybe<Scalars['Boolean']['output']>;
+  isList?: Maybe<Scalars['Boolean']['output']>;
+  name: Scalars['String']['output'];
   propertyList?: Maybe<Array<PropertySelector>>;
 };
 
 export type BlockInputOutputInput = {
   dataType?: InputMaybe<EnumDataType>;
-  dataTypeEntityName?: InputMaybe<Scalars['String']>;
-  description: Scalars['String'];
-  includeAllPropertiesByDefault?: InputMaybe<Scalars['Boolean']>;
-  isList?: InputMaybe<Scalars['Boolean']>;
-  name: Scalars['String'];
+  dataTypeEntityName?: InputMaybe<Scalars['String']['input']>;
+  description: Scalars['String']['input'];
+  includeAllPropertiesByDefault?: InputMaybe<Scalars['Boolean']['input']>;
+  isList?: InputMaybe<Scalars['Boolean']['input']>;
+  name: Scalars['String']['input'];
   propertyList?: InputMaybe<Array<PropertySelectorInput>>;
 };
 
@@ -143,13 +145,13 @@ export type BlockOrderByInput = {
 export type BlockVersion = {
   block: Block;
   commit?: Maybe<Commit>;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  settings?: Maybe<Scalars['JSONObject']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Int'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  settings?: Maybe<Scalars['JSONObject']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 export type BlockVersionOrderByInput = {
@@ -181,30 +183,30 @@ export type BlockWhereInput = {
 };
 
 export type BooleanFilter = {
-  equals?: InputMaybe<Scalars['Boolean']>;
-  not?: InputMaybe<Scalars['Boolean']>;
+  equals?: InputMaybe<Scalars['Boolean']['input']>;
+  not?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type Build = {
   action?: Maybe<Action>;
-  actionId: Scalars['String'];
-  archiveURI: Scalars['String'];
+  actionId: Scalars['String']['output'];
+  archiveURI: Scalars['String']['output'];
   commit: Commit;
-  commitId: Scalars['String'];
-  createdAt: Scalars['DateTime'];
+  commitId: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
   createdBy: User;
-  id: Scalars['String'];
-  message: Scalars['String'];
+  id: Scalars['String']['output'];
+  message: Scalars['String']['output'];
   resource?: Maybe<Resource>;
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['output'];
   status?: Maybe<EnumBuildStatus>;
-  userId: Scalars['String'];
-  version: Scalars['String'];
+  userId: Scalars['String']['output'];
+  version: Scalars['String']['output'];
 };
 
 export type BuildCreateInput = {
   commit: WhereParentIdInput;
-  message: Scalars['String'];
+  message: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
@@ -228,30 +230,30 @@ export type BuildWhereInput = {
 };
 
 export type ChangePasswordInput = {
-  newPassword: Scalars['String'];
-  oldPassword: Scalars['String'];
+  newPassword: Scalars['String']['input'];
+  oldPassword: Scalars['String']['input'];
 };
 
 export type Commit = {
   builds?: Maybe<Array<Build>>;
   changes?: Maybe<Array<PendingChange>>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  message: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  message: Scalars['String']['output'];
   user?: Maybe<User>;
-  userId: Scalars['String'];
+  userId: Scalars['String']['output'];
 };
 
 
 export type CommitBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
 export type CommitCreateInput = {
-  message: Scalars['String'];
+  message: Scalars['String']['input'];
   project: WhereParentIdInput;
 };
 
@@ -270,24 +272,24 @@ export type CommitWhereInput = {
 };
 
 export type CommitWhereUniqueInput = {
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CompleteInvitationInput = {
-  token: Scalars['String'];
+  token: Scalars['String']['input'];
 };
 
 export type ConnectGitRepositoryInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isOverrideGitRepository?: InputMaybe<Scalars['Boolean']>;
-  name: Scalars['String'];
-  resourceId: Scalars['String'];
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isOverrideGitRepository?: InputMaybe<Scalars['Boolean']['input']>;
+  name: Scalars['String']['input'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type CreateEntitiesFromPrismaSchemaInput = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type CreateEntitiesFromPrismaSchemaResponse = {
@@ -296,128 +298,128 @@ export type CreateEntitiesFromPrismaSchemaResponse = {
 };
 
 export type CreateGitRepositoryBaseInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isPublic: Scalars['Boolean'];
-  name: Scalars['String'];
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isPublic: Scalars['Boolean']['input'];
+  name: Scalars['String']['input'];
 };
 
 export type CreateGitRepositoryInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
   gitProvider: EnumGitProvider;
   /** Name of the git provider repository group. It is mandatory when GitOrganisation.useGroupingForRepositories is true */
-  groupName?: InputMaybe<Scalars['String']>;
-  isPublic: Scalars['Boolean'];
-  name: Scalars['String'];
-  resourceId?: InputMaybe<Scalars['String']>;
+  groupName?: InputMaybe<Scalars['String']['input']>;
+  isPublic: Scalars['Boolean']['input'];
+  name: Scalars['String']['input'];
+  resourceId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type DateTimeFilter = {
-  equals?: InputMaybe<Scalars['DateTime']>;
-  gt?: InputMaybe<Scalars['DateTime']>;
-  gte?: InputMaybe<Scalars['DateTime']>;
-  in?: InputMaybe<Array<Scalars['DateTime']>>;
-  lt?: InputMaybe<Scalars['DateTime']>;
-  lte?: InputMaybe<Scalars['DateTime']>;
-  not?: InputMaybe<Scalars['DateTime']>;
-  notIn?: InputMaybe<Array<Scalars['DateTime']>>;
+  equals?: InputMaybe<Scalars['DateTime']['input']>;
+  gt?: InputMaybe<Scalars['DateTime']['input']>;
+  gte?: InputMaybe<Scalars['DateTime']['input']>;
+  in?: InputMaybe<Array<Scalars['DateTime']['input']>>;
+  lt?: InputMaybe<Scalars['DateTime']['input']>;
+  lte?: InputMaybe<Scalars['DateTime']['input']>;
+  not?: InputMaybe<Scalars['DateTime']['input']>;
+  notIn?: InputMaybe<Array<Scalars['DateTime']['input']>>;
 };
 
 export type DefaultEntitiesInput = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 export type Entity = {
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
   fields?: Maybe<Array<EntityField>>;
-  id: Scalars['String'];
-  lockedAt?: Maybe<Scalars['DateTime']>;
+  id: Scalars['String']['output'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedByUser?: Maybe<User>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
   permissions?: Maybe<Array<EntityPermission>>;
-  pluralDisplayName: Scalars['String'];
+  pluralDisplayName: Scalars['String']['output'];
   resource?: Maybe<Resource>;
-  resourceId: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  resourceId: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
   versions?: Maybe<Array<EntityVersion>>;
 };
 
 
 export type EntityFieldsArgs = {
   orderBy?: InputMaybe<EntityFieldOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityFieldWhereInput>;
 };
 
 
 export type EntityVersionsArgs = {
   orderBy?: InputMaybe<EntityVersionOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityVersionWhereInput>;
 };
 
 export type EntityAddPermissionFieldInput = {
   action: EnumEntityAction;
   entity: WhereParentIdInput;
-  fieldName: Scalars['String'];
+  fieldName: Scalars['String']['input'];
 };
 
 export type EntityCreateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
   /** allow creating the id for the entity when using import prisma schema because we need it for the relation */
-  id?: InputMaybe<Scalars['String']>;
-  name: Scalars['String'];
-  pluralDisplayName: Scalars['String'];
+  id?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  pluralDisplayName: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
 export type EntityField = {
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
   dataType: EnumDataType;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
-  permanentId: Scalars['String'];
-  position?: Maybe<Scalars['Int']>;
-  properties?: Maybe<Scalars['JSONObject']>;
-  required: Scalars['Boolean'];
-  searchable: Scalars['Boolean'];
-  unique: Scalars['Boolean'];
-  updatedAt: Scalars['DateTime'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  permanentId: Scalars['String']['output'];
+  position?: Maybe<Scalars['Int']['output']>;
+  properties?: Maybe<Scalars['JSONObject']['output']>;
+  required: Scalars['Boolean']['output'];
+  searchable: Scalars['Boolean']['output'];
+  unique: Scalars['Boolean']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type EntityFieldCreateByDisplayNameInput = {
   dataType?: InputMaybe<EnumDataType>;
-  displayName: Scalars['String'];
+  displayName: Scalars['String']['input'];
   entity: WhereParentIdInput;
 };
 
 export type EntityFieldCreateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
   dataType: EnumDataType;
-  description: Scalars['String'];
-  displayName: Scalars['String'];
+  description: Scalars['String']['input'];
+  displayName: Scalars['String']['input'];
   entity: WhereParentIdInput;
-  name: Scalars['String'];
-  position?: InputMaybe<Scalars['Int']>;
-  properties: Scalars['JSONObject'];
-  required: Scalars['Boolean'];
-  searchable: Scalars['Boolean'];
-  unique: Scalars['Boolean'];
+  name: Scalars['String']['input'];
+  position?: InputMaybe<Scalars['Int']['input']>;
+  properties: Scalars['JSONObject']['input'];
+  required: Scalars['Boolean']['input'];
+  searchable: Scalars['Boolean']['input'];
+  unique: Scalars['Boolean']['input'];
 };
 
 export type EntityFieldFilter = {
@@ -443,16 +445,16 @@ export type EntityFieldOrderByInput = {
 };
 
 export type EntityFieldUpdateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
   dataType?: InputMaybe<EnumDataType>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  position?: InputMaybe<Scalars['Int']>;
-  properties?: InputMaybe<Scalars['JSONObject']>;
-  required?: InputMaybe<Scalars['Boolean']>;
-  searchable?: InputMaybe<Scalars['Boolean']>;
-  unique?: InputMaybe<Scalars['Boolean']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  position?: InputMaybe<Scalars['Int']['input']>;
+  properties?: InputMaybe<Scalars['JSONObject']['input']>;
+  required?: InputMaybe<Scalars['Boolean']['input']>;
+  searchable?: InputMaybe<Scalars['Boolean']['input']>;
+  unique?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type EntityFieldWhereInput = {
@@ -484,44 +486,44 @@ export type EntityOrderByInput = {
 export type EntityPermission = {
   action: EnumEntityAction;
   entityVersion?: Maybe<EntityVersion>;
-  entityVersionId: Scalars['String'];
-  id: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   permissionFields?: Maybe<Array<EntityPermissionField>>;
   permissionRoles?: Maybe<Array<EntityPermissionRole>>;
   type: EnumEntityPermissionType;
 };
 
 export type EntityPermissionField = {
-  entityVersionId: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
   field: EntityField;
-  fieldPermanentId: Scalars['String'];
-  id: Scalars['String'];
+  fieldPermanentId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   permission?: Maybe<EntityPermission>;
-  permissionId: Scalars['String'];
+  permissionId: Scalars['String']['output'];
   permissionRoles?: Maybe<Array<EntityPermissionRole>>;
 };
 
 export type EntityPermissionFieldWhereUniqueInput = {
   action: EnumEntityAction;
-  entityId: Scalars['String'];
-  fieldPermanentId: Scalars['String'];
+  entityId: Scalars['String']['input'];
+  fieldPermanentId: Scalars['String']['input'];
 };
 
 export type EntityPermissionRole = {
   action: EnumEntityAction;
   entityPermission?: Maybe<EntityPermission>;
-  entityVersionId: Scalars['String'];
-  id: Scalars['String'];
+  entityVersionId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   resourceRole: ResourceRole;
-  resourceRoleId: Scalars['String'];
+  resourceRoleId: Scalars['String']['output'];
 };
 
 export type EntityUpdateInput = {
-  customAttributes?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  pluralDisplayName?: InputMaybe<Scalars['String']>;
+  customAttributes?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  pluralDisplayName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type EntityUpdatePermissionFieldRolesInput = {
@@ -544,26 +546,26 @@ export type EntityUpdatePermissionRolesInput = {
 
 export type EntityVersion = {
   commit?: Maybe<Commit>;
-  createdAt: Scalars['DateTime'];
-  customAttributes?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  customAttributes?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
   entity: Entity;
-  entityId: Scalars['String'];
+  entityId: Scalars['String']['output'];
   fields: Array<EntityField>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   permissions?: Maybe<Array<EntityPermission>>;
-  pluralDisplayName: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Int'];
+  pluralDisplayName: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 
 export type EntityVersionFieldsArgs = {
   orderBy?: InputMaybe<EntityFieldOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityFieldWhereInput>;
 };
 
@@ -753,14 +755,14 @@ export enum EnumWorkspaceMemberType {
 }
 
 export type Environment = {
-  address: Scalars['String'];
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  address: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   resource: Resource;
-  resourceId: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  resourceId: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type GitGetInstallationUrlInput = {
@@ -769,103 +771,103 @@ export type GitGetInstallationUrlInput = {
 
 /** Group of Repositories */
 export type GitGroup = {
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
 };
 
 export type GitGroupInput = {
-  organizationId: Scalars['String'];
+  organizationId: Scalars['String']['input'];
 };
 
 export type GitOAuth2FlowInput = {
-  code: Scalars['String'];
+  code: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
 };
 
 export type GitOrganization = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  installationId: Scalars['String'];
-  name: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  installationId: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   provider: EnumGitProvider;
   type: EnumGitOrganizationType;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   /** Defines if a git organisation needs defined repository groups */
-  useGroupingForRepositories: Scalars['Boolean'];
+  useGroupingForRepositories: Scalars['Boolean']['output'];
 };
 
 export type GitOrganizationCreateInput = {
   gitProvider: EnumGitProvider;
-  installationId: Scalars['String'];
+  installationId: Scalars['String']['input'];
 };
 
 export type GitOrganizationWhereInput = {
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type GitRepository = {
-  createdAt?: Maybe<Scalars['DateTime']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
   gitOrganization: GitOrganization;
-  gitOrganizationId: Scalars['String'];
-  groupName?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
-  updatedAt?: Maybe<Scalars['DateTime']>;
+  gitOrganizationId: Scalars['String']['output'];
+  groupName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
 };
 
 export type IBlock = {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type IntFilter = {
-  equals?: InputMaybe<Scalars['Int']>;
-  gt?: InputMaybe<Scalars['Int']>;
-  gte?: InputMaybe<Scalars['Int']>;
-  in?: InputMaybe<Array<Scalars['Int']>>;
-  lt?: InputMaybe<Scalars['Int']>;
-  lte?: InputMaybe<Scalars['Int']>;
-  not?: InputMaybe<Scalars['Int']>;
-  notIn?: InputMaybe<Array<Scalars['Int']>>;
+  equals?: InputMaybe<Scalars['Int']['input']>;
+  gt?: InputMaybe<Scalars['Int']['input']>;
+  gte?: InputMaybe<Scalars['Int']['input']>;
+  in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  lt?: InputMaybe<Scalars['Int']['input']>;
+  lte?: InputMaybe<Scalars['Int']['input']>;
+  not?: InputMaybe<Scalars['Int']['input']>;
+  notIn?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 export type Invitation = {
-  createdAt: Scalars['DateTime'];
-  email: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  email: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   invitedByUser?: Maybe<User>;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   workspace?: Maybe<Workspace>;
 };
 
 export type InviteUserInput = {
-  email: Scalars['String'];
+  email: Scalars['String']['input'];
 };
 
 export type LoginInput = {
-  email: Scalars['String'];
-  password: Scalars['String'];
+  email: Scalars['String']['input'];
+  password: Scalars['String']['input'];
 };
 
 export type MessagePattern = {
-  topicId: Scalars['String'];
+  topicId: Scalars['String']['output'];
   type: EnumMessagePatternConnectionOptions;
 };
 
 export type MessagePatternCreateInput = {
-  topicId: Scalars['String'];
+  topicId: Scalars['String']['input'];
   type: EnumMessagePatternConnectionOptions;
 };
 
@@ -902,7 +904,7 @@ export type Mutation = {
   deleteEntity?: Maybe<Entity>;
   deleteEntityField: EntityField;
   deleteEntityPermissionField: EntityPermissionField;
-  deleteGitOrganization: Scalars['Boolean'];
+  deleteGitOrganization: Scalars['Boolean']['output'];
   deleteGitRepository: Resource;
   deletePluginInstallation: PluginInstallation;
   deleteProject?: Maybe<Project>;
@@ -912,7 +914,7 @@ export type Mutation = {
   deleteTopic: Topic;
   deleteUser?: Maybe<User>;
   deleteWorkspace?: Maybe<Workspace>;
-  discardPendingChanges?: Maybe<Scalars['Boolean']>;
+  discardPendingChanges?: Maybe<Scalars['Boolean']['output']>;
   disconnectResourceGitRepository: Resource;
   getGitResourceInstallationUrl: AuthorizeResourceWithGitResult;
   inviteUser?: Maybe<Invitation>;
@@ -978,7 +980,7 @@ export type MutationConnectResourceGitRepositoryArgs = {
 
 
 export type MutationConnectResourceToProjectRepositoryArgs = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 
@@ -998,24 +1000,24 @@ export type MutationCreateDefaultEntitiesArgs = {
 
 
 export type MutationCreateDefaultRelatedFieldArgs = {
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
   where: WhereUniqueInput;
 };
 
 
 export type MutationCreateEntitiesFromPrismaSchemaArgs = {
   data: CreateEntitiesFromPrismaSchemaInput;
-  file: Scalars['Upload'];
+  file: Scalars['Upload']['input'];
 };
 
 
 export type MutationCreateEntityFieldArgs = {
   data: EntityFieldCreateInput;
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1105,13 +1107,13 @@ export type MutationDeleteEntityPermissionFieldArgs = {
 
 
 export type MutationDeleteGitOrganizationArgs = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
 };
 
 
 export type MutationDeleteGitRepositoryArgs = {
-  gitRepositoryId: Scalars['String'];
+  gitRepositoryId: Scalars['String']['input'];
 };
 
 
@@ -1161,7 +1163,7 @@ export type MutationDiscardPendingChangesArgs = {
 
 
 export type MutationDisconnectResourceGitRepositoryArgs = {
-  resourceId: Scalars['String'];
+  resourceId: Scalars['String']['input'];
 };
 
 
@@ -1229,9 +1231,9 @@ export type MutationUpdateEntityArgs = {
 
 export type MutationUpdateEntityFieldArgs = {
   data: EntityFieldUpdateInput;
-  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']>;
-  relatedFieldDisplayName?: InputMaybe<Scalars['String']>;
-  relatedFieldName?: InputMaybe<Scalars['String']>;
+  relatedFieldAllowMultipleSelection?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedFieldDisplayName?: InputMaybe<Scalars['String']['input']>;
+  relatedFieldName?: InputMaybe<Scalars['String']['input']>;
   where: WhereUniqueInput;
 };
 
@@ -1309,25 +1311,25 @@ export type MutationUpdateWorkspaceArgs = {
 export type PaginatedGitGroup = {
   groups?: Maybe<Array<GitGroup>>;
   /** Page number */
-  page: Scalars['Float'];
+  page: Scalars['Float']['output'];
   /** Number of groups per page */
-  pageSize: Scalars['Float'];
+  pageSize: Scalars['Float']['output'];
   /** Total number of groups */
-  total: Scalars['Float'];
+  total: Scalars['Float']['output'];
 };
 
 export type Pagination = {
-  page: Scalars['Float'];
-  perPage: Scalars['Float'];
+  page: Scalars['Float']['output'];
+  perPage: Scalars['Float']['output'];
 };
 
 export type PendingChange = {
   action: EnumPendingChangeAction;
   origin: PendingChangeOrigin;
-  originId: Scalars['String'];
+  originId: Scalars['String']['output'];
   originType: EnumPendingChangeOriginType;
   resource: Resource;
-  versionNumber: Scalars['Int'];
+  versionNumber: Scalars['Int']['output'];
 };
 
 export type PendingChangeOrigin = Block | Entity;
@@ -1342,39 +1344,39 @@ export type PendingChangesFindInput = {
 
 export type PluginInstallation = IBlock & {
   blockType: EnumBlockType;
-  configurations?: Maybe<Scalars['JSONObject']>;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
-  id: Scalars['String'];
+  configurations?: Maybe<Scalars['JSONObject']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  enabled: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  npm: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  npm: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  pluginId: Scalars['String'];
-  resourceId?: Maybe<Scalars['String']>;
-  settings?: Maybe<Scalars['JSONObject']>;
-  updatedAt: Scalars['DateTime'];
-  version: Scalars['String'];
-  versionNumber: Scalars['Float'];
+  pluginId: Scalars['String']['output'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  settings?: Maybe<Scalars['JSONObject']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  version: Scalars['String']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type PluginInstallationCreateInput = {
-  configurations?: InputMaybe<Scalars['JSONObject']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
+  configurations?: InputMaybe<Scalars['JSONObject']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  enabled: Scalars['Boolean']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  npm: Scalars['String'];
+  npm: Scalars['String']['input'];
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
-  pluginId: Scalars['String'];
+  pluginId: Scalars['String']['input'];
   resource: WhereParentIdInput;
-  settings?: InputMaybe<Scalars['JSONObject']>;
-  version: Scalars['String'];
+  settings?: InputMaybe<Scalars['JSONObject']['input']>;
+  version: Scalars['String']['input'];
 };
 
 export type PluginInstallationOrderByInput = {
@@ -1387,12 +1389,12 @@ export type PluginInstallationOrderByInput = {
 };
 
 export type PluginInstallationUpdateInput = {
-  configurations?: InputMaybe<Scalars['JSONObject']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  enabled: Scalars['Boolean'];
-  settings?: InputMaybe<Scalars['JSONObject']>;
-  version: Scalars['String'];
+  configurations?: InputMaybe<Scalars['JSONObject']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  enabled: Scalars['Boolean']['input'];
+  settings?: InputMaybe<Scalars['JSONObject']['input']>;
+  version: Scalars['String']['input'];
 };
 
 export type PluginInstallationWhereInput = {
@@ -1411,65 +1413,65 @@ export type PluginInstallationsCreateInput = {
 
 export type PluginOrder = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   order: Array<PluginOrderItem>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type PluginOrderItem = {
-  order: Scalars['Int'];
-  pluginId: Scalars['String'];
+  order: Scalars['Int']['output'];
+  pluginId: Scalars['String']['output'];
 };
 
 export type PluginSetOrderInput = {
-  order: Scalars['Int'];
+  order: Scalars['Int']['input'];
 };
 
 export type Project = {
-  createdAt: Scalars['DateTime'];
-  demoRepoName?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  demoRepoName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   resources?: Maybe<Array<Resource>>;
-  updatedAt: Scalars['DateTime'];
-  useDemoRepo: Scalars['Boolean'];
+  updatedAt: Scalars['DateTime']['output'];
+  useDemoRepo: Scalars['Boolean']['output'];
 };
 
 export type ProjectConfigurationSettings = IBlock & {
-  baseDirectory: Scalars['String'];
+  baseDirectory: Scalars['String']['output'];
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ProjectConfigurationSettingsUpdateInput = {
-  baseDirectory?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
+  baseDirectory?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ProjectCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type ProjectOrderByInput = {
@@ -1479,38 +1481,38 @@ export type ProjectOrderByInput = {
 };
 
 export type ProjectUpdateInput = {
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ProjectWhereInput = {
   deletedAt?: InputMaybe<DateTimeFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   resources?: InputMaybe<ResourceListRelationFilter>;
 };
 
 export type PropertySelector = {
-  include: Scalars['Boolean'];
-  propertyName: Scalars['String'];
+  include: Scalars['Boolean']['output'];
+  propertyName: Scalars['String']['output'];
 };
 
 export type PropertySelectorInput = {
-  include: Scalars['Boolean'];
-  propertyName: Scalars['String'];
+  include: Scalars['Boolean']['input'];
+  propertyName: Scalars['String']['input'];
 };
 
 export type ProvisionSubscriptionInput = {
-  billingPeriod: Scalars['String'];
-  cancelUrl?: InputMaybe<Scalars['String']>;
-  intentionType: Scalars['String'];
-  planId: Scalars['String'];
-  successUrl?: InputMaybe<Scalars['String']>;
-  workspaceId: Scalars['String'];
+  billingPeriod: Scalars['String']['input'];
+  cancelUrl?: InputMaybe<Scalars['String']['input']>;
+  intentionType: Scalars['String']['input'];
+  planId: Scalars['String']['input'];
+  successUrl?: InputMaybe<Scalars['String']['input']>;
+  workspaceId: Scalars['String']['input'];
 };
 
 export type ProvisionSubscriptionResult = {
-  checkoutUrl?: Maybe<Scalars['String']>;
-  provisionStatus: Scalars['String'];
+  checkoutUrl?: Maybe<Scalars['String']['output']>;
+  provisionStatus: Scalars['String']['output'];
 };
 
 export type Query = {
@@ -1561,8 +1563,8 @@ export type QueryPluginInstallationArgs = {
 
 export type QueryPluginInstallationsArgs = {
   orderBy?: InputMaybe<PluginInstallationOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<PluginInstallationWhereInput>;
 };
 
@@ -1574,8 +1576,8 @@ export type QueryServiceTopicsArgs = {
 
 export type QueryServiceTopicsListArgs = {
   orderBy?: InputMaybe<ServiceTopicsOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ServiceTopicsWhereInput>;
 };
 
@@ -1587,8 +1589,8 @@ export type QueryTopicArgs = {
 
 export type QueryTopicsArgs = {
   orderBy?: InputMaybe<TopicOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<TopicWhereInput>;
 };
 
@@ -1605,8 +1607,8 @@ export type QueryBlockArgs = {
 
 export type QueryBlocksArgs = {
   orderBy?: InputMaybe<BlockOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BlockWhereInput>;
 };
 
@@ -1618,8 +1620,8 @@ export type QueryBuildArgs = {
 
 export type QueryBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
@@ -1632,16 +1634,16 @@ export type QueryCommitArgs = {
 export type QueryCommitsArgs = {
   cursor?: InputMaybe<CommitWhereUniqueInput>;
   orderBy?: InputMaybe<CommitOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<CommitWhereInput>;
 };
 
 
 export type QueryEntitiesArgs = {
   orderBy?: InputMaybe<EntityOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityWhereInput>;
 };
 
@@ -1662,8 +1664,8 @@ export type QueryGitOrganizationArgs = {
 
 
 export type QueryGitOrganizationsArgs = {
-  skip?: InputMaybe<Scalars['Float']>;
-  take?: InputMaybe<Scalars['Float']>;
+  skip?: InputMaybe<Scalars['Float']['input']>;
+  take?: InputMaybe<Scalars['Float']['input']>;
   where?: InputMaybe<GitOrganizationWhereInput>;
 };
 
@@ -1695,8 +1697,8 @@ export type QueryProjectConfigurationSettingsArgs = {
 
 export type QueryProjectsArgs = {
   orderBy?: InputMaybe<ProjectOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ProjectWhereInput>;
 };
 
@@ -1712,23 +1714,23 @@ export type QueryResourceArgs = {
 
 
 export type QueryResourceRoleArgs = {
-  version?: InputMaybe<Scalars['Float']>;
+  version?: InputMaybe<Scalars['Float']['input']>;
   where: WhereUniqueInput;
 };
 
 
 export type QueryResourceRolesArgs = {
   orderBy?: InputMaybe<ResourceRoleOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ResourceRoleWhereInput>;
 };
 
 
 export type QueryResourcesArgs = {
   orderBy?: InputMaybe<Array<ResourceOrderByInput>>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ResourceWhereInput>;
 };
 
@@ -1750,68 +1752,68 @@ export enum QueryMode {
 export type RemoteGitRepos = {
   pagination: Pagination;
   repos: Array<RemoteGitRepository>;
-  total: Scalars['Float'];
+  total: Scalars['Float']['output'];
 };
 
 export type RemoteGitRepositoriesWhereUniqueInput = {
-  gitOrganizationId: Scalars['String'];
+  gitOrganizationId: Scalars['String']['input'];
   gitProvider: EnumGitProvider;
-  groupName?: InputMaybe<Scalars['String']>;
+  groupName?: InputMaybe<Scalars['String']['input']>;
   /** The page number. One-based indexing */
-  page?: Scalars['Float'];
+  page?: Scalars['Float']['input'];
   /** The number of items to return per page */
-  perPage?: Scalars['Float'];
+  perPage?: Scalars['Float']['input'];
 };
 
 export type RemoteGitRepository = {
-  admin: Scalars['Boolean'];
-  defaultBranch: Scalars['String'];
-  fullName: Scalars['String'];
-  groupName?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
-  private: Scalars['Boolean'];
-  url: Scalars['String'];
+  admin: Scalars['Boolean']['output'];
+  defaultBranch: Scalars['String']['output'];
+  fullName: Scalars['String']['output'];
+  groupName?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  private: Scalars['Boolean']['output'];
+  url: Scalars['String']['output'];
 };
 
 export type Resource = {
   builds: Array<Build>;
-  createdAt: Scalars['DateTime'];
-  description: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description: Scalars['String']['output'];
   entities: Array<Entity>;
   environments: Array<Environment>;
   gitRepository?: Maybe<GitRepository>;
-  gitRepositoryId?: Maybe<Scalars['String']>;
-  gitRepositoryOverride: Scalars['Boolean'];
-  githubLastMessage?: Maybe<Scalars['String']>;
-  githubLastSync?: Maybe<Scalars['DateTime']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  gitRepositoryId?: Maybe<Scalars['String']['output']>;
+  gitRepositoryOverride: Scalars['Boolean']['output'];
+  githubLastMessage?: Maybe<Scalars['String']['output']>;
+  githubLastSync?: Maybe<Scalars['DateTime']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   project?: Maybe<Project>;
-  projectId?: Maybe<Scalars['String']>;
+  projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 
 export type ResourceBuildsArgs = {
   orderBy?: InputMaybe<BuildOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<BuildWhereInput>;
 };
 
 
 export type ResourceEntitiesArgs = {
   orderBy?: InputMaybe<EntityOrderByInput>;
-  skip?: InputMaybe<Scalars['Int']>;
-  take?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<EntityWhereInput>;
 };
 
 export type ResourceCreateInput = {
-  description: Scalars['String'];
+  description: Scalars['String']['input'];
   gitRepository?: InputMaybe<ConnectGitRepositoryInput>;
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
   project: WhereParentIdInput;
   resourceType: EnumResourceType;
   serviceSettings?: InputMaybe<ServiceSettingsUpdateInput>;
@@ -1819,25 +1821,25 @@ export type ResourceCreateInput = {
 
 export type ResourceCreateWithEntitiesEntityInput = {
   fields: Array<ResourceCreateWithEntitiesFieldInput>;
-  name: Scalars['String'];
-  relationsToEntityIndex?: InputMaybe<Array<Scalars['Int']>>;
+  name: Scalars['String']['input'];
+  relationsToEntityIndex?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 export type ResourceCreateWithEntitiesFieldInput = {
   dataType?: InputMaybe<EnumDataType>;
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type ResourceCreateWithEntitiesInput = {
-  authType: Scalars['String'];
-  commitMessage: Scalars['String'];
-  connectToDemoRepo: Scalars['Boolean'];
-  dbType: Scalars['String'];
+  authType: Scalars['String']['input'];
+  commitMessage: Scalars['String']['input'];
+  connectToDemoRepo: Scalars['Boolean']['input'];
+  dbType: Scalars['String']['input'];
   entities: Array<ResourceCreateWithEntitiesEntityInput>;
   plugins?: InputMaybe<PluginInstallationsCreateInput>;
-  repoType: Scalars['String'];
+  repoType: Scalars['String']['input'];
   resource: ResourceCreateInput;
-  wizardType: Scalars['String'];
+  wizardType: Scalars['String']['input'];
 };
 
 export type ResourceCreateWithEntitiesResult = {
@@ -1861,18 +1863,18 @@ export type ResourceOrderByInput = {
 };
 
 export type ResourceRole = {
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
-  name: Scalars['String'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type ResourceRoleCreateInput = {
-  description: Scalars['String'];
-  displayName: Scalars['String'];
-  name: Scalars['String'];
+  description: Scalars['String']['input'];
+  displayName: Scalars['String']['input'];
+  name: Scalars['String']['input'];
   resource: WhereParentIdInput;
 };
 
@@ -1886,34 +1888,34 @@ export type ResourceRoleOrderByInput = {
 };
 
 export type ResourceRoleUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceRoleWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
   description?: InputMaybe<StringFilter>;
   displayName?: InputMaybe<StringFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   resource?: InputMaybe<WhereUniqueInput>;
   updatedAt?: InputMaybe<DateTimeFilter>;
 };
 
 export type ResourceUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  gitRepositoryOverride?: InputMaybe<Scalars['Boolean']>;
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  gitRepositoryOverride?: InputMaybe<Scalars['Boolean']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceWhereInput = {
   createdAt?: InputMaybe<DateTimeFilter>;
   description?: InputMaybe<StringFilter>;
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<StringFilter>;
   project?: InputMaybe<ProjectWhereInput>;
-  projectId?: InputMaybe<Scalars['String']>;
+  projectId?: InputMaybe<Scalars['String']['input']>;
   resourceType?: InputMaybe<EnumResourceTypeFilter>;
   updatedAt?: InputMaybe<DateTimeFilter>;
 };
@@ -1926,69 +1928,69 @@ export enum Role {
 }
 
 export type ServerSettings = {
-  generateGraphQL: Scalars['Boolean'];
-  generateRestApi: Scalars['Boolean'];
-  serverPath: Scalars['String'];
+  generateGraphQL: Scalars['Boolean']['output'];
+  generateRestApi: Scalars['Boolean']['output'];
+  serverPath: Scalars['String']['output'];
 };
 
 export type ServerSettingsUpdateInput = {
-  generateGraphQL?: InputMaybe<Scalars['Boolean']>;
-  generateRestApi?: InputMaybe<Scalars['Boolean']>;
-  serverPath?: InputMaybe<Scalars['String']>;
+  generateGraphQL?: InputMaybe<Scalars['Boolean']['input']>;
+  generateRestApi?: InputMaybe<Scalars['Boolean']['input']>;
+  serverPath?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ServiceSettings = IBlock & {
   adminUISettings: AdminUiSettings;
   authProvider: EnumAuthProviderType;
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
+  resourceId?: Maybe<Scalars['String']['output']>;
   serverSettings: ServerSettings;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ServiceSettingsUpdateInput = {
   adminUISettings: AdminUiSettingsUpdateInput;
   authProvider: EnumAuthProviderType;
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
   serverSettings: ServerSettingsUpdateInput;
 };
 
 export type ServiceTopics = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  enabled: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  messageBrokerId: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  messageBrokerId: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
   patterns: Array<MessagePattern>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type ServiceTopicsCreateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  enabled: Scalars['Boolean'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
+  enabled: Scalars['Boolean']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  messageBrokerId: Scalars['String'];
+  messageBrokerId: Scalars['String']['input'];
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
   patterns?: InputMaybe<Array<MessagePatternCreateInput>>;
@@ -2005,10 +2007,10 @@ export type ServiceTopicsOrderByInput = {
 };
 
 export type ServiceTopicsUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  enabled: Scalars['Boolean'];
-  messageBrokerId: Scalars['String'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  enabled: Scalars['Boolean']['input'];
+  messageBrokerId: Scalars['String']['input'];
   patterns?: InputMaybe<Array<MessagePatternCreateInput>>;
 };
 
@@ -2023,11 +2025,11 @@ export type ServiceTopicsWhereInput = {
 };
 
 export type SignupInput = {
-  email: Scalars['String'];
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  password: Scalars['String'];
-  workspaceName: Scalars['String'];
+  email: Scalars['String']['input'];
+  firstName: Scalars['String']['input'];
+  lastName: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+  workspaceName: Scalars['String']['input'];
 };
 
 export enum SortOrder {
@@ -2036,57 +2038,57 @@ export enum SortOrder {
 }
 
 export type StringFilter = {
-  contains?: InputMaybe<Scalars['String']>;
-  endsWith?: InputMaybe<Scalars['String']>;
-  equals?: InputMaybe<Scalars['String']>;
-  gt?: InputMaybe<Scalars['String']>;
-  gte?: InputMaybe<Scalars['String']>;
-  in?: InputMaybe<Array<Scalars['String']>>;
-  lt?: InputMaybe<Scalars['String']>;
-  lte?: InputMaybe<Scalars['String']>;
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
   mode?: InputMaybe<QueryMode>;
-  not?: InputMaybe<Scalars['String']>;
-  notIn?: InputMaybe<Array<Scalars['String']>>;
-  startsWith?: InputMaybe<Scalars['String']>;
+  not?: InputMaybe<Scalars['String']['input']>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Subscription = {
-  cancelUrl?: Maybe<Scalars['String']>;
-  cancellationEffectiveDate?: Maybe<Scalars['DateTime']>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  nextBillDate?: Maybe<Scalars['DateTime']>;
-  price?: Maybe<Scalars['Float']>;
+  cancelUrl?: Maybe<Scalars['String']['output']>;
+  cancellationEffectiveDate?: Maybe<Scalars['DateTime']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  nextBillDate?: Maybe<Scalars['DateTime']['output']>;
+  price?: Maybe<Scalars['Float']['output']>;
   status: EnumSubscriptionStatus;
   subscriptionPlan: EnumSubscriptionPlan;
-  updateUrl?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
+  updateUrl?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
   workspace?: Maybe<Workspace>;
-  workspaceId: Scalars['String'];
+  workspaceId: Scalars['String']['output'];
 };
 
 export type Topic = IBlock & {
   blockType: EnumBlockType;
-  createdAt: Scalars['DateTime'];
-  description?: Maybe<Scalars['String']>;
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   inputParameters: Array<BlockInputOutput>;
-  lockedAt?: Maybe<Scalars['DateTime']>;
-  lockedByUserId?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
+  lockedAt?: Maybe<Scalars['DateTime']['output']>;
+  lockedByUserId?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
   outputParameters: Array<BlockInputOutput>;
   parentBlock?: Maybe<Block>;
-  resourceId?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['DateTime'];
-  versionNumber: Scalars['Float'];
+  resourceId?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+  versionNumber: Scalars['Float']['output'];
 };
 
 export type TopicCreateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName: Scalars['String'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName: Scalars['String']['input'];
   inputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   outputParameters?: InputMaybe<Array<BlockInputOutputInput>>;
   parentBlock?: InputMaybe<WhereParentIdInput>;
   resource: WhereParentIdInput;
@@ -2102,9 +2104,9 @@ export type TopicOrderByInput = {
 };
 
 export type TopicUpdateInput = {
-  description?: InputMaybe<Scalars['String']>;
-  displayName?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TopicWhereInput = {
@@ -2118,25 +2120,25 @@ export type TopicWhereInput = {
 };
 
 export type UpdateAccountInput = {
-  firstName?: InputMaybe<Scalars['String']>;
-  lastName?: InputMaybe<Scalars['String']>;
+  firstName?: InputMaybe<Scalars['String']['input']>;
+  lastName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type User = {
   account?: Maybe<Account>;
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
-  isOwner: Scalars['Boolean'];
-  updatedAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  isOwner: Scalars['Boolean']['output'];
+  updatedAt: Scalars['DateTime']['output'];
   userRoles?: Maybe<Array<UserRole>>;
   workspace?: Maybe<Workspace>;
 };
 
 export type UserRole = {
-  createdAt: Scalars['DateTime'];
-  id: Scalars['String'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
   role: Role;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
 };
 
 export type WhereParentIdInput = {
@@ -2144,22 +2146,22 @@ export type WhereParentIdInput = {
 };
 
 export type WhereUniqueInput = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type Workspace = {
-  createdAt: Scalars['DateTime'];
+  createdAt: Scalars['DateTime']['output'];
   gitOrganizations?: Maybe<Array<GitOrganization>>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   projects: Array<Project>;
   subscription?: Maybe<Subscription>;
-  updatedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime']['output'];
   users: Array<User>;
 };
 
 export type WorkspaceCreateInput = {
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
 };
 
 export type WorkspaceMember = {
@@ -2170,5 +2172,5 @@ export type WorkspaceMember = {
 export type WorkspaceMemberType = Invitation | User;
 
 export type WorkspaceUpdateInput = {
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };


### PR DESCRIPTION
Related #6454 

## PR Details

#6454 updated the `@graphql-codegen/typescript`   module leaving the repository with an out of date set of generated models. This PR align the other codegen dependency and update the models to match the new version.

More details https://github.com/dotansimha/graphql-code-generator/releases/tag/release-1687159967878