### PR TITLE
feat(server/git-sync): add resource name to createPullRequest/ create…

### DIFF
--- a/ee/packages/git-sync-manager/src/pull-request/pull-request.service.ts
+++ b/ee/packages/git-sync-manager/src/pull-request/pull-request.service.ts
@@ -60,6 +60,7 @@ export class PullRequestService {
 
   async createPullRequest({
     resourceId,
+    resourceName,
     oldBuildId,
     newBuildId,
     gitProvider,
@@ -76,7 +77,7 @@ export class PullRequestService {
     const { body, title } = commit;
     const head =
       pullRequestMode === EnumPullRequestMode.Accumulative
-        ? "amplication"
+        ? `amplication-${resourceName}`
         : `amplication-build-${newBuildId}`;
     const changedFiles = await this.diffService.listOfChangedFiles(
       resourceId,

--- a/libs/schema-registry/src/lib/create-pr-request/value.ts
+++ b/libs/schema-registry/src/lib/create-pr-request/value.ts
@@ -17,8 +17,7 @@ export class Value {
   @IsString()
   resourceId!: string;
   @IsString()
-  @IsOptional()
-  resourceName?: string;
+  resourceName!: string;
   @IsString()
   @IsOptional()
   oldBuildId?: string | undefined;

--- a/libs/schema-registry/src/lib/create-pr-request/value.ts
+++ b/libs/schema-registry/src/lib/create-pr-request/value.ts
@@ -18,6 +18,9 @@ export class Value {
   resourceId!: string;
   @IsString()
   @IsOptional()
+  resourceName?: string;
+  @IsString()
+  @IsOptional()
   oldBuildId?: string | undefined;
   @IsString()
   newBuildId!: string;

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -678,6 +678,7 @@ export class BuildService {
           const createPullRequestMessage: CreatePrRequest.Value = {
             ...gitSettings,
             resourceId: resource.id,
+            resourceName: resource.name,
             newBuildId: build.id,
             oldBuildId: oldBuild?.id,
             gitResourceMeta: {


### PR DESCRIPTION
Close: #6196 

## PR Details

Create pr per service for pro users (create branch per service name: amplication-[serviceName]). 
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5320b97</samp>

### Summary
:sparkles::recycle::memo:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or enhancement, which is the case for adding the `resourceName` property to the `Value` class and passing it to the `createPullRequest` method.
2.  :recycle: - This emoji represents the refactoring or improvement of existing code, which is the case for enhancing the `PullRequestService` class to support custom branch names for different resources and improving the branch naming convention.
3.  :memo: - This emoji represents the addition or update of documentation, which is the case for updating the docstrings and comments in the code to reflect the changes.
-->
This pull request enables custom branch names and pull request titles for different resources in the schema registry. It modifies the `PullRequestService` class, the `Value` class, and the `build.service.ts` file to support this feature.

> _We're sailing on the code sea, me hearties_
> _We're making pull requests with `resourceName`_
> _We'll heave away and hoist the sail on three_
> _We'll use the branch names for the title and the name_

### Walkthrough
*  Add `resourceName` parameter to `PullRequestService` class to customize branch name based on updated resource ([link](https://github.com/amplication/amplication/pull/6824/files?diff=unified&w=0#diff-d21bb82d93c8cb63e5e8f6098aa3a4119e9c866c1275c788ad0a036aadc6d919R63), [link](https://github.com/amplication/amplication/pull/6824/files?diff=unified&w=0#diff-5a02e9618c884abe0ae7dc2fa14d346ca1c6f6b323dc51449284fadc68e67837R21-R23), [link](https://github.com/amplication/amplication/pull/6824/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aR681))
*  Use `resourceName` in head branch name for accumulative pull requests instead of "amplication" ([link](https://github.com/amplication/amplication/pull/6824/files?diff=unified&w=0#diff-d21bb82d93c8cb63e5e8f6098aa3a4119e9c866c1275c788ad0a036aadc6d919L79-R80))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

