### PR TITLE
Feat/handling issues with id field

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
@@ -9,6 +9,7 @@ import {
   MODEL_TYPE_NAME,
   NOW_FUNCTION_NAME,
   UPDATED_AT_ATTRIBUTE_NAME,
+  idTypePropertyMapByFieldType,
 } from "./constants";
 import { EnumDataType } from "../../prisma";
 import { ScalarType } from "prisma-schema-dsl-types";
@@ -101,6 +102,10 @@ export function idField(field: Field) {
   if (fieldIdType) {
     return EnumDataType.Id;
   }
+}
+
+export function isValidIdFieldType(fieldType: string) {
+  return idTypePropertyMapByFieldType.hasOwnProperty(fieldType);
 }
 
 export function lookupField(schema: Schema, field: Field) {

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -565,7 +565,7 @@ describe("prismaSchemaParser", () => {
           
           model Admin {
             createdAt  DateTime @default(now())
-            username   String   @unique @db.VarChar(256)
+            username   String   @db.VarChar(256)
             roles      Json?
           }`;
           const existingEntities: ExistingEntitySelect[] = [];
@@ -603,7 +603,7 @@ describe("prismaSchemaParser", () => {
                   displayName: "Username",
                   dataType: EnumDataType.SingleLineText,
                   required: true,
-                  unique: true,
+                  unique: false,
                   searchable: false,
                   description: "",
                   properties: {
@@ -634,6 +634,149 @@ describe("prismaSchemaParser", () => {
                   description: "",
                   properties: {
                     idType: "CUID",
+                  },
+                  customAttributes: "",
+                },
+              ],
+            },
+          ];
+          expect(result).toEqual(expectedEntitiesWithFields);
+        });
+
+        it("should rename a field to id if it is a unique field and its type is a valid id type and add the id and the a map with the original name", async () => {
+          // arrange
+          const prismaSchema = `datasource db {
+            provider = "postgresql"
+            url      = env("DB_URL")
+          }
+          
+          generator client {
+            provider = "prisma-client-js"
+          }
+          
+          model Admin {
+            username   String   @unique @db.VarChar(256)
+            createdAt  DateTime @default(now())
+            roles      Json?
+          }`;
+          const existingEntities: ExistingEntitySelect[] = [];
+          // act
+          const result = await service.convertPrismaSchemaForImportObjects(
+            prismaSchema,
+            existingEntities,
+            actionContext
+          );
+          // assert
+          const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
+            {
+              id: expect.any(String),
+              name: "Admin",
+              displayName: "Admin",
+              pluralDisplayName: "Admins",
+              description: "",
+              customAttributes: "",
+              fields: [
+                {
+                  permanentId: expect.any(String),
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: true,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    idType: "CUID",
+                  },
+                  customAttributes: '@db.VarChar(256) @map("username")',
+                },
+                {
+                  permanentId: expect.any(String),
+                  name: "createdAt",
+                  displayName: "Created At",
+                  dataType: EnumDataType.CreatedAt,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {},
+                  customAttributes: "",
+                },
+                {
+                  permanentId: expect.any(String),
+                  name: "roles",
+                  displayName: "Roles",
+                  dataType: EnumDataType.Json,
+                  required: false,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {},
+                  customAttributes: "",
+                },
+              ],
+            },
+          ];
+          expect(result).toEqual(expectedEntitiesWithFields);
+        });
+
+        it("should add the @id attribute to a field if its name is id but it is only decorated with the @unique attribute and it can be used as a valid id field", async () => {
+          // arrange
+          const prismaSchema = `datasource db {
+            provider = "postgresql"
+            url      = env("DB_URL")
+          }
+          
+          generator client {
+            provider = "prisma-client-js"
+          }
+          
+          model Admin {
+            id Int @unique
+            username String
+          }`;
+          const existingEntities: ExistingEntitySelect[] = [];
+          // act
+          const result = await service.convertPrismaSchemaForImportObjects(
+            prismaSchema,
+            existingEntities,
+            actionContext
+          );
+          // assert
+          const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
+            {
+              id: expect.any(String),
+              name: "Admin",
+              displayName: "Admin",
+              pluralDisplayName: "Admins",
+              description: "",
+              customAttributes: "",
+              fields: [
+                {
+                  permanentId: expect.any(String),
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: true,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    idType: "AUTO_INCREMENT",
+                  },
+                  customAttributes: "",
+                },
+                {
+                  permanentId: expect.any(String),
+                  name: "username",
+                  displayName: "Username",
+                  dataType: EnumDataType.SingleLineText,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    maxLength: 256,
                   },
                   customAttributes: "",
                 },
@@ -823,152 +966,6 @@ describe("prismaSchemaParser", () => {
           expect(result).toEqual(expectedEntitiesWithFields);
         });
 
-        it("should add the @id attribute to a field if its name is id but it is only decorated with the @unique attribute", async () => {
-          // arrange
-          const prismaSchema = `datasource db {
-            provider = "postgresql"
-            url      = env("DB_URL")
-          }
-          
-          generator client {
-            provider = "prisma-client-js"
-          }
-          
-          model Admin {
-            id Int @unique
-            username String
-          }`;
-          const existingEntities: ExistingEntitySelect[] = [];
-          // act
-          const result = await service.convertPrismaSchemaForImportObjects(
-            prismaSchema,
-            existingEntities,
-            actionContext
-          );
-          // assert
-          const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
-            {
-              id: expect.any(String),
-              name: "Admin",
-              displayName: "Admin",
-              pluralDisplayName: "Admins",
-              description: "",
-              customAttributes: "",
-              fields: [
-                {
-                  permanentId: expect.any(String),
-                  name: "id",
-                  displayName: "Id",
-                  dataType: EnumDataType.Id,
-                  required: true,
-                  unique: true,
-                  searchable: false,
-                  description: "",
-                  properties: {
-                    idType: "AUTO_INCREMENT",
-                  },
-                  customAttributes: "",
-                },
-                {
-                  permanentId: expect.any(String),
-                  name: "username",
-                  displayName: "Username",
-                  dataType: EnumDataType.SingleLineText,
-                  required: true,
-                  unique: false,
-                  searchable: false,
-                  description: "",
-                  properties: {
-                    maxLength: 256,
-                  },
-                  customAttributes: "",
-                },
-              ],
-            },
-          ];
-          expect(result).toEqual(expectedEntitiesWithFields);
-        });
-
-        it("should add a field with the @id attribute if the model doesn't have an id filed but it has a field with @unique attribute that is not named id", async () => {
-          // arrange
-          const prismaSchema = `datasource db {
-            provider = "postgresql"
-            url      = env("DB_URL")
-          }
-          
-          generator client {
-            provider = "prisma-client-js"
-          }
-          
-          model Admin {
-            myUniqueField String @unique
-            username String
-          }`;
-          const existingEntities: ExistingEntitySelect[] = [];
-          // act
-          const result = await service.convertPrismaSchemaForImportObjects(
-            prismaSchema,
-            existingEntities,
-            actionContext
-          );
-          // assert
-          const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
-            {
-              id: expect.any(String),
-              name: "Admin",
-              displayName: "Admin",
-              pluralDisplayName: "Admins",
-              description: "",
-              customAttributes: "",
-              fields: [
-                {
-                  permanentId: expect.any(String),
-                  name: "myUniqueField",
-                  displayName: "My Unique Field",
-                  dataType: EnumDataType.SingleLineText,
-                  required: true,
-                  unique: true,
-                  searchable: false,
-                  description: "",
-                  properties: {
-                    maxLength: 256,
-                  },
-                  customAttributes: "",
-                },
-                {
-                  permanentId: expect.any(String),
-                  name: "username",
-                  displayName: "Username",
-                  dataType: EnumDataType.SingleLineText,
-                  required: true,
-                  unique: false,
-                  searchable: false,
-                  description: "",
-                  properties: {
-                    maxLength: 256,
-                  },
-                  customAttributes: "",
-                },
-                {
-                  permanentId: expect.any(String),
-                  name: "id",
-                  displayName: "Id",
-                  dataType: EnumDataType.Id,
-                  required: true,
-                  unique: false,
-                  searchable: false,
-                  description: "",
-                  properties: {
-                    idType: "CUID",
-                  },
-                  customAttributes: "",
-                },
-              ],
-            },
-          ];
-          expect(result).toEqual(expectedEntitiesWithFields);
-        });
-
         it("should NOT have the '@default' attribute as a custom attribute if it is an id field", async () => {
           // arrange
           const prismaSchema = `datasource db {
@@ -1053,118 +1050,6 @@ describe("prismaSchemaParser", () => {
                   dataType: EnumDataType.Id,
                   required: true,
                   unique: false,
-                  searchable: false,
-                  description: "",
-                  properties: {
-                    idType: "CUID",
-                  },
-                  customAttributes: '@map("test_id")',
-                },
-                {
-                  permanentId: expect.any(String),
-                  name: "value2",
-                  displayName: "Value2",
-                  dataType: EnumDataType.WholeNumber,
-                  required: true,
-                  unique: false,
-                  searchable: false,
-                  description: "",
-                  properties: {
-                    maximumValue: 99999999999,
-                    minimumValue: 0,
-                  },
-                  customAttributes: "",
-                },
-              ],
-            },
-          ];
-          expect(result).toEqual(expectedEntitiesWithFields);
-        });
-
-        it("should NOT have the '@default' attribute as a custom attribute if it is an id field AND it has more than one attribute", async () => {
-          // arrange
-          const prismaSchema = `datasource db {
-            provider = "postgresql"
-            url      = env("DB_URL")
-          }
-          
-          generator client {
-            provider = "prisma-client-js"
-          }
-          
-          model Example {
-            id    Int @id @default(0)
-            value Int    @default(123)    
-          }
-  
-          model Test {
-            test_id    String @unique @id @default("mock_id")
-            value2 Int        
-          }
-          `;
-          const existingEntities: ExistingEntitySelect[] = [];
-          // act
-          const result = await service.convertPrismaSchemaForImportObjects(
-            prismaSchema,
-            existingEntities,
-            actionContext
-          );
-          // assert
-          const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
-            {
-              id: expect.any(String),
-              name: "Example",
-              displayName: "Example",
-              pluralDisplayName: "Examples",
-              description: "",
-              customAttributes: "",
-              fields: [
-                {
-                  permanentId: expect.any(String),
-                  name: "id",
-                  displayName: "Id",
-                  dataType: EnumDataType.Id,
-                  required: true,
-                  unique: false,
-                  searchable: false,
-                  description: "",
-                  properties: {
-                    idType: "AUTO_INCREMENT",
-                  },
-                  customAttributes: "",
-                },
-                {
-                  permanentId: expect.any(String),
-                  name: "value",
-                  displayName: "Value",
-                  dataType: EnumDataType.WholeNumber,
-                  required: true,
-                  unique: false,
-                  searchable: false,
-                  description: "",
-                  properties: {
-                    maximumValue: 99999999999,
-                    minimumValue: 0,
-                  },
-                  customAttributes: "@default(123)",
-                },
-              ],
-            },
-            {
-              id: expect.any(String),
-              name: "Test",
-              displayName: "Test",
-              pluralDisplayName: "Tests",
-              description: "",
-              customAttributes: "",
-              fields: [
-                {
-                  permanentId: expect.any(String),
-                  name: "id",
-                  displayName: "Id",
-                  dataType: EnumDataType.Id,
-                  required: true,
-                  unique: true,
                   searchable: false,
                   description: "",
                   properties: {

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -1080,6 +1080,118 @@ describe("prismaSchemaParser", () => {
           ];
           expect(result).toEqual(expectedEntitiesWithFields);
         });
+
+        it("should NOT have the '@default' attribute as a custom attribute if it is an id field AND it has more than one attribute", async () => {
+          // arrange
+          const prismaSchema = `datasource db {
+            provider = "postgresql"
+            url      = env("DB_URL")
+          }
+          
+          generator client {
+            provider = "prisma-client-js"
+          }
+          
+          model Example {
+            id    Int @id @default(0)
+            value Int    @default(123)    
+          }
+  
+          model Test {
+            test_id    String @unique @id @default("mock_id")
+            value2 Int        
+          }
+          `;
+          const existingEntities: ExistingEntitySelect[] = [];
+          // act
+          const result = await service.convertPrismaSchemaForImportObjects(
+            prismaSchema,
+            existingEntities,
+            actionContext
+          );
+          // assert
+          const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
+            {
+              id: expect.any(String),
+              name: "Example",
+              displayName: "Example",
+              pluralDisplayName: "Examples",
+              description: "",
+              customAttributes: "",
+              fields: [
+                {
+                  permanentId: expect.any(String),
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    idType: "AUTO_INCREMENT",
+                  },
+                  customAttributes: "",
+                },
+                {
+                  permanentId: expect.any(String),
+                  name: "value",
+                  displayName: "Value",
+                  dataType: EnumDataType.WholeNumber,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    maximumValue: 99999999999,
+                    minimumValue: 0,
+                  },
+                  customAttributes: "@default(123)",
+                },
+              ],
+            },
+            {
+              id: expect.any(String),
+              name: "Test",
+              displayName: "Test",
+              pluralDisplayName: "Tests",
+              description: "",
+              customAttributes: "",
+              fields: [
+                {
+                  permanentId: expect.any(String),
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: true,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    idType: "CUID",
+                  },
+                  customAttributes: '@map("test_id")',
+                },
+                {
+                  permanentId: expect.any(String),
+                  name: "value2",
+                  displayName: "Value2",
+                  dataType: EnumDataType.WholeNumber,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    maximumValue: 99999999999,
+                    minimumValue: 0,
+                  },
+                  customAttributes: "",
+                },
+              ],
+            },
+          ];
+          expect(result).toEqual(expectedEntitiesWithFields);
+        });
       });
 
       describe("when model has @@index/@@id/@@unique attributes", () => {

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -786,6 +786,87 @@ describe("prismaSchemaParser", () => {
           expect(result).toEqual(expectedEntitiesWithFields);
         });
 
+        it("should add the @id attribute to unique field named id, when the model has other unique fields", async () => {
+          // arrange
+          const prismaSchema = `datasource db {
+            provider = "postgresql"
+            url      = env("DB_URL")
+          }
+          
+          generator client {
+            provider = "prisma-client-js"
+          }
+          
+          model Admin {
+            test String @unique
+            id Int @unique
+            username String
+          }`;
+          const existingEntities: ExistingEntitySelect[] = [];
+          // act
+          const result = await service.convertPrismaSchemaForImportObjects(
+            prismaSchema,
+            existingEntities,
+            actionContext
+          );
+          // assert
+          const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
+            {
+              id: expect.any(String),
+              name: "Admin",
+              displayName: "Admin",
+              pluralDisplayName: "Admins",
+              description: "",
+              customAttributes: "",
+              fields: [
+                {
+                  permanentId: expect.any(String),
+                  name: "test",
+                  displayName: "Test",
+                  dataType: EnumDataType.SingleLineText,
+                  required: true,
+                  unique: true,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    maxLength: 256,
+                  },
+                  customAttributes: "",
+                },
+                {
+                  permanentId: expect.any(String),
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: true,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    idType: "AUTO_INCREMENT",
+                  },
+                  customAttributes: "",
+                },
+                {
+                  permanentId: expect.any(String),
+                  name: "username",
+                  displayName: "Username",
+                  dataType: EnumDataType.SingleLineText,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    maxLength: 256,
+                  },
+                  customAttributes: "",
+                },
+              ],
+            },
+          ];
+          expect(result).toEqual(expectedEntitiesWithFields);
+        });
+
         it("should throw an error when the id field is the PK of the model AND the FK of the relation", async () => {
           const prismaSchema = `datasource db {
             provider = "postgresql"

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -777,6 +777,7 @@ export class PrismaSchemaParserService {
           field.attributes?.some((attr) => attr.name === UNIQUE_ATTRIBUTE_NAME)
       );
 
+      // if we have more than one unique field that can be used as id field, we pick the first one and convert it to id field
       if (!hasIdField && uniqueFieldAsIdField) {
         if (uniqueFieldAsIdField.name !== ID_FIELD_NAME) {
           builder

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -793,7 +793,6 @@ export class PrismaSchemaParserService {
               field.name = ID_FIELD_NAME;
             });
 
-          this.logger.debug("builder", { builder });
           mapper.idFields[uniqueFieldAsIdField.name] = {
             oldName: uniqueFieldAsIdField.name,
             newName: ID_FIELD_NAME,

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -740,25 +740,6 @@ export class PrismaSchemaParserService {
         (property) => property.type === FIELD_TYPE_NAME
       ) as Field[];
 
-      const hasIdField = modelFields.some(
-        (field) =>
-          field.attributes?.some((attr) => attr.name === ID_ATTRIBUTE_NAME) ??
-          false
-      );
-
-      // add the id field if it doesn't exist. The type is the default type for id field in Amplication - String
-      if (!hasIdField) {
-        builder
-          .model(model.name)
-          .field(ID_FIELD_NAME, "String")
-          .attribute(ID_ATTRIBUTE_NAME);
-
-        void actionContext.onEmitUserActionLog(
-          `id field was added to model "${model.name}"`,
-          EnumActionLogLevel.Warning
-        );
-      }
-
       modelFields.forEach((field: Field) => {
         const isIdField = field.attributes?.some(
           (attr) => attr.name === ID_ATTRIBUTE_NAME
@@ -779,7 +760,7 @@ export class PrismaSchemaParserService {
           builder
             .model(model.name)
             .field(field.name)
-            .attribute("map", [`"${model.name}Id"`]);
+            .attribute("map", [`"${field.name}"`]);
           builder
             .model(model.name)
             .field(field.name)
@@ -827,6 +808,25 @@ export class PrismaSchemaParserService {
             .field(field.name)
             .removeAttribute(DEFAULT_ATTRIBUTE_NAME);
       });
+
+      const hasIdField = modelFields.some(
+        (field) =>
+          field.attributes?.some((attr) => attr.name === ID_ATTRIBUTE_NAME) ??
+          false
+      );
+
+      // add the id field if it doesn't exist. The type is the default type for id field in Amplication - String
+      if (!hasIdField) {
+        builder
+          .model(model.name)
+          .field(ID_FIELD_NAME, "String")
+          .attribute(ID_ATTRIBUTE_NAME);
+
+        void actionContext.onEmitUserActionLog(
+          `id field was added to model "${model.name}"`,
+          EnumActionLogLevel.Warning
+        );
+      }
     });
     return {
       builder,

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -574,7 +574,7 @@ export class PrismaSchemaParserService {
    * This function handle cases where the model doesn't have an id field (field with "@id" attribute),
    * but it has a composite id - unique identifier for a record in a database that is formed by combining multiple field values.
    * Model with composite id are decorated with `@@id` attribute on the model.
-   * In this cases, we rename the `@@id` attribute to `@@unique` and add id filed of type String with `@id` attribute to the model
+   * In this cases, we rename the `@@id` attribute to `@@unique`
    */
   private prepareModelIdAttribute({
     builder,
@@ -607,16 +607,7 @@ export class PrismaSchemaParserService {
         EnumActionLogLevel.Warning
       );
 
-      // add an id field with id attribute to the model
-      builder
-        .model(model.name)
-        .field(ID_FIELD_NAME, "String")
-        .attribute(ID_ATTRIBUTE_NAME);
-
-      void actionContext.onEmitUserActionLog(
-        `id field was added to model "${model.name}"`,
-        EnumActionLogLevel.Warning
-      );
+      // adding the id field to the model is done in the prepareIdField operation
     });
 
     return {
@@ -749,10 +740,35 @@ export class PrismaSchemaParserService {
         (property) => property.type === FIELD_TYPE_NAME
       ) as Field[];
 
+      const hasIdField = modelFields.some(
+        (field) =>
+          field.attributes?.some((attr) => attr.name === ID_ATTRIBUTE_NAME) ??
+          false
+      );
+
+      // add the id field if it doesn't exist. The type is the default type for id field in Amplication - String
+      if (!hasIdField) {
+        builder
+          .model(model.name)
+          .field(ID_FIELD_NAME, "String")
+          .attribute(ID_ATTRIBUTE_NAME);
+
+        void actionContext.onEmitUserActionLog(
+          `id field was added to model "${model.name}"`,
+          EnumActionLogLevel.Warning
+        );
+      }
+
       modelFields.forEach((field: Field) => {
         const isIdField = field.attributes?.some(
           (attr) => attr.name === ID_ATTRIBUTE_NAME
         );
+
+        if (isIdField && this.isFkFieldOfARelation(schema, model, field)) {
+          throw new Error(
+            `Using the foreign key field as the primary key is not supported. The field "${field.name}" is a primary key on model "${model.name}" but also a foreign key on the related model. Please fix this issue and import the schema again.`
+          );
+        }
 
         if (!isIdField && field.name === ID_FIELD_NAME) {
           void actionContext.onEmitUserActionLog(


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6676

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4416e1c</samp>

### Summary
🧪🔧🚫

<!--
1.  🧪 for updating the test cases
2.  🔧 for refactoring the logic
3.  🚫 for adding validation and error handling
-->
This pull request improves the prisma schema parser service to handle id fields consistently and robustly. It ensures that every model has a `String` id field, and rejects schemas with id fields that are foreign keys. It also updates the test cases accordingly.

> _Prisma schema parse_
> _`id` field must be unique_
> _Autumn leaves fall fast_

### Walkthrough
*  Add `prepareIdField` operation to ensure every model has an id field compatible with Amplication ([link](https://github.com/amplication/amplication/pull/6677/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R743-R761))
  - Throw an error if the id field is also a foreign key field of a relation ([link](https://github.com/amplication/amplication/pull/6677/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R767-R772))
  - Add a test case for this operation ([link](https://github.com/amplication/amplication/pull/6677/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL666-R793))
* Remove code that adds an id field in `prepareModelIdAttribute` operation ([link](https://github.com/amplication/amplication/pull/6677/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L610-R610))
  - Update the comment to reflect the new logic ([link](https://github.com/amplication/amplication/pull/6677/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L577-R577))
  - Remove a test case that is no longer relevant ([link](https://github.com/amplication/amplication/pull/6677/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL181-L292))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
