### PR TITLE
fest(design-system):add input label tooltip

### DIFF
--- a/libs/ui/design-system/src/lib/components/InputTooltip/InputTooltip.scss
+++ b/libs/ui/design-system/src/lib/components/InputTooltip/InputTooltip.scss
@@ -1,0 +1,26 @@
+@import "../../style/index.scss";
+
+.input-tooltip {
+  display: inline-block;
+
+  &__icon {
+    color: var(--black60);
+    padding: 0 var(--icon-spacing);
+  }
+}
+
+.input-tooltip__popover {
+  .amp-popover {
+    &__content {
+      background: var(--white) !important;
+
+      padding: var(--default-spacing) !important;
+      border: 1px solid var(--black60);
+      color: var(--black90);
+    }
+
+    &__arrow {
+      color: var(--black60) !important;
+    }
+  }
+}

--- a/libs/ui/design-system/src/lib/components/InputTooltip/InputTooltip.stories.tsx
+++ b/libs/ui/design-system/src/lib/components/InputTooltip/InputTooltip.stories.tsx
@@ -1,0 +1,13 @@
+import React, { useEffect, useState } from "react";
+import { Meta } from "@storybook/react";
+import { InputTooltip } from "./InputTooltip";
+import { TextInput } from "../TextInput/TextInput";
+
+export default {
+  title: "InputTooltip",
+  component: InputTooltip,
+} as Meta;
+
+export const Default = () => {
+  return <InputTooltip content="Input tooltip text here" />;
+};

--- a/libs/ui/design-system/src/lib/components/InputTooltip/InputTooltip.tsx
+++ b/libs/ui/design-system/src/lib/components/InputTooltip/InputTooltip.tsx
@@ -1,0 +1,32 @@
+import classNames from "classnames";
+import { Icon } from "../Icon/Icon";
+import { Popover, Props as PopoverProps } from "../Popover/Popover";
+import "./InputTooltip.scss";
+
+export type Props = Omit<PopoverProps, "children">;
+
+const CLASS_NAME = "input-tooltip";
+
+export function InputTooltip({
+  className,
+  placement = "right",
+  ...rest
+}: Props) {
+  return (
+    <span className={CLASS_NAME}>
+      <Popover
+        className={classNames(`${CLASS_NAME}__popover`, className)}
+        placement={placement}
+        {...rest}
+      >
+        <div className={CLASS_NAME}>
+          <Icon
+            icon="help_circle"
+            size="xsmall"
+            className={`${CLASS_NAME}__icon`}
+          />
+        </div>
+      </Popover>
+    </span>
+  );
+}

--- a/libs/ui/design-system/src/lib/components/Label/Label.scss
+++ b/libs/ui/design-system/src/lib/components/Label/Label.scss
@@ -5,6 +5,13 @@
   &__error {
     color: var(--negative);
   }
+
+  &__inner {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
   &__normal {
     color: #53dbee;
     font-size: 8px;

--- a/libs/ui/design-system/src/lib/components/Label/Label.tsx
+++ b/libs/ui/design-system/src/lib/components/Label/Label.tsx
@@ -1,21 +1,30 @@
 import React from "react";
+import {
+  Props as InputToolTipProps,
+  InputTooltip,
+} from "../InputTooltip/InputTooltip";
+
 import "./Label.scss";
 export type LabelTypes = "normal" | "error";
 
 export type Props = React.HTMLProps<HTMLSpanElement> & {
   text: string;
   type?: LabelTypes;
+  inputToolTip?: InputToolTipProps | undefined;
 };
 
 const CLASS_NAME = "amplication-label";
 
-export function Label({ text, ...props }: Props) {
+export function Label({ text, inputToolTip, ...props }: Props) {
   return (
     <span
       {...props}
       className={`${CLASS_NAME}__${props.type || ""} ${props.className || ""}`}
     >
-      {text}
+      <span className={`${CLASS_NAME}__inner`}>
+        {text}
+        {inputToolTip && <InputTooltip {...inputToolTip} />}
+      </span>
     </span>
   );
 }

--- a/libs/ui/design-system/src/lib/components/TextInput/TextInput.tsx
+++ b/libs/ui/design-system/src/lib/components/TextInput/TextInput.tsx
@@ -4,6 +4,7 @@ import { Icon } from "../Icon/Icon";
 import { Button } from "../Button/Button";
 import "./TextInput.scss";
 import { Label, LabelTypes } from "../Label/Label";
+import { Props as InputToolTipProps } from "../InputTooltip/InputTooltip";
 
 export type Props = React.HTMLProps<HTMLTextAreaElement | HTMLInputElement> & {
   helpText?: string;
@@ -16,6 +17,7 @@ export type Props = React.HTMLProps<HTMLTextAreaElement | HTMLInputElement> & {
   hasError?: boolean;
   textarea?: boolean;
   labelType?: LabelTypes;
+  inputToolTip?: InputToolTipProps | undefined;
 };
 
 const CLASS_NAME = "text-input";
@@ -30,6 +32,7 @@ export function TextInput({
   hasError,
   textarea,
   labelType,
+  inputToolTip,
   ...rest
 }: Props) {
   const key = rest.key || rest.autoFocus?.toString();
@@ -42,7 +45,10 @@ export function TextInput({
     >
       <div className={`${CLASS_NAME}__inner-wrapper`}>
         <label className="input-label">
-          {!hideLabel && label && <Label text={label} />}
+          {!hideLabel && label && (
+            <Label text={label} inputToolTip={inputToolTip} />
+          )}
+
           {textarea ? (
             <textarea
               {...rest}

--- a/packages/amplication-client/src/Entity/EntityFieldForm.tsx
+++ b/packages/amplication-client/src/Entity/EntityFieldForm.tsx
@@ -173,7 +173,22 @@ const EntityFieldForm = ({
             <TextField
               autoComplete="off"
               disabled={isSystemDataType}
-              placeholder='Add custom attributes to fields using the format @attribute([parameters]) or @attribute. For example: @map(name: "fieldName") @unique @default(value)'
+              placeholder="Custom Prisma Attributes"
+              inputToolTip={{
+                content: (
+                  <span>
+                    Add custom attributes to fields using the format
+                    @attribute([parameters]) or @attribute. <br />
+                    <br /> For example:
+                    <br />
+                    @map(name: "fieldName")
+                    <br />
+                    @unique
+                    <br />
+                    @default(value)
+                  </span>
+                ),
+              }}
               textarea
               rows={3}
               name="customAttributes"

--- a/packages/amplication-client/src/Entity/EntityForm.tsx
+++ b/packages/amplication-client/src/Entity/EntityForm.tsx
@@ -122,7 +122,20 @@ const EntityForm = React.memo(({ entity, resourceId, onSubmit }: Props) => {
                 />
                 <TextField
                   autoComplete="off"
-                  placeholder='Add custom attributes to model using the format @@attribute([parameters]) or @@attribute(). For example: @@index([field_1, field_2])  @@map("modelName")'
+                  placeholder="Custom Prisma attributes"
+                  inputToolTip={{
+                    content: (
+                      <span>
+                        Add custom attributes to model using the format
+                        @@attribute([parameters]) or @@attribute().
+                        <br />
+                        <br /> For example:
+                        <br />
+                        @@index([field_1, field_2]) <br />
+                        @@map("modelName")
+                      </span>
+                    ),
+                  }}
                   textarea
                   rows={3}
                   name="customAttributes"


### PR DESCRIPTION


Close: https://github.com/amplication/amplication/issues/6524

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

Example:

<img width="861" alt="image" src="https://github.com/amplication/amplication/assets/43705455/a5a2a296-5859-4e58-a83d-574c39462292">


<img width="860" alt="image" src="https://github.com/amplication/amplication/assets/43705455/3237a1b7-8bba-4e5b-aef2-5b71853b1fe1">


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d50c91c</samp>

### Summary
🆕🏷️📝

<!--
1.  🆕 for adding a new UI component (InputTooltip) and its styles and stories.
2.  🏷️ for adding a new feature and prop to the Label component and updating its styles.
3.  📝 for adding a new feature and prop to the TextInput component and passing it to the Label component.
-->
This pull request introduces a new UI component, `InputTooltip`, which displays a help icon with a popover content. It also adds a new feature to the `Label` and `TextInput` components, which allows them to accept an `inputToolTip` prop and render the `InputTooltip` component next to the label. The pull request includes the TSX, SCSS, and story files for the new component, and the changes to the existing components.
 render it with TSX_
> _And pass it to the `Label` and the `TextInput`_

### Walkthrough
*  Add a new UI component, InputTooltip, that displays a help icon with a popover content ([link](https://github.com/amplication/amplication/pull/6523/files?diff=unified&w=0#diff-878a7e49b6ec4306d9dd540fcba2ecc2014f2d58221bb76d5d4af96193be8660R1-R26), [link](https://github.com/amplication/amplication/pull/6523/files?diff=unified&w=0#diff-01c3b3e0aa35f1af4821f25dc7838d4dfc3600d54f8b36f049563c61fff21263R1-R13), [link](https://github.com/amplication/amplication/pull/6523/files?diff=unified&w=0#diff-5a177fb0c967399a9ebfa82528ac545c771d12318a1f5eacede6ace01190faa5R1-R32))
*  Extend the Label component to accept an optional inputToolTip prop and render an InputTooltip component with it ([link](https://github.com/amplication/amplication/pull/6523/files?diff=unified&w=0#diff-cedd81caa6bc4fc3bea2ed1be8819fca6e0c16a2331dbac86761e81fc7682eb3R8-R14), [link](https://github.com/amplication/amplication/pull/6523/files?diff=unified&w=0#diff-b61b6320009e9be10e7d2cb65b4c757ef52c776b08e6a11ee326ee204c0e0e0dR2-R6), [link](https://github.com/amplication/amplication/pull/6523/files?diff=unified&w=0#diff-b61b6320009e9be10e7d2cb65b4c757ef52c776b08e6a11ee326ee204c0e0e0dL8-R18), [link](https://github.com/amplication/amplication/pull/6523/files?diff=unified&w=0#diff-b61b6320009e9be10e7d2cb65b4c757ef52c776b08e6a11ee326ee204c0e0e0dL18-R27))
*  Extend the TextInput component to accept an optional inputToolTip prop and pass it to the Label component ([link](https://github.com/amplication/amplication/pull/6523/files?diff=unified&w=0#diff-395cece8c479abbad9ac6816ac8d56552afd1e0ad33de69b177631c8b36e0850R7), [link](https://github.com/amplication/amplication/pull/6523/files?diff=unified&w=0#diff-395cece8c479abbad9ac6816ac8d56552afd1e0ad33de69b177631c8b36e0850R20), [link](https://github.com/amplication/amplication/pull/6523/files?diff=unified&w=0#diff-395cece8c479abbad9ac6816ac8d56552afd1e0ad33de69b177631c8b36e0850R35), [link](https://github.com/amplication/amplication/pull/6523/files?diff=unified&w=0#diff-395cece8c479abbad9ac6816ac8d56552afd1e0ad33de69b177631c8b36e0850L45-R51))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
