### PR TITLE
fix build status icon refresh on commits list

### DIFF
--- a/packages/amplication-client/src/VersionControl/CommitList.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitList.tsx
@@ -15,6 +15,7 @@ import "./CommitList.scss";
 
 type Props = {
   commits: models.Commit[];
+  lastCommit: models.Commit;
   error: ApolloError | undefined;
   loading: boolean;
   onLoadMoreClick: () => void;
@@ -25,6 +26,7 @@ const CLASS_NAME = "commit-list";
 
 const CommitList = ({
   commits,
+  lastCommit,
   error,
   loading,
   onLoadMoreClick,
@@ -37,7 +39,13 @@ const CommitList = ({
   return (
     <div className={CLASS_NAME}>
       {loading && <CircularProgress centerToParent />}
-
+      {currentProject && (
+        <CommitListItem
+          key={`${lastCommit.id}_${Date.now()}`}
+          commit={lastCommit}
+          projectId={currentProject.id}
+        />
+      )}
       {currentProject &&
         commits.map((commit) => (
           <CommitListItem

--- a/packages/amplication-client/src/VersionControl/CommitsPage.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitsPage.tsx
@@ -55,7 +55,8 @@ const CommitsPage: React.FC<Props> = ({ match, moduleClass }) => {
       sideContent={
         commitUtils.commits?.length ? (
           <CommitList
-            commits={commitUtils.commits}
+            commits={commitUtils.commits.slice(1)}
+            lastCommit={commitUtils.lastCommit}
             error={commitUtils.commitsError}
             loading={commitUtils.commitsLoading}
             onLoadMoreClick={handleOnLoadMoreClick}

--- a/packages/amplication-client/src/VersionControl/hooks/useCommitStatus.ts
+++ b/packages/amplication-client/src/VersionControl/hooks/useCommitStatus.ts
@@ -5,15 +5,19 @@ export const useCommitStatus = (commit: models.Commit | null) => {
   const commitBuilds = commit?.builds;
   const commitStatus = useMemo(() => {
     if (!commitBuilds?.length) return;
+
     const buildsInProgress = commitBuilds.some(
       (build) => build.status === models.EnumBuildStatus.Running
     );
+
     const buildsFailed = commitBuilds.some(
       (build) => build.status === models.EnumBuildStatus.Failed
     );
-    const buildsCompleted = commitBuilds.some(
+
+    const buildsCompleted = commitBuilds.every(
       (build) => build.status === models.EnumBuildStatus.Completed
     );
+
     if (buildsInProgress) return models.EnumBuildStatus.Running;
     if (buildsFailed) return models.EnumBuildStatus.Failed;
     if (buildsCompleted) return models.EnumBuildStatus.Completed;

--- a/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
+++ b/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
@@ -83,6 +83,7 @@ const useCommits = (currentProjectId: string, maxCommits?: number) => {
       });
       refetchFromStart && setCommits([]);
       setCommitsCount(refetchFromStart ? 1 : commitsCount + 1);
+      refetchFromStart && refetchLastCommit();
     },
     [refetchCommits, setCommitsCount, commitsCount]
   );

--- a/packages/amplication-client/src/VersionControl/useBuildWatchStatus.tsx
+++ b/packages/amplication-client/src/VersionControl/useBuildWatchStatus.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from "react";
+import { useContext, useEffect } from "react";
 import { gql, useQuery } from "@apollo/client";
 
 import * as models from "../models";
+import { AppContext } from "../context/appContext";
 
 const POLL_INTERVAL = 5000;
 /**
@@ -10,6 +11,7 @@ const POLL_INTERVAL = 5000;
 const useBuildWatchStatus = (
   build?: models.Build
 ): { data: { build?: models.Build } } => {
+  const { commitUtils } = useContext(AppContext);
   const { data, startPolling, stopPolling, refetch } = useQuery<{
     build: models.Build;
   }>(GET_BUILD, {
@@ -38,6 +40,13 @@ const useBuildWatchStatus = (
       stopPolling();
     };
   }, [stopPolling]);
+
+  useEffect(() => {
+    if (!data) return;
+
+    data?.build?.status === models.EnumBuildStatus.Completed &&
+      commitUtils.refetchLastCommit();
+  }, [data]);
 
   return { data: data || { build } };
 };


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6099 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 857aa96</samp>

### Summary
🔄🐛🌟

<!--
1.  🔄 This emoji represents the refetching of the latest commit data and the slicing of the rest of the commits data. It also implies the updating of the UI with the new data.
2. 🐛 This emoji represents the bug fix in the `useCommitStatus` hook logic. It also implies the improvement of the accuracy of the commit status.
3. 🌟 This emoji represents the new feature of showing the latest commit with a different style and a live status icon. It also implies the enhancement of the user experience and the visual appeal of the version control feature.
-->
This pull request adds a feature to show the latest commit with a live status icon in the `CommitList` component, and improves the data consistency and the UI feedback for the version control feature. It also fixes a bug in the `useCommitStatus` hook that determines the overall status of a commit. The changes affect the files `CommitList.tsx`, `useBuildWatchStatus.tsx`, `CommitsPage.tsx`, `useCommits.ts`, and `useCommitStatus.ts`.

> _`CommitList` shows_
> _latest commit with live status_
> _autumn of bugs ends_

### Walkthrough
*  Add `lastCommit` prop to `CommitList` component to render the latest commit separately ([link](https://github.com/amplication/amplication/pull/6532/files?diff=unified&w=0#diff-c9afe8e64d6197dfa7e81e35b03786d154363b6d4c28c6a53c3a58029818a869R18), [link](https://github.com/amplication/amplication/pull/6532/files?diff=unified&w=0#diff-c9afe8e64d6197dfa7e81e35b03786d154363b6d4c28c6a53c3a58029818a869R29), [link](https://github.com/amplication/amplication/pull/6532/files?diff=unified&w=0#diff-c9afe8e64d6197dfa7e81e35b03786d154363b6d4c28c6a53c3a58029818a869L40-R48))
*  Pass the latest commit data as `lastCommit` prop from `CommitsPage` component, and slice the rest of the commits data as `commits` prop ([link](https://github.com/amplication/amplication/pull/6532/files?diff=unified&w=0#diff-6bf2f4394daff58a8501cd2097f39550370ef58b42fe9d65f86de3da7a3793ccL58-R59))
*  Use `useCommits` hook to fetch the commits data from the server, and refetch the latest commit data when needed using `commitUtils.refetchLastCommit` function ([link](https://github.com/amplication/amplication/pull/6532/files?diff=unified&w=0#diff-6bf2f4394daff58a8501cd2097f39550370ef58b42fe9d65f86de3da7a3793ccL58-R59), [link](https://github.com/amplication/amplication/pull/6532/files?diff=unified&w=0#diff-ea74f30898d4da9abefb6e4d32bac377f69bb638c3d77eabbd941c71cd80d5c1R86))
*  Fix the logic of `useCommitStatus` hook to return `Completed` status only when all the builds of a commit are completed, using the `every` method instead of the `some` method ([link](https://github.com/amplication/amplication/pull/6532/files?diff=unified&w=0#diff-bb861415c7e053390b62a45eeec4274aa44cedb64602d2f28f3a1875270c2bb3L8-R20))
*  Use `useBuildWatchStatus` hook to subscribe to the build status updates of the latest commit, and refetch the latest commit data when the build status is `Completed`, using the `commitUtils.refetchLastCommit` function ([link](https://github.com/amplication/amplication/pull/6532/files?diff=unified&w=0#diff-80512cd1cd8c0efba79a4abcdaa72afa9d1dd460e9c49a05d73cc11a70f8ffb5L1-R5), [link](https://github.com/amplication/amplication/pull/6532/files?diff=unified&w=0#diff-80512cd1cd8c0efba79a4abcdaa72afa9d1dd460e9c49a05d73cc11a70f8ffb5R14), [link](https://github.com/amplication/amplication/pull/6532/files?diff=unified&w=0#diff-80512cd1cd8c0efba79a4abcdaa72afa9d1dd460e9c49a05d73cc11a70f8ffb5R44-R50))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
