### PR TITLE
chore(dsg): improve dsg logging

### DIFF
--- a/packages/data-service-generator/src/admin/create-admin.ts
+++ b/packages/data-service-generator/src/admin/create-admin.ts
@@ -47,12 +47,10 @@ async function createAdminModulesInternal(): Promise<ModuleMap> {
     clientDirectories,
   } = context;
 
+  await context.logger.info("Creating admin...");
   await context.logger.info(`Admin path: ${clientDirectories.baseDirectory}`);
 
-  await context.logger.info("Creating admin...");
-
   await context.logger.info("Copying static modules...");
-
   const staticModules = await readStaticModules(
     STATIC_MODULES_PATH,
     clientDirectories.baseDirectory
@@ -61,6 +59,7 @@ async function createAdminModulesInternal(): Promise<ModuleMap> {
   await context.logger.info("Creating gitignore...");
   const gitIgnore = await createGitIgnore();
 
+  await context.logger.info("Creating package.json...");
   const packageJson = await createAdminUIPackageJson();
 
   /**@todo: add code to auto import static DTOs from /server/static/src/util and strip the decorators
@@ -77,13 +76,18 @@ async function createAdminModulesInternal(): Promise<ModuleMap> {
     entities.map((entity) => [entity.name, entity])
   );
 
+  await context.logger.info("Creating public files...");
   const publicFilesModules = await createPublicFiles();
+  await context.logger.info("Creating public files...");
   const entityToDirectory = createEntityToDirectory(entities);
+  await context.logger.info("Creating DTOs...");
   const dtoNameToPath = createDTONameToPath(DTOs);
   const dtoModuleMap = await createDTOModules(DTOs, dtoNameToPath);
   const enumRolesModule = createEnumRolesModule(roles);
   const rolesModule = createRolesModule(roles, clientDirectories.srcDirectory);
+
   // Create title components first so they are available when creating entity modules
+  await context.logger.info("Creating entities components...");
   const entityToTitleComponent = await createEntityTitleComponents(
     entities,
     entityToDirectory,
@@ -104,15 +108,17 @@ async function createAdminModulesInternal(): Promise<ModuleMap> {
   const entityComponentsModules = await createEntityComponentsModules(
     entitiesComponents
   );
+
+  await context.logger.info("Creating application module...");
   const appModule = await createAppModule(entitiesComponents);
 
+  await context.logger.info("Creating Dot Env...");
   const dotEnvModule = await createDotEnvModule(
     appInfo,
     clientDirectories.baseDirectory
   );
 
   await context.logger.info("Formatting code...");
-
   const tsModules = new ModuleMap(context.logger);
   await tsModules.set(appModule);
   await tsModules.set(enumRolesModule);
@@ -123,6 +129,8 @@ async function createAdminModulesInternal(): Promise<ModuleMap> {
     entityComponentsModules,
   ]);
   await tsModules.replaceModulesCode((code) => formatCode(code));
+
+  await context.logger.info("Finalizing admin creation...");
 
   const allModules = new ModuleMap(context.logger);
   await allModules.mergeMany([

--- a/packages/data-service-generator/src/admin/create-admin.ts
+++ b/packages/data-service-generator/src/admin/create-admin.ts
@@ -78,8 +78,6 @@ async function createAdminModulesInternal(): Promise<ModuleMap> {
 
   await context.logger.info("Creating public files...");
   const publicFilesModules = await createPublicFiles();
-  await context.logger.info("Creating public files...");
-  const entityToDirectory = createEntityToDirectory(entities);
   await context.logger.info("Creating DTOs...");
   const dtoNameToPath = createDTONameToPath(DTOs);
   const dtoModuleMap = await createDTOModules(DTOs, dtoNameToPath);
@@ -88,6 +86,7 @@ async function createAdminModulesInternal(): Promise<ModuleMap> {
 
   // Create title components first so they are available when creating entity modules
   await context.logger.info("Creating entities components...");
+  const entityToDirectory = createEntityToDirectory(entities);
   const entityToTitleComponent = await createEntityTitleComponents(
     entities,
     entityToDirectory,

--- a/packages/data-service-generator/src/create-data-service.ts
+++ b/packages/data-service-generator/src/create-data-service.ts
@@ -26,6 +26,11 @@ export async function createDataService(
       pluginInstallationPath
     );
 
+    const { GIT_REF_NAME: gitRefName, GIT_SHA: gitSha } = process.env;
+    await context.logger.info(
+      `Running DSG version: ${gitRefName} <${gitSha?.substring(0, 6)}>`
+    );
+
     await context.logger.info("Creating application...", {
       resourceId: dSGResourceData.resourceInfo.id,
       buildId: dSGResourceData.buildId,
@@ -34,7 +39,6 @@ export async function createDataService(
     const { appInfo } = context;
     const { settings } = appInfo;
 
-    await context.logger.info("Copying static modules...");
     const serverModules = await createServer();
 
     const { adminUISettings } = settings;
@@ -48,6 +52,9 @@ export async function createDataService(
     await modules.merge(adminUIModules);
 
     // This code normalizes the path of each module to always use Unix path separator.
+    await context.logger.info(
+      "Normalizing modules path to use Unix path separator"
+    );
     await modules.replaceModulesPath((path) => normalize(path));
 
     const endTime = Date.now();
@@ -55,7 +62,9 @@ export async function createDataService(
       durationInMs: endTime - startTime,
     });
 
-    internalLogger.info("App generation process finished successfully");
+    await context.logger.info(
+      "Creating application process finished successfully"
+    );
 
     return modules;
   } catch (error) {

--- a/packages/data-service-generator/src/server/create-server.ts
+++ b/packages/data-service-generator/src/server/create-server.ts
@@ -36,21 +36,10 @@ async function createServerInternal(
 
   const context = DsgContext.getInstance;
 
-  await context.logger.info("Creating DTOs...");
-
-  const dtos = await createDTOs(context.entities);
-  context.DTOs = dtos;
-
-  const { GIT_REF_NAME: gitRefName, GIT_SHA: gitSha } = process.env;
-
-  await context.logger.info(
-    `Running DSG version: ${gitRefName} <${gitSha?.substring(0, 6)}>`
-  );
-
   await context.logger.info(`Server path: ${serverDirectories.baseDirectory}`);
   await context.logger.info("Creating server...");
-  await context.logger.info("Copying static modules...");
 
+  await context.logger.info("Copying static modules...");
   const staticModules = await readStaticModules(
     STATIC_DIRECTORY,
     serverDirectories.baseDirectory
@@ -59,10 +48,15 @@ async function createServerInternal(
   await context.logger.info("Creating gitignore...");
   const gitIgnore = await createGitIgnore();
 
+  await context.logger.info("Creating package.json...");
   const packageJsonModule = await createServerPackageJson();
 
-  await context.logger.info("Creating resources...");
+  await context.logger.info("Creating DTOs...");
+  const dtos = await createDTOs(context.entities);
+  context.DTOs = dtos;
   const dtoModules = await createDTOModules(dtos);
+
+  await context.logger.info("Creating resources...");
   const resourcesModules = await createResourcesModules(entities);
 
   await context.logger.info("Creating auth module...");
@@ -74,7 +68,7 @@ async function createServerInternal(
   await context.logger.info("Creating seed script...");
   const seedModule = await createSeed();
 
-  await context.logger.info("Creating message broker modules...");
+  await context.logger.info("Creating message broker...");
   const messageBrokerModules = await createMessageBroker({});
 
   await context.logger.info("Creating application module...");
@@ -83,8 +77,41 @@ async function createServerInternal(
   await appModuleInputModules.mergeMany([resourcesModules, staticModules]);
   const appModule = await createAppModule(appModuleInputModules);
 
-  const createdModules = new ModuleMap(context.logger);
-  await createdModules.mergeMany([
+  await context.logger.info("Formatting resources code...");
+  await resourcesModules.replaceModulesCode((code) => formatCode(code));
+  await context.logger.info("Formatting dtos code...");
+  await dtoModules.replaceModulesCode((code) => formatCode(code));
+  await context.logger.info("Formatting swagger code...");
+  await swagger.replaceModulesCode((code) => formatCode(code));
+  await context.logger.info("Formatting application module code...");
+  await appModule.replaceModulesCode((code) => formatCode(code));
+  await context.logger.info("Formatting seed code...");
+  await seedModule.replaceModulesCode((code) => formatCode(code));
+  await context.logger.info("Formatting auth module code...");
+  await authModules.replaceModulesCode((code) => formatCode(code));
+  await context.logger.info("Formatting message broker code...");
+  await messageBrokerModules.replaceModulesCode((code) => formatCode(code));
+  await context.logger.info("Formatting package.json code...");
+  await packageJsonModule.replaceModulesCode((code) => formatJson(code));
+
+  await context.logger.info("Creating Prisma schema...");
+  const prismaSchemaModule = await createPrismaSchemaModule(entities);
+
+  await context.logger.info("Creating Dot Env...");
+  const dotEnvModule = await createDotEnvModule({
+    envVariables: ENV_VARIABLES,
+  });
+
+  await context.logger.info("Creating Docker compose configurations...");
+  const dockerComposeFile = await createDockerComposeFile();
+  const dockerComposeDBFile = await createDockerComposeDBFile();
+
+  await context.logger.info("Finalizing server creation...");
+  const moduleMap = new ModuleMap(context.logger);
+  await moduleMap.mergeMany([
+    staticModules,
+    gitIgnore,
+    packageJsonModule,
     resourcesModules,
     dtoModules,
     swagger,
@@ -92,30 +119,6 @@ async function createServerInternal(
     seedModule,
     authModules,
     messageBrokerModules,
-  ]);
-
-  await context.logger.info("Formatting code...");
-  await createdModules.replaceModulesCode((code) => formatCode(code));
-  await packageJsonModule.replaceModulesCode((code) => formatJson(code));
-
-  await context.logger.info("Creating Prisma schema...");
-  const prismaSchemaModule = await createPrismaSchemaModule(entities);
-
-  await context.logger.info("Creating Dot Env...");
-
-  const dotEnvModule = await createDotEnvModule({
-    envVariables: ENV_VARIABLES,
-  });
-
-  const dockerComposeFile = await createDockerComposeFile();
-  const dockerComposeDBFile = await createDockerComposeDBFile();
-
-  const moduleMap = new ModuleMap(context.logger);
-  await moduleMap.mergeMany([
-    staticModules,
-    gitIgnore,
-    packageJsonModule,
-    createdModules,
     prismaSchemaModule,
     dotEnvModule,
     dockerComposeFile,


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6577 

## PR Details

This PR improve the DSG logging for a better UX and to allow us to get some insights of the code blocks perfomances.

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c2e5549</samp>

### Summary
📝🛠️🚀

<!--
1.  📝 for improved logging and formatting
2. 🛠️ for improved path handling and performance
3. 🚀 for avoiding unnecessary work and removing unused code
-->
This pull request enhances the logging and code quality of the data service generator. It adds more information and clarity to the log messages, fixes some formatting and path issues, and optimizes the creation of the server and the DTOs. It affects the files `create-admin.ts`, `create-data-service.ts`, and `create-server.ts`.

> _Sing, O Muse, of the skillful coder who enhanced the server's might_
> _With clear and timely messages, as a beacon in the night_
> _He trimmed the excess lines and words, and made the paths more straight_
> _And spared the DTOs from being formed again by cruel fate_

### Walkthrough
*  Show the DSG version based on the git reference name and sha environment variables in the createDataService function ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-49351fe06b663c0ae76597a6a63b848c9c27030188cf288f20d58a2ed7120f28R29-R33))
*  Normalize the modules path to use the Unix path separator in the createDataService function ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-49351fe06b663c0ae76597a6a63b848c9c27030188cf288f20d58a2ed7120f28R55-R57))
*  Change the order of the log messages to show the admin and server paths before creating them, instead of after, in the createAdmin and createServer functions ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-7e369d3fdc3528cd25d13aadc06d5132caf0697deaf539d51f7bbc36f53099d6L50-R53), [link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-9c1a5a055f94dfa5f9906d14a9dc82594d750eaa22bd3878db57d21e96f62aaaL39-R42))
*  Create the package.json files for the admin and server, and log the creation, in the createAdmin and createServer functions ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-7e369d3fdc3528cd25d13aadc06d5132caf0697deaf539d51f7bbc36f53099d6R62), [link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-9c1a5a055f94dfa5f9906d14a9dc82594d750eaa22bd3878db57d21e96f62aaaL62-R59))
*  Create the public files, the DTOs, and the entities components for the admin, and log the creation, in the createAdmin function ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-7e369d3fdc3528cd25d13aadc06d5132caf0697deaf539d51f7bbc36f53099d6L80-R90))
*  Create the application module for the admin, and log the creation, in the createAdmin function ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-7e369d3fdc3528cd25d13aadc06d5132caf0697deaf539d51f7bbc36f53099d6L107-R115))
*  Remove the redundant log message for the admin modules creation in the createDataService function ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-49351fe06b663c0ae76597a6a63b848c9c27030188cf288f20d58a2ed7120f28L37))
*  Remove the unnecessary createdModules variable and use the individual module variables instead in the createServer function ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-9c1a5a055f94dfa5f9906d14a9dc82594d750eaa22bd3878db57d21e96f62aaaL118-R121))
*  Move the creation of the DTOs after the creation of the package.json file for the server, and log the creation, in the createServer function ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-9c1a5a055f94dfa5f9906d14a9dc82594d750eaa22bd3878db57d21e96f62aaaL62-R59))
*  Change the log message to use the term "message broker" instead of "message broker modules" in the createServer function ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-9c1a5a055f94dfa5f9906d14a9dc82594d750eaa22bd3878db57d21e96f62aaaL77-R71))
*  Format the code separately for each module type, and log the formatting, in the createServer function ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-9c1a5a055f94dfa5f9906d14a9dc82594d750eaa22bd3878db57d21e96f62aaaL86-R94))
*  Create the Dot Env file and the Docker compose configurations for the server, and log the creation, in the createServer function ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-9c1a5a055f94dfa5f9906d14a9dc82594d750eaa22bd3878db57d21e96f62aaaL105-R109))
*  Change the log message to use the term "application" instead of "app" in the createDataService function ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-49351fe06b663c0ae76597a6a63b848c9c27030188cf288f20d58a2ed7120f28L58-R67))
*  Remove the empty line for code style consistency in the createAdmin function ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-7e369d3fdc3528cd25d13aadc06d5132caf0697deaf539d51f7bbc36f53099d6L115))
*  Log the finalization of the admin creation process in the createAdmin function ([link](https://github.com/amplication/amplication/pull/6578/files?diff=unified&w=0#diff-7e369d3fdc3528cd25d13aadc06d5132caf0697deaf539d51f7bbc36f53099d6R133-R134))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
