### PR TITLE
feat(git-sync): add branch-per-resource entitlement.

### DIFF
--- a/ee/packages/git-sync-manager/src/pull-request/pull-request.service.ts
+++ b/ee/packages/git-sync-manager/src/pull-request/pull-request.service.ts
@@ -72,11 +72,13 @@ export class PullRequestService {
     pullRequestMode,
     repositoryGroupName,
     baseBranchName,
+    isBranchPerResource,
   }: CreatePrRequest.Value): Promise<string> {
     const logger = this.logger.child({ resourceId, buildId: newBuildId });
     const { body, title } = commit;
     const head =
-      pullRequestMode === EnumPullRequestMode.Accumulative
+      pullRequestMode === EnumPullRequestMode.Accumulative &&
+      isBranchPerResource
         ? `amplication-${resourceName}`
         : `amplication-build-${newBuildId}`;
     const changedFiles = await this.diffService.listOfChangedFiles(

--- a/libs/schema-registry/src/lib/create-pr-request/value.ts
+++ b/libs/schema-registry/src/lib/create-pr-request/value.ts
@@ -4,7 +4,13 @@ import {
   GitProviderProperties,
   GitResourceMeta,
 } from "@amplication/util/git";
-import { IsEnum, IsOptional, IsString, ValidateNested } from "class-validator";
+import {
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from "class-validator";
 
 class Commit {
   @IsString()
@@ -43,4 +49,6 @@ export class Value {
   @IsString()
   @IsOptional()
   baseBranchName?: string;
+  @IsBoolean()
+  isBranchPerResource!: boolean;
 }

--- a/packages/amplication-server/src/core/billing/billing.types.ts
+++ b/packages/amplication-server/src/core/billing/billing.types.ts
@@ -19,4 +19,5 @@ export enum BillingFeature {
   Bitbucket = "feature-bitbucket",
   ImportDBSchema = "feature-import-db-schema",
   ChangeGitBaseBranch = "feature-change-git-base-branch",
+  BranchPerResource = "feature-branch-per-resource",
 }

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -675,6 +675,12 @@ export class BuildService {
               )
             : false;
 
+          const branchPerResourceEntitlement =
+            await this.billingService.getBooleanEntitlement(
+              project.workspaceId,
+              BillingFeature.BranchPerResource
+            );
+
           const createPullRequestMessage: CreatePrRequest.Value = {
             ...gitSettings,
             resourceId: resource.id,
@@ -689,6 +695,11 @@ export class BuildService {
               smartGitSyncEntitlement && smartGitSyncEntitlement.hasAccess
                 ? EnumPullRequestMode.Accumulative
                 : EnumPullRequestMode.Basic,
+            isBranchPerResource:
+              branchPerResourceEntitlement &&
+              branchPerResourceEntitlement.hasAccess
+                ? true
+                : false,
           };
 
           const createPullRequestEvent: CreatePrRequest.KafkaEvent = {


### PR DESCRIPTION
Close: #6196

## PR Details

Add branch per resource entitlement. 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 81ea2bd</samp>

### Summary
🌿💳🛠️

<!--
1.  🌿 - This emoji can represent the concept of branching, as well as the idea of creating new resources or features.
2.  💳 - This emoji can represent the concept of billing, as well as the idea of enabling or disabling features based on the user's subscription or plan.
3.  🛠️ - This emoji can represent the concept of pull requests, as well as the idea of modifying or improving the codebase or the application.
-->
This pull request adds a new feature that allows users to create a pull request with a separate branch for each resource, if they have the corresponding entitlement. It modifies the `Value` class, the `build.service.ts`, the `pull-request.service.ts`, and the `BillingFeature` enum to support this feature.

> _`BranchPerResource`_
> _A new feature for fall code_
> _Cut by `isBranchPerResource`_

### Walkthrough
*  Add a new billing feature for using a separate branch for each resource ([link](https://github.com/amplication/amplication/pull/6837/files?diff=unified&w=0#diff-dfa68e574b49dfe97f85d13ffe12404f479236a77840b9f720e05faf5902dabbR22))
*  Modify the logic for determining the head branch name for creating a pull request based on the new feature ([link](https://github.com/amplication/amplication/pull/6837/files?diff=unified&w=0#diff-d21bb82d93c8cb63e5e8f6098aa3a4119e9c866c1275c788ad0a036aadc6d919L75-R81))
*  Add a new property `isBranchPerResource` to the input for creating a pull request and validate it with the `IsBoolean` decorator ([link](https://github.com/amplication/amplication/pull/6837/files?diff=unified&w=0#diff-5a02e9618c884abe0ae7dc2fa14d346ca1c6f6b323dc51449284fadc68e67837L7-R13), [link](https://github.com/amplication/amplication/pull/6837/files?diff=unified&w=0#diff-5a02e9618c884abe0ae7dc2fa14d346ca1c6f6b323dc51449284fadc68e67837R52-R53))
*  Check the user's entitlement to the new feature using the `billingService` in the `createBuild` method of the `BuildService` class ([link](https://github.com/amplication/amplication/pull/6837/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aR678-R683))
*  Pass the `isBranchPerResource` property to the `createPullRequest` method of the `pullRequestService` in the `createBuild` method ([link](https://github.com/amplication/amplication/pull/6837/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aR698-R702))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

