### PR TITLE
fix(server): resourceName to kebab case

### DIFF
--- a/ee/packages/git-sync-manager/src/pull-request/pull-request.service.ts
+++ b/ee/packages/git-sync-manager/src/pull-request/pull-request.service.ts
@@ -76,11 +76,19 @@ export class PullRequestService {
   }: CreatePrRequest.Value): Promise<string> {
     const logger = this.logger.child({ resourceId, buildId: newBuildId });
     const { body, title } = commit;
-    const head =
-      pullRequestMode === EnumPullRequestMode.Accumulative &&
-      isBranchPerResource
-        ? `amplication-${resourceName}`
-        : `amplication-build-${newBuildId}`;
+
+    let head = null;
+
+    if (pullRequestMode === EnumPullRequestMode.Accumulative) {
+      if (isBranchPerResource) {
+        head = `amplication-${resourceName}`;
+      } else {
+        head = `amplication`;
+      }
+    } else {
+      head = `amplication-build-${newBuildId}`;
+    }
+
     const changedFiles = await this.diffService.listOfChangedFiles(
       resourceId,
       oldBuildId,

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -51,6 +51,7 @@ import {
   EnumEventType,
   SegmentAnalyticsService,
 } from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { kebabCase } from "lodash";
 
 const PROVIDERS_DISPLAY_NAME: { [key in EnumGitProvider]: string } = {
   [EnumGitProvider.AwsCodeCommit]: "AWS CodeCommit",
@@ -684,7 +685,7 @@ export class BuildService {
           const createPullRequestMessage: CreatePrRequest.Value = {
             ...gitSettings,
             resourceId: resource.id,
-            resourceName: resource.name,
+            resourceName: kebabCase(resource.name),
             newBuildId: build.id,
             oldBuildId: oldBuild?.id,
             gitResourceMeta: {


### PR DESCRIPTION
Close: #6196 

## PR Details

Add kebabCase function to resourceName. 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 25679ee</samp>

### Summary
📥🍖📝

<!--
1.  📥 - This emoji can be used to represent the import of the `kebabCase` function, as it suggests bringing something in from an external source or module.
2.  🍖 - This emoji can be used to represent the `kebabCase` function itself, as it is a humorous way of visualizing the format of lowercased words separated by hyphens, like skewered pieces of meat.
3.  📝 - This emoji can be used to represent the application of the `kebabCase` function to the `resourceName` property, as it suggests writing or editing a text or file.
-->
Used `kebabCase` function to format resource names consistently in build tasks. Updated `build.service.ts` file accordingly.

> _To create a build task with ease_
> _We need to format names as we please_
> _So we import `kebabCase`_
> _And apply it in place_
> _To the `resourceName` property_

### Walkthrough
* Import `kebabCase` function from `lodash` library to convert strings to kebab-case ([link](https://github.com/amplication/amplication/pull/6838/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aR54))
* Use `kebabCase` function to format `resourceName` property of the object passed to `createBuildTask` function ([link](https://github.com/amplication/amplication/pull/6838/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aL687-R688))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

