### PR TITLE
Add-acount-last-active

### DIFF
--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -26,6 +26,7 @@ export type Account = {
   firstName: Scalars['String']['output'];
   githubId?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
+  lastActive?: Maybe<Scalars['DateTime']['output']>;
   lastName: Scalars['String']['output'];
   password: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -29,6 +29,7 @@ export type Account = {
   firstName: Scalars['String']['output'];
   githubId?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
+  lastActive?: Maybe<Scalars['DateTime']['output']>;
   lastName: Scalars['String']['output'];
   password: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -26,6 +26,7 @@ export type Account = {
   firstName: Scalars['String']['output'];
   githubId?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
+  lastActive?: Maybe<Scalars['DateTime']['output']>;
   lastName: Scalars['String']['output'];
   password: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -26,6 +26,7 @@ export type Account = {
   firstName: Scalars['String']['output'];
   githubId?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
+  lastActive?: Maybe<Scalars['DateTime']['output']>;
   lastName: Scalars['String']['output'];
   password: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];

--- a/packages/amplication-prisma-db/prisma/migrations/20230711141247_add_account_last_active/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20230711141247_add_account_last_active/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Account" ADD COLUMN     "lastActive" TIMESTAMP(3);

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -18,17 +18,18 @@ datasource db {
 }
 
 model Account {
-  id            String   @id @default(cuid())
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
-  email         String   @unique(map: "Account.email_unique")
+  id            String    @id @default(cuid())
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  email         String    @unique(map: "Account.email_unique")
   firstName     String
   lastName      String
   password      String
-  currentUserId String?  @unique(map: "Account.currentUserId_unique")
+  currentUserId String?   @unique(map: "Account.currentUserId_unique")
   githubId      String?
-  currentUser   User?    @relation(fields: [currentUserId], references: [id])
-  users         User[]   @relation("AccountOnUser")
+  currentUser   User?     @relation(fields: [currentUserId], references: [id])
+  users         User[]    @relation("AccountOnUser")
+  lastActive    DateTime?
 }
 
 model Workspace {

--- a/packages/amplication-server/src/core/account/account.service.spec.ts
+++ b/packages/amplication-server/src/core/account/account.service.spec.ts
@@ -21,7 +21,7 @@ const EXAMPLE_ACCOUNT: Account = {
   password: EXAMPLE_PASSWORD,
   currentUserId: EXAMPLE_CURRENT_USER_ID,
   githubId: null,
-  lastActive: new Date(),
+  lastActive: null,
 };
 
 const segmentAnalyticsIdentifyMock = jest.fn(() => {
@@ -166,6 +166,24 @@ describe("AccountService", () => {
     expect(await service.setPassword(args.accountId, args.password)).toEqual(
       EXAMPLE_ACCOUNT
     );
+    expect(prismaAccountUpdateMock).toBeCalledTimes(1);
+    expect(prismaAccountUpdateMock).toBeCalledWith(returnArgs);
+  });
+
+  it("should set lastActive", async () => {
+    const args = {
+      accountId: EXAMPLE_ACCOUNT_ID,
+      lastActive: new Date(),
+    };
+    const returnArgs = {
+      data: {
+        lastActive: args.lastActive,
+      },
+      where: { id: args.accountId },
+    };
+    expect(
+      await service.setLastActive(args.accountId, args.lastActive)
+    ).toEqual(EXAMPLE_ACCOUNT);
     expect(prismaAccountUpdateMock).toBeCalledTimes(1);
     expect(prismaAccountUpdateMock).toBeCalledWith(returnArgs);
   });

--- a/packages/amplication-server/src/core/account/account.service.spec.ts
+++ b/packages/amplication-server/src/core/account/account.service.spec.ts
@@ -21,6 +21,7 @@ const EXAMPLE_ACCOUNT: Account = {
   password: EXAMPLE_PASSWORD,
   currentUserId: EXAMPLE_CURRENT_USER_ID,
   githubId: null,
+  lastActive: new Date(),
 };
 
 const segmentAnalyticsIdentifyMock = jest.fn(() => {

--- a/packages/amplication-server/src/core/account/account.service.ts
+++ b/packages/amplication-server/src/core/account/account.service.ts
@@ -87,4 +87,13 @@ export class AccountService {
       where: { id: accountId },
     });
   }
+
+  setLastActive(accountId: string, lastActive: Date): Promise<Account> {
+    return this.prisma.account.update({
+      data: {
+        lastActive,
+      },
+      where: { id: accountId },
+    });
+  }
 }

--- a/packages/amplication-server/src/core/auth/auth.service.spec.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.spec.ts
@@ -32,6 +32,7 @@ const EXAMPLE_ACCOUNT: Account = {
   updatedAt: new Date(),
   currentUserId: null,
   githubId: null,
+  lastActive: new Date(),
 };
 
 const EXAMPLE_PROJECT: Project = {

--- a/packages/amplication-server/src/core/workspace/workspace.resolver.spec.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.resolver.spec.ts
@@ -22,6 +22,7 @@ import { BillingService } from "../billing/billing.service";
 import { SubscriptionService } from "../subscription/subscription.service";
 import { ApolloServerBase } from "apollo-server-core";
 import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { AccountService } from "../account/account.service";
 
 const EXAMPLE_USER_ID = "exampleUserId";
 const EXAMPLE_WORKSPACE_ID = "exampleWorkspaceId";
@@ -209,6 +210,12 @@ describe("WorkspaceResolver", () => {
             track: jest.fn(() => {
               return;
             }),
+          })),
+        },
+        {
+          provide: AccountService,
+          useClass: jest.fn(() => ({
+            setLastActive: jest.fn(),
           })),
         },
       ],

--- a/packages/amplication-server/src/core/workspace/workspace.resolver.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.resolver.ts
@@ -37,6 +37,7 @@ import {
   EnumEventType,
   SegmentAnalyticsService,
 } from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { AccountService } from "../account/account.service";
 
 @Resolver(() => Workspace)
 @UseFilters(GqlResolverExceptionsFilter)
@@ -47,7 +48,8 @@ export class WorkspaceResolver {
     private readonly projectService: ProjectService,
     private readonly billingService: BillingService,
     private readonly subscriptionService: SubscriptionService,
-    private readonly analytics: SegmentAnalyticsService
+    private readonly analytics: SegmentAnalyticsService,
+    private readonly accountService: AccountService
   ) {}
 
   @Query(() => Workspace, {
@@ -71,6 +73,7 @@ export class WorkspaceResolver {
       },
       event: EnumEventType.WorkspaceSelected,
     });
+    await this.accountService.setLastActive(currentUser.account.id, new Date());
 
     return currentUser.workspace;
   }

--- a/packages/amplication-server/src/models/Account.ts
+++ b/packages/amplication-server/src/models/Account.ts
@@ -48,4 +48,9 @@ export class Account {
     nullable: true,
   })
   githubId?: string | null;
+
+  @Field(() => Date, {
+    nullable: true,
+  })
+  lastActive?: Date | null;
 }

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -8,6 +8,7 @@ type Account {
   firstName: String!
   githubId: String
   id: String!
+  lastActive: DateTime
   lastName: String!
   password: String!
   updatedAt: DateTime!

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -26,6 +26,7 @@ export type Account = {
   firstName: Scalars['String']['output'];
   githubId?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
+  lastActive?: Maybe<Scalars['DateTime']['output']>;
   lastName: Scalars['String']['output'];
   password: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: https://github.com/amplication/private-issues/issues/28

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 52c7a7a</samp>

### Summary
🕒🛠️🧪

<!--
1.  🕒 - This emoji represents the concept of time and activity, which are related to the new field `lastActive` and the function `setLastActive`.
2.  🛠️ - This emoji represents the tools and modifications that are involved in adding the new field and function to the various packages, files, and schemas.
3.  🧪 - This emoji represents the testing and verification of the new feature, which are done by adding new fields, test cases, and mock providers.
-->
This pull request adds a new feature to track the last active date of users in the account service. It adds a new field `lastActive` of type `DateTime` to the `Account` type and model in various packages and files. It also adds a new function `setLastActive` to the account service and calls it from the workspace resolver. It updates the database schema, the GraphQL schema, and the tests accordingly.

> _Sing, O Muse, of the skillful pull request_
> _That added `lastActive` to the `Account` type_
> _And altered many packages with respect_
> _To keep the schema and the code aligned._

### Walkthrough
*  Add a new optional field `lastActive` of type `DateTime` to the `Account` type in various packages and modules to indicate the last time the account was active. ([link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-8e34f7703a0b39fa5e612bb39ad750167d90a6b75df578f54f35a9348dd0a509R29), [link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-b9ccc53c48e521fb7c98b07ad7f4761ba0ea91eb649e157d159b065ac2487c1dR32), [link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-3860f234d2c5629bf7aeb4e7439fe3b357be4e00c08a9f008b56d3610bb017c0R29), [link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-6137baa91c68c17d5e3716428198a16a3cb5cdd263e22998503daa29c86a296eR29), [link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-0e716dabdf541866099ee6bc1bb744ac2ab10191595c4b9f2d38e05b2f7aada3R51-R55), [link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75R11), [link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-a54fca1e77b31822272d37bef66289ad466ba9d835ac76a5474a6808d4bcaaabR29))
*  Alter the `Account` table in the database and add a new column `lastActive` of type `TIMESTAMP(3)` to persist the field. ([link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-07e463030f32de289f30ec32b343dec51a1be93ea63a4419434e7c020ab158ecR1-R2), [link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-f83d54c896f6ae6f938ed753a6856094bef91365a576da08c393e51868d3ce76L21-R32))
*  Implement and test a new function `setLastActive` in the `account.service.ts` file that updates the `lastActive` field of the account with a given date using the Prisma `account.update` function. ([link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-ceb7aeeb9ff4e40183c2c4389f985f46db0218fcfd73b25a9f1d5133ef669d1cR90-R98), [link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-ae42334766d36b8ad73deaed92d47e2c2fc5356348868e1c0428ce08dfe96c57R172-R189))
*  Call the `setLastActive` function in the `findWorkspace` function of the `workspace.resolver.ts` file whenever the user accesses a workspace. ([link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-1cb226bf6e90c823b799286689bcc7b8adce3fecf71b6a9187f008bce747cb76R76))
*  Inject the `AccountService` as a dependency for the `WorkspaceResolver` class and mock it for testing the workspace resolver functions. ([link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-b342064d588dab368993c9df58bc5e2eb4e84e0614a6a9590dc84a81dd517682R25), [link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-b342064d588dab368993c9df58bc5e2eb4e84e0614a6a9590dc84a81dd517682R215-R220), [link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-1cb226bf6e90c823b799286689bcc7b8adce3fecf71b6a9187f008bce747cb76R40), [link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-1cb226bf6e90c823b799286689bcc7b8adce3fecf71b6a9187f008bce747cb76L50-R52))
*  Provide mock account objects with valid or null `lastActive` values for testing the account and auth service functions. ([link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-ae42334766d36b8ad73deaed92d47e2c2fc5356348868e1c0428ce08dfe96c57R24), [link](https://github.com/amplication/amplication/pull/6505/files?diff=unified&w=0#diff-fc4d38c9140325ee628c3312d3c18e59662bbe923d9cd15947d15f8dad8aa8c0R35))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
