### PR TITLE
Feat/kafka pace maker

### DIFF
--- a/libs/util/nestjs/kafka/src/Kafka.module.ts
+++ b/libs/util/nestjs/kafka/src/Kafka.module.ts
@@ -8,7 +8,7 @@ import {
   createNestjsKafkaConfig,
   KAFKA_CLIENT,
 } from "./createNestjsKafkaConfig";
-import { KafkaProducerService } from "./producer/KafkaProducer.service";
+import { KafkaProducerService } from "./producer";
 
 @Module({
   imports: [

--- a/libs/util/nestjs/kafka/src/index.ts
+++ b/libs/util/nestjs/kafka/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./createNestjsKafkaConfig";
 export * from "./Kafka.module";
 export * from "./producer/";
+export * from "./pacemaker/";

--- a/libs/util/nestjs/kafka/src/pacemaker/index.ts
+++ b/libs/util/nestjs/kafka/src/pacemaker/index.ts
@@ -1,0 +1,1 @@
+export { KafkaPacemaker } from "./pacemaker.service";

--- a/libs/util/nestjs/kafka/src/pacemaker/pacemaker.service.ts
+++ b/libs/util/nestjs/kafka/src/pacemaker/pacemaker.service.ts
@@ -1,0 +1,33 @@
+import { KafkaContext } from "@nestjs/microservices";
+import { promisify } from "util";
+
+export class KafkaPacemaker {
+  static async wrapLongRunningMethod<T>(
+    kafkaContext: KafkaContext,
+    fn: () => Promise<T>,
+    timeout = 3000
+  ) {
+    const heartbeat = kafkaContext.getHeartbeat();
+    const sleep = promisify(setTimeout);
+    let isFnDone = false;
+
+    const wrappedFn = async () => {
+      const result = await fn();
+      isFnDone = true;
+      return result;
+    };
+
+    const fnPromise = wrappedFn();
+
+    while (!isFnDone) {
+      await Promise.race([fnPromise, sleep(timeout)]);
+      try {
+        await heartbeat();
+      } catch (error) {
+        // swallow the error as we don't want to fail the fn() because of a heartbeat failure
+      }
+    }
+
+    return await fnPromise;
+  }
+}

--- a/libs/util/nestjs/kafka/src/pacemaker/pacemaker.service.ts
+++ b/libs/util/nestjs/kafka/src/pacemaker/pacemaker.service.ts
@@ -4,7 +4,7 @@ import { promisify } from "util";
 export class KafkaPacemaker {
   static async wrapLongRunningMethod<T>(
     kafkaContext: KafkaContext,
-    fn: () => Promise<T>,
+    fn: (...args: unknown[]) => Promise<T>,
     timeout = 3000
   ) {
     const heartbeat = kafkaContext.getHeartbeat();

--- a/libs/util/nestjs/kafka/src/pacemaker/pacemaker.service.ts
+++ b/libs/util/nestjs/kafka/src/pacemaker/pacemaker.service.ts
@@ -4,7 +4,7 @@ import { promisify } from "util";
 export class KafkaPacemaker {
   static async wrapLongRunningMethod<T>(
     kafkaContext: KafkaContext,
-    fn: (...args: unknown[]) => Promise<T>,
+    fn: () => Promise<T>,
     timeout = 3000
   ) {
     const heartbeat = kafkaContext.getHeartbeat();

--- a/libs/util/nestjs/kafka/src/pacemaker/pacemaker.spec.ts
+++ b/libs/util/nestjs/kafka/src/pacemaker/pacemaker.spec.ts
@@ -1,0 +1,101 @@
+import { KafkaPacemaker } from "./pacemaker.service";
+
+describe("KafkaPacemaker", () => {
+  it("should wrap a long running method with heartbeat and return the result of the method", async () => {
+    const mockedHeartbeat = jest.fn();
+    const kafkaContext = {
+      getHeartbeat: jest.fn().mockReturnValue(mockedHeartbeat),
+    };
+
+    const expectedHeartbeatCalls = 10;
+    const timeout = 100;
+    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    const fn = jest.fn().mockImplementation(async () => {
+      await sleep(timeout * expectedHeartbeatCalls + 1);
+      return "Test Complete";
+    });
+
+    const result = await KafkaPacemaker.wrapLongRunningMethod(
+      kafkaContext as any,
+      fn,
+      timeout
+    );
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(result).toBe("Test Complete");
+    expect(mockedHeartbeat).toHaveBeenCalledTimes(expectedHeartbeatCalls);
+  });
+
+  it("should throw the fn() exception when the fn() fails", async () => {
+    const mockedHeartbeat = jest.fn();
+    const kafkaContext = {
+      getHeartbeat: jest.fn().mockReturnValue(mockedHeartbeat),
+    };
+
+    const timeout = 100;
+
+    const expectedError = new Error("Invalid data");
+    const fn = jest.fn().mockRejectedValue(expectedError);
+
+    await expect(
+      KafkaPacemaker.wrapLongRunningMethod(kafkaContext as any, fn, timeout)
+    ).rejects.toThrow(expectedError);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  describe("when the heartbeat fails", () => {
+    const mockedHeartbeat = jest
+      .fn()
+      .mockRejectedValue(new Error("Failed to connect to Kafka"));
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should wrap a long running method with heartbeat and return the result of the method", async () => {
+      const kafkaContext = {
+        getHeartbeat: jest.fn().mockReturnValue(mockedHeartbeat),
+      };
+
+      const expectedHeartbeatCalls = 10;
+      const timeout = 100;
+      const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+      const fn = jest.fn().mockImplementation(async () => {
+        await sleep(timeout * expectedHeartbeatCalls + 1);
+        return "Test Complete";
+      });
+
+      const result = await KafkaPacemaker.wrapLongRunningMethod(
+        kafkaContext as any,
+        fn,
+        timeout
+      );
+
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(result).toBe("Test Complete");
+      expect(mockedHeartbeat).toHaveBeenCalledTimes(expectedHeartbeatCalls);
+    });
+
+    it("should throw the fn() exception when the fn() fails", async () => {
+      const kafkaContext = {
+        getHeartbeat: jest.fn().mockReturnValue(mockedHeartbeat),
+      };
+
+      const timeout = 100;
+
+      const expectedError = new Error("Invalid data");
+      const fn = jest.fn().mockRejectedValue(expectedError);
+
+      await expect(
+        KafkaPacemaker.wrapLongRunningMethod(kafkaContext as any, fn, timeout)
+      ).rejects.toThrow(expectedError);
+
+      expect(mockedHeartbeat).toHaveBeenCalledTimes(0);
+
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/amplication-git-pull-request-service/src/pull-request/pull-request.controller.ts
+++ b/packages/amplication-git-pull-request-service/src/pull-request/pull-request.controller.ts
@@ -12,7 +12,10 @@ import { validateOrReject } from "class-validator";
 import { Env } from "../env";
 import { PullRequestService } from "./pull-request.service";
 import { KafkaTopics } from "./pull-request.type";
-import { KafkaProducerService } from "@amplication/util/nestjs/kafka";
+import {
+  KafkaProducerService,
+  KafkaPacemaker,
+} from "@amplication/util/nestjs/kafka";
 import {
   CreatePrFailure,
   CreatePrRequest,
@@ -58,8 +61,9 @@ export class PullRequestController {
     });
 
     try {
-      const pullRequest = await this.pullRequestService.createPullRequest(
-        validArgs
+      const pullRequest = await KafkaPacemaker.wrapLongRunningMethod<string>(
+        context,
+        () => this.pullRequestService.createPullRequest(validArgs)
       );
 
       logger.info(`Finish process, committing`, {


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6565

## PR Details

- Wrapping the pull request with the kafkapacemaker
<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4bcfb8a</samp>

### Summary
📦🧹💓

<!--
1.  📦 - This emoji represents the export of the `pacemaker` folder and the `KafkaPacemaker` class, which can be seen as packaging them for other modules to use.
2.  🧹 - This emoji represents the simplification of the import path of `KafkaProducerService`, which can be seen as cleaning up the code and removing unnecessary clutter.
3.  💓 - This emoji represents the heartbeat mechanism that `KafkaPacemaker` provides, which can be seen as keeping the Kafka consumer alive and healthy.
-->
Added a `KafkaPacemaker` utility class to the `@amplication/util/nestjs/kafka` module and used it in the pull request controller to prevent Kafka consumer timeouts. Simplified some import paths and exported the `pacemaker` folder.

> _Sing, O Muse, of the skillful Amplication team_
> _Who crafted a pacemaker for the swift-winged Kafka_
> _To keep alive the messages of gods and men_
> _And ease the task of pull request creation._

### Walkthrough
* Export `pacemaker` folder from `@amplication/util/nestjs/kafka` module to enable Kafka heartbeat functionality for other modules ([link](https://github.com/amplication/amplication/pull/6566/files?diff=unified&w=0#diff-e6c583e815c92c135a8b593f2576109ecd446621700eb77ce2119ef9d21fd078R4), [link](https://github.com/amplication/amplication/pull/6566/files?diff=unified&w=0#diff-6f62ab7e1cfb6b6935e03b78647a881b8dc9469b91dff18cfab187c581465a52R1))
* Implement and export `KafkaPacemaker` class in `pacemaker.service.ts` to provide a utility method that wraps a long running method with periodic Kafka heartbeats ([link](https://github.com/amplication/amplication/pull/6566/files?diff=unified&w=0#diff-d8819905a8873304e52006d57fa1ae4b697191b7c1dcfa21a66496a1132c7bb2R1-R33))
* Test `KafkaPacemaker` class in `pacemaker.spec.ts` with different scenarios to ensure its functionality and behavior ([link](https://github.com/amplication/amplication/pull/6566/files?diff=unified&w=0#diff-2db746cb74590dfb65ac5307b4e3c8d868789477b1254970734cc41fdef3044cR1-R101))
* Simplify import path of `KafkaProducerService` in `Kafka.module.ts` by removing redundant file name ([link](https://github.com/amplication/amplication/pull/6566/files?diff=unified&w=0#diff-f52b27468655a6835511179e1afe1c44c8dcb9795df3af09b1a4aaf3a32b86a4L11-R11))
* Import and use `KafkaPacemaker` class in `PullRequestController` to wrap `createPullRequest` method of `PullRequestService` with Kafka heartbeats in the Kafka consumer handler ([link](https://github.com/amplication/amplication/pull/6566/files?diff=unified&w=0#diff-4b07a52bc7104d1e0e87f740342a822e1dbc605919ba3f96e702f4895eb09210L15-R19), [link](https://github.com/amplication/amplication/pull/6566/files?diff=unified&w=0#diff-4b07a52bc7104d1e0e87f740342a822e1dbc605919ba3f96e702f4895eb09210L61-R66))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
