### PR TITLE
Fix(server): fkholder import schema

### DIFF
--- a/packages/amplication-server/src/core/entity/entity.resolver.spec.ts
+++ b/packages/amplication-server/src/core/entity/entity.resolver.spec.ts
@@ -1094,6 +1094,7 @@ describe("EntityResolver", () => {
     expect(createFieldMock).toBeCalledWith(
       { data: { ...variables, entity: { connect: { id: EXAMPLE_ID } } } },
       EXAMPLE_USER,
+      null,
       true,
       true
     );

--- a/packages/amplication-server/src/core/entity/entity.resolver.ts
+++ b/packages/amplication-server/src/core/entity/entity.resolver.ts
@@ -238,7 +238,7 @@ export class EntityResolver {
     @UserEntity() user: User,
     @Args() args: CreateOneEntityFieldArgs
   ): Promise<EntityField> {
-    return this.entityService.createField(args, user, true, true);
+    return this.entityService.createField(args, user, null, true, true);
   }
 
   @Mutation(() => EntityField, { nullable: false })

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -124,6 +124,7 @@ export type CreateBulkFieldsInput = Omit<
   "entity" | "properties"
 > & {
   properties: JsonObject;
+  permanentId: string;
   relatedFieldName?: string;
   relatedFieldDisplayName?: string;
   relatedFieldAllowMultipleSelection?: boolean;

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -121,6 +121,7 @@ describe("prismaSchemaParser", () => {
             customAttributes: "",
             fields: [
               {
+                permanentId: expect.any(String),
                 name: "id",
                 displayName: "Id",
                 dataType: EnumDataType.Id,
@@ -134,6 +135,7 @@ describe("prismaSchemaParser", () => {
                 customAttributes: "",
               },
               {
+                permanentId: expect.any(String),
                 name: "createdAt",
                 displayName: "Created At",
                 dataType: EnumDataType.CreatedAt,
@@ -145,6 +147,7 @@ describe("prismaSchemaParser", () => {
                 customAttributes: "",
               },
               {
+                permanentId: expect.any(String),
                 name: "username",
                 displayName: "Username",
                 dataType: EnumDataType.SingleLineText,
@@ -158,6 +161,7 @@ describe("prismaSchemaParser", () => {
                 customAttributes: "@db.VarChar(256)",
               },
               {
+                permanentId: expect.any(String),
                 name: "roles",
                 displayName: "Roles",
                 dataType: EnumDataType.Json,
@@ -209,6 +213,7 @@ describe("prismaSchemaParser", () => {
             customAttributes: '@@map("admin")',
             fields: [
               {
+                permanentId: expect.any(String),
                 name: "id",
                 displayName: "Id",
                 dataType: EnumDataType.Id,
@@ -222,6 +227,7 @@ describe("prismaSchemaParser", () => {
                 customAttributes: "",
               },
               {
+                permanentId: expect.any(String),
                 name: "createdAt",
                 displayName: "Created At",
                 dataType: EnumDataType.CreatedAt,
@@ -233,6 +239,7 @@ describe("prismaSchemaParser", () => {
                 customAttributes: "",
               },
               {
+                permanentId: expect.any(String),
                 name: "username",
                 displayName: "Username",
                 dataType: EnumDataType.SingleLineText,
@@ -246,6 +253,7 @@ describe("prismaSchemaParser", () => {
                 customAttributes: "@db.VarChar(256)",
               },
               {
+                permanentId: expect.any(String),
                 name: "roles",
                 displayName: "Roles",
                 dataType: EnumDataType.Json,
@@ -320,6 +328,7 @@ describe("prismaSchemaParser", () => {
           orders      Order[]
         }`;
         const existingEntities: ExistingEntitySelect[] = [];
+        const customerFieldPermanentId = expect.any(String);
         // act
         const result = await service.convertPrismaSchemaForImportObjects(
           prismaSchema,
@@ -337,6 +346,7 @@ describe("prismaSchemaParser", () => {
             customAttributes: "",
             fields: [
               {
+                permanentId: expect.any(String),
                 name: "id",
                 displayName: "Id",
                 dataType: EnumDataType.Id,
@@ -350,6 +360,7 @@ describe("prismaSchemaParser", () => {
                 customAttributes: "",
               },
               {
+                permanentId: customerFieldPermanentId,
                 name: "customer",
                 displayName: "Customer",
                 dataType: EnumDataType.Lookup,
@@ -360,7 +371,7 @@ describe("prismaSchemaParser", () => {
                 properties: {
                   relatedEntityId: expect.any(String),
                   allowMultipleSelection: false,
-                  fkHolder: null,
+                  fkHolder: customerFieldPermanentId,
                   fkFieldName: "customerId",
                 },
                 customAttributes: "",
@@ -379,6 +390,7 @@ describe("prismaSchemaParser", () => {
             customAttributes: "",
             fields: [
               {
+                permanentId: expect.any(String),
                 name: "id",
                 displayName: "Id",
                 dataType: EnumDataType.Id,

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -1314,7 +1314,7 @@ export class PrismaSchemaParserService {
       const properties = <types.Lookup>{
         relatedEntityId: relatedEntity.id,
         allowMultipleSelection: field.array || false,
-        fkHolder: null,
+        fkHolder: entityField.permanentId, // we are on the "main", annotated side of the relation, meaning that this field is the fkHolder
         fkFieldName: fkFieldName,
       };
 

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.spec.ts
@@ -18,6 +18,7 @@ import { Mapper } from "./types";
 import { EnumDataType } from "../../enums/EnumDataType";
 import { EnumActionLogLevel } from "../action/dto";
 import { ActionContext } from "../userAction/types";
+import { CreateBulkFieldsInput } from "../entity/entity.service";
 
 describe("schema-utils", () => {
   beforeEach(() => {
@@ -32,12 +33,14 @@ describe("schema-utils", () => {
         attributes: [{ name: "unique" }],
       } as unknown as Field;
 
-      const result = createOneEntityFieldCommonProperties(
-        mockField,
-        EnumDataType.SingleLineText
-      );
+      const result: CreateBulkFieldsInput =
+        createOneEntityFieldCommonProperties(
+          mockField,
+          EnumDataType.SingleLineText
+        );
 
       expect(result).toEqual({
+        permanentId: expect.any(String),
         name: "mockField",
         displayName: "Mock Field",
         dataType: EnumDataType.SingleLineText,

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
@@ -34,6 +34,7 @@ import { CreateBulkFieldsInput } from "../entity/entity.service";
 import { EnumDataType } from "../../enums/EnumDataType";
 import { EnumActionLogLevel } from "../action/dto";
 import { ActionContext } from "../userAction/types";
+import cuid from "cuid";
 
 /**
  * create the common properties of one entity field from model field
@@ -58,6 +59,7 @@ export function createOneEntityFieldCommonProperties(
     .join(" ");
 
   return {
+    permanentId: cuid(),
     name: field.name,
     displayName: fieldDisplayName,
     dataType: fieldDataType,


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6583

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e74877e</samp>

### Summary
🆕🔧🧪

<!--
1.  🆕 - This emoji represents the creation of new permanent IDs for fields using the `cuid` library. It also implies a new feature or improvement for the schema.
2.  🔧 - This emoji represents the modification and refactoring of existing code to use permanent IDs for fields instead of generated IDs. It also implies a bug fix or enhancement for the schema.
3.  🧪 - This emoji represents the addition and modification of tests to check the permanent IDs and the relation fields. It also implies a quality assurance or verification of the schema.
-->
Refactor the server code to use permanent IDs for entity fields using the `cuid` library. This improves the stability and consistency of the schema and the references to fields across versions and environments. Update the tests and the schema parser to reflect the changes. Fix the `fkHolder` property for relation fields.

> _Sing, O Muse, of the mighty refactor of the code_
> _That gave to the fields of the entities permanent IDs_
> _And freed them from the changing whims of Prisma's mode_
> _That often broke the schema's order and harmony._

### Walkthrough
*  Refactor the `EntityService` and the `EntityResolver` to use permanent IDs for fields instead of Prisma-generated IDs ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-e03add6e3cbb1b4ea5a78a80fe5db4a16cd0cb0cf8a4f1bbc8e267cc32712d13L241-R241), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R127), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R638), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L655-R657), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L2002-R2004), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R2214), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L2255-R2258), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L2288-R2291), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R2398-R2400), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L2417-R2423), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1317-R1317), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R37), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R62))
  * Add a new property `permanentId` to the `CreateBulkFieldsInput` type and the `EntityField` model to store the unique and stable identifier for each field ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R127), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L2288-R2291))
  * Modify the `createField` method of the `EntityService` to accept an optional `permanentId` parameter and use it as the value for the `permanentId` property of the `EntityField` model, or generate a new one using the `cuid` library if not provided ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L2002-R2004), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R2214))
  * Modify the `createRelationField` method of the `EntityService` to pass the `permanentId` parameter to the `createField` method ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L2255-R2258))
  * Modify the `createOneEntityField` mutation in the `EntityResolver` to pass `null` as the `fieldId` argument to the `createField` method of the `EntityService`, which will trigger the generation of a new permanent ID ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-e03add6e3cbb1b4ea5a78a80fe5db4a16cd0cb0cf8a4f1bbc8e267cc32712d13L241-R241))
  * Modify the `createBulkFields` method of the `EntityService` to pass the `permanentId` property of each `CreateBulkFieldsInput` object to the `createField` method ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R638))
  * Modify the `createField` method of the `EntityService` to use the `fkHolder` parameter as the value for the `fkHolder` property of the `EntityField` model, which represents the permanent ID of the field that holds the foreign key for the relation ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L2417-R2423))
  * Modify the `parseField` method of the `PrismaSchemaParserService` to use the `permanentId` property of the `EntityField` object as the value for the `fkHolder` property of the `EntityFieldProperties` object for a relation field on the annotated side of the relation ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1317-R1317))
  * Add a debug log statement to the `createField` method of the `EntityService` to print the value of the `relatedFieldId` variable, which is the ID of the related field that is created by the Prisma client when a relation field is created ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R2398-R2400))
* Update the `parseSchema` method of the `PrismaSchemaParserService` and its tests to use permanent IDs for fields ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR124), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR138), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR150), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR164), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR216), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR230), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR242), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR256), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR331), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR349), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR363), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL363-R374), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR393))
  * Add expectations to the `parseSchema` test in the `prismaSchemaParser.service.spec.ts` file to check that the `permanentId` property of each `CreateBulkFieldsInput` object that is returned by the `parseSchema` method is a string ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR124), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR138), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR150), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR164), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR216), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR230), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR242), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR256), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR349), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR393))
  * Declare a new variable `customerFieldPermanentId` in the `parseSchema` test to store the permanent ID of the `customer` field of the `Order` model and use it as the expected value for the `permanentId` and `fkHolder` properties of the `orders` field of the `Customer` model, which is a relation field on the implicit side of the relation ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR331), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR363), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL363-R374))
* Add an import statement to the `schema-utils.spec.ts` file to import the `CreateBulkFieldsInput` type from the `EntityService` and modify the `createOneEntityFieldCommonProperties` test to declare the result variable as a `CreateBulkFieldsInput` type and to add an expectation to check that the `permanentId` property of the result object is a string ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-729822b2dc6d7e1d96b58a6a13873902a54700227afd424960f528b4ea4ff09fR21), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-729822b2dc6d7e1d96b58a6a13873902a54700227afd424960f528b4ea4ff09fL35-R43))
* Add an import statement to the `schema-utils.ts` file to import the `cuid` library and add a new property `permanentId` to the object that is returned by the `createOneEntityFieldCommonProperties` function, which is assigned a value generated by the `cuid` library ([link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R37), [link](https://github.com/amplication/amplication/pull/6584/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R62))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
