### PR TITLE
feat(client): open contact us when connecting AWS Code Commit

### DIFF
--- a/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnectionList.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnectionList.tsx
@@ -92,7 +92,9 @@ export const GitProviderConnectionList: React.FC<Props> = ({
       />
       <GitProviderConnection
         provider={EnumGitProvider.AwsCodeCommit}
-        onSyncNewGitOrganizationClick={() => {}}
+        onSyncNewGitOrganizationClick={() => {
+          window.open("https://amplication.com/contact-us");
+        }}
         disabled={!showAwsCodeCommitConnect.hasAccess}
       />
     </div>


### PR DESCRIPTION
Fixes: amplication/private-issues/issues/33

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 22a40d8</samp>

### Summary
🪟📞🚧

<!--
1.  🪟 - This emoji can be used to indicate that a new window was opened as part of the change. It is also known as the window emoji and it shows a frame with four panes of glass.
2.  📞 - This emoji can be used to indicate that the contact us page was used as a placeholder for the AWS CodeCommit integration. It is also known as the telephone emoji and it shows a classic handset with a coiled cord.
3.  🚧 - This emoji can be used to indicate that the AWS CodeCommit integration is not yet fully supported and is under construction. It is also known as the construction emoji and it shows a sign with a yellow and black striped border and a yellow crane.
-->
Updated the AWS CodeCommit connection UI to direct users to the contact us page. This is part of the git provider integration feature in the client package.

> _`onSyncNewGitOrganizationClick`_
> _Opens contact page_
> _Amplication awaits feedback_

### Walkthrough
*  Update the contact us page URL for AWS CodeCommit integration ([link](https://github.com/amplication/amplication/pull/6655/files?diff=unified&w=0#diff-5af106441ba9187b6775a40d93abe24a8d709f56acd1bb7a60d58a1167fe4ef8L95-R97))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
