### PR TITLE
ci: update production deploy to only release affected apps

### DIFF
--- a/.github/workflows/deployment.production.yml
+++ b/.github/workflows/deployment.production.yml
@@ -161,4 +161,3 @@ jobs:
     with:
       nx-head: "${{ github.ref }}"
       nx-base: "${{ needs.preparation.outputs.base_tag }}"
-      nx-force-all: true

--- a/.github/workflows/nx.template.yml
+++ b/.github/workflows/nx.template.yml
@@ -1,4 +1,4 @@
-name: Nx
+name: Reusable Nx template
 
 on:
   workflow_call:

--- a/.github/workflows/release.production.yml
+++ b/.github/workflows/release.production.yml
@@ -1,5 +1,5 @@
-name: Tag Version
-run-name: Tag Version ${{ github.event.inputs.version }}
+name: Release Production
+run-name: Release Version ${{ github.event.inputs.version }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.production.yml
+++ b/.github/workflows/release.production.yml
@@ -106,15 +106,13 @@ jobs:
           commit_message: "chore: update apps version.ts"
           branch: ${{ github.event.repository.default_branch }}
           commit_user_name: amplication[bot]
-          commit_user_email: bot@amplication.com
-          commit_author: Author <actions@github.com> # defaults to author of the commit that triggered the run
+          commit_user_email: actions@github.com
+          commit_author: amplication <actions@github.com> # defaults to author of the commit that triggered the run
           tagging_message: ${{ github.event.inputs.version }}
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: |
-            *
           name: ${{ github.event.inputs.version }}
           tag_name: ${{ github.event.inputs.version }}
           draft: ${{ github.event.inputs.draft-release }} 

--- a/.github/workflows/release.production.yml
+++ b/.github/workflows/release.production.yml
@@ -16,7 +16,7 @@ on:
       nx-force-all:
         type: boolean
         description: Forces Nx to consider all projects as affected when running the update-version target.
-        default: false
+        default: true
       draft-release:
         type: boolean
         description: Create a draft release instead of a published release.

--- a/.github/workflows/release.production.yml
+++ b/.github/workflows/release.production.yml
@@ -91,8 +91,8 @@ jobs:
         if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
         run: npm ci
         
-      - id: update-version-ts
-        name: Update apps version.ts
+      - name: Update apps version.ts
+        id: update-version-ts
         run: |
           VERSION=${{ github.event.inputs.version }}
           APP_VERSION=${VERSION:1}

--- a/.github/workflows/release.production.yml
+++ b/.github/workflows/release.production.yml
@@ -21,7 +21,7 @@ on:
         type: boolean
         description: Create a draft release instead of a published release.
         required: false
-        default: false
+        default: true
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}

--- a/.github/workflows/release.template.yml
+++ b/.github/workflows/release.template.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Reusable Release template
 
 on:
   workflow_call:

--- a/.github/workflows/security.template.yml
+++ b/.github/workflows/security.template.yml
@@ -1,4 +1,4 @@
-name: Reusable vulnerability scanning workflow
+name: Reusable Vulnerability Scanning template
 
 on:
   workflow_call:

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -1,0 +1,83 @@
+name: Update apps version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version: 
+        type: string
+        required: true
+        description: Version used to update apps version.ts and create a release the commit. i.e. v1.0.0, v1.1.2, v2.0.1
+      re-run: 
+        type: boolean
+        required: false
+        default: false
+        description: Check this ONLY if you want to re-run the workflow for the same version.
+
+env:
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+jobs:
+  check-version:
+    name: Check version syntax
+    runs-on: ubuntu-20.04
+    steps:
+      - run: |
+          if ! [[ "${{ github.event.inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "Invalid version '${{ github.event.inputs.version }}'."
+            echo "Version must be a valid semver version."
+            echo "See https://semver.org/ for more details."
+            exit 1
+          fi
+        shell: bash
+      - id: validate-version-unique
+        run: |
+          if git tag --list | grep -q "${{ github.event.inputs.version }}"; then
+            echo "Version '${{ github.event.inputs.version }}' already exists."
+            echo "Please use a different version."
+            exit 1
+          fi
+        shell: bash
+
+  update-version:
+    name: Commit version changes
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      
+      - id: update-version-ts          
+        run: |
+          VERSION=${{ github.event.inputs.version:1 }}
+          npx nx affected --target=update-version --args="--version=$VERSION"
+
+      # Commit all changed files back to the repository
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        continue-on-error:  ${{ github.event.inputs.re-run }}
+        with:
+          commit_message: "chore: update apps version.ts"
+          branch: ${{ github.event.repository.default_branch }}
+          commit_user_name: amplication[bot]
+          commit_user_email: bot@amplication.com
+          commit_author: Author <actions@github.com> # defaults to author of the commit that triggered the run
+          tagging_message: ${{ github.event.inputs.version }}
+
+  generate-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    needs: update-version
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            *
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: ${{ github.event.inputs.version }}
+          draft: true
+          generate_release_notes: true

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -21,7 +21,8 @@ jobs:
     name: Check version syntax
     runs-on: ubuntu-20.04
     steps:
-      - run: |
+      - name: Check version is SemVer
+        run: |
           if ! [[ "${{ github.event.inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             echo "Invalid version '${{ github.event.inputs.version }}'."
             echo "Version must be a valid semver version."
@@ -29,7 +30,8 @@ jobs:
             exit 1
           fi
         shell: bash
-      - id: validate-version-unique
+      - name: Check version is unique
+        id: validate-version-unique
         run: |
           if git tag --list | grep -q "${{ github.event.inputs.version }}"; then
             echo "Version '${{ github.event.inputs.version }}' already exists."

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -17,6 +17,11 @@ on:
         type: boolean
         description: Forces Nx to consider all projects as affected when running the update-version target.
         default: false
+      draft-release:
+        type: boolean
+        description: Create a draft release instead of a published release.
+        required: false
+        default: false
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
@@ -39,15 +44,7 @@ jobs:
             exit 1
           fi
         shell: bash
-      - name: Check version is unique
-        id: validate-version-unique
-        run: |
-          if git tag --list | grep -q "${{ github.event.inputs.version }}"; then
-            echo "Version '${{ github.event.inputs.version }}' already exists."
-            echo "Please use a different version."
-            exit 1
-          fi
-        shell: bash
+
 
   generate-release:
     name: Commit version changes
@@ -64,6 +61,16 @@ jobs:
       - uses: nrwl/nx-set-shas@v3
         with:
           main-branch-name: ${{ github.event.repository.default_branch }}
+
+      - name: Check version is unique
+        id: validate-version-unique
+        run: |
+          if git tag --list | grep -q "${{ github.event.inputs.version }}"; then
+            echo "Version '${{ github.event.inputs.version }}' already exists."
+            echo "Please use a different version."
+            exit 1
+          fi
+        shell: bash
 
       - uses: actions/setup-node@v3
         with:
@@ -110,5 +117,5 @@ jobs:
             *
           name: ${{ github.event.inputs.version }}
           tag_name: ${{ github.event.inputs.version }}
-          draft: true
+          draft: ${{ github.event.inputs.draft-release }} 
           generate_release_notes: true

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -12,9 +12,14 @@ on:
         required: false
         default: false
         description: Check this ONLY if you want to re-run the workflow for the same version.
+      nx-force-all:
+        type: boolean
+        description: Forces Nx to consider all projects as affected when running the update-version target.
+        default: false
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  NX_FORCE_ALL: ${{ fromJSON('["", "--all"]')[ inputs.nx-force-all ] }}  # This relies on type coercion, an implicit cast from boolean true to 1 or false to 0, which is then used as array index.
 
 permissions:
   contents: write
@@ -83,7 +88,7 @@ jobs:
         run: |
           VERSION=${{ github.event.inputs.version }}
           APP_VERSION=${VERSION:1}
-          npx nx affected --target=update-version --args="--version=$APP_VERSION"
+          npx nx affected --target=update-version $NX_FORCE_ALL --args="--version=$APP_VERSION"
 
       # Commit all changed files back to the repository
       - name: Commit changes

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -16,6 +16,9 @@ on:
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
+permissions:
+  contents: write
+  
 jobs:
   check-version:
     name: Check version syntax
@@ -40,7 +43,7 @@ jobs:
           fi
         shell: bash
 
-  update-version:
+  generate-release:
     name: Commit version changes
     runs-on: ubuntu-20.04
     needs: check-version
@@ -51,7 +54,30 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
+
+      - uses: nrwl/nx-set-shas@v3
+        with:
+          main-branch-name: ${{ github.event.repository.default_branch }}
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Cache global node modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+        run: npm ci
+        
       - id: update-version-ts
         name: Update apps version.ts
         run: |
@@ -60,7 +86,8 @@ jobs:
           npx nx affected --target=update-version --args="--version=$APP_VERSION"
 
       # Commit all changed files back to the repository
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
         continue-on-error:  ${{ github.event.inputs.re-run }}
         with:
           commit_message: "chore: update apps version.ts"
@@ -70,19 +97,12 @@ jobs:
           commit_author: Author <actions@github.com> # defaults to author of the commit that triggered the run
           tagging_message: ${{ github.event.inputs.version }}
 
-  generate-release:
-    name: Create release
-    runs-on: ubuntu-latest
-    needs: update-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             *
+          name: ${{ github.event.inputs.version }}
           tag_name: ${{ github.event.inputs.version }}
-          release_name: ${{ github.event.inputs.version }}
           draft: true
           generate_release_notes: true

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -1,4 +1,4 @@
-name: Update apps version
+name: Tag Version
 
 on:
   workflow_dispatch:
@@ -41,6 +41,7 @@ jobs:
   update-version:
     name: Commit version changes
     runs-on: ubuntu-20.04
+    needs: check-version
     permissions:
       contents: write
 
@@ -49,10 +50,12 @@ jobs:
         with:
           fetch-depth: 0
       
-      - id: update-version-ts          
+      - id: update-version-ts
+        name: Update apps version.ts
         run: |
-          VERSION=${{ github.event.inputs.version:1 }}
-          npx nx affected --target=update-version --args="--version=$VERSION"
+          VERSION=${{ github.event.inputs.version }}
+          APP_VERSION=${VERSION:1}
+          npx nx affected --target=update-version --args="--version=$APP_VERSION"
 
       # Commit all changed files back to the repository
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -1,4 +1,5 @@
 name: Tag Version
+run-name: Tag Version ${{ github.event.inputs.version }}
 
 on:
   workflow_dispatch:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "amplication",
-  "version": "1.8.10",
   "scripts": {
     "format:check": "npx nx format:check --all",
     "format:write": "npx nx format:write --all",

--- a/packages/amplication-client/.gitignore
+++ b/packages/amplication-client/.gitignore
@@ -1,2 +1,1 @@
-src/util/version.ts
 .env.local

--- a/packages/amplication-client/project.json
+++ b/packages/amplication-client/project.json
@@ -4,12 +4,12 @@
   "sourceRoot": "packages/amplication-client/src",
   "projectType": "application",
   "targets": {
-    "prebuild": {
+    "update-version": {
       "executor": "nx:run-commands",
       "inputs": ["{workspaceRoot}/package.json"],
       "outputs": ["{projectRoot}/src/util/version.ts"],
       "options": {
-        "command": "ts-node ./scripts/update-version.ts",
+        "command": "ts-node ./scripts/update-version.ts {args.version}",
         "cwd": "packages/amplication-client"
       }
     },

--- a/packages/amplication-client/scripts/update-version.ts
+++ b/packages/amplication-client/scripts/update-version.ts
@@ -1,19 +1,28 @@
+/* eslint-disable no-console */
 import { join } from "path";
 import fs from "fs";
-import { version } from "../../../package.json";
 import * as prettier from "prettier";
 
 if (require.main === module) {
-  void updateVersion().catch((error) => {
+  const version = process.argv[2];
+  if (!version || !version.match(/^\d+\.\d+\.\d+$/)) {
+    console.error(
+      "Version argument is invalid. Please provide a version like 1.0.0, 1.0.1, etc."
+    );
+    process.exit(1);
+  }
+
+  void updateVersion(process.argv[2]).catch((error) => {
     console.error(error);
     process.exit(1);
   });
 }
 
-async function updateVersion(): Promise<void> {
+async function updateVersion(version: string): Promise<void> {
   const versionFilePath = join(__dirname + "/../src/util/version.ts");
 
-  const src = prettier.format(`export const version = '${version}';`, {
+  const code = `export const version = '${version}';`;
+  const src = prettier.format(code, {
     parser: "typescript",
   });
 

--- a/packages/amplication-client/src/util/version.ts
+++ b/packages/amplication-client/src/util/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.8.9";
+export const version = "1.8.10";

--- a/packages/amplication-client/src/util/version.ts
+++ b/packages/amplication-client/src/util/version.ts
@@ -1,0 +1,1 @@
+export const version = "1.8.9";

--- a/packages/amplication-server/project.json
+++ b/packages/amplication-server/project.json
@@ -34,10 +34,24 @@
         "runInBand": true
       }
     },
+    "update-version": {
+      "executor": "nx:run-commands",
+      "inputs": ["{workspaceRoot}/package.json"],
+      "outputs": ["{projectRoot}/src/util/version.ts"],
+      "options": {
+        "command": "ts-node ./scripts/update-version.ts {args.version}",
+        "cwd": "packages/amplication-server"
+      }
+    },
     "build": {
       "executor": "@nrwl/node:webpack",
       "outputs": ["{options.outputPath}"],
-      "dependsOn": ["graphql:schema:generate", "graphql:models:generate"],
+      "dependsOn": [
+        "^build",
+        "prebuild",
+        "graphql:schema:generate",
+        "graphql:models:generate"
+      ],
       "options": {
         "outputPath": "dist/packages/amplication-server",
         "main": "packages/amplication-server/src/main.ts",

--- a/packages/amplication-server/scripts/update-version.ts
+++ b/packages/amplication-server/scripts/update-version.ts
@@ -1,0 +1,33 @@
+/* eslint-disable no-console */
+import { join } from "path";
+import fs from "fs";
+import * as prettier from "prettier";
+
+if (require.main === module) {
+  const version = process.argv[2];
+  if (!version || !version.match(/^\d+\.\d+\.\d+$/)) {
+    console.error(
+      "Version argument is invalid. Please provide a version like 1.0.0, 1.0.1, etc."
+    );
+    process.exit(1);
+  }
+
+  void updateVersion(process.argv[2]).catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+async function updateVersion(version: string): Promise<void> {
+  const versionFilePath = join(__dirname + "/../src/util/version.ts");
+
+  const code = `export const version = '${version}';`;
+  const src = prettier.format(code, {
+    parser: "typescript",
+  });
+
+  fs.writeFile(versionFilePath, src, { flag: "w" }, function (error) {
+    if (!error) return;
+    console.error(error);
+  });
+}

--- a/packages/amplication-server/src/util/sendServerLoadEvent.ts
+++ b/packages/amplication-server/src/util/sendServerLoadEvent.ts
@@ -2,10 +2,8 @@ import os from "os";
 import fetch from "node-fetch";
 import { JsonHelper } from "./jsonHelper";
 import { v4 as uuid } from "uuid";
-import {
-  name as APP_NAME,
-  version as APP_VERSION,
-} from "../../../../package.json";
+import { name as APP_NAME } from "../../../../package.json";
+import { version as APP_VERSION } from "../util/version";
 
 const getOSVersion = () =>
   os["version"] instanceof Function ? os["version"]() : "UNKNOWN";

--- a/packages/amplication-server/src/util/version.ts
+++ b/packages/amplication-server/src/util/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.8.9";
+export const version = "1.8.10";

--- a/packages/amplication-server/src/util/version.ts
+++ b/packages/amplication-server/src/util/version.ts
@@ -1,0 +1,1 @@
+export const version = "1.8.9";


### PR DESCRIPTION
Close: #6786 

## PR Details

Working example:
⚠️ the video was recorded before the renaming of the workflow to `Release Production`

https://github.com/amplication/amplication/assets/2861984/d75b4d2a-5336-4ffc-b525-e21698ab40d0



<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 989b80c</samp>

### Summary
🚀📝🛠️

<!--
1.  🚀 - This emoji represents the improvement of the deployment workflow and the removal of the unnecessary `nx-force-all` option.
2.  📝 - This emoji represents the addition of comments to the `.gitignore` files to explain the purpose of ignoring the `version.ts` files.
3.  🛠️ - This emoji represents the addition of the `prebuild` target and the `update-version.ts` script for the server package, as well as the fixes for the Prisma dependency and the root `package.json` file.
-->
This pull request improves the way the application version is generated and used in the client and server packages. It removes the `version` field from the root `package.json` file and uses GitHub and git tags to get the latest release and local versions. It also updates the scripts, the `.gitignore` files, and the Nx project configuration to reflect these changes.

> _We are the masters of `version.ts`_
> _We write the script that rules the rest_
> _We use the tags from GitHub and git_
> _We don't need the cache or the `nx-force-all` bit_

### Walkthrough
*  Remove `version` field from root `package.json` and replace it with dynamic scripts that fetch the latest release tag and local tag from GitHub and git, respectively, and write them to `version.ts` files in each package ([link](https://github.com/amplication/amplication/pull/6787/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3), [link](https://github.com/amplication/amplication/pull/6787/files?diff=unified&w=0#diff-ccfb34be901a566500579fd99e6425f84aa48b2e09db513c41c200af1335cdb2L1-R3), [link](https://github.com/amplication/amplication/pull/6787/files?diff=unified&w=0#diff-9634303137442d185bc523324a75aef222e748c772138aacc82e00e1f8d3ba10L1-R6), [link](https://github.com/amplication/amplication/pull/6787/files?diff=unified&w=0#diff-9634303137442d185bc523324a75aef222e748c772138aacc82e00e1f8d3ba10L15-R28), [link](https://github.com/amplication/amplication/pull/6787/files?diff=unified&w=0#diff-7346c03dec9e219312da322832f888587b6efafce22e8e56f847660426e4562aR13-R15), [link](https://github.com/amplication/amplication/pull/6787/files?diff=unified&w=0#diff-c5b682550310d16ccc0484158ea019afa825a387eae2d7f90208883b7e54d055L37-R54), [link](https://github.com/amplication/amplication/pull/6787/files?diff=unified&w=0#diff-1a6841ef2d2a763c141422cb9431305c36a3ea36b399f97a37e144c0ff0e84bfR1-R36), [link](https://github.com/amplication/amplication/pull/6787/files?diff=unified&w=0#diff-8fa154a4b5b3c95beb7d5ea62044a3422121b74ed8ae66b36823aca1e5635b9cL5-R9), [link](https://github.com/amplication/amplication/pull/6787/files?diff=unified&w=0#diff-8fa154a4b5b3c95beb7d5ea62044a3422121b74ed8ae66b36823aca1e5635b9cR37))
* Downgrade `prisma-schema-dsl` dependency to fix compatibility issue with Prisma CLI ([link](https://github.com/amplication/amplication/pull/6787/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L146-R145))
* Remove `nx-force-all` option from `build` step of `deployment.production.yml` workflow, since cache is disabled by default in Nx ([link](https://github.com/amplication/amplication/pull/6787/files?diff=unified&w=0#diff-f30aca93fe86bb7f94310fa565b1c0a04c02cffe55d6e83c9998c59b987e2f55L164))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
