### PR TITLE
fix(client): installing auth plugin to services fails

### DIFF
--- a/packages/amplication-client/src/Plugins/PluginsCatalog.tsx
+++ b/packages/amplication-client/src/Plugins/PluginsCatalog.tsx
@@ -182,7 +182,7 @@ const PluginsCatalog: React.FC<Props> = ({ match }: Props) => {
             variables: {
               data: {
                 displayName: plugin.name,
-                pluginId: plugin.id,
+                pluginId: plugin.pluginId,
                 enabled: true,
                 npm: plugin.npm,
                 version: pluginVersion.version,

--- a/packages/amplication-client/src/Plugins/PluginsCatalogItem.tsx
+++ b/packages/amplication-client/src/Plugins/PluginsCatalogItem.tsx
@@ -137,7 +137,7 @@ function PluginsCatalogItem({
       <div className={`${CLASS_NAME}__row `}>
         <span className="spacer" />
         <span className={`${CLASS_NAME}__repo`}>
-          <a href={plugin.github} target="github_plugin">
+          <a href={plugin?.github} target="github_plugin">
             View on GitHub
           </a>
         </span>


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6661 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f7b15fe</samp>

### Summary
🔧🔄🚧

<!--
1.  🔧 - This emoji represents a fix or improvement of an existing feature or functionality. The change to use the `pluginId` property instead of the `id` property is a fix for a potential bug or inconsistency in the plugin management logic.
2.  🔄 - This emoji represents a change or update of an existing feature or functionality. The change to make the `plugin` object optional in the `href` attribute is an update to handle a possible edge case or scenario where the plugin data is not available yet.
3.  🚧 - This emoji represents a work in progress or an incomplete feature or functionality. The change to make the `plugin` object optional in the `href` attribute may also indicate that the plugin data loading logic is not fully implemented or tested yet, and that the feature is still under development.
-->
Fixed a bug in the plugins catalog that caused incorrect plugin toggling and a potential error when loading plugin data. Changed the `pluginId` property of the `data` object in `PluginsCatalog.tsx` and made the `plugin` object optional in the `href` attribute of the anchor element in `PluginsCatalogItem.tsx`.

> _`pluginId` is key_
> _to toggle the right plugin_
> _avoid errors too_

### Walkthrough
*  Use `pluginId` instead of `id` to identify plugins in `PluginsCatalog` ([link](https://github.com/amplication/amplication/pull/6722/files?diff=unified&w=0#diff-c04b321b9fbe9466d4437357cde44fb0d2d37ff0f142837eadadc332969f99cbL185-R185))
*  Make `plugin` object optional in `href` attribute of anchor element in `PluginsCatalogItem` to avoid error when plugin data is not loaded ([link](https://github.com/amplication/amplication/pull/6722/files?diff=unified&w=0#diff-069de3b168a7ec6810b1453bcb08a63346d53aff23003da53f0ea774bd4324e1L140-R140))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
