### PR TITLE
chore: update auto-generated models and schema.graphql

### DIFF
--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -961,7 +961,7 @@ export type Mutation = {
   updateEntityPermission: EntityPermission;
   updateEntityPermissionFieldRoles: EntityPermissionField;
   updateEntityPermissionRoles: EntityPermission;
-  updateGitRepository: Resource;
+  updateGitRepository: GitRepository;
   updatePluginInstallation: PluginInstallation;
   updateProject: Project;
   updateProjectConfigurationSettings?: Maybe<ProjectConfigurationSettings>;

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -964,7 +964,7 @@ export type Mutation = {
   updateEntityPermission: EntityPermission;
   updateEntityPermissionFieldRoles: EntityPermissionField;
   updateEntityPermissionRoles: EntityPermission;
-  updateGitRepository: Resource;
+  updateGitRepository: GitRepository;
   updatePluginInstallation: PluginInstallation;
   updateProject: Project;
   updateProjectConfigurationSettings?: Maybe<ProjectConfigurationSettings>;

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -961,7 +961,7 @@ export type Mutation = {
   updateEntityPermission: EntityPermission;
   updateEntityPermissionFieldRoles: EntityPermissionField;
   updateEntityPermissionRoles: EntityPermission;
-  updateGitRepository: Resource;
+  updateGitRepository: GitRepository;
   updatePluginInstallation: PluginInstallation;
   updateProject: Project;
   updateProjectConfigurationSettings?: Maybe<ProjectConfigurationSettings>;

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -961,7 +961,7 @@ export type Mutation = {
   updateEntityPermission: EntityPermission;
   updateEntityPermissionFieldRoles: EntityPermissionField;
   updateEntityPermissionRoles: EntityPermission;
-  updateGitRepository: Resource;
+  updateGitRepository: GitRepository;
   updatePluginInstallation: PluginInstallation;
   updateProject: Project;
   updateProjectConfigurationSettings?: Maybe<ProjectConfigurationSettings>;

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -931,7 +931,7 @@ type Mutation {
   updateEntityPermission(data: EntityUpdatePermissionInput!, where: WhereUniqueInput!): EntityPermission!
   updateEntityPermissionFieldRoles(data: EntityUpdatePermissionFieldRolesInput!): EntityPermissionField!
   updateEntityPermissionRoles(data: EntityUpdatePermissionRolesInput!): EntityPermission!
-  updateGitRepository(data: GitRepositoryUpdateInput!, where: WhereUniqueInput!): Resource!
+  updateGitRepository(data: GitRepositoryUpdateInput!, where: WhereUniqueInput!): GitRepository!
   updatePluginInstallation(data: PluginInstallationUpdateInput!, where: WhereUniqueInput!): PluginInstallation!
   updateProject(data: ProjectUpdateInput!, where: WhereUniqueInput!): Project!
   updateProjectConfigurationSettings(data: ProjectConfigurationSettingsUpdateInput!, where: WhereUniqueInput!): ProjectConfigurationSettings

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -961,7 +961,7 @@ export type Mutation = {
   updateEntityPermission: EntityPermission;
   updateEntityPermissionFieldRoles: EntityPermissionField;
   updateEntityPermissionRoles: EntityPermission;
-  updateGitRepository: Resource;
+  updateGitRepository: GitRepository;
   updatePluginInstallation: PluginInstallation;
   updateProject: Project;
   updateProjectConfigurationSettings?: Maybe<ProjectConfigurationSettings>;


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Related to: #https://github.com/amplication/amplication/issues/6195
Related to changes in [this commit](https://github.com/amplication/amplication/pull/6522/commits/54d17514f142cf5c994b25046bc3aa5865757ffb#diff-b9ccc53c48e521fb7c98b07ad7f4761ba0ea91eb649e157d159b065ac2487c1d)

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4aed326</samp>

### Summary
🔄🛠️📦

<!--
1.  🔄 - This emoji represents the change of the type of the `updateGitRepository` field from `Resource` to `GitRepository` in the `Mutation` type, which is a refactoring that updates the schema and the models to be more consistent and specific.
2.  🛠️ - This emoji represents the change of the type of the `updateGitRepository` field in the `Mutation` type in the GraphQL schema, which is a fix that aligns the schema with the updated type definition and the expected input and output of the mutation.
3.  📦 - This emoji represents the change of the type of the `updateGitRepository` field in the `Mutation` type in the different packages that use the same models as the `amplication-cli` package, which is a maintenance that updates the dependencies and the code generation to be compatible with the updated schema and models.
-->
Changed the type of the `updateGitRepository` field in the `Mutation` type from `Resource` to `GitRepository` in several packages that share the same models. This change aligns the type definition with the schema and the specific logic of the mutation.

> _`Mutation` type changed_
> _`Resource` to `GitRepository`_
> _A schema update_

### Walkthrough
*  Change the type of the `updateGitRepository` field in the `Mutation` type from `Resource` to `GitRepository` to match the updated schema and the specific type of the git repository resource ([link](https://github.com/amplication/amplication/pull/6542/files?diff=unified&w=0#diff-8e34f7703a0b39fa5e612bb39ad750167d90a6b75df578f54f35a9348dd0a509L964-R964), [link](https://github.com/amplication/amplication/pull/6542/files?diff=unified&w=0#diff-b9ccc53c48e521fb7c98b07ad7f4761ba0ea91eb649e157d159b065ac2487c1dL967-R967), [link](https://github.com/amplication/amplication/pull/6542/files?diff=unified&w=0#diff-3860f234d2c5629bf7aeb4e7439fe3b357be4e00c08a9f008b56d3610bb017c0L964-R964), [link](https://github.com/amplication/amplication/pull/6542/files?diff=unified&w=0#diff-6137baa91c68c17d5e3716428198a16a3cb5cdd263e22998503daa29c86a296eL964-R964), [link](https://github.com/amplication/amplication/pull/6542/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75L934-R934), [link](https://github.com/amplication/amplication/pull/6542/files?diff=unified&w=0#diff-a54fca1e77b31822272d37bef66289ad466ba9d835ac76a5474a6808d4bcaaabL964-R964))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
