### PR TITLE
Fix/complete user action log event

### DIFF
--- a/libs/schema-registry/src/lib/user-action-log/value.ts
+++ b/libs/schema-registry/src/lib/user-action-log/value.ts
@@ -1,5 +1,6 @@
+import { EnumActionStepStatus } from "@amplication/code-gen-types/models";
 import { LogEntry } from "@amplication/util/logging";
-import { IsString } from "class-validator";
+import { IsBoolean, IsEnum, IsString } from "class-validator";
 
 export class Value implements LogEntry {
   @IsString()
@@ -10,6 +11,12 @@ export class Value implements LogEntry {
 
   @IsString()
   message!: string;
+
+  @IsEnum(EnumActionStepStatus)
+  status!: EnumActionStepStatus;
+
+  @IsBoolean()
+  isCompleted!: boolean;
 
   [key: string]: any;
 }

--- a/packages/amplication-server/src/core/action/action.service.spec.ts
+++ b/packages/amplication-server/src/core/action/action.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { ActionService, SELECT_ID } from "./action.service";
+import { ACTION_LOG_LEVEL, ActionService, SELECT_ID } from "./action.service";
 import { PrismaService } from "../../prisma/prisma.service";
 import { Action } from "./dto/Action";
 import { ActionStep } from "./dto/ActionStep";
@@ -8,6 +8,7 @@ import { FindOneActionArgs } from "./dto/FindOneActionArgs";
 import { EnumActionLogLevel } from "./dto";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
 import { KafkaProducerService } from "@amplication/util/nestjs/kafka";
+import { UserActionLog } from "@amplication/schema-registry";
 
 const EXAMPLE_ACTION_ID = "exampleActionId";
 const EXAMPLE_ACTION_STEP_ID = "exampleActionStepId";
@@ -40,6 +41,12 @@ const prismaActionLogCreateMock = jest.fn();
 describe("ActionService", () => {
   let service: ActionService;
 
+  const mockServiceEmitMessage = jest
+    .fn()
+    .mockImplementation((topic: string, message: UserActionLog.KafkaEvent) =>
+      Promise.resolve()
+    );
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -65,7 +72,7 @@ describe("ActionService", () => {
         {
           provide: KafkaProducerService,
           useClass: jest.fn(() => ({
-            emitMessage: jest.fn(),
+            emitMessage: mockServiceEmitMessage,
           })),
         },
         {
@@ -252,6 +259,212 @@ describe("ActionService", () => {
         },
       },
       select: SELECT_ID,
+    });
+  });
+
+  describe("onUserActionLog", () => {
+    it("should log the action and update action step status if completed", async () => {
+      const logByStepIdSpy = jest
+        .spyOn(service, "logByStepId")
+        .mockImplementation();
+      const updateActionStepStatusSpy = jest
+        .spyOn(service, "updateActionStepStatus")
+        .mockImplementation();
+
+      const mockLogEntry: UserActionLog.Value = {
+        stepId: "test-step",
+        message: "Test message",
+        level: "Info",
+        status: EnumActionStepStatus.Success,
+        isCompleted: true,
+      };
+
+      await service.onUserActionLog(mockLogEntry);
+
+      expect(logByStepIdSpy).toHaveBeenCalledWith(
+        mockLogEntry.stepId,
+        ACTION_LOG_LEVEL[mockLogEntry.level.toLowerCase()],
+        mockLogEntry.message
+      );
+
+      expect(updateActionStepStatusSpy).toHaveBeenCalledWith(
+        mockLogEntry.stepId,
+        mockLogEntry.status
+      );
+
+      // restore mocks (spyOn) to avoid test pollution
+      logByStepIdSpy.mockRestore();
+      updateActionStepStatusSpy.mockRestore();
+    });
+
+    it("should log the action and not update action step status if not completed", async () => {
+      const logByStepIdSpy = jest
+        .spyOn(service, "logByStepId")
+        .mockImplementation();
+      const updateActionStepStatusSpy = jest
+        .spyOn(service, "updateActionStepStatus")
+        .mockImplementation();
+
+      const mockLogEntry: UserActionLog.Value = {
+        stepId: "test-step",
+        message: "Test message",
+        level: "Info",
+        status: EnumActionStepStatus.Running,
+        isCompleted: false,
+      };
+
+      await service.onUserActionLog(mockLogEntry);
+
+      expect(logByStepIdSpy).toHaveBeenCalledWith(
+        mockLogEntry.stepId,
+        ACTION_LOG_LEVEL[mockLogEntry.level.toLowerCase()],
+        mockLogEntry.message
+      );
+
+      expect(updateActionStepStatusSpy).not.toHaveBeenCalled();
+
+      // restore mocks (spyOn) to avoid test pollution
+      logByStepIdSpy.mockRestore();
+      updateActionStepStatusSpy.mockRestore();
+    });
+
+    it("should log to the database before updating the action step status", async () => {
+      const logEntry: UserActionLog.Value = {
+        stepId: "test-step-id",
+        message: "test-message",
+        level: "Info",
+        status: EnumActionStepStatus.Success,
+        isCompleted: true,
+      };
+
+      const logByStepIdSpy = jest
+        .spyOn(service, "logByStepId")
+        .mockImplementation(() => Promise.resolve());
+
+      const updateActionStepStatusSpy = jest
+        .spyOn(service, "updateActionStepStatus")
+        .mockImplementation(() => Promise.resolve());
+
+      await service.onUserActionLog(logEntry);
+
+      // get call order and ensure both functions are called in the same order of their invocation
+      const logByStepIdCallOrder = logByStepIdSpy.mock.invocationCallOrder[0];
+      const updateActionStepStatusCallOrder =
+        updateActionStepStatusSpy.mock.invocationCallOrder[0];
+
+      // compare call order
+      expect(logByStepIdCallOrder).toBeLessThan(
+        updateActionStepStatusCallOrder
+      );
+
+      // restore mocks (spyOn) to avoid test pollution
+      logByStepIdSpy.mockRestore();
+      updateActionStepStatusSpy.mockRestore();
+    });
+  });
+
+  describe("Action Context functions", () => {
+    let step: ActionStep;
+    let userActionId: string;
+    let topicName: string;
+    let actionContext;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      step = {
+        id: "1",
+        name: "some-step-name",
+        message: "some-message",
+        status: EnumActionStepStatus.Success,
+        createdAt: new Date(),
+      };
+      userActionId = "user-action-id";
+      topicName = "topic-name"; // Replace with the actual topic name you're working with
+      actionContext = service.createActionContext(
+        userActionId,
+        step,
+        topicName
+      );
+    });
+
+    it("onEmitUserActionLog should call emitUserActionLog", async () => {
+      const message = "Test message";
+      const level = EnumActionLogLevel.Info;
+      const status = EnumActionStepStatus.Running;
+      const isStepCompleted = false;
+
+      const expectedKafkaMessage: UserActionLog.KafkaEvent =
+        service.createKafkaMessageForUserActionLog(userActionId, step.id)(
+          message,
+          level,
+          status,
+          isStepCompleted
+        );
+
+      await actionContext.onEmitUserActionLog(
+        message,
+        level,
+        status,
+        isStepCompleted
+      );
+
+      expect(mockServiceEmitMessage).toHaveBeenCalledWith(
+        topicName,
+        expectedKafkaMessage
+      );
+    });
+
+    it("onCompleteWithLog should call emitUserActionLog and updateActionStepStatus", async () => {
+      const message = "Test message";
+      const level = EnumActionLogLevel.Info;
+      const status = EnumActionStepStatus.Success;
+      const isStepCompleted = true;
+
+      const emitUserActionLogSpy = jest.spyOn(service, "emitUserActionLog");
+      const updateActionStepStatusSpy = jest.spyOn(
+        service,
+        "updateActionStepStatus"
+      );
+
+      await actionContext.onCompleteWithLog(
+        message,
+        level,
+        status,
+        isStepCompleted
+      );
+
+      expect(emitUserActionLogSpy).toHaveBeenCalledTimes(1);
+      expect(updateActionStepStatusSpy).toHaveBeenCalledWith(step.id, status);
+    });
+
+    it("createKafkaMessageForUserActionLog should return a Kafka message", () => {
+      const userActionId = "user-action-id";
+      const stepId = "step-id";
+      const message = "test message";
+      const level = EnumActionLogLevel.Info;
+      const status = EnumActionStepStatus.Running;
+      const isStepCompleted = false;
+
+      const kafkaMessage: UserActionLog.KafkaEvent = {
+        key: {
+          userActionId,
+        },
+        value: {
+          stepId,
+          message,
+          level,
+          status,
+          isCompleted: isStepCompleted,
+        },
+      };
+
+      const result = service.createKafkaMessageForUserActionLog(
+        userActionId,
+        stepId
+      )(message, level, status, isStepCompleted);
+
+      expect(result).toEqual(kafkaMessage);
     });
   });
 });

--- a/packages/amplication-server/src/core/action/action.service.spec.ts
+++ b/packages/amplication-server/src/core/action/action.service.spec.ts
@@ -415,29 +415,6 @@ describe("ActionService", () => {
       );
     });
 
-    it("onCompleteWithLog should call emitUserActionLog and updateActionStepStatus", async () => {
-      const message = "Test message";
-      const level = EnumActionLogLevel.Info;
-      const status = EnumActionStepStatus.Success;
-      const isStepCompleted = true;
-
-      const emitUserActionLogSpy = jest.spyOn(service, "emitUserActionLog");
-      const updateActionStepStatusSpy = jest.spyOn(
-        service,
-        "updateActionStepStatus"
-      );
-
-      await actionContext.onCompleteWithLog(
-        message,
-        level,
-        status,
-        isStepCompleted
-      );
-
-      expect(emitUserActionLogSpy).toHaveBeenCalledTimes(1);
-      expect(updateActionStepStatusSpy).toHaveBeenCalledWith(step.id, status);
-    });
-
     it("createKafkaMessageForUserActionLog should return a Kafka message", () => {
       const userActionId = "user-action-id";
       const stepId = "step-id";

--- a/packages/amplication-server/src/core/action/action.service.ts
+++ b/packages/amplication-server/src/core/action/action.service.ts
@@ -116,7 +116,7 @@ export class ActionService {
       level: EnumActionLogLevel,
       status: EnumActionStepStatus.Success | EnumActionStepStatus.Failed,
       isStepCompleted: boolean
-    ) => {
+    ): Promise<void> => {
       const kafkaMessage: UserActionLog.KafkaEvent = {
         key: {
           userActionId,
@@ -215,7 +215,7 @@ export class ActionService {
   }
 
   /**
-   * Creates an ActionContext for emitLogByStepId and complete functions.
+   * Creates an ActionContext for emitLogByStepId and completeWithLog functions.
    * These functions are invoked as Promises and potential errors are immediately caught and logged.
    * The onEmitLogByStepId can be invoked synchronously.
    * This provides a means to fire-and-forget these actions without the need to await their completion.

--- a/packages/amplication-server/src/core/action/action.service.ts
+++ b/packages/amplication-server/src/core/action/action.service.ts
@@ -12,7 +12,6 @@ import { StepNameEmptyError } from "./errors/StepNameEmptyError";
 import { EnumActionStepStatus } from "./dto/EnumActionStepStatus";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
 import { KafkaProducerService } from "@amplication/util/nestjs/kafka";
-import { DecodedKafkaMessage } from "@amplication/util/kafka";
 import { ActionContext } from "../userAction/types";
 import { UserActionLog } from "@amplication/schema-registry";
 
@@ -181,7 +180,7 @@ export class ActionService {
   }
 
   emitUserActionLog(
-    kafkaMessage: DecodedKafkaMessage,
+    kafkaMessage: UserActionLog.KafkaEvent,
     topicName: string
   ): Promise<void> {
     return this.kafkaProducerService.emitMessage(topicName, kafkaMessage);

--- a/packages/amplication-server/src/core/action/action.service.ts
+++ b/packages/amplication-server/src/core/action/action.service.ts
@@ -110,31 +110,6 @@ export class ActionService {
     });
   }
 
-  completeWithLog(step: ActionStep, userActionId: string, topicName: string) {
-    return async (
-      message: string,
-      level: EnumActionLogLevel,
-      status: EnumActionStepStatus.Success | EnumActionStepStatus.Failed,
-      isStepCompleted: boolean
-    ): Promise<void> => {
-      const kafkaMessage: UserActionLog.KafkaEvent = {
-        key: {
-          userActionId,
-        },
-        value: {
-          stepId: step.id,
-          level,
-          message,
-          status,
-          isCompleted: isStepCompleted,
-        },
-      };
-
-      await this.emitUserActionLog(kafkaMessage, topicName);
-      await this.updateActionStepStatus(step.id, status);
-    };
-  }
-
   async updateActionStepStatus(
     actionStepId: string,
     status: EnumActionStepStatus
@@ -267,26 +242,8 @@ export class ActionService {
       );
     };
 
-    const onCompleteWithLog = async (
-      message: string,
-      level: EnumActionLogLevel,
-      status: EnumActionStepStatus.Success | EnumActionStepStatus.Failed,
-      isStepCompleted = true
-    ) =>
-      this.completeWithLog(step, userActionId, topicName)(
-        message,
-        level,
-        status,
-        isStepCompleted
-      ).catch((error) =>
-        this.logger.error(`Failed to complete action step ${step.id}`, error, {
-          stepId: step.id,
-        })
-      );
-
     return {
       onEmitUserActionLog,
-      onCompleteWithLog,
     };
   }
 

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -376,7 +376,7 @@ export class EntityService {
     resourceId: string,
     user: User
   ): Promise<Entity[]> {
-    const { onEmitUserActionLog, onComplete } = actionContext;
+    const { onEmitUserActionLog } = actionContext;
 
     const resourceWithProject = await this.prisma.resource.findUnique({
       where: {
@@ -458,17 +458,10 @@ export class EntityService {
 
         void onEmitUserActionLog(
           `Import operation aborted due to errors. See the log for more details.`,
-          EnumActionLogLevel.Error
+          EnumActionLogLevel.Error,
+          EnumActionStepStatus.Failed,
+          true
         );
-        this.logger.debug("before onComplete", {
-          status: EnumActionStepStatus.Failed,
-        });
-
-        await onComplete(EnumActionStepStatus.Failed);
-
-        this.logger.debug("after onComplete", {
-          status: EnumActionStepStatus.Failed,
-        });
 
         return [];
       } else {
@@ -488,18 +481,10 @@ export class EntityService {
 
         void onEmitUserActionLog(
           `Import operation completed successfully.`,
-          EnumActionLogLevel.Info
+          EnumActionLogLevel.Info,
+          EnumActionStepStatus.Success,
+          true
         );
-
-        this.logger.debug("before onComplete", {
-          status: EnumActionStepStatus.Success,
-        });
-
-        await onComplete(EnumActionStepStatus.Success);
-
-        this.logger.debug("after onComplete", {
-          status: EnumActionStepStatus.Success,
-        });
 
         await this.analytics.track({
           userId: user.account.id,
@@ -537,16 +522,12 @@ export class EntityService {
         functionName: "createEntitiesFromPrismaSchema",
       });
 
-      void onEmitUserActionLog(error.message, EnumActionLogLevel.Error);
-      this.logger.debug("before onComplete", {
-        status: EnumActionStepStatus.Failed,
-      });
-
-      await onComplete(EnumActionStepStatus.Failed);
-
-      this.logger.debug("after onComplete", {
-        status: EnumActionStepStatus.Failed,
-      });
+      void onEmitUserActionLog(
+        error.message,
+        EnumActionLogLevel.Error,
+        EnumActionStepStatus.Failed,
+        true
+      );
 
       return [];
     }

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -27,7 +27,7 @@ describe("prismaSchemaParser", () => {
 
     actionContext = {
       onEmitUserActionLog: jest.fn(),
-      onComplete: jest.fn(),
+      onCompleteWithLog: jest.fn(),
     };
   });
 

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -27,7 +27,6 @@ describe("prismaSchemaParser", () => {
 
     actionContext = {
       onEmitUserActionLog: jest.fn(),
-      onCompleteWithLog: jest.fn(),
     };
   });
 

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.spec.ts
@@ -367,7 +367,7 @@ describe("schema-utils", () => {
     beforeEach(() => {
       actionContext = {
         onEmitUserActionLog: jest.fn(),
-        onComplete: jest.fn(),
+        onCompleteWithLog: jest.fn(),
       };
     });
 

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.spec.ts
@@ -367,7 +367,6 @@ describe("schema-utils", () => {
     beforeEach(() => {
       actionContext = {
         onEmitUserActionLog: jest.fn(),
-        onCompleteWithLog: jest.fn(),
       };
     });
 

--- a/packages/amplication-server/src/core/userAction/types.ts
+++ b/packages/amplication-server/src/core/userAction/types.ts
@@ -27,10 +27,4 @@ export type ActionContext = {
     status?: EnumActionStepStatus,
     isStepCompleted?: boolean
   ) => Promise<void>;
-  onCompleteWithLog: (
-    message: string,
-    level: EnumActionLogLevel,
-    status: EnumActionStepStatus.Success | EnumActionStepStatus.Failed,
-    isStepCompleted: boolean
-  ) => Promise<void>;
 };

--- a/packages/amplication-server/src/core/userAction/types.ts
+++ b/packages/amplication-server/src/core/userAction/types.ts
@@ -23,9 +23,14 @@ registerEnumType(EnumUserActionStatus, {
 export type ActionContext = {
   onEmitUserActionLog: (
     message: string,
-    level: EnumActionLogLevel
+    level: EnumActionLogLevel,
+    status?: EnumActionStepStatus,
+    isStepCompleted?: boolean
   ) => Promise<void>;
-  onComplete: (
-    status: EnumActionStepStatus.Success | EnumActionStepStatus.Failed
+  onCompleteWithLog: (
+    message: string,
+    level: EnumActionLogLevel,
+    status: EnumActionStepStatus.Success | EnumActionStepStatus.Failed,
+    isStepCompleted: boolean
   ) => Promise<void>;
 };


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

part of: #6541

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 298d189</samp>

### Summary
🔄📝🚀

<!--
1.  🔄 - This emoji represents the refactoring of the existing methods in the `ActionService` class to use a new type and pass additional parameters for status and completion. It also implies the improvement of the consistency and reliability of the user action logging and action step tracking.
2.  📝 - This emoji represents the addition of the `onCompleteWithLog` function to the `ActionContext` type and the `emitUserActionLogAndUpdateStepStatus` method to the `ActionService` class, which allow emitting user action logs and updating action step statuses in a single function. It also implies the simplification of the logging logic of the `importEntities` method by using only the `onEmitUserActionLog` function from the action context.
3.  🚀 - This emoji represents the enhancement of the `ActionContext` type by adding the `status` and `isStepCompleted` parameters to the `onEmitUserActionLog` function, which allow tracking the progress of the action steps more accurately and efficiently. It also implies the addition of the status and isCompleted fields to the `Value` class to store the action step progress.
-->
This pull request enhances the user action logging and action step tracking features by adding new fields, types, and methods to the schema-registry and amplication-server packages. It also simplifies and refactors some existing logic to use the new functionality and improve performance and readability. The main files affected are `value.ts`, `action.service.ts`, `entity.service.ts`, and `types.ts`.

> _`ActionContext` is changing, no more `onComplete`_
> _We need to track the status and the log of each action_
> _`ActionService` is refactored, a new method is born_
> _To emit the user action log and update the action step_

### Walkthrough
*  Add `status` and `isCompleted` properties to the `Value` class in `libs/schema-registry/src/lib/user-action-log/value.ts` to indicate the status and completion state of an action step, and decorate them with the appropriate validators ([link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-fe90d81125d7183924f49244c9548120432196af1faf1bf755abf56bc992c232L1-R3), [link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-fe90d81125d7183924f49244c9548120432196af1faf1bf755abf56bc992c232R15-R20))
*  Replace the `DecodedKafkaMessage` type with the `UserActionLog.KafkaEvent` type in the `ActionService` class in `packages/amplication-server/src/core/action/action.service.ts` to use a more specific type for the kafka messages related to user action logs ([link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-98a64e75d3e418ee905c9980f6f29df46345301e11d6b722ebb44110073f1852L15), [link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-98a64e75d3e418ee905c9980f6f29df46345301e11d6b722ebb44110073f1852L184-R211))
*  Add the `completeWithLog` method to the `ActionService` class in `packages/amplication-server/src/core/action/action.service.ts` to emit a user action log event to a kafka topic and update the action step status in the database ([link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-98a64e75d3e418ee905c9980f6f29df46345301e11d6b722ebb44110073f1852R113-R137))
*  Modify the `onUserActionLog` method in the `ActionService` class in `packages/amplication-server/src/core/action/action.service.ts` to destructure the `status` and `isCompleted` properties from the log entry parameter, and to conditionally update the action step status in the database if the `isCompleted` property is true ([link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-98a64e75d3e418ee905c9980f6f29df46345301e11d6b722ebb44110073f1852L154-R179), [link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-98a64e75d3e418ee905c9980f6f29df46345301e11d6b722ebb44110073f1852L161-R188))
*  Modify the `createActionContext` method of the `ActionService` class in `packages/amplication-server/src/core/action/action.service.ts` to accept two additional parameters in the `onEmitUserActionLog` function: `status` and `isStepCompleted`, which are optional and default to `EnumActionStepStatus.Running` and `false`, respectively, and to pass them to the partially applied `onCreateKafkaMessageForUserActionLog` function ([link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-98a64e75d3e418ee905c9980f6f29df46345301e11d6b722ebb44110073f1852L205-R248), [link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-98a64e75d3e418ee905c9980f6f29df46345301e11d6b722ebb44110073f1852L221-R259))
*  Replace the `onComplete` function with the `onCompleteWithLog` function in the `createActionContext` method of the `ActionService` class in `packages/amplication-server/src/core/action/action.service.ts`, which accepts a message, a level, a status, and a completion flag, and calls the `completeWithLog` method of the `ActionService` class, and return the `onCompleteWithLog` function instead of the `onComplete` function ([link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-98a64e75d3e418ee905c9980f6f29df46345301e11d6b722ebb44110073f1852L232-R281), [link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-98a64e75d3e418ee905c9980f6f29df46345301e11d6b722ebb44110073f1852L243-R289))
*  Modify the `createKafkaMessageForUserActionLog` method of the `ActionService` class in `packages/amplication-server/src/core/action/action.service.ts` to accept two additional parameters: `status` and `isStepCompleted`, which are required and indicate the status and completion state of an action step, and to include them in the value of the kafka message ([link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-98a64e75d3e418ee905c9980f6f29df46345301e11d6b722ebb44110073f1852L250-R298), [link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-98a64e75d3e418ee905c9980f6f29df46345301e11d6b722ebb44110073f1852R307-R308))
*  Modify the `importEntities` method of the `EntityService` class in `packages/amplication-server/src/core/entity/entity.service.ts` to destructure only the `onEmitUserActionLog` function from the action context parameter, as the `onComplete` function was no longer used, and to call the `onEmitUserActionLog` function with the appropriate `status` and `isStepCompleted` parameters, and to remove the redundant calls to the `onComplete` function and the logger debug statements ([link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L379-R379), [link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L461-R465), [link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L491-R488), [link](https://github.com/amplication/amplication/pull/6552/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L540-R531))



## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
