### PR TITLE
Fix/reference attr with duplicate field names

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -640,6 +640,9 @@ export class PrismaSchemaParserService {
 
     models.forEach((model: Model) => {
       builder.model(model.name).then<Model>((modelItem) => {
+        const modelFields = modelItem.properties.filter(
+          (prop) => prop.type === FIELD_TYPE_NAME
+        ) as Field[];
         const modelAttributes = modelItem.properties.filter(
           (prop) =>
             prop.type === ATTRIBUTE_TYPE_NAME && prop.kind === OBJECT_KIND_NAME
@@ -698,11 +701,15 @@ export class PrismaSchemaParserService {
                 // avoid formatting an arg when the field in the model was not formatted, for example: the fk field of a relation
                 // or a field that represents an enum value
                 for (const [index, arg] of attrArgArr.entries()) {
-                  const newFieldName = mapper.fieldNames[arg];
-
-                  if (newFieldName) {
-                    attrArgArr[index] = newFieldName.newName;
-                  }
+                  modelFields.forEach((field) => {
+                    // check that we are at the right field
+                    if (formatFieldName(field.name) === formatFieldName(arg)) {
+                      // if the field was formatted, we format the arg, otherwise we leave it as it is
+                      if (field.name !== arg) {
+                        attrArgArr[index] = field.name;
+                      }
+                    }
+                  });
                 }
               }
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

part of: https://github.com/amplication/amplication/issues/6612

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7a4290b</samp>

### Summary
🧪🛠️🗃️

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate that the change adds a new test case or improves the testing coverage or quality of the code.
2.  🛠️ - This emoji represents tools, fixing, or construction, and can be used to indicate that the change enhances or refactors an existing method or function, or improves the performance or reliability of the code.
3.  🗃️ - This emoji represents files, folders, or databases, and can be used to indicate that the change involves the Prisma schema, the database models, or the index attributes, or affects the data storage or manipulation of the code.
-->
This pull request improves the parsing of Prisma schema files for importing entities and fields. It fixes a bug in the handling of field names and index attributes, and adds a test case to verify the expected behavior. It affects the files `prismaSchemaParser.service.ts` and `prismaSchemaParser.service.spec.ts` in the `amplication-server` package.

> _`PrismaSchemaParser`_
> _Tests and improves index fields_
> _Autumn of bug fixes_

### Walkthrough
*  Add a new test case for the `convertPrismaSchemaForImportObjects` method of the `PrismaSchemaParserService` class, to check that the service does not format the arguments in the `@@index` attribute of a model if they were not formatted in the model fields and even if the field name exists on another model ([link](https://github.com/amplication/amplication/pull/6631/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR836-R1058))
* Modify the logic of the `convertPrismaSchemaForImportObjects` method of the `PrismaSchemaParserService` class, to handle the `@@index` attribute of a model more accurately ([link](https://github.com/amplication/amplication/pull/6631/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L701-R712))
  * Add a new variable `modelFields` to the method, to hold an array of `Field` objects that represent the fields of the current model being processed by the method ([link](https://github.com/amplication/amplication/pull/6631/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R643-R645))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
