### PR TITLE
refactor(server): use enum to avoid eslint-disable

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaParser/constants.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/constants.ts
@@ -29,34 +29,23 @@ export const ID_TYPE_CUID = "CUID";
 export const ID_TYPE_UUID = "UUID";
 export const ID_TYPE_AUTO_INCREMENT = "AUTO_INCREMENT";
 export const ID_TYPE_AUTO_INCREMENT_BIG_INT = "AUTO_INCREMENT_BIG_INT";
-export const INT_TYPE = "INT";
-export const BIG_INT_TYPE = "BIG_INT";
-export const DECIMAL_TYPE = "DECIMAL";
-export const FLOAT_TYPE = "FLOAT";
 
 export const PRISMA_TYPE_STRING = "String";
 export const PRISMA_TYPE_INT = "Int";
 export const PRISMA_TYPE_BIG_INT = "BigInt";
 
-export const wholeNumberMap = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  Int: INT_TYPE,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  BigInt: BIG_INT_TYPE,
-};
+export enum WholeNumberType {
+  Int = "INT",
+  BigInt = "BIG_INT",
+}
 
-export const decimalNumberMap = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  Float: FLOAT_TYPE,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  Decimal: DECIMAL_TYPE,
-};
+export enum DecimalNumberType {
+  Float = "FLOAT",
+  Decimal = "DECIMAL",
+}
 
-export const idTypePropertyMapByFieldType = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  Int: ID_TYPE_AUTO_INCREMENT,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  String: ID_TYPE_CUID,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  BigInt: ID_TYPE_AUTO_INCREMENT_BIG_INT,
+export const idTypePropertyMapByPrismaFieldType = {
+  [PRISMA_TYPE_INT]: ID_TYPE_AUTO_INCREMENT,
+  [PRISMA_TYPE_STRING]: ID_TYPE_CUID,
+  [PRISMA_TYPE_BIG_INT]: ID_TYPE_AUTO_INCREMENT_BIG_INT,
 };

--- a/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/helpers.ts
@@ -9,7 +9,7 @@ import {
   MODEL_TYPE_NAME,
   NOW_FUNCTION_NAME,
   UPDATED_AT_ATTRIBUTE_NAME,
-  idTypePropertyMapByFieldType,
+  idTypePropertyMapByPrismaFieldType,
 } from "./constants";
 import { EnumDataType } from "../../prisma";
 import { ScalarType } from "prisma-schema-dsl-types";
@@ -106,7 +106,7 @@ export function idField(field: Field) {
 }
 
 export function isValidIdFieldType(fieldType: string) {
-  return idTypePropertyMapByFieldType.hasOwnProperty(fieldType);
+  return idTypePropertyMapByPrismaFieldType.hasOwnProperty(fieldType);
 }
 
 export function lookupField(schema: Schema, field: Field) {

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -84,9 +84,9 @@ import {
   PRISMA_TYPE_STRING,
   RELATION_ATTRIBUTE_NAME,
   UNIQUE_ATTRIBUTE_NAME,
-  decimalNumberMap,
-  idTypePropertyMapByFieldType,
-  wholeNumberMap,
+  WholeNumberType,
+  DecimalNumberType,
+  idTypePropertyMapByPrismaFieldType,
 } from "./constants";
 import { isValidSchema } from "./validators";
 import { EnumDataType } from "../../enums/EnumDataType";
@@ -1225,7 +1225,7 @@ export class PrismaSchemaParserService {
     );
 
     const properties = <types.DecimalNumber>{
-      databaseFieldType: decimalNumberMap[field.fieldType as string],
+      databaseFieldType: DecimalNumberType[field.fieldType as string],
       minimumValue: 0,
       maximumValue: 99999999999,
       precision: 8,
@@ -1266,7 +1266,7 @@ export class PrismaSchemaParserService {
     );
 
     const properties = <types.WholeNumber>{
-      databaseFieldType: wholeNumberMap[field.fieldType as string],
+      databaseFieldType: WholeNumberType[field.fieldType as string],
       minimumValue: 0,
       maximumValue: 99999999999,
     };
@@ -1379,7 +1379,7 @@ export class PrismaSchemaParserService {
 
     if (!defaultIdAttribute) {
       const properties = <types.Id>{
-        idType: idTypePropertyMapByFieldType[field.fieldType as string],
+        idType: idTypePropertyMapByPrismaFieldType[field.fieldType as string],
       };
       entityField.properties = properties as unknown as {
         [key: string]: JsonValue;


### PR DESCRIPTION
Relates: #6618

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a47cbdf</samp>

### Summary
🔧📝🎨

<!--
1.  🔧 - This emoji represents a change that fixes or improves something, such as a bug, a typo, a performance issue, or a refactoring. In this case, the change simplifies the code and makes it more consistent with Prisma and Amplication types, which can be considered an improvement.
2.  📝 - This emoji represents a change that involves documentation, comments, or naming. In this case, the change renames a constant and updates its usage, which can be considered a documentation or naming improvement.
3.  🎨 - This emoji represents a change that involves style, formatting, or design. In this case, the change refactors the code to use enums and constants, which can be considered a style or formatting improvement.
-->
Refactored the `prismaSchemaParser` service and related files to use enums and constants for database field types and properties. This improves the code quality and consistency with Prisma and Amplication types.

> _We are the parsers of the Prisma schema_
> _We use enums and constants to defy the data_
> _We simplify the code with our logic and skill_
> _We are the masters of the field types we build_

### Walkthrough
*  Replace constants for database field types with enums for type safety and readability ([link](https://github.com/amplication/amplication/pull/6742/files?diff=unified&w=0#diff-cea4199f26aaa9b9523a10e1f9172902449f42942f11f91d2cfe8bc4924941b7L32-L35), [link](https://github.com/amplication/amplication/pull/6742/files?diff=unified&w=0#diff-cea4199f26aaa9b9523a10e1f9172902449f42942f11f91d2cfe8bc4924941b7L41-R50), [link](https://github.com/amplication/amplication/pull/6742/files?diff=unified&w=0#diff-aeb3a345e8fc10eda18645cc829cc19037c48dedaa7f858a5b6fef7db7d8bb1aL12-R12), [link](https://github.com/amplication/amplication/pull/6742/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L87-R89), [link](https://github.com/amplication/amplication/pull/6742/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1228-R1228), [link](https://github.com/amplication/amplication/pull/6742/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1269-R1269))
* Rename idTypePropertyMapByFieldType to idTypePropertyMapByPrismaFieldType to reflect its purpose ([link](https://github.com/amplication/amplication/pull/6742/files?diff=unified&w=0#diff-cea4199f26aaa9b9523a10e1f9172902449f42942f11f91d2cfe8bc4924941b7L41-R50), [link](https://github.com/amplication/amplication/pull/6742/files?diff=unified&w=0#diff-aeb3a345e8fc10eda18645cc829cc19037c48dedaa7f858a5b6fef7db7d8bb1aL109-R109), [link](https://github.com/amplication/amplication/pull/6742/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L87-R89), [link](https://github.com/amplication/amplication/pull/6742/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1382-R1382))
* Update `prismaSchemaParser.service.ts` to use the new enums and constant for parsing the Prisma schema and generating the Amplication properties ([link](https://github.com/amplication/amplication/pull/6742/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1228-R1228), [link](https://github.com/amplication/amplication/pull/6742/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1269-R1269), [link](https://github.com/amplication/amplication/pull/6742/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1382-R1382))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
