### PR TITLE
fix(client): properly send step name to BI

### DIFF
--- a/packages/amplication-client/src/Resource/create-resource/ServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/ServiceWizard.tsx
@@ -24,7 +24,7 @@ export type WizardStep = {
   hideFooter?: boolean;
   hideBackButton?: boolean;
   analyticsEventName: AnalyticsEventNames;
-  stepName?: string;
+  stepName: string;
 };
 
 interface ServiceWizardProps {
@@ -247,9 +247,7 @@ const ServiceWizard: React.FC<ServiceWizardProps> = ({
           buttonStyle={EnumButtonStyle.Clear}
           className={`${moduleCss}__close`}
           onClick={() =>
-            handleCloseWizard(
-              (currentPage.type as React.JSXElementConstructor<any>).name
-            )
+            handleCloseWizard(wizardSteps[currWizardPatternIndex]?.stepName)
           }
         >
           <Icon icon="close" size="xsmall"></Icon>


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #5755

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 03a8afa</samp>

### Summary
📊🧭🧙

<!--
1.  📊 - This emoji represents analytics or data, and could be used to indicate that the change improves the analytics of the resource creation wizard by using the `stepName` as a parameter for tracking user actions and progress.
2.  🧭 - This emoji represents navigation or direction, and could be used to indicate that the change improves the navigation of the resource creation wizard by using the `stepName` as a key for closing the wizard and returning to the previous screen.
3.  🧙 - This emoji represents a wizard or magic, and could be used to indicate that the change affects the resource creation wizard component and its functionality.
-->
Improved resource creation wizard by making `stepName` mandatory and using it for closing. This affects the file `ServiceWizard.tsx` and the analytics and navigation of the wizard.

> _Wizard steps require_
> _`stepName` for analytics_
> _Closing in autumn_

### Walkthrough
* Make `stepName` mandatory for wizard steps to enable analytics and navigation ([link](https://github.com/amplication/amplication/pull/6719/files?diff=unified&w=0#diff-0273c6a1bce77418f4703e81ff3c453ac85e01c023ebfe753abdf09901227424L27-R27))
* Use `stepName` instead of component name to close wizard more reliably ([link](https://github.com/amplication/amplication/pull/6719/files?diff=unified&w=0#diff-0273c6a1bce77418f4703e81ff3c453ac85e01c023ebfe753abdf09901227424L250-R250))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
