### PR TITLE
fix(server): pascal case are not converted to camel case

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
@@ -11,6 +11,7 @@ import {
 } from "./constants";
 import { EnumDataType } from "../../prisma";
 import { ScalarType } from "prisma-schema-dsl-types";
+import { camelCase } from "lodash";
 
 export function capitalizeFirstLetter(string): string {
   return string.charAt(0).toUpperCase() + string.slice(1);
@@ -75,18 +76,11 @@ export function formatFieldName(fieldName: string | Func): string {
     const isCamelCase = /^[a-z][A-Za-z0-9]*$/.test(fieldName);
 
     if (!isCamelCase) {
-      // first, convert the entire string to lowercase
-      fieldName = fieldName.toLowerCase();
-
-      // then, convert any character (letter or digit) that follows an underscore to uppercase in order to get camel case
-      fieldName = fieldName.replace(/_([a-z0-9])/g, (g) => g[1].toUpperCase());
+      fieldName = camelCase(fieldName);
     }
 
-    // ensure the first letter is always lowercased (in case it was made uppercase by the previous step)
-    fieldName = fieldName.charAt(0).toLowerCase() + fieldName.slice(1);
-
     if (isReservedName(fieldName.toLowerCase().trim())) {
-      fieldName = `${fieldName}Field`;
+      fieldName = `${camelCase(fieldName)}Field`;
     }
 
     return fieldName;


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6571

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 65c7514</samp>

### Summary
🐫🛠️📄

<!--
1.  🐫 - This emoji represents the camelCase function, which is used to convert field names to camel case format.
2.  🛠️ - This emoji represents the improvement and simplification of the Prisma schema parser, which is a tool for generating Prisma models from database schemas.
3.  📄 - This emoji represents the Prisma schema file, which is the output of the Prisma schema parser and contains the Prisma model definitions.
-->
Improved field name formatting in Prisma schema parser by using `camelCase` function from `lodash` library. Updated `helpers.ts` file to import and apply the function.

> _Oh we are the coders of the Prisma schema_
> _We parse the fields with a camelCase formula_
> _We import the function from a handy module_
> _And we heave away on the count of three_

### Walkthrough
* Import the `camelCase` function from `lodash` to simplify and standardize field name formatting ([link](https://github.com/amplication/amplication/pull/6572/files?diff=unified&w=0#diff-aeb3a345e8fc10eda18645cc829cc19037c48dedaa7f858a5b6fef7db7d8bb1aR14))
* Use the `camelCase` function in the `formatFieldName` function to convert field names to camel case and handle reserved names with a camel case suffix ([link](https://github.com/amplication/amplication/pull/6572/files?diff=unified&w=0#diff-aeb3a345e8fc10eda18645cc829cc19037c48dedaa7f858a5b6fef7db7d8bb1aL78-R83))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
