### PR TITLE
fix(server): call refresh token if needed in bitbucket methods

### DIFF
--- a/libs/util/git/src/git-client.service.spec.ts
+++ b/libs/util/git/src/git-client.service.spec.ts
@@ -58,7 +58,6 @@ describe("GitClientService", () => {
   const getGitInstallationUrlMock = jest.fn();
   const getCurrentOAuthUserMock = jest.fn();
   const getOAuthTokensMock = jest.fn();
-  const refreshAccessTokenMock = jest.fn();
   const getGitGroupsMock = jest.fn();
   const getRepositoryMock = jest.fn();
   const getRepositoriesMock = jest.fn();
@@ -79,7 +78,6 @@ describe("GitClientService", () => {
     getGitInstallationUrl: getGitInstallationUrlMock,
     getCurrentOAuthUser: getCurrentOAuthUserMock,
     getOAuthTokens: getOAuthTokensMock,
-    refreshAccessToken: refreshAccessTokenMock,
     getGitGroups: getGitGroupsMock,
     getRepository: getRepositoryMock,
     getRepositories: getRepositoriesMock,

--- a/libs/util/git/src/git-client.service.ts
+++ b/libs/util/git/src/git-client.service.ts
@@ -68,10 +68,6 @@ export class GitClientService {
     return this.provider.getOAuthTokens(authorizationCode);
   }
 
-  async refreshAccessToken(): Promise<OAuthTokens> {
-    return this.provider.refreshAccessToken();
-  }
-
   async getCurrentOAuthUser(accessToken: string): Promise<CurrentUser> {
     return this.provider.getCurrentOAuthUser(accessToken);
   }

--- a/libs/util/git/src/git-provider.interface.ts
+++ b/libs/util/git/src/git-provider.interface.ts
@@ -30,7 +30,6 @@ export interface GitProvider {
   getGitInstallationUrl(amplicationWorkspaceId: string): Promise<string>;
   getCurrentOAuthUser(accessToken: string): Promise<CurrentUser>;
   getOAuthTokens(authorizationCode: string): Promise<OAuthTokens>;
-  refreshAccessToken(): Promise<OAuthTokens>;
   getGitGroups(): Promise<PaginatedGitGroup>;
   getRepository(
     getRepositoryArgs: GetRepositoryArgs

--- a/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.spec.ts
@@ -70,12 +70,6 @@ describe("AwsCodeCommit", () => {
     );
   });
 
-  it("should throw an error when calling refreshAccessToken()", async () => {
-    await expect(gitProvider.refreshAccessToken()).rejects.toThrowError(
-      "Method not implemented."
-    );
-  });
-
   it("should throw an error when calling getGitGroups()", async () => {
     await expect(gitProvider.getGitGroups()).rejects.toThrowError(
       "Method not implemented."

--- a/libs/util/git/src/providers/aws/aws-code-commit.service.ts
+++ b/libs/util/git/src/providers/aws/aws-code-commit.service.ts
@@ -107,9 +107,6 @@ export class AwsCodeCommitService implements GitProvider {
   async getOAuthTokens(): Promise<OAuthTokens> {
     throw NotImplementedError;
   }
-  async refreshAccessToken(): Promise<OAuthTokens> {
-    throw NotImplementedError;
-  }
   async getGitGroups(): Promise<PaginatedGitGroup> {
     throw NotImplementedError;
   }

--- a/libs/util/git/src/providers/bitbucket/bitbucket.service.spec.ts
+++ b/libs/util/git/src/providers/bitbucket/bitbucket.service.spec.ts
@@ -648,6 +648,16 @@ describe("bitbucket.service", () => {
         .spyOn(requests, "createCommentOnPrRequest")
         .mockResolvedValue(mockedCreateCommentOnResponse);
 
+      const spyOnRefreshToken = jest
+        .spyOn(service, "refreshAccessToken")
+        .mockResolvedValue({
+          accessToken: "my-token",
+          expiresAt: 3600,
+          refreshToken: "my-refresh-token",
+          scopes: ["repository:write", "pullrequest:write"],
+          tokenType: "bearer",
+        });
+
       await service.createPullRequestComment({
         where: {
           issueNumber: 1,
@@ -658,6 +668,7 @@ describe("bitbucket.service", () => {
         data: { body: "this is my comment for the pull request" },
       });
 
+      expect(spyOnRefreshToken).toHaveBeenCalledTimes(1);
       expect(spyOnCreateCommentOnPrRequest).toHaveBeenCalledTimes(1);
       expect(spyOnCreateCommentOnPrRequest).toHaveBeenCalledWith(
         "my-group",
@@ -1044,6 +1055,16 @@ describe("bitbucket.service", () => {
         .spyOn(requests, "createPullRequestFromRequest")
         .mockResolvedValue(mockedCreatePullRequestResponse);
 
+      const spyOnRefreshToken = jest
+        .spyOn(service, "refreshAccessToken")
+        .mockResolvedValue({
+          accessToken: "my-token",
+          expiresAt: 3600,
+          refreshToken: "my-refresh-token",
+          scopes: ["repository:write", "pullrequest:write"],
+          tokenType: "bearer",
+        });
+
       const result = await service.createPullRequest({
         owner: "maccheroni",
         repositoryName: "best-repo",
@@ -1059,6 +1080,7 @@ describe("bitbucket.service", () => {
         number: 2,
       };
 
+      expect(spyOnRefreshToken).toHaveBeenCalledTimes(1);
       expect(spyOnCreatePullRequestFromRequest).toBeCalledTimes(1);
       expect(result).toEqual(expectedResult);
     });

--- a/libs/util/git/src/providers/bitbucket/bitbucket.service.spec.ts
+++ b/libs/util/git/src/providers/bitbucket/bitbucket.service.spec.ts
@@ -77,11 +77,22 @@ describe("bitbucket.service", () => {
         ],
       } as unknown as PaginatedTreeEntry;
 
+      const spyOnRefreshToken = jest
+        .spyOn(service, "refreshAccessToken")
+        .mockResolvedValue({
+          accessToken: "my-token",
+          expiresAt: 3600,
+          refreshToken: "my-refresh-token",
+          scopes: ["repository:write", "pullrequest:write"],
+          tokenType: "bearer",
+        });
+
       const spyOnGetFileRequest = jest
         .spyOn(requests, "getFileMetaRequest")
         .mockResolvedValue(mockedGetFileMetaResponse);
 
-      expect.assertions(2);
+      expect.assertions(3);
+
       try {
         await service.getFile({
           path: "tests/",
@@ -95,6 +106,8 @@ describe("bitbucket.service", () => {
           "Path points to a directory, please provide a file path"
         );
       }
+
+      expect(spyOnRefreshToken).toHaveBeenCalledTimes(1);
       expect(spyOnGetFileRequest).toHaveBeenCalledTimes(1);
     });
 
@@ -135,6 +148,16 @@ describe("bitbucket.service", () => {
         .spyOn(requests, "getFileRequest")
         .mockResolvedValue(Buffer.from("Mocked content", "utf-8"));
 
+      const spyOnRefreshToken = jest
+        .spyOn(service, "refreshAccessToken")
+        .mockResolvedValue({
+          accessToken: "my-token",
+          expiresAt: 3600,
+          refreshToken: "my-refresh-token",
+          scopes: ["repository:write", "pullrequest:write"],
+          tokenType: "bearer",
+        });
+
       const result = await service.getFile({
         path: "tests/__init__.py",
         owner: "mr-bucket",
@@ -151,6 +174,7 @@ describe("bitbucket.service", () => {
         path: mockedGetFileResponse.path,
       };
 
+      expect(spyOnRefreshToken).toHaveBeenCalledTimes(1);
       expect(spyOnGetFileMetaRequest).toHaveBeenCalledTimes(1);
       expect(result).toEqual(expectedResult);
     });
@@ -259,6 +283,16 @@ describe("bitbucket.service", () => {
         .spyOn(requests, "getFirstCommitRequest")
         .mockResolvedValue(mockedGetFirstCommitResponse);
 
+      const spyOnRefreshToken = jest
+        .spyOn(service, "refreshAccessToken")
+        .mockResolvedValue({
+          accessToken: "my-token",
+          expiresAt: 3600,
+          refreshToken: "my-refresh-token",
+          scopes: ["repository:write", "pullrequest:write"],
+          tokenType: "bearer",
+        });
+
       const result = await service.getFirstCommitOnBranch({
         owner: "maccheroni",
         branchName: "master",
@@ -269,6 +303,7 @@ describe("bitbucket.service", () => {
 
       const expected = { sha: mockedGetFirstCommitResponse.hash };
 
+      expect(spyOnRefreshToken).toHaveBeenCalledTimes(1);
       expect(spyOnGetFirstCommitRequest).toHaveBeenCalledTimes(1);
       expect(result).toEqual(expected);
     });
@@ -287,12 +322,23 @@ describe("bitbucket.service", () => {
       }
     });
     it("returns the clone url", async () => {
+      const spyOnRefreshToken = jest
+        .spyOn(service, "refreshAccessToken")
+        .mockResolvedValue({
+          accessToken: "my-token",
+          expiresAt: 3600,
+          refreshToken: "my-refresh-token",
+          scopes: ["repository:write", "pullrequest:write"],
+          tokenType: "bearer",
+        });
+
       const result = await service.getCloneUrl({
         owner: "maccheroni",
         repositoryName: "myrepo",
         repositoryGroupName: "mygroup",
       });
 
+      expect(spyOnRefreshToken).toHaveBeenCalledTimes(1);
       expect(result).toEqual(
         "https://x-token-auth:my-token@bitbucket.org/mygroup/myrepo.git"
       );
@@ -418,6 +464,16 @@ describe("bitbucket.service", () => {
         .spyOn(requests, "getBranchRequest")
         .mockResolvedValue(mockedGetBranchResponse);
 
+      const spyOnRefreshToken = jest
+        .spyOn(service, "refreshAccessToken")
+        .mockResolvedValue({
+          accessToken: "my-token",
+          expiresAt: 3600,
+          refreshToken: "my-refresh-token",
+          scopes: ["repository:write", "pullrequest:write"],
+          tokenType: "bearer",
+        });
+
       const result = await service.getBranch({
         owner: "maccheroni",
         branchName: "master",
@@ -430,6 +486,7 @@ describe("bitbucket.service", () => {
         sha: "bbfe95276c624e76c50aa640e7dba4af31b84961",
       };
 
+      expect(spyOnRefreshToken).toHaveBeenCalledTimes(1);
       expect(spyOnGetBranchRequest).toBeCalledTimes(1);
       expect(result).toEqual(expectedResult);
     });
@@ -550,6 +607,16 @@ describe("bitbucket.service", () => {
         default_merge_strategy: "merge_commit",
       } as unknown as Branch;
 
+      const spyOnRefreshToken = jest
+        .spyOn(service, "refreshAccessToken")
+        .mockResolvedValue({
+          accessToken: "my-token",
+          expiresAt: 3600,
+          refreshToken: "my-refresh-token",
+          scopes: ["repository:write", "pullrequest:write"],
+          tokenType: "bearer",
+        });
+
       const spyOnGetBranchRequest = jest
         .spyOn(requests, "createBranchRequest")
         .mockResolvedValue(mockedCreateBranchResponse);
@@ -568,6 +635,7 @@ describe("bitbucket.service", () => {
         sha: mockedCreateBranchResponse.target.hash,
       };
 
+      expect(spyOnRefreshToken).toHaveBeenCalledTimes(1);
       expect(spyOnGetBranchRequest).toBeCalledTimes(1);
       expect(result).toEqual(expectedResult);
     });
@@ -848,6 +916,16 @@ describe("bitbucket.service", () => {
         page: 1,
       } as unknown as PaginatedPullRequest;
 
+      const spyOnRefreshToken = jest
+        .spyOn(service, "refreshAccessToken")
+        .mockResolvedValue({
+          accessToken: "my-token",
+          expiresAt: 3600,
+          refreshToken: "my-refresh-token",
+          scopes: ["repository:write", "pullrequest:write"],
+          tokenType: "bearer",
+        });
+
       const spyOnGetPullRequestByBranchNameRequest = jest
         .spyOn(requests, "getPullRequestByBranchNameRequest")
         .mockResolvedValue(mockedGetPullRequestResponse);
@@ -866,6 +944,7 @@ describe("bitbucket.service", () => {
         number: 1,
       };
 
+      expect(spyOnRefreshToken).toHaveBeenCalledTimes(1);
       expect(spyOnGetPullRequestByBranchNameRequest).toBeCalledTimes(1);
       expect(result).toEqual(expectedResult);
     });

--- a/libs/util/git/src/providers/bitbucket/bitbucket.service.spec.ts
+++ b/libs/util/git/src/providers/bitbucket/bitbucket.service.spec.ts
@@ -78,7 +78,7 @@ describe("bitbucket.service", () => {
       } as unknown as PaginatedTreeEntry;
 
       const spyOnRefreshToken = jest
-        .spyOn(service, "refreshAccessToken")
+        .spyOn(service, "refreshAccessTokenIfNeeded")
         .mockResolvedValue({
           accessToken: "my-token",
           expiresAt: 3600,
@@ -149,7 +149,7 @@ describe("bitbucket.service", () => {
         .mockResolvedValue(Buffer.from("Mocked content", "utf-8"));
 
       const spyOnRefreshToken = jest
-        .spyOn(service, "refreshAccessToken")
+        .spyOn(service, "refreshAccessTokenIfNeeded")
         .mockResolvedValue({
           accessToken: "my-token",
           expiresAt: 3600,
@@ -284,7 +284,7 @@ describe("bitbucket.service", () => {
         .mockResolvedValue(mockedGetFirstCommitResponse);
 
       const spyOnRefreshToken = jest
-        .spyOn(service, "refreshAccessToken")
+        .spyOn(service, "refreshAccessTokenIfNeeded")
         .mockResolvedValue({
           accessToken: "my-token",
           expiresAt: 3600,
@@ -323,7 +323,7 @@ describe("bitbucket.service", () => {
     });
     it("returns the clone url", async () => {
       const spyOnRefreshToken = jest
-        .spyOn(service, "refreshAccessToken")
+        .spyOn(service, "refreshAccessTokenIfNeeded")
         .mockResolvedValue({
           accessToken: "my-token",
           expiresAt: 3600,
@@ -465,7 +465,7 @@ describe("bitbucket.service", () => {
         .mockResolvedValue(mockedGetBranchResponse);
 
       const spyOnRefreshToken = jest
-        .spyOn(service, "refreshAccessToken")
+        .spyOn(service, "refreshAccessTokenIfNeeded")
         .mockResolvedValue({
           accessToken: "my-token",
           expiresAt: 3600,
@@ -608,7 +608,7 @@ describe("bitbucket.service", () => {
       } as unknown as Branch;
 
       const spyOnRefreshToken = jest
-        .spyOn(service, "refreshAccessToken")
+        .spyOn(service, "refreshAccessTokenIfNeeded")
         .mockResolvedValue({
           accessToken: "my-token",
           expiresAt: 3600,
@@ -717,7 +717,7 @@ describe("bitbucket.service", () => {
         .mockResolvedValue(mockedCreateCommentOnResponse);
 
       const spyOnRefreshToken = jest
-        .spyOn(service, "refreshAccessToken")
+        .spyOn(service, "refreshAccessTokenIfNeeded")
         .mockResolvedValue({
           accessToken: "my-token",
           expiresAt: 3600,
@@ -917,7 +917,7 @@ describe("bitbucket.service", () => {
       } as unknown as PaginatedPullRequest;
 
       const spyOnRefreshToken = jest
-        .spyOn(service, "refreshAccessToken")
+        .spyOn(service, "refreshAccessTokenIfNeeded")
         .mockResolvedValue({
           accessToken: "my-token",
           expiresAt: 3600,
@@ -1135,7 +1135,7 @@ describe("bitbucket.service", () => {
         .mockResolvedValue(mockedCreatePullRequestResponse);
 
       const spyOnRefreshToken = jest
-        .spyOn(service, "refreshAccessToken")
+        .spyOn(service, "refreshAccessTokenIfNeeded")
         .mockResolvedValue({
           accessToken: "my-token",
           expiresAt: 3600,

--- a/libs/util/git/src/providers/bitbucket/bitbucket.service.ts
+++ b/libs/util/git/src/providers/bitbucket/bitbucket.service.ts
@@ -99,10 +99,6 @@ export class BitBucketService implements GitProvider {
     );
 
     this.auth.accessToken = authData.access_token;
-    this.auth.refreshToken = authData.refresh_token;
-    this.auth.expiresAt = Date.now() + authData.expires_in * 1000; // 7200 seconds = 2 hours
-    this.auth.tokenType = authData.token_type;
-    this.auth.scopes = authData.scopes.split(" ");
 
     this.logger.info("BitBucketService: getAccessToken");
 

--- a/libs/util/git/src/providers/bitbucket/bitbucket.service.ts
+++ b/libs/util/git/src/providers/bitbucket/bitbucket.service.ts
@@ -126,7 +126,7 @@ export class BitBucketService implements GitProvider {
     return true;
   }
 
-  async refreshAccessToken(): Promise<OAuthTokens> {
+  async refreshAccessTokenIfNeeded(): Promise<OAuthTokens> {
     if (!this.shouldRefreshToken()) {
       return this.auth;
     }
@@ -137,7 +137,7 @@ export class BitBucketService implements GitProvider {
       this.auth.refreshToken
     );
 
-    this.logger.info("BitBucketService: refreshAccessToken");
+    this.logger.info("BitBucketService: refreshAccessTokenIfNeeded");
     this.auth.accessToken = newOAuthTokens.access_token;
 
     return {
@@ -166,7 +166,7 @@ export class BitBucketService implements GitProvider {
   }
 
   async getGitGroups(): Promise<PaginatedGitGroup> {
-    await this.refreshAccessToken();
+    await this.refreshAccessTokenIfNeeded();
 
     const paginatedWorkspaceMembership = await currentUserWorkspacesRequest(
       this.auth.accessToken
@@ -215,7 +215,7 @@ export class BitBucketService implements GitProvider {
       throw new CustomError("Missing groupName");
     }
 
-    await this.refreshAccessToken();
+    await this.refreshAccessTokenIfNeeded();
 
     const repository = await repositoryRequest(
       groupName,
@@ -249,7 +249,7 @@ export class BitBucketService implements GitProvider {
       throw new CustomError("Missing groupName");
     }
 
-    await this.refreshAccessToken();
+    await this.refreshAccessTokenIfNeeded();
 
     const repositoriesInWorkspace = await repositoriesInWorkspaceRequest(
       groupName,
@@ -294,7 +294,7 @@ export class BitBucketService implements GitProvider {
       throw new CustomError("Missing groupName");
     }
 
-    await this.refreshAccessToken();
+    await this.refreshAccessTokenIfNeeded();
 
     const newRepository = await repositoryCreateRequest(
       groupName,
@@ -346,7 +346,7 @@ export class BitBucketService implements GitProvider {
       gitReference = ref;
     }
 
-    await this.refreshAccessToken();
+    await this.refreshAccessTokenIfNeeded();
 
     const fileResponse = await getFileMetaRequest(
       repositoryGroupName,
@@ -399,7 +399,7 @@ export class BitBucketService implements GitProvider {
       throw new CustomError("Missing repositoryGroupName");
     }
 
-    await this.refreshAccessToken();
+    await this.refreshAccessTokenIfNeeded();
 
     const pullRequest = await getPullRequestByBranchNameRequest(
       repositoryGroupName,
@@ -449,7 +449,7 @@ export class BitBucketService implements GitProvider {
       },
     };
 
-    await this.refreshAccessToken();
+    await this.refreshAccessTokenIfNeeded();
 
     const newPullRequest = await createPullRequestFromRequest(
       repositoryGroupName,
@@ -471,7 +471,7 @@ export class BitBucketService implements GitProvider {
       throw new CustomError("Missing repositoryGroupName");
     }
 
-    await this.refreshAccessToken();
+    await this.refreshAccessTokenIfNeeded();
 
     try {
       const branch = await getBranchRequest(
@@ -500,7 +500,7 @@ export class BitBucketService implements GitProvider {
       throw new CustomError("Missing repositoryGroupName");
     }
 
-    await this.refreshAccessToken();
+    await this.refreshAccessTokenIfNeeded();
 
     const branch = await createBranchRequest(
       repositoryGroupName,
@@ -523,7 +523,7 @@ export class BitBucketService implements GitProvider {
         throw new CustomError("Missing repositoryGroupName");
       }
 
-      await this.refreshAccessToken();
+      await this.refreshAccessTokenIfNeeded();
 
       const firstCommit = await getFirstCommitRequest(
         repositoryGroupName,
@@ -550,7 +550,7 @@ export class BitBucketService implements GitProvider {
       throw new CustomError("Missing repositoryGroupName");
     }
 
-    await this.refreshAccessToken();
+    await this.refreshAccessTokenIfNeeded();
 
     return Promise.resolve(
       `https://x-token-auth:${this.auth.accessToken}@bitbucket.org/${repositoryGroupName}/${repositoryName}.git`
@@ -574,7 +574,7 @@ export class BitBucketService implements GitProvider {
       throw new CustomError("Missing repositoryGroupName");
     }
 
-    await this.refreshAccessToken();
+    await this.refreshAccessTokenIfNeeded();
 
     await createCommentOnPrRequest(
       repositoryGroupName,

--- a/libs/util/git/src/providers/bitbucket/bitbucket.service.ts
+++ b/libs/util/git/src/providers/bitbucket/bitbucket.service.ts
@@ -53,13 +53,7 @@ import { BitbucketNotFoundError } from "./errors";
 export class BitBucketService implements GitProvider {
   private clientId: string;
   private clientSecret: string;
-  private auth: {
-    accessToken: string;
-    refreshToken: string;
-    expiresAt: number;
-    tokenType: string;
-    scopes: string[];
-  };
+  private auth: OAuthTokens;
   public readonly name = EnumGitProvider.Bitbucket;
   public readonly domain = "bitbucket.com";
   private logger: ILogger;

--- a/libs/util/git/src/providers/github/github.service.ts
+++ b/libs/util/git/src/providers/github/github.service.ts
@@ -643,10 +643,6 @@ export class GithubService implements GitProvider {
     throw NotImplementedError;
   }
 
-  async refreshAccessToken(): Promise<OAuthTokens> {
-    throw NotImplementedError;
-  }
-
   async getCurrentOAuthUser(accessToken: string): Promise<CurrentUser> {
     throw NotImplementedError;
   }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6693 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0db0978</samp>

### Summary
:sparkles::arrows_clockwise::lock:

<!--
1.  :sparkles: - This emoji represents the enhancement of the `BitBucketService` class to store and use the OAuth token type and scopes.
2.  :arrows_clockwise: - This emoji represents the addition of the logic to refresh the access token when needed before calling the Bitbucket API.
3.  :lock: - This emoji represents the security aspect of using OAuth tokens with the appropriate scopes and expiration times.
-->
This pull request improves the authentication and authorization of the `BitBucketService` class by using and refreshing OAuth tokens with the appropriate type and scopes. This allows the class to interact with the Bitbucket API more securely and reliably.

> _To call Bitbucket with ease_
> _We need OAuth tokens, if you please_
> _They have a type and scopes_
> _And sometimes they elope_
> _So we refresh them with `BitBucketService`_

### Walkthrough
*  Add `tokenType` and `scopes` properties to `BitBucketService` class to store OAuth token information ([link](https://github.com/amplication/amplication/pull/6753/files?diff=unified&w=0#diff-56ef914963af52878160ed7c5190fba1204419b6c2b525819d6846f6b0824f5aR60-R61), [link](https://github.com/amplication/amplication/pull/6753/files?diff=unified&w=0#diff-56ef914963af52878160ed7c5190fba1204419b6c2b525819d6846f6b0824f5aL75-R80), [link](https://github.com/amplication/amplication/pull/6753/files?diff=unified&w=0#diff-56ef914963af52878160ed7c5190fba1204419b6c2b525819d6846f6b0824f5aR107-R112))
*  Add `shouldRefreshToken` method to `BitBucketService` class to check and log token expiration status ([link](https://github.com/amplication/amplication/pull/6753/files?diff=unified&w=0#diff-56ef914963af52878160ed7c5190fba1204419b6c2b525819d6846f6b0824f5aL116-R142))
*  Call `refreshAccessToken` method before fetching repositories and branches from Bitbucket API in `getRepositories` and `getBranches` methods of `BitBucketService` class ([link](https://github.com/amplication/amplication/pull/6753/files?diff=unified&w=0#diff-56ef914963af52878160ed7c5190fba1204419b6c2b525819d6846f6b0824f5aR433-R434), [link](https://github.com/amplication/amplication/pull/6753/files?diff=unified&w=0#diff-56ef914963af52878160ed7c5190fba1204419b6c2b525819d6846f6b0824f5aR562-R564))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
