### PR TITLE
feat(server):git org type

### DIFF
--- a/packages/amplication-client/src/Resource/git/AuthResourceWithBitbucketCallback.tsx
+++ b/packages/amplication-client/src/Resource/git/AuthResourceWithBitbucketCallback.tsx
@@ -28,9 +28,6 @@ const AuthResourceWithBitbucketCallback = () => {
     const urlParams = new URLSearchParams(queryString);
     const authorizationCode = urlParams.get("code");
     if (window.opener) {
-      trackEvent({
-        eventName: AnalyticsEventNames.GitHubAuthResourceComplete,
-      });
       completeAuthWithGit({
         variables: {
           code: authorizationCode,

--- a/packages/amplication-client/src/Resource/git/AuthResourceWithGithubCallback.tsx
+++ b/packages/amplication-client/src/Resource/git/AuthResourceWithGithubCallback.tsx
@@ -29,9 +29,6 @@ const AuthResourceWithGithubCallback = () => {
     const urlParams = new URLSearchParams(queryString);
     const installationId = urlParams.get("installation_id");
     if (window.opener) {
-      trackEvent({
-        eventName: AnalyticsEventNames.GitHubAuthResourceComplete,
-      });
       completeAuthWithGit({
         variables: {
           installationId,

--- a/packages/amplication-client/src/util/analytics-events.types.ts
+++ b/packages/amplication-client/src/util/analytics-events.types.ts
@@ -95,7 +95,6 @@ export enum AnalyticsEventNames {
 
   // GitHub
   GitHubAuthResourceStart = "startAuthResourceWithGitHub",
-  GitHubAuthResourceComplete = "completeAuthResourceWithGitHub",
   GitHubRepositoryCreate = "createGitRepository",
   GithubRepositoryChange = "changeGithubRepository",
   GithubOpenPullRequest = "openGithubPullRequest",

--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -517,16 +517,15 @@ export class ResourceService {
 
     const { gitRepository, serviceSettings } = data.resource;
 
+    const gitOrganization = await this.gitOrganizationByResource({
+      where: {
+        id: resource.id,
+      },
+    });
+
     const provider = data.connectToDemoRepo
       ? "demo-repo"
-      : gitRepository &&
-        (
-          await this.gitOrganizationByResource({
-            where: {
-              id: resource.id,
-            },
-          })
-        ).provider;
+      : gitRepository && gitOrganization.provider;
 
     const totalEntities = data.entities.length;
     const totalFields = data.entities.reduce((acc, entity) => {
@@ -553,6 +552,7 @@ export class ResourceService {
         workspaceId: project.workspaceId,
         totalEntities,
         totalFields,
+        gitOrgType: gitOrganization?.type,
       },
     });
 


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: https://github.com/amplication/private-issues/issues/15

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d24e66b</samp>

### Summary
:lock::arrows_counterclockwise::chart_with_upwards_trend:

<!--
1.  :lock: This emoji represents the removal of the tracking logic from the client side and the move to the server side, where the authentication process can be handled more securely and consistently.
2.  :arrows_counterclockwise: This emoji represents the change of the event name from GitHubAuthResourceComplete to GitAuthResourceComplete, which reflects the support for multiple git providers and the generic nature of the event.
3.  :chart_with_upwards_trend: This emoji represents the addition of the git organization type to the resource service, which allows the service to improve the analytics of the user actions and the resources that they create or update.
-->
This pull request refactors the git provider integration and analytics tracking logic. It moves the tracking of the user's authentication process with any git provider from the client side to the server side, and adds the git organization type to the resource service. It also removes the GitHubAuthResourceComplete event name and replaces it with a more generic one.

> _Sing, O Muse, of the cunning code review_
> _That changed the tracking of the git providers_
> _And how the noble `AuthResourceWithCallback` components_
> _Ceased to send the `GitHubAuthResourceComplete` event_

### Walkthrough
*  Remove client-side tracking of GitHubAuthResourceComplete event and move it to server-side ([link](https://github.com/amplication/amplication/pull/6526/files?diff=unified&w=0#diff-6a5da699abe2fad9901dd52129afd957e480d92ca77fe49cb67c581335f2453eL31-L33), [link](https://github.com/amplication/amplication/pull/6526/files?diff=unified&w=0#diff-255e9d9d9cb2232f05646c62b005b95dbbe0b94c4ba46ca22747a83ee682878dL32-L34), [link](https://github.com/amplication/amplication/pull/6526/files?diff=unified&w=0#diff-917333793bfc12bbce1fed70cf28308c74cf550fb42d3653f076a65ad209e697L98))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
