### PR TITLE
fix(client): auth entity list value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplication",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "scripts": {
     "postinstall": "nx run-many --target=install",
     "format:check": "npx nx format:check --all",

--- a/packages/amplication-client/src/Components/EntitySelectField.tsx
+++ b/packages/amplication-client/src/Components/EntitySelectField.tsx
@@ -7,6 +7,7 @@ type TEntities = {
     {
       id: string;
       displayName: string;
+      name: string;
     }
   ];
 };
@@ -30,7 +31,7 @@ const EntitySelectField = ({ resourceId, isValueId, ...props }: Props) => {
   const entityListOptions = useMemo(() => {
     return entityList
       ? entityList.entities.map((entity) => ({
-          value: isValueId ? entity.id : entity.displayName,
+          value: isValueId ? entity.id : entity.name,
           label: entity.displayName,
         }))
       : [];
@@ -46,6 +47,7 @@ export const GET_ENTITIES_FOR_ENTITY_SELECT_FIELD = gql`
     entities(where: { resource: { id: $resourceId } }) {
       id
       displayName
+      name
     }
   }
 `;


### PR DESCRIPTION
Close: #6636 6636

## PR Details

Get the value of the auth entity from the name field and not from the display name field. 
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 23b54a5</samp>

### Summary
🆕🔄🛠️

<!--
1.  🆕 - This emoji can be used to indicate that a new feature or functionality was added, such as support for selecting entities by name.
2.  🔄 - This emoji can be used to indicate that something was changed or updated, such as the properties of the select field options and the type definition.
3.  🛠️ - This emoji can be used to indicate that something was fixed or improved, such as the GraphQL query.
-->
Improved the user experience of choosing entities in forms by allowing name-based search in the EntitySelectField component. Modified the component's code and query in `EntitySelectField.tsx` to handle the name-based selection.

> _Oh we're the coders of the sea, and we work with GraphQL_
> _We query and we mutate, and we fetch data by name_
> _We've changed the `value` and the `name` of the options in the field_
> _And we've updated the `TEntities` type, so the component is sealed_

### Walkthrough
*  Add `name` property to `TEntities` type to store entity name ([link](https://github.com/amplication/amplication/pull/6637/files?diff=unified&w=0#diff-816ca7a6d01e226f1bffe316b8ddaa9e253716ae934275fd3e019bcb776f94eeR10))
*  Use entity name as value of select field options when `isValueId` is false ([link](https://github.com/amplication/amplication/pull/6637/files?diff=unified&w=0#diff-816ca7a6d01e226f1bffe316b8ddaa9e253716ae934275fd3e019bcb776f94eeL33-R34))
*  Fetch entity name from server in GraphQL query for `EntitySelectField.tsx` ([link](https://github.com/amplication/amplication/pull/6637/files?diff=unified&w=0#diff-816ca7a6d01e226f1bffe316b8ddaa9e253716ae934275fd3e019bcb776f94eeR50))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
