### PR TITLE
feat(prisma-db): add code generator version to the build model

### DIFF
--- a/packages/amplication-prisma-db/prisma/migrations/20230901121347_add_code_generator_version_to_build_model/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20230901121347_add_code_generator_version_to_build_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Build" ADD COLUMN     "codeGeneratorVersion" TEXT;

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -394,6 +394,7 @@ model Build {
   deployments              Deployment[]
   blockVersions            BlockVersion[]
   entityVersions           EntityVersion[]
+  codeGeneratorVersion     String?
 
   @@unique([resourceId, version], map: "Build.resourceId_version_unique")
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6800

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6d1f53f</samp>

### Summary
:sparkles::card_file_box::wrench:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or enhancement, which is the case for adding a new column to the database and allowing users to select different versions of the code generator.
2.  :card_file_box: - This emoji represents changes related to the database, which is the case for modifying the `Build` table schema and adding a new column.
3.  :wrench: - This emoji represents changes related to tooling or configuration, which is the case for updating the Prisma schema and synchronizing it with the database.
-->
This pull request adds a new column `codeGeneratorVersion` to the `Build` model in the database and the Prisma schema. This column enables users to choose different versions of the code generator for their applications.

> _`Build` table grows_
> _New column for code gen_
> _Autumn of changes_

### Walkthrough
* Add a new column `codeGeneratorVersion` to the `Build` table to store the version of the code generator used for each build ([link](https://github.com/amplication/amplication/pull/6814/files?diff=unified&w=0#diff-230889ba2f9c356877fe43872bfb39d55fede9873742e5eb778ea0b41937cad9R1-R2))
* Update the Prisma schema to reflect the new column in the `Build` model and mark it as optional and String type ([link](https://github.com/amplication/amplication/pull/6814/files?diff=unified&w=0#diff-f83d54c896f6ae6f938ed753a6856094bef91365a576da08c393e51868d3ce76R397))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
