### PR TITLE
Chore(server): update `prisma-ast` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@google-cloud/storage": "^5.20.5",
     "@google-cloud/trace-agent": "^5.1.6",
     "@monaco-editor/react": "^4.5.1",
-    "@mrleebo/prisma-ast": "^0.5.2",
+    "@mrleebo/prisma-ast": "^0.6.0",
     "@mui/lab": "^5.0.0-alpha.123",
     "@mui/material": "^5.13.5",
     "@mui/system": "^5.10.7",

--- a/packages/amplication-server/src/core/prismaSchemaUtils/constants.ts
+++ b/packages/amplication-server/src/core/prismaSchemaUtils/constants.ts
@@ -4,6 +4,9 @@ export const ENUM_TYPE_NAME = "enum";
 export const ENUMERATOR_TYPE_NAME = "enumerator";
 export const ATTRIBUTE_TYPE_NAME = "attribute";
 export const MAP_ATTRIBUTE_NAME = "map";
+export const KEY_VALUE_ARG_TYPE_NAME = "keyValue";
+export const ARRAY_ARG_TYPE_NAME = "array";
+export const OBJECT_KIND_NAME = "object";
 
 export const DEFAULT_ATTRIBUTE_NAME = "default";
 export const UNIQUE_ATTRIBUTE_NAME = "unique";

--- a/packages/amplication-server/src/core/prismaSchemaUtils/prismaSchemaUtils.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaUtils/prismaSchemaUtils.service.ts
@@ -789,7 +789,7 @@ export class PrismaSchemaUtilsService {
     if (!attributes && !attributes?.length) {
       return [];
     }
-    return attributes.map((attribute) => {
+    return attributes.map((attribute: BlockAttribute) => {
       const attributeGroup = attribute.group;
       if (!attribute.args && !attribute.args?.length) {
         return `${modelAttrPrefix}${attribute.name}`;
@@ -823,7 +823,7 @@ export class PrismaSchemaUtilsService {
     if (!attributes && !attributes?.length) {
       return [];
     }
-    return attributes.map((attribute: Attribute | BlockAttribute) => {
+    return attributes.map((attribute: Attribute) => {
       const attributeGroup = attribute.group;
       if (!attribute.args && !attribute.args?.length) {
         return `${fieldAttrPrefix}${attribute.name}`;

--- a/packages/amplication-server/src/core/prismaSchemaUtils/prismaSchemaUtils.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaUtils/prismaSchemaUtils.service.ts
@@ -13,8 +13,9 @@ import {
   Enumerator,
   ConcretePrismaSchemaBuilder,
   Attribute,
-  ModelAttribute,
+  BlockAttribute,
   AttributeArgument,
+  Value,
 } from "@mrleebo/prisma-ast";
 import {
   booleanField,
@@ -57,14 +58,17 @@ import {
   CreateBulkFieldsInput,
 } from "../entity/entity.service";
 import {
+  ARRAY_ARG_TYPE_NAME,
   ATTRIBUTE_TYPE_NAME,
   ENUMERATOR_TYPE_NAME,
   ENUM_TYPE_NAME,
   FIELD_TYPE_NAME,
   ID_ATTRIBUTE_NAME,
   ID_FIELD_NAME,
+  KEY_VALUE_ARG_TYPE_NAME,
   MAP_ATTRIBUTE_NAME,
   MODEL_TYPE_NAME,
+  OBJECT_KIND_NAME,
   UNIQUE_ATTRIBUTE_NAME,
 } from "./constants";
 import { ActionLog, EnumActionLogLevel } from "../action/dto";
@@ -387,8 +391,9 @@ export class PrismaSchemaUtilsService {
     ) as Model[];
     modelList.map((model: Model) => {
       const modelAttributes = model.properties.filter(
-        (prop) => prop.type === ATTRIBUTE_TYPE_NAME
-      ) as ModelAttribute[];
+        (prop) =>
+          prop.type === ATTRIBUTE_TYPE_NAME && prop.kind === OBJECT_KIND_NAME
+      ) as BlockAttribute[];
 
       const hasMapAttribute = modelAttributes?.some(
         (attribute) => attribute.name === MAP_ATTRIBUTE_NAME
@@ -584,8 +589,9 @@ export class PrismaSchemaUtilsService {
 
     models.forEach((model: Model) => {
       const modelAttributes = model.properties.filter(
-        (item) => item.type === ATTRIBUTE_TYPE_NAME
-      ) as ModelAttribute[];
+        (prop) =>
+          prop.type === ATTRIBUTE_TYPE_NAME && prop.kind === OBJECT_KIND_NAME
+      ) as BlockAttribute[];
 
       const modelIdAttribute = modelAttributes.find(
         (attribute) => attribute.name === ID_ATTRIBUTE_NAME
@@ -720,10 +726,12 @@ export class PrismaSchemaUtilsService {
   private convertModelToEntity(model: Model): CreateBulkEntitiesInput {
     const modelDisplayName = formatDisplayName(model.name);
     const modelAttributes = model.properties.filter(
-      (prop) => prop.type === ATTRIBUTE_TYPE_NAME
-    );
+      (prop) =>
+        prop.type === ATTRIBUTE_TYPE_NAME && prop.kind === OBJECT_KIND_NAME
+    ) as BlockAttribute[];
     const entityPluralDisplayName = pluralize(model.name);
-    const entityAttributes = this.prepareAttributes(modelAttributes).join(" ");
+    const entityAttributes =
+      this.prepareModelAttributes(modelAttributes).join(" ");
 
     return {
       id: cuid(), // creating here the entity id because we need it for the relation
@@ -748,11 +756,11 @@ export class PrismaSchemaUtilsService {
   ): CreateBulkFieldsInput {
     const fieldDisplayName = formatDisplayName(field.name);
     const isUniqueField =
-      field.attributes?.some((attr) => attr.name === "unique") ?? false;
+      field.attributes?.some((attr) => attr.name === UNIQUE_ATTRIBUTE_NAME) ??
+      false;
 
-    // eslint-disable-next-line prefer-const
     const fieldAttributes = filterOutAmplicationAttributes(
-      this.prepareAttributes(field.attributes)
+      this.prepareFieldAttributes(field.attributes)
     )
       // in some case we get "@default()" as an attribute, we want to filter it out
       .filter((attr) => attr !== "@default()")
@@ -776,23 +784,24 @@ export class PrismaSchemaUtilsService {
    * @param attributes the attributes to prepare and convert from the AST form to array of strings
    * @returns array of strings representing the attributes
    */
-  private prepareAttributes(attributes): string[] {
+  private prepareModelAttributes(attributes: BlockAttribute[]): string[] {
+    const modelAttrPrefix = "@@";
     if (!attributes && !attributes?.length) {
       return [];
     }
     return attributes.map((attribute) => {
       const attributeGroup = attribute.group;
       if (!attribute.args && !attribute.args?.length) {
-        return attribute.kind === MODEL_TYPE_NAME
-          ? `@@${attribute.name}`
-          : `@${attribute.name}`;
+        return `${modelAttrPrefix}${attribute.name}`;
       }
-      const args = attribute.args.map((arg) => {
+      const args = attribute.args.map((arg: AttributeArgument) => {
         if (typeof arg.value === "object" && arg.value !== null) {
-          if (arg.value.type === "array") {
-            return `[${arg.value.args.join(", ")}]`;
-          } else if (arg.value.type === "keyValue") {
-            return `${arg.value.key}: ${arg.value.value}`;
+          const argValueArray = arg.value as Value as RelationArray;
+          const argKeyValue = arg.value as KeyValue;
+          if (argValueArray.type === ARRAY_ARG_TYPE_NAME) {
+            return `[${argValueArray.args.join(", ")}]`;
+          } else if (argKeyValue.type === KEY_VALUE_ARG_TYPE_NAME) {
+            return `${argKeyValue.key}: ${argKeyValue.value}`;
           }
         } else {
           return arg.value;
@@ -800,13 +809,45 @@ export class PrismaSchemaUtilsService {
       });
 
       if (attributeGroup) {
-        return `${
-          attribute.kind === MODEL_TYPE_NAME ? "@@" : "@"
-        }${attributeGroup}.${attribute.name}(${args.join(", ")})`;
-      } else {
-        return `${attribute.kind === MODEL_TYPE_NAME ? "@@" : "@"}${
+        return `${modelAttrPrefix}${attributeGroup}.${
           attribute.name
         }(${args.join(", ")})`;
+      } else {
+        return `${modelAttrPrefix}${attribute.name}(${args.join(", ")})`;
+      }
+    });
+  }
+
+  private prepareFieldAttributes(attributes: Attribute[]): string[] {
+    const fieldAttrPrefix = "@";
+    if (!attributes && !attributes?.length) {
+      return [];
+    }
+    return attributes.map((attribute: Attribute | BlockAttribute) => {
+      const attributeGroup = attribute.group;
+      if (!attribute.args && !attribute.args?.length) {
+        return `${fieldAttrPrefix}${attribute.name}`;
+      }
+      const args = attribute.args.map((arg: AttributeArgument) => {
+        if (typeof arg.value === "object" && arg.value !== null) {
+          const argArray = arg.value as RelationArray;
+          const argKeyValue = arg.value as KeyValue;
+          if (argArray.type === ARRAY_ARG_TYPE_NAME) {
+            return `[${argArray.args.join(", ")}]`;
+          } else if (argKeyValue.type === KEY_VALUE_ARG_TYPE_NAME) {
+            return `${argKeyValue.key}: ${argKeyValue.value}`;
+          }
+        } else {
+          return arg.value;
+        }
+      });
+
+      if (attributeGroup) {
+        return `${fieldAttrPrefix}${attributeGroup}.${
+          attribute.name
+        }(${args.join(", ")})`;
+      } else {
+        return `${fieldAttrPrefix}${attribute.name}(${args.join(", ")})`;
       }
     });
   }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6484 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0cb273b</samp>

### Summary
🆙🧮🔧

<!--
1.  🆙 - This emoji can be used to indicate that a dependency was updated to a newer version, which may introduce new features or bug fixes.
2.  🧮 - This emoji can be used to indicate that some constants or variables were added or changed, which may affect the logic or calculations of the code.
3.  🔧 - This emoji can be used to indicate that some code was refactored or improved, which may enhance the readability, performance, or maintainability of the code.
-->
The pull request refactors the `PrismaSchemaUtilsService` class to use the `@mrleebo/prisma-ast` library and constants for parsing and generating Prisma schema files. It also updates the dependency version and adds some constants to the `./constants` module.

> _To parse Prisma schema files with ease_
> _We updated the `prisma-ast` dependency_
> _We added some constants for types and kinds_
> _And split `prepareAttributes` into two methods_
> _To handle model and field attributes of different kinds_

### Walkthrough
*  Update the dependency `@mrleebo/prisma-ast` to use the latest features and bug fixes ([link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L45-R45))
*  Add constants for the types and kinds of attributes and arguments in Prisma schema files ([link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-b5be81781d293f79ac5277d34d4c5556e3401b3159d7d89722e68d518248b36bR7-R9))
*  Import the `Value` and `BlockAttribute` types from `@mrleebo/prisma-ast` to handle different kinds of attribute values and block-level attributes ([link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L16-R18))
*  Import the constants `ARRAY_ARG_TYPE_NAME`, `KEY_VALUE_ARG_TYPE_NAME`, and `OBJECT_KIND_NAME` from `./constants` to use them for checking the type and kind of attribute arguments and object-level attributes ([link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911R61), [link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L66-R71))
*  Change the filter condition and the type of the `modelAttributes` variable in the `prepareSchema` and `prepareSchemaForPreview` methods of the `PrismaSchemaUtilsService` class to only include the model-level attributes with the type `ATTRIBUTE_TYPE_NAME` and the kind `OBJECT_KIND_NAME` ([link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L390-R396), [link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L587-R594), [link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L723-R734))
*  Replace the `prepareAttributes` method with the `prepareModelAttributes` and `prepareFieldAttributes` methods, which handle the model-level and field-level attributes differently in the `prepareSchemaForPreview` method of the `PrismaSchemaUtilsService` class ([link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L751-R763), [link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L779-R788), [link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L803-R850))
*  Use the constants `UNIQUE_ATTRIBUTE_NAME`, `modelAttrPrefix`, and `fieldAttrPrefix` instead of hard-coded strings to prepend the prefixes to the attributes in Prisma schema files ([link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L751-R763), [link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L779-R788), [link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L803-R850))
*  Use the constants `ARRAY_ARG_TYPE_NAME` and `KEY_VALUE_ARG_TYPE_NAME` instead of hard-coded strings to check the type of attribute arguments that are arrays or key-value pairs in Prisma schema files, and use the type alias `Value` from `@mrleebo/prisma-ast` to narrow and cast the argument values to `RelationArray` and `KeyValue` types ([link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L786-R804), [link](https://github.com/amplication/amplication/pull/6485/files?diff=unified&w=0#diff-6d2f9b6e412102f9d454bbb69cf5f32684a95c3d0ccf6d1db870687a35c0a911L803-R850))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
