### PR TITLE
Fix(server): adding map attribute to formatted models and fields only if it doesn't exists

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -268,7 +268,7 @@ describe("prismaSchemaParser", () => {
           },
         ];
         expect(result).toEqual(expectedEntitiesWithFields);
-        expect(actionContext.onEmitUserActionLog).toBeCalledTimes(7);
+        expect(actionContext.onEmitUserActionLog).toBeCalledTimes(8);
         expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
           1,
           "Starting Prisma Schema Validation",
@@ -286,21 +286,26 @@ describe("prismaSchemaParser", () => {
         );
         expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
           4,
-          `Model name "admin" was changed to "Admin"`,
+          `attribute "@@map" was added to the model "admin"`,
           EnumActionLogLevel.Info
         );
         expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
           5,
-          `Prepare Prisma Schema for import completed`,
+          `Model name "admin" was changed to "Admin"`,
           EnumActionLogLevel.Info
         );
         expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
           6,
-          `Create import objects from Prisma Schema`,
+          `Prepare Prisma Schema for import completed`,
           EnumActionLogLevel.Info
         );
         expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
           7,
+          `Create import objects from Prisma Schema`,
+          EnumActionLogLevel.Info
+        );
+        expect(actionContext.onEmitUserActionLog).toHaveBeenNthCalledWith(
+          8,
           `Create import objects from Prisma Schema completed`,
           EnumActionLogLevel.Info
         );
@@ -689,6 +694,83 @@ describe("prismaSchemaParser", () => {
                     idType: "CUID",
                   },
                   customAttributes: '@db.VarChar(256) @map("username")',
+                },
+                {
+                  permanentId: expect.any(String),
+                  name: "createdAt",
+                  displayName: "Created At",
+                  dataType: EnumDataType.CreatedAt,
+                  required: true,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {},
+                  customAttributes: "",
+                },
+                {
+                  permanentId: expect.any(String),
+                  name: "roles",
+                  displayName: "Roles",
+                  dataType: EnumDataType.Json,
+                  required: false,
+                  unique: false,
+                  searchable: false,
+                  description: "",
+                  properties: {},
+                  customAttributes: "",
+                },
+              ],
+            },
+          ];
+          expect(result).toEqual(expectedEntitiesWithFields);
+        });
+
+        it("should rename a field to id if it is a unique field and its type is a valid id type and add the id and should NOT add the a map with the original name", async () => {
+          // arrange
+          const prismaSchema = `datasource db {
+            provider = "postgresql"
+            url      = env("DB_URL")
+          }
+          
+          generator client {
+            provider = "prisma-client-js"
+          }
+          
+          model Admin {
+            username   String   @unique @db.VarChar(256) @map("username_123")
+            createdAt  DateTime @default(now())
+            roles      Json?
+          }`;
+          const existingEntities: ExistingEntitySelect[] = [];
+          // act
+          const result = await service.convertPrismaSchemaForImportObjects(
+            prismaSchema,
+            existingEntities,
+            actionContext
+          );
+          // assert
+          const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
+            {
+              id: expect.any(String),
+              name: "Admin",
+              displayName: "Admin",
+              pluralDisplayName: "Admins",
+              description: "",
+              customAttributes: "",
+              fields: [
+                {
+                  permanentId: expect.any(String),
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: true,
+                  searchable: false,
+                  description: "",
+                  properties: {
+                    idType: "CUID",
+                  },
+                  customAttributes: '@db.VarChar(256) @map("username_123")',
                 },
                 {
                   permanentId: expect.any(String),

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -12,7 +12,6 @@ import {
   RelationArray,
   Func,
   ConcretePrismaSchemaBuilder,
-  Attribute,
   BlockAttribute,
 } from "@mrleebo/prisma-ast";
 import {
@@ -45,6 +44,8 @@ import {
   addIdFieldIfNotExists,
   handleIdFieldNotNamedId,
   handleNotIdFieldNotUniqueNamedId,
+  addMapAttributeToField,
+  addMapAttributeToModel,
 } from "./schema-utils";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
 import pluralize from "pluralize";
@@ -66,7 +67,6 @@ import {
   ID_ATTRIBUTE_NAME,
   ID_FIELD_NAME,
   INDEX_ATTRIBUTE_NAME,
-  MAP_ATTRIBUTE_NAME,
   MODEL_TYPE_NAME,
   OBJECT_KIND_NAME,
   RELATION_ATTRIBUTE_NAME,
@@ -393,15 +393,6 @@ export class PrismaSchemaParserService {
       (item) => item.type === MODEL_TYPE_NAME
     ) as Model[];
     modelList.map((model: Model) => {
-      const modelAttributes = model.properties.filter(
-        (prop) =>
-          prop.type === ATTRIBUTE_TYPE_NAME && prop.kind === OBJECT_KIND_NAME
-      ) as BlockAttribute[];
-
-      const hasMapAttribute = modelAttributes?.some(
-        (attribute) => attribute.name === MAP_ATTRIBUTE_NAME
-      );
-
       const formattedModelName = formatModelName(model.name);
 
       if (formattedModelName !== model.name) {
@@ -417,15 +408,12 @@ export class PrismaSchemaParserService {
           newName: newModelName,
         };
 
+        addMapAttributeToModel(builder, model, actionContext);
+
         void actionContext.onEmitUserActionLog(
           `Model name "${model.name}" was changed to "${newModelName}"`,
           EnumActionLogLevel.Info
         );
-
-        !hasMapAttribute &&
-          builder
-            .model(model.name)
-            .blockAttribute(MAP_ATTRIBUTE_NAME, model.name);
 
         builder.model(model.name).then<Model>((model) => {
           model.name = newModelName;
@@ -469,17 +457,6 @@ export class PrismaSchemaParserService {
         if (this.isOptionSetField(schema, field)) return builder;
         if (this.isMultiSelectOptionSetField(schema, field)) return builder;
 
-        const fieldAttributes = field.attributes?.filter(
-          (attr) => attr.type === ATTRIBUTE_TYPE_NAME
-        ) as Attribute[];
-
-        const hasMapAttribute = fieldAttributes?.find(
-          (attribute: Attribute) => attribute.name === MAP_ATTRIBUTE_NAME
-        );
-
-        const shouldAddMapAttribute =
-          !hasMapAttribute && !this.isLookupField(schema, field);
-
         const formattedFieldName = formatFieldName(field.name);
 
         if (formattedFieldName !== field.name) {
@@ -502,11 +479,7 @@ export class PrismaSchemaParserService {
             EnumActionLogLevel.Info
           );
 
-          shouldAddMapAttribute &&
-            builder
-              .model(model.name)
-              .field(field.name)
-              .attribute(MAP_ATTRIBUTE_NAME, [`"${field.name}"`]);
+          addMapAttributeToField(builder, schema, model, field, actionContext);
 
           builder
             .model(model.name)
@@ -792,6 +765,7 @@ export class PrismaSchemaParserService {
       if (!hasIdField && uniqueFieldAsIdField) {
         convertUniqueFieldNotNamedIdToIdField(
           builder,
+          schema,
           model,
           uniqueFieldAsIdField,
           mapper,
@@ -814,13 +788,21 @@ export class PrismaSchemaParserService {
           // if the field is named "id" but it is not decorated with id, nor with @unique - we rename it to ${modelName}Id
           handleNotIdFieldNotUniqueNamedId(
             builder,
+            schema,
             model,
             field,
             mapper,
             actionContext
           );
         } else if (isIdField && field.name !== ID_FIELD_NAME) {
-          handleIdFieldNotNamedId(builder, model, field, mapper, actionContext);
+          handleIdFieldNotNamedId(
+            builder,
+            schema,
+            model,
+            field,
+            mapper,
+            actionContext
+          );
         }
 
         const hasDefaultAttributeOnIdField =

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
@@ -32,6 +32,7 @@ import {
   filterOutAmplicationAttributes,
   formatDisplayName,
   formatModelName,
+  lookupField,
 } from "./helpers";
 import { ExistingEntitySelect, Mapper } from "./types";
 import { CreateBulkFieldsInput } from "../entity/entity.service";
@@ -459,16 +460,29 @@ export function convertUniqueFieldNamedIdToIdField(
 
 export function convertUniqueFieldNotNamedIdToIdField(
   builder: ConcretePrismaSchemaBuilder,
+  schema: Schema,
   model: Model,
   uniqueFieldAsIdField: Field,
   mapper: Mapper,
   actionContext: ActionContext
 ) {
+  addMapAttributeToField(
+    builder,
+    schema,
+    model,
+    uniqueFieldAsIdField,
+    actionContext
+  );
+
   builder
     .model(model.name)
     .field(uniqueFieldAsIdField.name)
-    .attribute(ID_ATTRIBUTE_NAME)
-    .attribute("map", [`"${uniqueFieldAsIdField.name}"`]);
+    .attribute(ID_ATTRIBUTE_NAME);
+
+  void actionContext.onEmitUserActionLog(
+    `attribute "@id" was added to the field "${uniqueFieldAsIdField.name}" on model "${model.name}"`,
+    EnumActionLogLevel.Info
+  );
 
   mapper.idFields[uniqueFieldAsIdField.name] = {
     oldName: uniqueFieldAsIdField.name,
@@ -477,10 +491,6 @@ export function convertUniqueFieldNotNamedIdToIdField(
 
   void actionContext.onEmitUserActionLog(
     `field ${uniqueFieldAsIdField.name} was renamed to ${ID_FIELD_NAME}`,
-    EnumActionLogLevel.Info
-  );
-  void actionContext.onEmitUserActionLog(
-    `attribute "@id" was added to the field "${uniqueFieldAsIdField.name}" on model "${model.name}"`,
     EnumActionLogLevel.Info
   );
 
@@ -494,6 +504,7 @@ export function convertUniqueFieldNotNamedIdToIdField(
 
 export function handleIdFieldNotNamedId(
   builder: ConcretePrismaSchemaBuilder,
+  schema: Schema,
   model: Model,
   field: Field,
   mapper: Mapper,
@@ -504,10 +515,7 @@ export function handleIdFieldNotNamedId(
     EnumActionLogLevel.Info
   );
 
-  builder
-    .model(model.name)
-    .field(field.name)
-    .attribute("map", [`"${field.name}"`]);
+  addMapAttributeToField(builder, schema, model, field, actionContext);
 
   builder
     .model(model.name)
@@ -524,6 +532,7 @@ export function handleIdFieldNotNamedId(
 
 export function handleNotIdFieldNotUniqueNamedId(
   builder: ConcretePrismaSchemaBuilder,
+  schema: Schema,
   model: Model,
   field: Field,
   mapper: Mapper,
@@ -534,10 +543,8 @@ export function handleNotIdFieldNotUniqueNamedId(
     EnumActionLogLevel.Info
   );
 
-  builder
-    .model(model.name)
-    .field(field.name)
-    .attribute("map", [`"${field.name}"`]);
+  addMapAttributeToField(builder, schema, model, field, actionContext);
+
   builder
     .model(model.name)
     .field(field.name)
@@ -549,4 +556,60 @@ export function handleNotIdFieldNotUniqueNamedId(
     oldName: field.name,
     newName: `${model.name}Id`,
   };
+}
+
+// add map attribute to model if the model was formatted and if the map attribute is not already exists
+export function addMapAttributeToModel(
+  builder: ConcretePrismaSchemaBuilder,
+  model: Model,
+  actionContext: ActionContext
+) {
+  const modelAttributes = model.properties.filter(
+    (prop) =>
+      prop.type === ATTRIBUTE_TYPE_NAME && prop.kind === OBJECT_KIND_NAME
+  ) as BlockAttribute[];
+
+  const hasMapAttribute = modelAttributes?.some(
+    (attribute) => attribute.name === MAP_ATTRIBUTE_NAME
+  );
+
+  if (!hasMapAttribute) {
+    builder.model(model.name).blockAttribute(MAP_ATTRIBUTE_NAME, model.name);
+
+    void actionContext.onEmitUserActionLog(
+      `attribute "@@map" was added to the model "${model.name}"`,
+      EnumActionLogLevel.Info
+    );
+  }
+}
+
+// add map attribute to field if the field was formatted and if the map attribute is not already exists and if the field is not a lookup field
+export function addMapAttributeToField(
+  builder: ConcretePrismaSchemaBuilder,
+  schema: Schema,
+  model: Model,
+  field: Field,
+  actionContext: ActionContext
+) {
+  const fieldAttributes = field.attributes?.filter(
+    (attr) => attr.type === ATTRIBUTE_TYPE_NAME
+  ) as Attribute[];
+
+  const hasMapAttribute = fieldAttributes?.find(
+    (attribute: Attribute) => attribute.name === MAP_ATTRIBUTE_NAME
+  );
+
+  const shouldAddMapAttribute = !hasMapAttribute && !lookupField(schema, field);
+
+  if (shouldAddMapAttribute) {
+    builder
+      .model(model.name)
+      .field(field.name)
+      .attribute(MAP_ATTRIBUTE_NAME, [`"${field.name}"`]);
+
+    void actionContext.onEmitUserActionLog(
+      `attribute "@map" was added to the field "${field.name}" on model "${model.name}"`,
+      EnumActionLogLevel.Info
+    );
+  }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6697 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cff7b9d</samp>

### Summary
📝🔧🗺️

<!--
1.  📝 - This emoji represents the addition of a new log message and a new test case for handling `@map` attributes in Prisma schema parsing. It also implies updating the existing test cases to match the new logic and order of operations. The emoji suggests writing, documenting, or testing code.
2.  🔧 - This emoji represents the refactoring of the code that adds `@map` and `@@map` attributes to fields and models in the prisma schema parser service. It also implies extracting common logic into separate functions and passing the schema parameter where needed. The emoji suggests fixing, improving, or optimizing code.
3.  🗺️ - This emoji represents the addition of `addMapAttributeToModel` and `addMapAttributeToField` functions to simplify and unify the logic of adding `@@map` and `@map` attributes to models and fields that were formatted by the prisma schema parser. It also implies refactoring existing functions that used this logic to use the new functions and pass the `schema` parameter as needed. The emoji suggests mapping, transforming, or renaming data or code.
-->
Refactored and improved the prisma schema parser service and its tests. Extracted common logic for adding `@map` and `@@map` attributes to models and fields into separate functions in `schema-utils.ts`. Added a new log message and a test case for handling `@map` attributes. Updated existing test cases to match the new logic and order of operations.

> _`@map` attributes_
> _added to schema models_
> _autumn leaves falling_

### Walkthrough
*  Add `addMapAttributeToModel` and `addMapAttributeToField` functions to handle adding `@@map` and `@map` attributes to models and fields that were formatted, and emit log messages for these actions ([link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R47-R48), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R560-R615))
*  Call `addMapAttributeToModel` before changing the model name, and remove the redundant code that checked and added the `@@map` attribute ([link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L396-L404), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R411-R412), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L425-L429))
*  Call `addMapAttributeToField` instead of adding the `@map` attribute directly, and remove the redundant code that checked the `@map` attribute ([link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L472-L482), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L505-R482), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L467-R486), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L507-R518), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L537-R550))
*  Add log messages for adding the `@id` attribute to a field in `convertUniqueFieldNotNamedIdToIdField` ([link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L467-R486), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L482-L485))
*  Add `schema` parameter to `convertUniqueFieldNotNamedIdToIdField`, `handleIdFieldNotNamedId`, and `handleNotIdFieldNotUniqueNamedId` functions, and pass it from `prismaSchemaParser.service.ts` ([link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R768), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R791), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L823-R805), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R463), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R507), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R535))
*  Export `lookupField` function, which is used by `addMapAttributeToField` ([link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R35))
*  Remove unused imports and constants from `prismaSchemaParser.service.ts` ([link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L15), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L69))
*  Update and reorder expected log messages and number of calls in `prismaSchemaParser.service.spec.ts` ([link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL271-R271), [link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL289-R308))
*  Add a new test case in `prismaSchemaParser.service.spec.ts` for the scenario where a field is a unique field and its type is a valid id type, but it is not named `id` ([link](https://github.com/amplication/amplication/pull/6699/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR728-R804))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
