### PR TITLE
Fix(server): db import schema issues

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -833,6 +833,171 @@ describe("prismaSchemaParser", () => {
           expect(result).toEqual(expectedEntitiesWithFields);
         });
 
+        it("should NOT format the args in the @@index attribute if they were not formatted in the model fields", async () => {
+          // arrange
+          const prismaSchema = `datasource db {
+            provider = "postgresql"
+            url      = env("DB_URL")
+          }
+          
+          generator client {
+            provider = "prisma-client-js"
+          }
+
+          model Order {
+            id         String    @id @default(cuid())
+            order_number   Int
+            the_customer   Customer? @relation(fields: [customer_id], references: [id])
+            customer_id String?
+
+            @@index([customer_id, order_number], map: "customer_id_order_number")
+          }
+          
+          model Customer {
+            id          String     @id @default(cuid())
+            customer_type CustomerType? @default(INDIVIDUAL)
+            customer_id_number Int
+            orders  Order[]
+
+            @@index([customer_type, customer_id_number], map: "customer_type_customer_id_number")
+          }
+
+          enum CustomerType {
+            INDIVIDUAL
+            COMPANY
+          }
+          `;
+          const customerFieldPermanentId = expect.any(String);
+          const existingEntities: ExistingEntitySelect[] = [];
+          // act
+          const result = await service.convertPrismaSchemaForImportObjects(
+            prismaSchema,
+            existingEntities,
+            actionContext
+          );
+          // assert
+          const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
+            {
+              id: expect.any(String),
+              name: "Order",
+              displayName: "Order",
+              pluralDisplayName: "Orders",
+              description: "",
+              customAttributes:
+                '@@index([customer_id, orderNumber], map: "customer_id_order_number")',
+              fields: [
+                {
+                  permanentId: expect.any(String),
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    idType: "CUID",
+                  },
+                  customAttributes: "",
+                },
+                {
+                  permanentId: expect.any(String),
+                  name: "orderNumber",
+                  displayName: "Order Number",
+                  dataType: EnumDataType.WholeNumber,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    maximumValue: 99999999999,
+                    minimumValue: 0,
+                  },
+                  customAttributes: '@map("order_number")',
+                },
+                {
+                  permanentId: expect.any(String),
+                  name: "theCustomer",
+                  displayName: "The Customer",
+                  dataType: EnumDataType.Lookup,
+                  required: false,
+                  unique: false,
+                  searchable: true,
+                  description: "",
+                  properties: {
+                    relatedEntityId: expect.any(String),
+                    allowMultipleSelection: false,
+                    fkHolder: customerFieldPermanentId,
+                    fkFieldName: "customer_id",
+                  },
+                  customAttributes: "",
+                  relatedFieldAllowMultipleSelection: true,
+                  relatedFieldDisplayName: "Orders",
+                  relatedFieldName: "orders",
+                },
+              ],
+            },
+            {
+              id: expect.any(String),
+              name: "Customer",
+              displayName: "Customer",
+              pluralDisplayName: "Customers",
+              description: "",
+              customAttributes:
+                '@@index([customer_type, customerIdNumber], map: "customer_type_customer_id_number")',
+              fields: [
+                {
+                  permanentId: expect.any(String),
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    idType: "CUID",
+                  },
+                  customAttributes: "",
+                },
+                {
+                  permanentId: expect.any(String),
+                  name: "customer_type",
+                  displayName: "Customer Type",
+                  dataType: EnumDataType.OptionSet,
+                  required: false,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    options: [
+                      { label: "INDIVIDUAL", value: "INDIVIDUAL" },
+                      { label: "COMPANY", value: "COMPANY" },
+                    ],
+                  },
+                  customAttributes: "@default(INDIVIDUAL)",
+                },
+                {
+                  permanentId: expect.any(String),
+                  name: "customerIdNumber",
+                  displayName: "Customer Id Number",
+                  dataType: EnumDataType.WholeNumber,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    maximumValue: 99999999999,
+                    minimumValue: 0,
+                  },
+                  customAttributes: '@map("customer_id_number")',
+                },
+              ],
+            },
+          ];
+          expect(result).toEqual(expectedEntitiesWithFields);
+        });
+
         it("should format the args in the range @@index attribute in the same way they were formatted in the model fields", async () => {
           // arrange
           const prismaSchema = `datasource db {

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -178,6 +178,118 @@ describe("prismaSchemaParser", () => {
         expect(result).toEqual(expectedEntitiesWithFields);
       });
 
+      it("should NOT have the '@default' attribute as a custom attribute if it is an id field", async () => {
+        // arrange
+        const prismaSchema = `datasource db {
+          provider = "postgresql"
+          url      = env("DB_URL")
+        }
+        
+        generator client {
+          provider = "prisma-client-js"
+        }
+        
+        model Example {
+          id    Int @id @default(0)
+          value Int    @default(123)    
+        }
+
+        model Test {
+          test_id    String @id @default("mock_id")
+          value2 Int        
+        }
+        `;
+        const existingEntities: ExistingEntitySelect[] = [];
+        // act
+        const result = await service.convertPrismaSchemaForImportObjects(
+          prismaSchema,
+          existingEntities,
+          actionContext
+        );
+        // assert
+        const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
+          {
+            id: expect.any(String),
+            name: "Example",
+            displayName: "Example",
+            pluralDisplayName: "Examples",
+            description: "",
+            customAttributes: "",
+            fields: [
+              {
+                permanentId: expect.any(String),
+                name: "id",
+                displayName: "Id",
+                dataType: EnumDataType.Id,
+                required: true,
+                unique: false,
+                searchable: false,
+                description: "",
+                properties: {
+                  idType: "AUTO_INCREMENT",
+                },
+                customAttributes: "",
+              },
+              {
+                permanentId: expect.any(String),
+                name: "value",
+                displayName: "Value",
+                dataType: EnumDataType.WholeNumber,
+                required: true,
+                unique: false,
+                searchable: false,
+                description: "",
+                properties: {
+                  maximumValue: 99999999999,
+                  minimumValue: 0,
+                },
+                customAttributes: "@default(123)",
+              },
+            ],
+          },
+          {
+            id: expect.any(String),
+            name: "Test",
+            displayName: "Test",
+            pluralDisplayName: "Tests",
+            description: "",
+            customAttributes: "",
+            fields: [
+              {
+                permanentId: expect.any(String),
+                name: "id",
+                displayName: "Id",
+                dataType: EnumDataType.Id,
+                required: true,
+                unique: false,
+                searchable: false,
+                description: "",
+                properties: {
+                  idType: "CUID",
+                },
+                customAttributes: '@map("test_id")',
+              },
+              {
+                permanentId: expect.any(String),
+                name: "value2",
+                displayName: "Value2",
+                dataType: EnumDataType.WholeNumber,
+                required: true,
+                unique: false,
+                searchable: false,
+                description: "",
+                properties: {
+                  maximumValue: 99999999999,
+                  minimumValue: 0,
+                },
+                customAttributes: "",
+              },
+            ],
+          },
+        ];
+        expect(result).toEqual(expectedEntitiesWithFields);
+      });
+
       it("should rename models starting in lower case to upper case, add a `@@map` attribute to the model with the original model name and a log informing what happened", async () => {
         // arrange
         const prismaSchema = `datasource db {

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -639,6 +639,7 @@ export class PrismaSchemaParserService {
     ) as Model[];
 
     const originalFieldNames = Object.keys(mapper.fieldNames);
+    const newFieldNames = Object.values(mapper.fieldNames);
 
     models.forEach((model: Model) => {
       builder.model(model.name).then<Model>((modelItem) => {
@@ -699,13 +700,15 @@ export class PrismaSchemaParserService {
               if (compositeArgs && !rangeIndexAttribute) {
                 const attrArgArr = (compositeArgs.value as RelationArray)?.args;
 
-                const shouldRename = attrArgArr?.some((arg) => {
-                  return originalFieldNames.includes(arg as string);
-                });
+                // avoid formatting an arg when the field in the model was not formatted, for example: the fk field of a relation
+                // or a field that represents an enum value
+                for (const [index, arg] of attrArgArr.entries()) {
+                  const newFieldName = newFieldNames.find(
+                    (item) => item.oldName === arg
+                  );
 
-                if (shouldRename) {
-                  for (const [index, arg] of attrArgArr.entries()) {
-                    attrArgArr[index] = formatFieldName(arg);
+                  if (newFieldName) {
+                    attrArgArr[index] = newFieldName.newName;
                   }
                 }
               }

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -638,9 +638,6 @@ export class PrismaSchemaParserService {
       (item) => item.type === MODEL_TYPE_NAME
     ) as Model[];
 
-    const originalFieldNames = Object.keys(mapper.fieldNames);
-    const newFieldNames = Object.values(mapper.fieldNames);
-
     models.forEach((model: Model) => {
       builder.model(model.name).then<Model>((modelItem) => {
         const modelAttributes = modelItem.properties.filter(
@@ -684,14 +681,12 @@ export class PrismaSchemaParserService {
                   rangeIndexAttribute.value as RelationArray
                 ).args as unknown as Array<Func>;
 
-                const shouldRename = rangeIndexArgArr?.some((arg) => {
-                  return originalFieldNames.includes(arg.name as string);
-                });
+                for (const arg of rangeIndexArgArr) {
+                  if (typeof arg.name === "string") {
+                    const newFieldName = mapper.fieldNames[arg.name].newName;
 
-                if (shouldRename) {
-                  for (const arg of rangeIndexArgArr) {
-                    if (typeof arg.name === "string") {
-                      arg.name = formatFieldName(arg.name);
+                    if (newFieldName) {
+                      arg.name = newFieldName;
                     }
                   }
                 }
@@ -703,9 +698,7 @@ export class PrismaSchemaParserService {
                 // avoid formatting an arg when the field in the model was not formatted, for example: the fk field of a relation
                 // or a field that represents an enum value
                 for (const [index, arg] of attrArgArr.entries()) {
-                  const newFieldName = newFieldNames.find(
-                    (item) => item.oldName === arg
-                  );
+                  const newFieldName = mapper.fieldNames[arg];
 
                   if (newFieldName) {
                     attrArgArr[index] = newFieldName.newName;

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -683,7 +683,7 @@ export class PrismaSchemaParserService {
 
                 for (const arg of rangeIndexArgArr) {
                   if (typeof arg.name === "string") {
-                    const newFieldName = mapper.fieldNames[arg.name].newName;
+                    const newFieldName = mapper.fieldNames[arg.name]?.newName;
 
                     if (newFieldName) {
                       arg.name = newFieldName;


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6616 and part of #6612

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 77aa88b</samp>

### Summary
🧪🛠️🗃️

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the addition of new test cases to the codebase.
2.  🛠️ - This emoji represents tools, construction, or repair, and can be used to indicate the improvement or refactoring of existing code or functionality.
3.  🗃️ - This emoji represents files, folders, or databases, and can be used to indicate the manipulation or conversion of data or schemas.
-->
This pull request enhances the `PrismaSchemaParserService` class and its tests to support more features and scenarios of the prisma schema language. It improves the conversion of prisma models and fields to amplication entities and fields, and adds new test cases to verify the correctness of the conversion.

> _`PrismaSchemaParser`_
> _Tests and refactors its code_
> _Autumn of improvement_

### Walkthrough
*  Add constant `DEFAULT_ATTRIBUTE_NAME` to hold the value of the `@default` attribute name used by prisma ([link](https://github.com/amplication/amplication/pull/6617/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R56))
  - Create an array of objects with the old and new names of the model fields after formatting ([link](https://github.com/amplication/amplication/pull/6617/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R642))
  - Iterate over each argument of the `@relation` attribute and replace it with the new name if there is a match in the array ([link](https://github.com/amplication/amplication/pull/6617/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L701-R711))
  - Remove the `@default` attribute from any id field if it exists, since it is handled by the idType property ([link](https://github.com/amplication/amplication/pull/6617/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R734), [link](https://github.com/amplication/amplication/pull/6617/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R801-R812))
  - Add an empty line and a comment to improve readability and explain the logic ([link](https://github.com/amplication/amplication/pull/6617/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R788), [link](https://github.com/amplication/amplication/pull/6617/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R734))
*  Replace hard-coded string "default" with the constant `DEFAULT_ATTRIBUTE_NAME` in `convertFieldToEntityField` method ([link](https://github.com/amplication/amplication/pull/6617/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1307-R1325))
  - Verify that the `@default` attribute is not added as a custom attribute to the id field of an entity ([link](https://github.com/amplication/amplication/pull/6617/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR181-R292))
  - Verify that the arguments in the `@@index` attribute of a model are not formatted if they were not formatted in the model fields ([link](https://github.com/amplication/amplication/pull/6617/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR836-R1000))



## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
