### PR TITLE
issue #6296, checkmark now shows up on successful build

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,12 +179,12 @@
     "tar-stream": "^2.2.0",
     "ts-morph": "^17.0.1",
     "tslib": "^2.5.0",
+    "type-fest": "^3.11.0",
     "use-debounce": "^3.4.3",
     "uuid": "^8.3.2",
     "winston": "3.8.2",
     "winston-cloud-logging": "^1.0.2",
-    "yaml": "2.2.2",
-    "type-fest": "^3.11.0"
+    "yaml": "2.2.2"
   },
   "devDependencies": {
     "@babel/core": "7.12.13",
@@ -296,7 +296,7 @@
     "npm-run-all": "^4.1.5",
     "nx": "15.4.5",
     "path-browserify": "^1.0.1",
-    "prisma": "^4.16.2",
+    "prisma": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-is": "^18.2.0",

--- a/packages/amplication-client/src/VersionControl/ActionLog.tsx
+++ b/packages/amplication-client/src/VersionControl/ActionLog.tsx
@@ -121,7 +121,7 @@ const ActionLog = ({ action, title, versionNumber }: Props) => {
         )}
       </div>
       <div className={`${CLASS_NAME}__body`}>
-        {logData.map((stepData) => (
+        {logData.map((stepData, index) => (
           <div className={`${CLASS_NAME}__step`} key={stepData.id}>
             <div className={`${CLASS_NAME}__step__row`}>
               <span
@@ -136,6 +136,7 @@ const ActionLog = ({ action, title, versionNumber }: Props) => {
               <span className={`${CLASS_NAME}__step__message`}>
                 {stepData.message}
               </span>
+
               <span className={`${CLASS_NAME}__step__duration`}>
                 {stepData.duration}
               </span>

--- a/packages/amplication-client/src/VersionControl/BuildSteps.tsx
+++ b/packages/amplication-client/src/VersionControl/BuildSteps.tsx
@@ -24,7 +24,7 @@ export const EMPTY_STEP: models.ActionStep = {
   message: "",
 };
 
-export const GENERATE_STEP_NAME = "GENERATE_APPLICATION";
+export const GENERATE_STEP_NAME = "ADD_TO_QUEUE";
 export const BUILD_DOCKER_IMAGE_STEP_NAME = "BUILD_DOCKER";
 export const DEPLOY_STEP_NAME = "DEPLOY_RESOURCE";
 export const PUSH_TO_GIT_STEP_NAME = (gitProvider: models.EnumGitProvider) =>
@@ -47,6 +47,12 @@ const BuildSteps = ({ build }: Props) => {
     if (!data.build.action?.steps?.length) {
       return EMPTY_STEP;
     }
+    console.log(
+      "TESTING DATA -----------------",
+      data.build.action.steps[0].status || EMPTY_STEP
+    );
+    console.log("DATA STEPS -----------------", data.build.action.steps);
+
     return (
       data.build.action.steps.find(
         (step) => step.name === GENERATE_STEP_NAME
@@ -54,6 +60,7 @@ const BuildSteps = ({ build }: Props) => {
     );
   }, [data.build.action]);
 
+  console.log("generateCode STATUS-------------", stepGenerateCode);
   const stepGithub = useMemo(() => {
     if (!data.build.action?.steps?.length) {
       return null;


### PR DESCRIPTION
## PR Details
This PR only fixes the checkmark, but I will be working on the system returning a build log message in the next PR

## Proposal

### Please re-state the problem that we are trying to solve in this issue.

- The current issue is that the panel for the 'Generate Code' is not properly displaying the correct status:

![image](https://github.com/amplication/amplication/assets/109321774/c5faaffb-bc7a-4d2c-b9e0-a7105a2c3d81)


### What is the root cause of that problem?

- The root cause of the problem seems to be coming from BuildSteps.tsx on line 27:

![image](https://github.com/amplication/amplication/assets/109321774/8c30a09e-6a76-4a1f-89dd-dece6cc3de17)


- The `data.build.action.steps.find((step) => step.name === GENERATE_STEP_NAME)` is calling for a `step.name` that is `GENERATE_APPLICATION`

![image](https://github.com/amplication/amplication/assets/109321774/8b6e87d8-5ae6-4877-9618-42f649f4aa20)


- But upon successful completion, the object returns`ADD_TO_QUEUE`:

![image](https://github.com/amplication/amplication/assets/109321774/20c1354f-6448-4010-bc32-61f9869036b9)



### What changes do you think we should make in order to solve the problem?

- Changing `GENERATE_STEP_NAME` to `ADD_TO_QUEUE` leads to the expected result:

![image](https://github.com/amplication/amplication/assets/109321774/e1964c5c-7fd1-4d9d-bbca-2a27f782dd0b)
![image](https://github.com/amplication/amplication/assets/109321774/eb14816a-30fe-4856-b31f-b11de54a7e25)

