### PR TITLE
fix(client): ERD view is not showing properly the entities after updates #6741

### DIFF
--- a/packages/amplication-client/src/Entity/EntityERD/EntitiesERD.tsx
+++ b/packages/amplication-client/src/Entity/EntityERD/EntitiesERD.tsx
@@ -49,6 +49,7 @@ export default function EntitiesERD({ resourceId }: { resourceId: string }) {
       setNodes(nodes);
       setEdges(edges);
     },
+    fetchPolicy: "no-cache",
   });
 
   const errorMessage = error && formatError(error);


### PR DESCRIPTION
This fixes the issue [#6741 ](https://github.com/amplication/amplication/issues/6741), by forcing apollo to refetch when viewing the ERD again, instead of using cached version. 