### PR TITLE
Feat(server): prepare field attributes

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaParser/constants.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/constants.ts
@@ -3,6 +3,8 @@ export const FIELD_TYPE_NAME = "field";
 export const ENUM_TYPE_NAME = "enum";
 export const ENUMERATOR_TYPE_NAME = "enumerator";
 export const ATTRIBUTE_TYPE_NAME = "attribute";
+export const DATA_SOURCE_TYPE_NAME = "datasource";
+export const PROVIDER_TYPE_NAME = "provider";
 
 export const KEY_VALUE_ARG_TYPE_NAME = "keyValue";
 export const ARRAY_ARG_TYPE_NAME = "array";

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -1767,6 +1767,73 @@ describe("prismaSchemaParser", () => {
           });
         });
       });
+
+      it("should replace the group attribute name to the provider name", async () => {
+        // arrange
+        const prismaSchema = `datasource db {
+          provider = "postgresql"
+          url      = env("DB_URL")
+        }
+        
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        model Admin {
+          id          Int     @id @default(cuid())
+          name        String @db.VarChar(255)
+        }
+        `;
+        const existingEntities: ExistingEntitySelect[] = [];
+        // act
+        const result = await service.convertPrismaSchemaForImportObjects(
+          prismaSchema,
+          existingEntities,
+          actionContext
+        );
+        // assert
+        const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
+          {
+            id: expect.any(String),
+            name: "Admin",
+            displayName: "Admin",
+            pluralDisplayName: "Admins",
+            description: "",
+            customAttributes: "",
+            fields: [
+              {
+                permanentId: expect.any(String),
+                name: "id",
+                displayName: "Id",
+                dataType: EnumDataType.Id,
+                required: true,
+                unique: false,
+                searchable: false,
+                description: "",
+                properties: {
+                  idType: "AUTO_INCREMENT",
+                },
+                customAttributes: "",
+              },
+              {
+                permanentId: expect.any(String),
+                name: "name",
+                displayName: "Name",
+                dataType: EnumDataType.SingleLineText,
+                required: true,
+                unique: false,
+                searchable: false,
+                description: "",
+                properties: {
+                  maxLength: 256,
+                },
+                customAttributes: "@postgresql.VarChar(255)",
+              },
+            ],
+          },
+        ];
+        expect(result).toEqual(expectedEntitiesWithFields);
+      });
     });
   });
 });

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -158,7 +158,7 @@ describe("prismaSchemaParser", () => {
                 properties: {
                   maxLength: 256,
                 },
-                customAttributes: "@db.VarChar(256)",
+                customAttributes: "@postgresql.VarChar(256)",
               },
               {
                 permanentId: expect.any(String),
@@ -362,7 +362,7 @@ describe("prismaSchemaParser", () => {
                 properties: {
                   maxLength: 256,
                 },
-                customAttributes: "@db.VarChar(256)",
+                customAttributes: "@postgresql.VarChar(256)",
               },
               {
                 permanentId: expect.any(String),
@@ -607,7 +607,7 @@ describe("prismaSchemaParser", () => {
                 properties: {
                   maxLength: 256,
                 },
-                customAttributes: "@db.VarChar(256)",
+                customAttributes: "@postgresql.VarChar(256)",
               },
               {
                 permanentId: expect.any(String),


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6439 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2f85fef</samp>

### Summary
🆕🧪🛠️

<!--
1.  🆕 for adding new constants and a new test case.
2.  🧪 for testing the new logic of the prisma schema parser service.
3.  🛠️ for fixing the import objects logic to work with the provider name.
-->
This pull request updates the prisma schema parser service and its test case to support the import objects logic. It adds a new method that changes the field custom attributes to use the provider name as the group name. It also adds some constants for the datasource and provider types.

> _`PrismaSchemaParser`_
> _Changes group to provider name_
> _Autumn of imports_

### Walkthrough
*  Add constants for datasource and provider type names ([link](https://github.com/amplication/amplication/pull/6665/files?diff=unified&w=0#diff-cea4199f26aaa9b9523a10e1f9172902449f42942f11f91d2cfe8bc4924941b7R6-R7))
*  Import additional types from `prisma-schema` package ([link](https://github.com/amplication/amplication/pull/6665/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R17-R18))
*  Import constants from `constants.ts` file ([link](https://github.com/amplication/amplication/pull/6665/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R58), [link](https://github.com/amplication/amplication/pull/6665/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R69))
*  Add and implement `prepareFieldAttributes` method to change the group attribute name of the field custom attributes to the provider name ([link](https://github.com/amplication/amplication/pull/6665/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R87), [link](https://github.com/amplication/amplication/pull/6665/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R579-R622))
*  Add test case for `prepareFieldAttributes` method ([link](https://github.com/amplication/amplication/pull/6665/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR1770-R1836))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
