### PR TITLE
chore(dsg): add workflow to ensure that dsg version is bumped when it changes

### DIFF
--- a/.github/workflows/dsg-version-validator.yml
+++ b/.github/workflows/dsg-version-validator.yml
@@ -1,0 +1,53 @@
+name: DSG Version Validator
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+
+env:
+  DSG_PACKAGE_JSON: packages/data-service-generator/package.json
+
+jobs:
+  nx:
+    name: Nx
+    uses: ./.github/workflows/nx.template.yml
+    with:
+      nx-head: "${{ github.ref }}"
+      nx-base: "${{ github.event.repository.default_branch }}"
+
+  dsg-version-validator:
+    name: Validate DSG Version Bump
+    runs-on: ubuntu-latest
+    needs: nx
+    if: ${{ contains(needs.nx.outputs.affected-package-container, 'data-service-generator') }}
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - id: get-version
+        name: Get current package.json version
+        run: |
+          echo "::set-output name=version::$(cat $DSG_PACKAGE_JSON  | jq -r '.version')"
+      - name: Checkout target branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+          fetch-depth: 0
+      - id: get-version-target
+        name: Get package.json version from target branch
+        run: |
+          echo "::set-output name=version::$(cat $DSG_PACKAGE_JSON | jq -r '.version')"
+      - name: Check if versions are equal
+        id: check-version
+        run: |
+          if [ "${{ steps.get-version.outputs.version }}" == "${{ steps.get-version-target.outputs.version }}" ]; then
+            echo "❌ Versions are equal. Please bump the version in $DSG_PACKAGE_JSON 😵"
+            exit 1
+          else
+            echo "✅ Versions are not equal. All good"
+            exit 0
+          fi
+


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6810 

## PR Details

This new github workflow will fail if the `data-service-generator` has been changed but the version was not bumped when trying to merge into `master`
i.e.
<img width="1468" alt="image" src="https://github.com/amplication/amplication/assets/2861984/80535db4-6e1b-401c-851e-8f0a3c405cee">

<img width="1083" alt="image" src="https://github.com/amplication/amplication/assets/2861984/5f6c45d5-0558-4930-b7c1-8e9bf473f736">

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 11c29ab</samp>

### Summary
:sparkles::package::white_check_mark:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or functionality, which is the case for the new workflow file.
2.  :package: - This emoji represents the involvement of a package or dependency, which is relevant for the `data-service-generator` package that is being validated by the workflow.
3.  :white_check_mark: - This emoji represents the aspect of testing or validation, which is the main purpose of the workflow.
-->
Add a GitHub workflow to validate `data-service-generator` version. This workflow checks that the `data-service-generator` package version is incremented in any pull request that modifies it.

> _`dsg-version` check_
> _enforces versioning policy_
> _a workflow for fall_

### Walkthrough
*  Add a new workflow to validate `data-service-generator` version ([link](https://github.com/amplication/amplication/pull/6811/files?diff=unified&w=0#diff-6de3a46d28e8ad5599d6653dabf24c680548329c8e61a9066ccfc6b6c9a2af85R1-R54))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
