### PR TITLE
fix(github service): change no commit error message

### DIFF
--- a/libs/util/git/src/git-provider.interface.ts
+++ b/libs/util/git/src/git-provider.interface.ts
@@ -51,7 +51,7 @@ export interface GitProvider {
   ) => Promise<PullRequest | null>;
   createPullRequest: (
     createPullRequestArgs: GitProviderCreatePullRequestArgs
-  ) => Promise<PullRequest>;
+  ) => Promise<PullRequest | null>;
   getBranch: (args: GetBranchArgs) => Promise<Branch | null>;
   createBranch: (args: CreateBranchArgs) => Promise<Branch>;
   getCloneUrl: (args: CloneUrlArgs) => Promise<string>;

--- a/libs/util/git/src/providers/bitbucket/bitbucket.service.ts
+++ b/libs/util/git/src/providers/bitbucket/bitbucket.service.ts
@@ -420,7 +420,7 @@ export class BitBucketService implements GitProvider {
 
   async createPullRequest(
     createPullRequestArgs: GitProviderCreatePullRequestArgs
-  ): Promise<PullRequest> {
+  ): Promise<PullRequest | null> {
     const {
       repositoryGroupName,
       repositoryName,

--- a/libs/util/git/src/providers/github/github.service.ts
+++ b/libs/util/git/src/providers/github/github.service.ts
@@ -442,16 +442,25 @@ export class GithubService implements GitProvider {
     pullRequestTitle,
     pullRequestBody,
     baseBranchName,
-  }: GitProviderCreatePullRequestArgs): Promise<PullRequest> {
-    const { data: pullRequest } = await this.octokit.rest.pulls.create({
-      owner,
-      repo: repositoryName,
-      title: pullRequestTitle,
-      body: pullRequestBody,
-      head: branchName,
-      base: baseBranchName,
-    });
-    return { url: pullRequest.html_url, number: pullRequest.number };
+  }: GitProviderCreatePullRequestArgs): Promise<PullRequest | null> {
+    try {
+      const { data: pullRequest } = await this.octokit.rest.pulls.create({
+        owner,
+        repo: repositoryName,
+        title: pullRequestTitle,
+        body: pullRequestBody,
+        head: branchName,
+        base: baseBranchName,
+      });
+      return { url: pullRequest.html_url, number: pullRequest.number };
+    } catch (error) {
+      if (error.status === 422) {
+        throw new Error(
+          `Hey there! Looks like your code hasn't changed since the last build. We skipped creating a new pull request to keep things tidy.`
+        );
+      }
+    }
+    return null;
   }
 
   async getBranch({


### PR DESCRIPTION
Close: #31

## PR Details

Change the error message when there is no new commits
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d9ffb02</samp>

### Summary
🔄🚫📝

<!--
1.  🔄 - This emoji represents the change in the return type of the `createPullRequest` method from `Promise<PullRequest>` to `Promise<PullRequest | null>`. The emoji suggests that the method can now return either a pull request or nothing, depending on the outcome of the operation. The emoji also implies that the caller of the method needs to handle the possible `null` value accordingly.
2.  🚫 - This emoji represents the error handling logic that was added to the `createPullRequest` method in the `GithubService` class. The emoji suggests that the method can now throw an error and return `null` when the pull request creation is not possible due to the head and base branches being identical. The emoji also implies that the user should be aware of this scenario and avoid creating unnecessary pull requests.
3.  📝 - This emoji represents the custom error message that was added to the `createPullRequest` method in the `GithubService` class. The emoji suggests that the method can now provide more information and feedback to the user when the pull request creation fails or is skipped. The emoji also implies that the error message is clear and helpful for debugging and troubleshooting purposes.
-->
Changed the `createPullRequest` method in the `GitProvider` interface and the `GithubService` class to handle the case when no pull request can be created due to no code changes or identical branches. Updated the `git-provider.interface.ts` and `github.service.ts` files accordingly.

> _`createPullRequest`_
> _Returns null if no changes_
> _Autumn leaves falling_

### Walkthrough
* Change the return type of `createPullRequest` method in `GitProvider` interface to allow `null` value ([link](https://github.com/amplication/amplication/pull/6792/files?diff=unified&w=0#diff-ff8aa5b0325c531705eb125cbdd735571a8001b8ca941f9ee0665e627c7fe3c6L54-R54))
* Implement the new interface and handle the error when GitHub API returns 422 status code in `createPullRequest` method in `GithubService` class ([link](https://github.com/amplication/amplication/pull/6792/files?diff=unified&w=0#diff-7825d1b6180f809d60624f1acd8e9ee0f7acfcab132ec45ce7480e4252b1120bL445-R463))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error


Expected result: 

<img width="1396" alt="image" src="https://github.com/amplication/amplication/assets/97830649/ca6ca671-09db-47a1-93eb-241e704fed24">
