### PR TITLE
refactor(git): replace  git providers `getFirstCommitOnBranch` with `GitCli` implementation

### DIFF
--- a/libs/util/git/src/git-client.service.spec.ts
+++ b/libs/util/git/src/git-client.service.spec.ts
@@ -36,6 +36,7 @@ describe("GitClientService", () => {
   let service: GitClientService;
   const gitDiffMock = jest.fn();
   const gitLogMock = jest.fn();
+  const gitGetFirstCommitShaMock = jest.fn();
   const cherryPickMock = jest.fn();
   const cherryPickAbortMock = jest.fn();
 
@@ -49,6 +50,7 @@ describe("GitClientService", () => {
     diff: gitDiffMock,
     cherryPick: cherryPickMock,
     cherryPickAbort: cherryPickAbortMock,
+    getFirstCommitSha: gitGetFirstCommitShaMock,
   } as unknown as GitCli;
 
   const amplicationBotIdentityMock = jest.fn();
@@ -69,7 +71,6 @@ describe("GitClientService", () => {
   const createPullRequestMock = jest.fn();
   const getBranchMock = jest.fn();
   const createBranchMock = jest.fn();
-  const getFirstCommitOnBranchMock = jest.fn();
   const getCloneUrlMock = jest.fn();
   const createPullRequestCommentMock = jest.fn();
   const gitProviderMock: GitProvider = {
@@ -91,7 +92,6 @@ describe("GitClientService", () => {
     createPullRequest: createPullRequestMock,
     getBranch: getBranchMock,
     createBranch: createBranchMock,
-    getFirstCommitOnBranch: getFirstCommitOnBranchMock,
     getCloneUrl: getCloneUrlMock,
     createPullRequestComment: createPullRequestCommentMock,
     name: EnumGitProvider.Github,
@@ -215,7 +215,7 @@ describe("GitClientService", () => {
         };
         getBranchMock.mockResolvedValueOnce(null);
 
-        getFirstCommitOnBranchMock.mockResolvedValueOnce({
+        gitGetFirstCommitShaMock.mockResolvedValueOnce({
           sha: "first-commit-sha",
         });
 
@@ -239,12 +239,7 @@ describe("GitClientService", () => {
         // Assert the result
         expect(result).toEqual({ name: "new-branch" });
         expect(gitProviderMock.getBranch).toHaveBeenCalledWith(args);
-        expect(gitProviderMock.getFirstCommitOnBranch).toHaveBeenCalledWith({
-          owner: "owner",
-          repositoryName: "repository",
-          branchName: "default",
-          repositoryGroupName: "group",
-        });
+        expect(gitGetFirstCommitShaMock).toHaveBeenCalledWith("default");
         expect(gitProviderMock.createBranch).toHaveBeenCalledWith({
           owner: "owner",
           branchName: "new-branch",
@@ -274,7 +269,7 @@ describe("GitClientService", () => {
 
         getBranchMock.mockResolvedValueOnce(null);
 
-        getFirstCommitOnBranchMock.mockResolvedValueOnce({
+        gitGetFirstCommitShaMock.mockResolvedValueOnce({
           sha: "first-commit-sha",
         });
 
@@ -304,7 +299,7 @@ describe("GitClientService", () => {
         // Assert the result
         expect(result).toEqual({ name: "new-branch" });
         expect(gitProviderMock.getBranch).toHaveBeenCalledWith(args);
-        expect(gitProviderMock.getFirstCommitOnBranch).toHaveBeenCalledTimes(1);
+        expect(gitGetFirstCommitShaMock).toHaveBeenCalledTimes(1);
         expect(gitProviderMock.createBranch).toHaveBeenCalledTimes(1);
         expect(gitLogMock).toHaveBeenCalledTimes(1);
         expect(cherryPickMock).toHaveBeenCalledTimes(3);
@@ -331,7 +326,7 @@ describe("GitClientService", () => {
 
       expect(result).toEqual({ name: "existing-branch" });
       expect(gitProviderMock.getBranch).toHaveBeenCalledWith(args);
-      expect(gitProviderMock.getFirstCommitOnBranch).not.toHaveBeenCalled();
+      expect(gitGetFirstCommitShaMock).not.toHaveBeenCalled();
       expect(gitProviderMock.createBranch).not.toHaveBeenCalled();
       expect(gitLogMock).not.toHaveBeenCalled();
     });

--- a/libs/util/git/src/git-client.service.ts
+++ b/libs/util/git/src/git-client.service.ts
@@ -155,16 +155,11 @@ export class GitClientService {
         groupName: repositoryGroupName,
       });
 
+      await gitCli.clone();
       const haveFirstCommitInDefaultBranch =
-        await this.isHaveFirstCommitInDefaultBranch({
-          owner,
-          repositoryName,
-          repositoryGroupName,
-          defaultBranch,
-        });
+        (await gitCli.getFirstCommitSha(defaultBranch))?.sha !== null;
 
       if (haveFirstCommitInDefaultBranch === false) {
-        await gitCli.clone();
         await this.createInitialCommit({
           gitRepoDir,
           gitCli,
@@ -415,13 +410,10 @@ export class GitClientService {
     if (branch) {
       return branch;
     }
-    const firstCommitOnDefaultBranch =
-      await this.provider.getFirstCommitOnBranch({
-        owner,
-        repositoryName,
-        branchName: defaultBranch,
-        repositoryGroupName,
-      });
+
+    const firstCommitOnDefaultBranch = await gitCli.getFirstCommitSha(
+      defaultBranch
+    );
 
     if (firstCommitOnDefaultBranch === null) {
       throw new NoCommitOnBranch(defaultBranch);
@@ -534,24 +526,5 @@ export class GitClientService {
         deleted: false,
       },
     ]);
-  }
-
-  private async isHaveFirstCommitInDefaultBranch(args: {
-    owner: string;
-    repositoryName: string;
-    repositoryGroupName?: string;
-    defaultBranch: string;
-  }): Promise<boolean> {
-    const { owner, repositoryName, repositoryGroupName, defaultBranch } = args;
-    const defaultBranchFirstCommit = await this.provider.getFirstCommitOnBranch(
-      {
-        branchName: defaultBranch,
-        owner,
-        repositoryName,
-        repositoryGroupName,
-      }
-    );
-
-    return Boolean(defaultBranchFirstCommit);
   }
 }

--- a/libs/util/git/src/git-provider.interface.ts
+++ b/libs/util/git/src/git-provider.interface.ts
@@ -56,7 +56,6 @@ export interface GitProvider {
   ) => Promise<PullRequest>;
   getBranch: (args: GetBranchArgs) => Promise<Branch | null>;
   createBranch: (args: CreateBranchArgs) => Promise<Branch>;
-  getFirstCommitOnBranch: (args: GetBranchArgs) => Promise<Commit | null>;
   getCloneUrl: (args: CloneUrlArgs) => Promise<string>;
   createPullRequestComment: (
     args: CreatePullRequestCommentArgs

--- a/libs/util/git/src/providers/git-cli.spec.ts
+++ b/libs/util/git/src/providers/git-cli.spec.ts
@@ -205,6 +205,9 @@ describe("GitCli", () => {
       gitBranchMock.mockResolvedValue({
         all: ["origin/main", "origin/a-specific-branch"],
       });
+      gitStatusMock.mockResolvedValue(<simpleGit.StatusResult>{
+        current: "main",
+      });
     });
 
     it("should return the first commit on the branch", async () => {

--- a/libs/util/git/src/providers/git-cli.spec.ts
+++ b/libs/util/git/src/providers/git-cli.spec.ts
@@ -203,7 +203,7 @@ describe("GitCli", () => {
     beforeEach(() => {
       gitFetchMock.mockResolvedValue(undefined);
       gitBranchMock.mockResolvedValue({
-        all: ["origin/main", "original/a-specific-branch"],
+        all: ["origin/main", "origin/a-specific-branch"],
       });
     });
 
@@ -250,14 +250,18 @@ describe("GitCli", () => {
       let currentBranch = "";
       const expectedBranch = "a-specific-branch";
 
+      gitStatusMock.mockImplementation(() => {
+        return <simpleGit.StatusResult>{
+          current: currentBranch,
+        };
+      });
       gitCheckoutMock.mockImplementation((branchName) => {
-        if (branchName === "-") currentBranch = expectedBranch;
-        else currentBranch = branchName;
+        currentBranch = branchName;
       });
       gitLogMock.mockResolvedValueOnce({});
 
       // Set current status
-      gitCli.checkout(expectedBranch);
+      await gitCli.checkout(expectedBranch);
 
       // Act
       await gitCli.getFirstCommitSha("main");

--- a/libs/util/git/src/providers/git-cli.ts
+++ b/libs/util/git/src/providers/git-cli.ts
@@ -175,10 +175,15 @@ export class GitCli {
   }
 
   async getFirstCommitSha(branchName: string): Promise<Commit | null> {
+    const originalStatus = await this.git.status();
+
     await this.checkout(branchName);
     const log = await this.git.log(["--reverse"]);
-    await this.git.checkout("-");
     const commit = log.latest?.hash;
+
+    if (originalStatus.current) {
+      await this.git.checkout(originalStatus.current);
+    }
     return commit ? { sha: commit } : null;
   }
 

--- a/libs/util/git/src/providers/git-cli.ts
+++ b/libs/util/git/src/providers/git-cli.ts
@@ -5,7 +5,7 @@ import {
   simpleGit,
   SimpleGit,
 } from "simple-git";
-import { UpdateFile } from "../types";
+import { Commit, UpdateFile } from "../types";
 import { mkdir, writeFile, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { existsSync } from "node:fs";
@@ -172,6 +172,14 @@ export class GitCli {
    */
   async diff(ref: string) {
     return this.git.diff(["--full-index", ref]);
+  }
+
+  async getFirstCommitSha(branchName: string): Promise<Commit | null> {
+    await this.checkout(branchName);
+    const log = await this.git.log(["--reverse"]);
+    await this.git.checkout("-");
+    const commit = log.latest?.hash;
+    return commit ? { sha: commit } : null;
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Part of: #6351
## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 81a285e</samp>

### Summary
🗑️🧪🚀

<!--
1.  🗑️ - This emoji represents the removal of the `getFirstCommitOnBranch` method from the `GitProvider` interface, as it is no longer needed and can be discarded.
2.  🧪 - This emoji represents the update and addition of tests for the `GitCli` class and the `GitClientService` class, as they improve the quality and coverage of the code.
3.  🚀 - This emoji represents the refactoring and improvement of the `GitClientService` class to use the `GitCli` class for getting the first commit SHA of a branch, as it enhances the performance and reliability of the code.
-->
This pull request improves the git operations of the `GitClientService` class by using the `GitCli` class instead of the git provider API. It also updates the tests and the `GitProvider` interface to reflect the new implementation. It affects the files `git-client.service.spec.ts`, `git-client.service.ts`, `git-cli.spec.ts`, `git-cli.ts`, and `git-provider.interface.ts`.

> _We don't need the `getFirstCommitOnBranch`_
> _We have the power of the `GitCli`_
> _We mock the `log` and we test the `sha`_
> _We are the masters of the git history_

### Walkthrough
*  Replace the `getFirstCommitOnBranch` method of the `GitProvider` interface with the `getFirstCommitSha` method of the `GitCli` class, which uses the `log` method of the `simpleGit` library, to improve the performance and reliability of the `cloneRepository` and `createBranch` methods of the `GitClientService` class ([link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-7030ed1d7460a9345852066fcdbb545162d9aa94cf278b82f9d0e5eebe1a9600L158-R162), [link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-7030ed1d7460a9345852066fcdbb545162d9aa94cf278b82f9d0e5eebe1a9600L418-R417), [link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-ff8aa5b0325c531705eb125cbdd735571a8001b8ca941f9ee0665e627c7fe3c6L59), [link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-299340b9a106b410204f30fd8481219507e7c5329f5e2d83126a6cb8e7e43f12R177-R184))
*  Remove the `isHaveFirstCommitInDefaultBranch` method of the `GitClientService` class, which is no longer needed ([link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-7030ed1d7460a9345852066fcdbb545162d9aa94cf278b82f9d0e5eebe1a9600L538-L556))
*  Add mock functions for `gitGetFirstCommitSha` and `gitLog` in the test files `git-client.service.spec.ts` and `git-cli.spec.ts`, respectively, to simulate the behavior of the `GitCli` class and the `simpleGit` library ([link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aR39), [link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-cc01eeb1204c726afa88830582a99ff9316b9d28ffab7d4d3cdc1cfb1ec3763aR14))
*  Add the mock functions to the `gitCli` and `simpleGit` mock objects, which are used to inject the dependencies into the `GitClientService` and `GitCli` classes under test ([link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aR53), [link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-cc01eeb1204c726afa88830582a99ff9316b9d28ffab7d4d3cdc1cfb1ec3763aL33-R35))
*  Remove the mock functions for `getFirstCommitOnBranch` in the test file `git-client.service.spec.ts`, which are no longer needed ([link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL72), [link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL94))
*  Replace the mock functions for `getFirstCommitOnBranch` with the mock functions for `gitGetFirstCommitSha` in the test cases for the `createBranch` method of the `GitClientService` class ([link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL218-R218), [link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL242-R242), [link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL277-R272), [link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL307-R302), [link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-a1600a4494f1ff70306b12cca22bd3001ad469f8a0803727550a74e4126b1c3aL334-R329))
*  Add a new `describe` block for the `getFirstCommitSha` method of the `GitCli` class in the test file `git-cli.spec.ts`, with three test cases that cover different scenarios ([link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-cc01eeb1204c726afa88830582a99ff9316b9d28ffab7d4d3cdc1cfb1ec3763aR201-R267))
*  Add the `Commit` type to the import statement in the source file `git-cli.ts`, which is used by the `getFirstCommitSha` method of the `GitCli` class ([link](https://github.com/amplication/amplication/pull/6489/files?diff=unified&w=0#diff-299340b9a106b410204f30fd8481219507e7c5329f5e2d83126a6cb8e7e43f12L8-R8))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
