### PR TITLE
Refactor(server): db schema mapper

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
@@ -13,6 +13,7 @@ import {
 import { EnumDataType } from "../../prisma";
 import { ScalarType } from "prisma-schema-dsl-types";
 import { camelCase } from "lodash";
+import { Mapper } from "./types";
 
 export function capitalizeFirstLetter(string): string {
   return string.charAt(0).toUpperCase() + string.slice(1);
@@ -211,4 +212,29 @@ export function jsonField(field: Field) {
   if (field.fieldType === ScalarType.Json) {
     return EnumDataType.Json;
   }
+}
+
+export function findOriginalModelName(
+  mapper: Mapper,
+  modelName: string
+): string {
+  return (
+    Object.values(mapper.modelNames).find((item) => item.newName === modelName)
+      ?.originalName || modelName
+  );
+}
+
+export function findOriginalFieldName(
+  mapper: Mapper,
+  fieldName: string
+): string {
+  for (const [, fields] of Object.entries(mapper.fieldNames)) {
+    const field = Object.values(fields).find(
+      (value) => value.newName === fieldName
+    );
+    if (field) {
+      return field.originalName;
+    }
+  }
+  return fieldName;
 }

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -571,11 +571,6 @@ export class PrismaSchemaParserService {
               };
             }
 
-            mapper.fieldTypes[model.name][field.name][field.fieldType] = {
-              originalName: field.fieldType,
-              newName,
-            };
-
             void actionContext.onEmitUserActionLog(
               `field type "${field.fieldType}" on model "${model.name}" was changed to "${newName}"`,
               EnumActionLogLevel.Info

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -31,6 +31,8 @@ import {
   singleLineTextField,
   updateAtField,
   wholeNumberField,
+  findOriginalFieldName,
+  findOriginalModelName,
 } from "./helpers";
 import {
   handleModelNamesCollision,
@@ -453,12 +455,7 @@ export class PrismaSchemaParserService {
     const schema = builder.getSchema();
     const models = schema.list.filter((item) => item.type === MODEL_TYPE_NAME);
     models.map((model: Model) => {
-      const findOriginalModelName = (modelName: string): string =>
-        Object.values(mapper.modelNames).find(
-          (item) => item.newName === modelName
-        )?.originalName || modelName;
-
-      const originalModelName = findOriginalModelName(model.name);
+      const originalModelName = findOriginalModelName(mapper, model.name);
 
       const modelFieldList = model.properties.filter(
         (property) =>
@@ -554,25 +551,8 @@ export class PrismaSchemaParserService {
 
     Object.entries(mapper.modelNames).map(([originalName, { newName }]) => {
       models.map((model: Model) => {
-        const findOriginalModelName = (modelName: string): string =>
-          Object.values(mapper.modelNames).find(
-            (item) => item.newName === modelName
-          )?.originalName || modelName;
-
-        const findOriginalFieldName = (fieldName: string): string => {
-          for (const [, fields] of Object.entries(mapper.fieldNames)) {
-            const field = Object.values(fields).find(
-              (value) => value.newName === fieldName
-            );
-            if (field) {
-              return field.originalName;
-            }
-          }
-          return fieldName;
-        };
-
-        const originalModelName = findOriginalModelName(model.name);
-        const originalFieldName = findOriginalFieldName(model.name);
+        const originalModelName = findOriginalModelName(mapper, model.name);
+        const originalFieldName = findOriginalFieldName(mapper, model.name);
         const fields = model.properties.filter(
           (property) => property.type === FIELD_TYPE_NAME
         ) as Field[];

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -136,8 +136,6 @@ export class PrismaSchemaParserService {
         actionContext,
       });
 
-      this.logger.debug("mapper", preparedSchemaResult.mapper);
-
       void onEmitUserActionLog(
         "Prepare Prisma Schema for import completed",
         EnumActionLogLevel.Info

--- a/packages/amplication-server/src/core/prismaSchemaParser/types.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/types.ts
@@ -20,19 +20,18 @@ export type PrepareOperationIO = {
   actionContext: ActionContext;
 };
 
-type OriginalModelName = string;
-type OriginalFieldName = string;
-type NewModelName = string;
-type NewFieldName = string;
+type ModelName = string; // formatted model name
+type FieldName = string; // formatted field name
+type FieldTypeName = string; // formatted field type name
 
 export type Mapper = {
-  modelNames: Record<OriginalModelName, MapperItem>;
-  fieldNames: Record<NewModelName, Record<OriginalFieldName, MapperItem>>;
+  modelNames: Record<ModelName, MapperItem>;
+  fieldNames: Record<ModelName, Record<FieldName, MapperItem>>;
   fieldTypes: Record<
-    NewModelName,
-    Record<NewFieldName, Record<string, MapperItem>>
+    ModelName,
+    Record<ModelName, Record<FieldTypeName, MapperItem>>
   >;
-  idFields: Record<NewModelName, Record<NewFieldName, MapperItem>>;
+  idFields: Record<ModelName, Record<FieldName, MapperItem>>;
 };
 
 export type MapperItem = {

--- a/packages/amplication-server/src/core/prismaSchemaParser/types.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/types.ts
@@ -20,15 +20,23 @@ export type PrepareOperationIO = {
   actionContext: ActionContext;
 };
 
+type OriginalModelName = string;
+type OriginalFieldName = string;
+type NewModelName = string;
+type NewFieldName = string;
+
 export type Mapper = {
-  modelNames: Record<string, MapperItem>;
-  fieldNames: Record<string, MapperItem>;
-  fieldTypes: Record<string, MapperItem>;
-  idFields: Record<string, MapperItem>;
+  modelNames: Record<OriginalModelName, MapperItem>;
+  fieldNames: Record<NewModelName, Record<OriginalFieldName, MapperItem>>;
+  fieldTypes: Record<
+    NewModelName,
+    Record<NewFieldName, Record<string, MapperItem>>
+  >;
+  idFields: Record<NewModelName, Record<NewFieldName, MapperItem>>;
 };
 
 export type MapperItem = {
-  oldName: string;
+  originalName: string;
   newName: string;
 };
 

--- a/packages/amplication-server/src/core/prismaSchemaParser/types.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/types.ts
@@ -20,9 +20,9 @@ export type PrepareOperationIO = {
   actionContext: ActionContext;
 };
 
-type ModelName = string; // formatted model name
-type FieldName = string; // formatted field name
-type FieldTypeName = string; // formatted field type name
+type ModelName = string; // original model name
+type FieldName = string; // original field name
+type FieldTypeName = string; // original field type name
 
 export type Mapper = {
   modelNames: Record<ModelName, MapperItem>;

--- a/packages/amplication-server/src/core/prismaSchemaParser/types.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/types.ts
@@ -20,9 +20,18 @@ export type PrepareOperationIO = {
   actionContext: ActionContext;
 };
 
-type ModelName = string; // original model name
-type FieldName = string; // original field name
-type FieldTypeName = string; // original field type name
+/**
+ * original model name
+ */
+type ModelName = string;
+/**
+ * Original field name
+ */
+type FieldName = string;
+/**
+ * original field type name
+ */
+type FieldTypeName = string;
 
 export type Mapper = {
   modelNames: Record<ModelName, MapperItem>;


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6651

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 847b047</samp>

### Summary
📝♻️🐛

<!--
1.  📝 for updating the type definitions
2.  ♻️ for refactoring the `Mapper` type and its properties
3.  🐛 for adding a debug log statement and renaming some variables
-->
This pull request improves the Prisma schema parser service by refactoring the `Mapper` type and its usage, to avoid name conflicts and enhance readability and debugging. It also updates the corresponding type definitions in `types.ts`.

> _`Mapper` type changed_
> _Nested objects with new keys_
> _Autumn leaves falling_

### Walkthrough
*  Rename the `oldName` property of the `MapperItem` type to `originalName`, and update the variable name accordingly ([link](https://github.com/amplication/amplication/pull/6685/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L410-R412), [link](https://github.com/amplication/amplication/pull/6685/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L537-R548))
*  Change the structure of the `fieldNames`, `fieldTypes`, and `idFields` properties of the `Mapper` type to nested objects, using the new model name, the new field name, and the original field type as keys, and add conditional checks to create the nested objects if they do not exist ([link](https://github.com/amplication/amplication/pull/6685/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L489-R503), [link](https://github.com/amplication/amplication/pull/6685/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L543-R575), [link](https://github.com/amplication/amplication/pull/6685/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L774-R817))
*  Update the access and assignment of the `fieldNames`, `fieldTypes`, and `idFields` properties of the `Mapper` type, using the new keys and the constant `ID_FIELD_NAME` ([link](https://github.com/amplication/amplication/pull/6685/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L689-R720), [link](https://github.com/amplication/amplication/pull/6685/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L796-R848))
*  Update the type definitions of the `Mapper` and the `MapperItem` types in `types.ts`, using more descriptive and specific type aliases ([link](https://github.com/amplication/amplication/pull/6685/files?diff=unified&w=0#diff-e63e35639170ef509c305f88cb604991597f84c7c18a46aba7b00423f7dbfee6L23-R39))
*  Add a debug log statement to print the mapper object in `prismaSchemaParser.service.ts` ([link](https://github.com/amplication/amplication/pull/6685/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R137-R138))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
