### PR TITLE
fix(client): serviceSettings undefined

### DIFF
--- a/packages/amplication-client/src/Entity/EntityForm.tsx
+++ b/packages/amplication-client/src/Entity/EntityForm.tsx
@@ -107,7 +107,7 @@ const EntityForm = React.memo(({ entity, resourceId, onSubmit }: Props) => {
                 <NameField
                   name="name"
                   disabled={
-                    resourceSettings.serviceSettings.authEntityName ===
+                    resourceSettings?.serviceSettings?.authEntityName ===
                     entity?.name
                   }
                   capitalized

--- a/packages/amplication-client/src/Entity/EntityListItem.tsx
+++ b/packages/amplication-client/src/Entity/EntityListItem.tsx
@@ -107,12 +107,12 @@ export const EntityListItem = ({
 
   const handleConfirmDelete = useCallback(() => {
     setConfirmDelete(false);
-    const { serviceSettings } = resourceSettings;
-    const authEntity = serviceSettings.authEntityName;
+
+    const authEntity = resourceSettings?.serviceSettings?.authEntityName;
 
     if (authEntity === entity.name) {
       const updateServiceSettings = {
-        ...serviceSettings,
+        ...resourceSettings?.serviceSettings,
         authEntityName: null,
       };
       handleSubmit(updateServiceSettings);
@@ -133,8 +133,8 @@ export const EntityListItem = ({
 
   const [latestVersion] = entity.versions || [];
 
-  const isAuthEntity = resourceSettings.serviceSettings.authEntityName
-    ? entity.name === resourceSettings.serviceSettings.authEntityName
+  const isAuthEntity = resourceSettings?.serviceSettings?.authEntityName
+    ? entity.name === resourceSettings?.serviceSettings?.authEntityName
     : entity.name === USER_ENTITY;
 
   const isDeleteButtonDisable = isAuthEntity && isUserEntityMandatory;


### PR DESCRIPTION
Close: #6642 6642

## PR Details

Fix the crash on entityPage after refreshing/creating a new service and navigate to the entities page.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7769750</samp>

### Summary
🛡️🧹🐛

<!--
1.  🛡️ - This emoji represents the optional chaining operators, which act as a shield or guard against errors when accessing potentially undefined or null properties.
2.  🧹 - This emoji represents the cleanup and simplification of the code that renders entity list items, which makes it more readable and maintainable.
3.  🐛 - This emoji represents the bug fix for identifying the authentication entity, which was previously using the wrong property name.
-->
This pull request enhances the code quality and stability of the entity list and entity form components. It adds checks for undefined or null values of `resourceSettings` and `serviceSettings`, and fixes a bug in identifying the authentication entity.

> _To avoid errors and crashes galore_
> _We added some chaining to `resourceSettings` and more_
> _We also improved the rendering of list items_
> _And simplified the access to `serviceSettings`_
> _And fixed the auth entity, which was a chore_

### Walkthrough
*  Add optional chaining operators to `resourceSettings` and `serviceSettings` properties in `EntityForm.tsx` and `EntityListItem.tsx` to prevent errors when they are undefined or null ([link](https://github.com/amplication/amplication/pull/6643/files?diff=unified&w=0#diff-3062ace441feb59b0e7217df972f54ac6636f46703985818fdeefbf5a0854262L110-R110), [link](https://github.com/amplication/amplication/pull/6643/files?diff=unified&w=0#diff-10474dd63018ac20f39737ada065b27c77c77e7af13cd7ea3626fda58a9f450aL110-R115), [link](https://github.com/amplication/amplication/pull/6643/files?diff=unified&w=0#diff-10474dd63018ac20f39737ada065b27c77c77e7af13cd7ea3626fda58a9f450aL136-R137))
*  Remove unnecessary destructuring of `serviceSettings` from `resourceSettings` in `EntityListItem.tsx` to simplify the code and avoid duplication ([link](https://github.com/amplication/amplication/pull/6643/files?diff=unified&w=0#diff-10474dd63018ac20f39737ada065b27c77c77e7af13cd7ea3626fda58a9f450aL110-R115))
*  Use `resourceSettings` and `serviceSettings` properties to determine whether an entity is the authentication entity for the application in `EntityListItem.tsx` and display a lock icon and disable some actions accordingly ([link](https://github.com/amplication/amplication/pull/6643/files?diff=unified&w=0#diff-10474dd63018ac20f39737ada065b27c77c77e7af13cd7ea3626fda58a9f450aL136-R137))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

