### PR TITLE
fix(build-manager): failing to start

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "dependencies": {
-    "@amplication/opentelemetry-nestjs": "^4.3.0",
+    "@amplication/opentelemetry-nestjs": "^4.3.7",
     "@amplication/react-compound-timer": "^2.1.0",
     "@amplication/react-diff-viewer-continued": "^3.4.3",
     "@apollo/client": "^3.7.1",

--- a/packages/amplication-build-manager/src/app.module.ts
+++ b/packages/amplication-build-manager/src/app.module.ts
@@ -6,6 +6,7 @@ import { HealthModule } from "./health/health.module";
 import { AmplicationLoggerModule } from "@amplication/util/nestjs/logging";
 import { Env } from "./env";
 import { TracingModule } from "@amplication/util/nestjs/tracing";
+import { ControllerInjector } from "@amplication/opentelemetry-nestjs";
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { TracingModule } from "@amplication/util/nestjs/tracing";
     }),
     TracingModule.forRoot({
       serviceName: Env.SERVICE_NAME,
+      traceAutoInjectors: [ControllerInjector],
     }),
     HealthModule,
     BuildRunnerModule,

--- a/packages/amplication-storage-gateway/src/app.module.ts
+++ b/packages/amplication-storage-gateway/src/app.module.ts
@@ -8,6 +8,11 @@ import { ServeStaticModule } from "@nestjs/serve-static";
 import { ServeStaticOptionsService } from "./serveStaticOptions.service";
 import { StorageModule } from "./storage/storage.module";
 import { AuthModule } from "./auth/auth.module";
+import { TracingModule } from "@amplication/util/nestjs/tracing";
+import {
+  ControllerInjector,
+  GuardInjector,
+} from "@amplication/opentelemetry-nestjs";
 
 @Module({
   controllers: [],
@@ -23,6 +28,10 @@ import { AuthModule } from "./auth/auth.module";
     }),
     ServeStaticModule.forRootAsync({
       useClass: ServeStaticOptionsService,
+    }),
+    TracingModule.forRoot({
+      serviceName: "amplication-storage-gateway",
+      traceAutoInjectors: [ControllerInjector, GuardInjector],
     }),
   ],
   providers: [


### PR DESCRIPTION
Close: https://github.com/amplication/amplication/issues/6648
Leverage: https://github.com/amplication/opentelemetry-nestjs/pull/5

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4f7f636</samp>

### Summary
🐛🕵️🚀

<!--
1.  🐛 - for the bug fixes and improvements in the updated dependency.
2.  🕵️ - for the tracing support for NestJS controllers in the build manager package.
3.  🚀 - for the tracing configuration and injectors in the storage gateway package, which can improve the performance and reliability of the application.
-->
Added tracing support for NestJS applications in `amplication-build-manager` and `amplication-storage-gateway` packages. Updated `@amplication/opentelemetry-nestjs` dependency to the latest version.

> _Sing, O Muse, of the skillful builders of Amplication_
> _Who updated their tracing dependency with great care_
> _And with the help of the ControllerInjector, swift and wise_
> _They adorned their NestJS packages with spans of light_

### Walkthrough
*  Update `@amplication/opentelemetry-nestjs` dependency to version 4.3.7 ([link](https://github.com/amplication/amplication/pull/6708/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L32-R32))
*  Enable tracing for NestJS controllers in `amplication-build-manager` package using `ControllerInjector` ([link](https://github.com/amplication/amplication/pull/6708/files?diff=unified&w=0#diff-bb7fed01d4077da01de8a825066ecfc44cdaf8fd0d14bc8fcc30fc686d1bb428R9), [link](https://github.com/amplication/amplication/pull/6708/files?diff=unified&w=0#diff-bb7fed01d4077da01de8a825066ecfc44cdaf8fd0d14bc8fcc30fc686d1bb428R22))
*  Enable tracing for NestJS controllers and guards in `amplication-storage-gateway` package using `ControllerInjector` and `GuardInjector` ([link](https://github.com/amplication/amplication/pull/6708/files?diff=unified&w=0#diff-fd985c5a8b4b124c59f092c8563c819be77edb5994b4733b45869c8aaa5ded2eR11-R15), [link](https://github.com/amplication/amplication/pull/6708/files?diff=unified&w=0#diff-fd985c5a8b4b124c59f092c8563c819be77edb5994b4733b45869c8aaa5ded2eR32-R35))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
