### PR TITLE
refactor(server): pass model list as argument instead of taking it from the schema or the builder

### DIFF
--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -2395,9 +2395,6 @@ export class EntityService {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     fkHolder?: string
   ): Promise<EntityField> {
-    this.logger.debug("relatedFieldId===fieldId===permanentId", {
-      relatedFieldId,
-    });
     return await this.useLocking(entityId, user, async () => {
       return this.prisma.entityField.create({
         data: {

--- a/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
@@ -102,7 +102,7 @@ export function idField(field: Field) {
   }
 }
 
-export function lookupField(schema: Schema, field: Field, modelList: Model[]) {
+export function lookupField(field: Field, modelList: Model[]) {
   const isFieldTypeIsModel = modelList.some(
     (modelItem: Model) => modelItem.name === field.fieldType
   );

--- a/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
@@ -104,7 +104,9 @@ export function idField(field: Field) {
 
 export function lookupField(field: Field, modelList: Model[]) {
   const isFieldTypeIsModel = modelList.some(
-    (modelItem: Model) => modelItem.name === field.fieldType
+    (modelItem: Model) =>
+      formatModelName(modelItem.name) ===
+      formatModelName(field.fieldType as string)
   );
 
   if (isFieldTypeIsModel) {

--- a/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
@@ -6,7 +6,6 @@ import {
   DEFAULT_ATTRIBUTE_NAME,
   ENUM_TYPE_NAME,
   ID_ATTRIBUTE_NAME,
-  MODEL_TYPE_NAME,
   NOW_FUNCTION_NAME,
   UPDATED_AT_ATTRIBUTE_NAME,
 } from "./constants";
@@ -103,12 +102,8 @@ export function idField(field: Field) {
   }
 }
 
-export function lookupField(schema: Schema, field: Field) {
-  const models = schema.list.filter(
-    (item) => item.type === MODEL_TYPE_NAME
-  ) as Model[];
-
-  const isFieldTypeIsModel = models.some(
+export function lookupField(schema: Schema, field: Field, modelList: Model[]) {
+  const isFieldTypeIsModel = modelList.some(
     (modelItem: Model) => modelItem.name === field.fieldType
   );
 

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -238,8 +238,9 @@ export class PrismaSchemaParserService {
         }
 
         if (
-          this.isNotAnnotatedRelationField(schema, field, modelList) &&
-          !isManyToMany
+          this.isNotAnnotatedRelationField(schema, field, modelList) ||
+          (this.isNotAnnotatedRelationField(schema, field, modelList) &&
+            !isManyToMany)
         ) {
           continue;
         }
@@ -859,9 +860,11 @@ export class PrismaSchemaParserService {
     field: Field,
     modelList: Model[]
   ): boolean {
-    // at this time, we already know that we are in a lookup field and this is not an annotated relation field
-    // we only need to check if the field is an array (relation array i.e. order[])
-    if (field.array) {
+    if (
+      lookupField(field, modelList) &&
+      this.isNotAnnotatedRelationField(schema, field, modelList) &&
+      field.array
+    ) {
       // find the other side of the relation
       const hasManyToManyRelation = modelList.some((modelItem: Model) => {
         const modelFields = modelItem.properties.filter(

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -1422,7 +1422,8 @@ export class PrismaSchemaParserService {
       const remoteModelAndField = findRemoteRelatedModelAndField(
         schema,
         model,
-        field
+        field,
+        modelList
       );
 
       if (!remoteModelAndField) {

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -799,7 +799,7 @@ export class PrismaSchemaParserService {
     field: Field,
     modelList: Model[]
   ): boolean {
-    return lookupField(schema, field, modelList) === EnumDataType.Lookup;
+    return lookupField(field, modelList) === EnumDataType.Lookup;
   }
 
   private isOptionSetField(

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
@@ -17,7 +17,6 @@ import {
   ARRAY_ARG_TYPE_NAME,
   KEY_VALUE_ARG_TYPE_NAME,
   UNIQUE_ATTRIBUTE_NAME,
-  MODEL_TYPE_NAME,
   FIELD_TYPE_NAME,
   ATTRIBUTE_TYPE_NAME,
   MAP_ATTRIBUTE_NAME,
@@ -191,7 +190,8 @@ export function prepareFieldAttributes(attributes: Attribute[]): string[] {
 export function findRemoteRelatedModelAndField(
   schema: Schema,
   model: Model,
-  field: Field
+  field: Field,
+  modelList: Model[]
 ): { remoteModel: Model; remoteField: Field } | undefined {
   let relationAttributeName: string | undefined;
   let remoteField: Field | undefined;
@@ -212,11 +212,10 @@ export function findRemoteRelatedModelAndField(
       (relationAttributeStringArgument.value as string);
   });
 
-  const remoteModel = schema.list.find(
-    (item) =>
-      item.type === MODEL_TYPE_NAME &&
-      formatModelName(item.name) === formatModelName(field.fieldType as string)
-  ) as Model;
+  const remoteModel = modelList.find(
+    (model) =>
+      formatModelName(model.name) === formatModelName(field.fieldType as string)
+  );
 
   if (!remoteModel) {
     throw new Error(

--- a/packages/amplication-server/src/core/prismaSchemaParser/types.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/types.ts
@@ -1,4 +1,4 @@
-import { ConcretePrismaSchemaBuilder } from "@mrleebo/prisma-ast";
+import { ConcretePrismaSchemaBuilder, Model } from "@mrleebo/prisma-ast";
 import { CreateBulkEntitiesInput } from "../entity/entity.service";
 import { ActionLog } from "../action/dto";
 import { ActionContext } from "../userAction/types";
@@ -15,6 +15,7 @@ export type PrepareOperationInput = {
 
 export type PrepareOperationIO = {
   builder: ConcretePrismaSchemaBuilder;
+  modelList: Model[];
   existingEntities: ExistingEntitySelect[];
   mapper: Mapper;
   actionContext: ActionContext;


### PR DESCRIPTION


<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6599

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 52075c4</samp>

### Summary
🛠️🚀🧠

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate the refactoring of the `lookupField` function and the `prismaSchemaParser.service.ts` file.
2.  🚀 - This emoji represents speed or performance, and can be used to indicate the improvement of efficiency and readability of the code by avoiding repeated filtering operations and passing the `modelList` parameter.
3.  🧠 - This emoji represents intelligence or logic, and can be used to indicate the enhancement of the `PrepareOperationIO` type and the schema parser's ability to access and manipulate the models.
-->
This pull request refactors and optimizes the prisma schema parser service and its helper functions by using a `modelList` parameter that contains the filtered models from the schema. This reduces unnecessary computations and improves code clarity. It also updates the `PrepareOperationIO` type to include the `modelList` property.

> _To parse schemas with less strain_
> _We filter the models and then_
> _We pass `modelList`_
> _To functions that exist_
> _In `helpers` and `prismaSchemaParser` again_

### Walkthrough
*  Add `modelList` parameter to various functions that process the schema and the fields, and pass it from the `prepareOperationIO` object ([link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-aeb3a345e8fc10eda18645cc829cc19037c48dedaa7f858a5b6fef7db7d8bb1aL106-R106), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R145), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L188-R196), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L197-R203), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L210-R218), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L226-R234), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L232-R319), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L308-R345), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R363), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R373), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R446), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R463), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R533), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R583), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R639), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R718), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L760-R828), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L818-R880), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R960), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R991), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R1022), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R1053), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R1093), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R1134), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R1174), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R1243), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R1297), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R1348), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R1399), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1380-R1458), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-e63e35639170ef509c305f88cb604991597f84c7c18a46aba7b00423f7dbfee6L1-R1), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-e63e35639170ef509c305f88cb604991597f84c7c18a46aba7b00423f7dbfee6R18))
*  Remove unused import of `MODEL_TYPE_NAME` from `helpers.ts` ([link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-aeb3a345e8fc10eda18645cc829cc19037c48dedaa7f858a5b6fef7db7d8bb1aL9))
*  Remove redundant filtering of models from the schema in various functions, and use the `modelList` parameter instead ([link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L376-R403), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L447-R469), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L525-R554), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L576-R603), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L635-R661), [link](https://github.com/amplication/amplication/pull/6600/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L794-R866))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
