### PR TITLE
Fix(server): skip renaming and mapping of relation fields

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -298,134 +298,231 @@ describe("prismaSchemaParser", () => {
         );
       });
 
-      it("should return object with entities and fields with the right relations and a log", async () => {
-        // arrange
-        const prismaSchema = `datasource db {
-          provider = "postgresql"
-          url      = env("DB_URL")
-        }
-        
-        generator client {
-          provider = "prisma-client-js"
-        }
-        
-        model Order {
-          id         String    @id @default(cuid())
-          customer   Customer? @relation(fields: [customerId], references: [id])
-          customerId String?
-        }
-        
-        model Customer {
-          id          String     @id @default(cuid())
-          orders      Order[]
-        }`;
-        const existingEntities: ExistingEntitySelect[] = [];
-        // act
-        const result = await service.convertPrismaSchemaForImportObjects(
-          prismaSchema,
-          existingEntities,
-          actionContext
-        );
-        // assert
-        const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
-          {
-            id: expect.any(String),
-            name: "Order",
-            displayName: "Order",
-            pluralDisplayName: "Orders",
-            description: "",
-            customAttributes: "",
-            fields: [
-              {
-                name: "id",
-                displayName: "Id",
-                dataType: EnumDataType.Id,
-                required: true,
-                unique: false,
-                searchable: false,
-                description: "",
-                properties: {
-                  idType: "CUID",
+      describe("when we handle a relation field", () => {
+        it("should return object with entities and fields with the right relations and a log", async () => {
+          const prismaSchema = `datasource db {
+            provider = "postgresql"
+            url      = env("DB_URL")
+          }
+          
+          generator client {
+            provider = "prisma-client-js"
+          }
+          
+          model Order {
+            id         String    @id @default(cuid())
+            customer   Customer? @relation(fields: [customerId], references: [id])
+            customerId String?
+          }
+          
+          model Customer {
+            id          String     @id @default(cuid())
+            orders      Order[]
+          }`;
+          const existingEntities: ExistingEntitySelect[] = [];
+          const result = await service.convertPrismaSchemaForImportObjects(
+            prismaSchema,
+            existingEntities,
+            actionContext
+          );
+
+          const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
+            {
+              id: expect.any(String),
+              name: "Order",
+              displayName: "Order",
+              pluralDisplayName: "Orders",
+              description: "",
+              customAttributes: "",
+              fields: [
+                {
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    idType: "CUID",
+                  },
+                  customAttributes: "",
                 },
-                customAttributes: "",
-              },
-              {
-                name: "customer",
-                displayName: "Customer",
-                dataType: EnumDataType.Lookup,
-                required: false,
-                unique: false,
-                searchable: true,
-                description: "",
-                properties: {
-                  relatedEntityId: expect.any(String),
-                  allowMultipleSelection: false,
-                  fkHolder: null,
-                  fkFieldName: "customerId",
+                {
+                  name: "customer",
+                  displayName: "Customer",
+                  dataType: EnumDataType.Lookup,
+                  required: false,
+                  unique: false,
+                  searchable: true,
+                  description: "",
+                  properties: {
+                    relatedEntityId: expect.any(String),
+                    allowMultipleSelection: false,
+                    fkHolder: null,
+                    fkFieldName: "customerId",
+                  },
+                  customAttributes: "",
+                  relatedFieldAllowMultipleSelection: true,
+                  relatedFieldDisplayName: "Orders",
+                  relatedFieldName: "orders",
                 },
-                customAttributes: "",
-                relatedFieldAllowMultipleSelection: true,
-                relatedFieldDisplayName: "Orders",
-                relatedFieldName: "orders",
-              },
-            ],
-          },
-          {
-            id: expect.any(String),
-            name: "Customer",
-            displayName: "Customer",
-            pluralDisplayName: "Customers",
-            description: "",
-            customAttributes: "",
-            fields: [
-              {
-                name: "id",
-                displayName: "Id",
-                dataType: EnumDataType.Id,
-                required: true,
-                unique: false,
-                searchable: false,
-                description: "",
-                properties: {
-                  idType: "CUID",
+              ],
+            },
+            {
+              id: expect.any(String),
+              name: "Customer",
+              displayName: "Customer",
+              pluralDisplayName: "Customers",
+              description: "",
+              customAttributes: "",
+              fields: [
+                {
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    idType: "CUID",
+                  },
+                  customAttributes: "",
                 },
-                customAttributes: "",
-              },
-            ],
-          },
-        ];
-        expect(result).toEqual(expectedEntitiesWithFields);
-        expect(actionContext.onEmitUserActionLog).toBeCalledTimes(6);
-        expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
-          1,
-          "Starting Prisma Schema Validation",
-          EnumActionLogLevel.Info
-        );
-        expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
-          2,
-          `Prisma Schema Validation completed successfully`,
-          EnumActionLogLevel.Info
-        );
-        expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
-          3,
-          `Prepare Prisma Schema for import`,
-          EnumActionLogLevel.Info
-        );
-        expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
-          4,
-          `Prepare Prisma Schema for import completed`,
-          EnumActionLogLevel.Info
-        );
-        expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
-          5,
-          `Create import objects from Prisma Schema`,
-          EnumActionLogLevel.Info
-        );
-        expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
-          6,
-          `Create import objects from Prisma Schema completed`,
-          EnumActionLogLevel.Info
-        );
+              ],
+            },
+          ];
+          expect(result).toEqual(expectedEntitiesWithFields);
+          expect(actionContext.onEmitUserActionLog).toBeCalledTimes(6);
+          expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
+            1,
+            "Starting Prisma Schema Validation",
+            EnumActionLogLevel.Info
+          );
+          expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
+            2,
+            `Prisma Schema Validation completed successfully`,
+            EnumActionLogLevel.Info
+          );
+          expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
+            3,
+            `Prepare Prisma Schema for import`,
+            EnumActionLogLevel.Info
+          );
+          expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
+            4,
+            `Prepare Prisma Schema for import completed`,
+            EnumActionLogLevel.Info
+          );
+          expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
+            5,
+            `Create import objects from Prisma Schema`,
+            EnumActionLogLevel.Info
+          );
+          expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
+            6,
+            `Create import objects from Prisma Schema completed`,
+            EnumActionLogLevel.Info
+          );
+        });
+
+        it("should not rename the field and therefore, should not add the @map attribute if it is a relation field", async () => {
+          const prismaSchema = `datasource db {
+            provider = "postgresql"
+            url      = env("DB_URL")
+          }
+          
+          generator client {
+            provider = "prisma-client-js"
+          }
+          
+          model Order {
+            id         String    @id @default(cuid())
+            the_customer   Customer? @relation(fields: [customerId], references: [id])
+            customerId String?
+          }
+          
+          model Customer {
+            id          String     @id @default(cuid())
+            orders      Order[]
+          }`;
+          const existingEntities: ExistingEntitySelect[] = [];
+          const result = await service.convertPrismaSchemaForImportObjects(
+            prismaSchema,
+            existingEntities,
+            actionContext
+          );
+          // assert
+          const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
+            {
+              id: expect.any(String),
+              name: "Order",
+              displayName: "Order",
+              pluralDisplayName: "Orders",
+              description: "",
+              customAttributes: "",
+              fields: [
+                {
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    idType: "CUID",
+                  },
+                  customAttributes: "",
+                },
+                {
+                  name: "the_customer", // should not be formatted to theCustomer because it is a relation field
+                  displayName: "The Customer",
+                  dataType: EnumDataType.Lookup,
+                  required: false,
+                  unique: false,
+                  searchable: true,
+                  description: "",
+                  properties: {
+                    relatedEntityId: expect.any(String),
+                    allowMultipleSelection: false,
+                    fkHolder: null,
+                    fkFieldName: "customerId",
+                  },
+                  customAttributes: "",
+                  relatedFieldAllowMultipleSelection: true,
+                  relatedFieldDisplayName: "Orders",
+                  relatedFieldName: "orders",
+                },
+              ],
+            },
+            {
+              id: expect.any(String),
+              name: "Customer",
+              displayName: "Customer",
+              pluralDisplayName: "Customers",
+              description: "",
+              customAttributes: "",
+              fields: [
+                {
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    idType: "CUID",
+                  },
+                  customAttributes: "",
+                },
+              ],
+            },
+          ];
+          expect(result).toEqual(expectedEntitiesWithFields);
+        });
       });
     });
   });

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -433,7 +433,7 @@ export class PrismaSchemaParserService {
         if (this.isOptionSetField(schema, field)) return builder;
         if (this.isMultiSelectOptionSetField(schema, field)) return builder;
         // we are not renaming lookup fields because
-        // 1. relation field is not really a field in the DB0
+        //  1. relation field is not really a field in the DB
         //  2. other attributes than @relation are not supported on relation fields
         if (this.isLookupField(schema, field)) return builder;
 

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -429,8 +429,13 @@ export class PrismaSchemaParserService {
       modelFieldList.map((field: Field) => {
         // we don't want to rename field if it is a foreign key holder
         if (this.isFkFieldOfARelation(schema, model, field)) return builder;
+        // we are not renaming enum fields because we are not supporting custom attributes on enum fields
         if (this.isOptionSetField(schema, field)) return builder;
         if (this.isMultiSelectOptionSetField(schema, field)) return builder;
+        // we are not renaming lookup fields because
+        // 1. relation field is not really a field in the DB0
+        //  2. other attributes than @relation are not supported on relation fields
+        if (this.isLookupField(schema, field)) return builder;
 
         const fieldAttributes = field.attributes?.filter(
           (attr) => attr.type === ATTRIBUTE_TYPE_NAME

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.spec.ts
@@ -25,29 +25,111 @@ describe("schema-utils", () => {
   });
 
   describe("createOneEntityFieldCommonProperties", () => {
-    it("should return common properties of an entity field", () => {
-      const mockField = {
-        name: "mockField",
-        optional: false,
-        attributes: [{ name: "unique" }],
-      } as unknown as Field;
+    const mockAttributes = [
+      {
+        type: "attribute",
+        name: "map",
+        kind: "field",
+        args: [
+          {
+            type: "attributeArgument",
+            value: '"mock_field"',
+          },
+        ],
+      },
+    ] as unknown as Attribute[];
 
-      const result = createOneEntityFieldCommonProperties(
-        mockField,
-        EnumDataType.SingleLineText
-      );
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+    it("should create properties for a standard field", () => {
+      const field = {
+        name: "testField",
+        optional: false,
+        attributes: mockAttributes,
+      } as unknown as Field;
+      const dataType = EnumDataType.SingleLineText;
+
+      const result = createOneEntityFieldCommonProperties(field, dataType);
 
       expect(result).toEqual({
-        name: "mockField",
-        displayName: "Mock Field",
-        dataType: EnumDataType.SingleLineText,
+        name: "testField",
+        displayName: "Test Field",
+        dataType: dataType,
         required: true,
-        unique: true,
+        unique: false,
         searchable: false,
         description: "",
         properties: {},
-        customAttributes: "",
+        customAttributes: '@map("mock_field")',
       });
+    });
+
+    it("should handle unique attribute", () => {
+      const field = {
+        name: "testField",
+        optional: false,
+        attributes: [{ name: "unique" }],
+      } as unknown as Field;
+      const dataType = EnumDataType.SingleLineText;
+
+      const result = createOneEntityFieldCommonProperties(field, dataType);
+
+      expect(result.unique).toEqual(true);
+    });
+
+    it("should handle optional field", () => {
+      const field = {
+        name: "testField",
+        optional: true,
+        attributes: [],
+      } as unknown as Field;
+      const dataType = EnumDataType.SingleLineText;
+
+      const result = createOneEntityFieldCommonProperties(field, dataType);
+
+      expect(result.required).toEqual(false);
+    });
+
+    it("should mark Lookup field as searchable", () => {
+      const field = {
+        name: "testField",
+        optional: false,
+        attributes: [],
+      } as unknown as Field;
+      const dataType = EnumDataType.Lookup;
+
+      const result = createOneEntityFieldCommonProperties(field, dataType);
+
+      expect(result.searchable).toEqual(true);
+    });
+
+    it("should throw error if Lookup field has custom attributes", () => {
+      const field = {
+        name: "testField",
+        optional: false,
+        attributes: mockAttributes,
+      } as unknown as Field;
+      const dataType = EnumDataType.Lookup;
+
+      expect(() =>
+        createOneEntityFieldCommonProperties(field, dataType)
+      ).toThrowError(
+        "Custom attributes are not allowed on relation fields. Only @relation attribute is allowed"
+      );
+    });
+
+    it("should add custom attributes for non-Lookup field", () => {
+      const field = {
+        name: "testField",
+        optional: false,
+        attributes: mockAttributes,
+      } as unknown as Field;
+      const dataType = EnumDataType.SingleLineText;
+
+      const result = createOneEntityFieldCommonProperties(field, dataType);
+
+      expect(result.customAttributes).toEqual('@map("mock_field")');
     });
   });
 

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
@@ -50,6 +50,9 @@ export function createOneEntityFieldCommonProperties(
     field.attributes?.some((attr) => attr.name === UNIQUE_ATTRIBUTE_NAME) ??
     false;
 
+  const isSearchableField =
+    fieldDataType === EnumDataType.Lookup ? true : false;
+
   const fieldAttributes = filterOutAmplicationAttributes(
     prepareFieldAttributes(field.attributes)
   )
@@ -57,13 +60,19 @@ export function createOneEntityFieldCommonProperties(
     .filter((attr) => attr !== "@default()")
     .join(" ");
 
+  if (fieldDataType === EnumDataType.Lookup && fieldAttributes !== "") {
+    throw new Error(
+      `Custom attributes are not allowed on relation fields. Only @relation attribute is allowed`
+    );
+  }
+
   return {
     name: field.name,
     displayName: fieldDisplayName,
     dataType: fieldDataType,
     required: !field.optional || false,
     unique: isUniqueField,
-    searchable: fieldDataType === EnumDataType.Lookup ? true : false,
+    searchable: isSearchableField,
     description: "",
     properties: {},
     customAttributes: fieldAttributes,


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6581

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cf0fff9</samp>

### Summary
🧪🛠️🔒

<!--
1.  🧪 - This emoji represents testing and experimentation, and can be used for the first and the third change, as they both involve adding or modifying test cases.
2.  🛠️ - This emoji represents tools and fixing, and can be used for the second change, as it involves adding a condition to the `createFieldBuilder` method to handle relation fields correctly.
3.  🔒 - This emoji represents security and validation, and can be used for the fourth change, as it involves adding an error check to the `createOneEntityFieldCommonProperties` function to prevent invalid custom attributes on relation fields.
-->
This pull request enhances the validation and handling of relation fields in the prisma schema parser. It adds a new condition to avoid renaming relation fields, a new variable to determine the searchable property, and a new error for custom attributes on relation fields. It also updates and adds test cases for the relevant functions.

> _`schema-utils` changed_
> _Validation and tests added_
> _Autumn of refactoring_

### Walkthrough
*  Validate and handle relation fields in Prisma schema parser ([link](https://github.com/amplication/amplication/pull/6582/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L432-R438), [link](https://github.com/amplication/amplication/pull/6582/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R63-R68), [link](https://github.com/amplication/amplication/pull/6582/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL301-R525))
  - Add a condition to `createFieldBuilder` to return the builder without renaming or adding `@map` for lookup fields ([link](https://github.com/amplication/amplication/pull/6582/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L432-R438))
  - Add a condition to `createOneEntityFieldCommonProperties` to throw an error if lookup fields have custom attributes ([link](https://github.com/amplication/amplication/pull/6582/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R63-R68))
  - Add a test case for `convertPrismaSchemaForImportObjects` to verify that relation fields are preserved ([link](https://github.com/amplication/amplication/pull/6582/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL301-R525))
* Refactor and improve test coverage for `createOneEntityFieldCommonProperties` ([link](https://github.com/amplication/amplication/pull/6582/files?diff=unified&w=0#diff-729822b2dc6d7e1d96b58a6a13873902a54700227afd424960f528b4ea4ff09fL28-R133), [link](https://github.com/amplication/amplication/pull/6582/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R53-R55), [link](https://github.com/amplication/amplication/pull/6582/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L66-R75))
  - Extract the logic for determining the searchable property of the field to a variable `isSearchableField` ([link](https://github.com/amplication/amplication/pull/6582/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R53-R55), [link](https://github.com/amplication/amplication/pull/6582/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L66-R75))
  - Replace the single test case with a `describe` block that contains multiple test cases for different scenarios ([link](https://github.com/amplication/amplication/pull/6582/files?diff=unified&w=0#diff-729822b2dc6d7e1d96b58a6a13873902a54700227afd424960f528b4ea4ff09fL28-R133))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
