### PR TITLE
feat(server): error message when trying to import a schema with exist…

### DIFF
--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -553,7 +553,7 @@ export class EntityService {
     if (existingEntities.length > 0) {
       existingEntities.forEach((entity) => {
         void actionContext.onEmitUserActionLog(
-          `Entity "${entity.name}" already exists`,
+          `Entity "${entity.name}" already exists, exists in the service. To proceed with the import, please rename or remove the entity in your schema file or remove the conflicting entity from the service.`,
           EnumActionLogLevel.Error
         );
 

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -553,7 +553,7 @@ export class EntityService {
     if (existingEntities.length > 0) {
       existingEntities.forEach((entity) => {
         void actionContext.onEmitUserActionLog(
-          `Entity "${entity.name}" already exists, exists in the service. To proceed with the import, please rename or remove the entity in your schema file or remove the conflicting entity from the service.`,
+          `Entity "${entity.name}" already exists in the service. To proceed with the import, please rename or remove the entity in your schema file or remove the conflicting entity from the service.`,
           EnumActionLogLevel.Error
         );
 


### PR DESCRIPTION

Close: #6716

## PR Details

This PR will give clear error message when trying to import a schema with an entity that already exists in the service

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f69eafe</samp>

### Summary
📝🚀🛠️

<!--
1.  📝 This emoji represents the improvement of the error message, which is a documentation or text-related change.
2.  🚀 This emoji represents the implementation of the import feature, which is a new feature or enhancement that adds functionality to the service.
3.  🛠️ This emoji represents the validation and creation of entities, which is a bug fix or improvement that affects the service logic or performance.
-->
Improve error message for entity name conflict in `EntityService`. This is part of a feature to import entities from a schema file.

> _`EntityService`_
> _Checks for name collisions_
> _Error message helps_

### Walkthrough
* Improve error message for entity name conflict ([link](https://github.com/amplication/amplication/pull/6717/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L556-R556))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
