### PR TITLE
refactor(dsg-catalog): moved logic for version selection from build-manager

### DIFF
--- a/packages/amplication-build-manager/src/build-runner/build-runner.controller.spec.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.controller.spec.ts
@@ -308,6 +308,7 @@ describe("BuildRunnerController", () => {
 
   it("On code generation request with unhandled exception thrown, log `error.message` with log level `error` and emit Kafka failure event", async () => {
     const errorMock = new Error("Test error");
+    const expectedCodeGeneratorVersion = "v1.2.2";
     const codeGenerationRequestDTOMock: CodeGenerationRequest.Value = {
       resourceId: "resourceId",
       buildId: "buildId",
@@ -317,7 +318,7 @@ describe("BuildRunnerController", () => {
         pluginInstallations: [],
         resourceInfo: {
           codeGeneratorVersionOptions: {
-            version: "v1.0.1",
+            version: expectedCodeGeneratorVersion,
             selectionStrategy: CodeGeneratorVersionStrategy.Specific,
           },
         } as unknown as AppInfo,
@@ -329,17 +330,14 @@ describe("BuildRunnerController", () => {
       value: <CodeGenerationFailure.Value>{
         buildId: codeGenerationRequestDTOMock.buildId,
         error: errorMock,
-        codeGeneratorVersion:
-          codeGenerationRequestDTOMock.dsgResourceData.resourceInfo
-            .codeGeneratorVersionOptions.codeGeneratorVersion,
+        codeGeneratorVersion: expectedCodeGeneratorVersion,
       },
     } as unknown as CodeGenerationFailure.KafkaEvent;
 
     mockKafkaServiceEmitMessage.mockResolvedValue(undefined);
     mockRunnerServiceSaveDsgResourceData.mockRejectedValue(errorMock);
     mockCodeGeneratorServiceGetCodeGeneratorVersion.mockResolvedValue(
-      codeGenerationRequestDTOMock.dsgResourceData.resourceInfo
-        .codeGeneratorVersionOptions.codeGeneratorStrategy
+      expectedCodeGeneratorVersion
     );
 
     await controller.onCodeGenerationRequest(codeGenerationRequestDTOMock);

--- a/packages/amplication-build-manager/src/code-generator/code-generator-catalog.service.spec.ts
+++ b/packages/amplication-build-manager/src/code-generator/code-generator-catalog.service.spec.ts
@@ -4,7 +4,6 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { Env } from "../env";
 import axios from "axios";
 import { CodeGeneratorVersionStrategy } from "@amplication/code-gen-types/models";
-import { Version } from "./version.interface";
 
 jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;

--- a/packages/amplication-build-manager/src/code-generator/code-generator-catalog.service.spec.ts
+++ b/packages/amplication-build-manager/src/code-generator/code-generator-catalog.service.spec.ts
@@ -4,6 +4,7 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { Env } from "../env";
 import axios from "axios";
 import { CodeGeneratorVersionStrategy } from "@amplication/code-gen-types/models";
+import { Version } from "./version.interface";
 
 jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -23,7 +24,7 @@ describe("CodeGeneratorService", () => {
             get: (variable) => {
               switch (variable) {
                 case Env.DSG_CATALOG_SERVICE_URL:
-                  return "http://localhost:3000";
+                  return "http://localhost:3000/";
                 default:
                   return "";
               }
@@ -47,96 +48,30 @@ describe("CodeGeneratorService", () => {
     ["v1.2.0", CodeGeneratorVersionStrategy.LatestMinor],
   ])(
     `should return version %s when %s is selected`,
-    async (expected: string, strategy: CodeGeneratorVersionStrategy) => {
+    async (
+      expected: string,
+      codeGeneratorStrategy: CodeGeneratorVersionStrategy
+    ) => {
       const selectedVersion = "v1.0.1";
 
-      mockedAxios.get.mockImplementation(() =>
-        Promise.resolve({
-          data: ["v2.1.1", "v0.8.1", "v1.0.1", "v1.2.0"],
-        })
-      );
+      mockedAxios.post.mockImplementation((url) => {
+        if (
+          url === "http://localhost:3000/api/versions/code-generator-version"
+        ) {
+          return Promise.resolve({
+            data: {
+              name: expected,
+            },
+          });
+        }
+      });
 
       const result = await service.getCodeGeneratorVersion({
         codeGeneratorVersion: selectedVersion,
-        codeGeneratorStrategy: strategy,
+        codeGeneratorStrategy,
       });
 
       expect(result).toEqual(expected);
     }
   );
-
-  describe("getCodeGeneratorAvailableVersions", () => {
-    it("should return all available versions", async () => {
-      mockedAxios.get.mockImplementation(() =>
-        Promise.resolve({
-          data: [
-            "v1.0.0",
-            "v1.0.1",
-            "v0.8.1",
-            "v2.0.0",
-            "v1.1.0",
-            "v1.10.1",
-            "v2.2.0",
-            "v1.2.0",
-          ],
-        })
-      );
-
-      const versions = await service["getCodeGeneratorAvailableVersions"]();
-      expect(versions).toEqual([
-        "v1.0.0",
-        "v1.0.1",
-        "v0.8.1",
-        "v2.0.0",
-        "v1.1.0",
-        "v1.10.1",
-        "v2.2.0",
-        "v1.2.0",
-      ]);
-    });
-  });
-
-  describe("getLatestVersion", () => {
-    it("should return the latest minor version for a selected version", async () => {
-      const versions = [
-        "v1.0.0",
-        "v1.0.1",
-        "v0.8.1",
-        "v0.2.1",
-        "v2.0.0",
-        "v1.1.0",
-        "v1.10.0",
-        "v1.10.1",
-        "v2.2.0",
-        "v1.2.0",
-      ];
-
-      const selectedVersion = "v1.0.1";
-
-      const selected = await service["getLatestVersion"](
-        versions,
-        selectedVersion
-      );
-
-      expect(selected).toEqual("v1.10.1");
-    });
-    it("should return the latest version", async () => {
-      const versions = [
-        "v1.0.0",
-        "v1.0.1",
-        "v0.8.1",
-        "v0.2.1",
-        "v2.0.0",
-        "v1.1.0",
-        "v1.10.0",
-        "v1.10.1",
-        "v2.2.0",
-        "v1.2.0",
-      ];
-
-      const selected = await service["getLatestVersion"](versions);
-
-      expect(selected).toEqual("v2.2.0");
-    });
-  });
 });

--- a/packages/amplication-build-manager/src/code-generator/code-generator-catalog.service.ts
+++ b/packages/amplication-build-manager/src/code-generator/code-generator-catalog.service.ts
@@ -4,78 +4,12 @@ import { Env } from "../env";
 import { Traceable } from "@amplication/opentelemetry-nestjs";
 import { CodeGeneratorVersionStrategy } from "@amplication/code-gen-types/models";
 import axios from "axios";
+import { Version } from "./version.interface";
 
 @Traceable()
 @Injectable()
 export class CodeGeneratorService {
   constructor(private readonly configService: ConfigService<Env, true>) {}
-
-  private sortVersions(versions: string[]): string[] {
-    return versions.sort((version1: string, version2: string): number => {
-      const parseVersion = (version: string): number[] => {
-        const versionParts = version.replace("v", "").split(".");
-        return versionParts.map((part) => parseInt(part, 10));
-      };
-
-      const parsedVersion1 = parseVersion(version1);
-      const parsedVersion2 = parseVersion(version2);
-
-      for (
-        let i = 0;
-        i < Math.max(parsedVersion1.length, parsedVersion2.length);
-        i++
-      ) {
-        const part1 = parsedVersion1[i] || 0;
-        const part2 = parsedVersion2[i] || 0;
-
-        if (part1 < part2) {
-          return 1; // version2 is greater
-        } else if (part1 > part2) {
-          return -1; // version1 is greater
-        }
-      }
-
-      return 0; // versions are equal
-    });
-  }
-
-  private async getCodeGeneratorAvailableVersions(): Promise<string[]> {
-    const catalogServiceUrl = this.configService.get(
-      Env.DSG_CATALOG_SERVICE_URL
-    );
-    const response = await axios.get<string[]>(
-      `${catalogServiceUrl}/versions`,
-      {
-        params: {},
-      }
-    );
-
-    return response.data;
-  }
-
-  private async getLatestVersion(
-    versions: string[],
-    specificVersion?: string
-  ): Promise<string> {
-    const sortedVersions = this.sortVersions(versions);
-    if (!specificVersion) {
-      // return the most recent version
-      return sortedVersions[0];
-    }
-    const specificVersionParts = specificVersion.replace("v", "").split(".");
-    const specificVersionMajor = specificVersionParts[0];
-
-    const latestMinorVersion = sortedVersions.find((version) => {
-      const versionParts = version.replace("v", "").split(".");
-      return versionParts[0] === specificVersionMajor;
-    });
-    if (!latestMinorVersion) {
-      throw new Error(
-        `Could not find latest minor version for ${specificVersion}`
-      );
-    }
-    return latestMinorVersion;
-  }
 
   async getCodeGeneratorVersion({
     codeGeneratorVersion,
@@ -84,23 +18,26 @@ export class CodeGeneratorService {
     codeGeneratorVersion?: string;
     codeGeneratorStrategy?: CodeGeneratorVersionStrategy;
   }): Promise<string | undefined> {
-    if (!codeGeneratorVersion) {
-      return;
-    }
+    const catalogServiceUrl = this.configService.get(
+      Env.DSG_CATALOG_SERVICE_URL
+    );
+    try {
+      const response = await axios.post(
+        `${catalogServiceUrl}api/versions/code-generator-version`,
+        {
+          codeGeneratorVersion,
+          codeGeneratorStrategy,
+        }
+      );
 
-    const versions =
-      codeGeneratorStrategy !== CodeGeneratorVersionStrategy.Specific
-        ? await this.getCodeGeneratorAvailableVersions()
-        : [];
-
-    switch (codeGeneratorStrategy) {
-      case CodeGeneratorVersionStrategy.Specific:
-        return codeGeneratorVersion;
-      case CodeGeneratorVersionStrategy.LatestMinor:
-        return this.getLatestVersion(versions, codeGeneratorVersion);
-      case CodeGeneratorVersionStrategy.LatestMajor:
-      default:
-        return this.getLatestVersion(versions);
+      return response.data.name;
+    } catch (error) {
+      throw new Error(error.message, {
+        cause: {
+          code: error.response?.status,
+          message: error.response?.data?.message,
+        },
+      });
     }
   }
 }

--- a/packages/amplication-build-manager/src/code-generator/code-generator-catalog.service.ts
+++ b/packages/amplication-build-manager/src/code-generator/code-generator-catalog.service.ts
@@ -30,7 +30,7 @@ export class CodeGeneratorService {
         }
       );
 
-      return response.data.name;
+      return (<Version>response.data).name;
     } catch (error) {
       throw new Error(error.message, {
         cause: {

--- a/packages/amplication-build-manager/src/code-generator/version.interface.ts
+++ b/packages/amplication-build-manager/src/code-generator/version.interface.ts
@@ -1,0 +1,12 @@
+interface Version {
+  changelog: string | null;
+  createdAt: Date;
+  deletedAt: Date | null;
+  id: string;
+  isActive: boolean;
+  isDeprecated: boolean | null;
+  name: string | null;
+  updatedAt: Date;
+}
+
+export { Version };

--- a/packages/data-service-generator-catalog/src/version/GetCodeGeneratorVersionInput.ts
+++ b/packages/data-service-generator-catalog/src/version/GetCodeGeneratorVersionInput.ts
@@ -1,0 +1,29 @@
+import { CodeGeneratorVersionStrategy } from "@amplication/code-gen-types/models";
+import { Field, InputType, registerEnumType } from "@nestjs/graphql";
+import { ApiProperty } from "@nestjs/swagger";
+import { IsOptional, IsString } from "class-validator";
+
+@InputType()
+class GetCodeGeneratorVersionInput {
+  @ApiProperty({
+    required: false,
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  @Field(() => String, { nullable: true })
+  codeGeneratorVersion?: string;
+
+  @ApiProperty({
+    required: true,
+    enum: CodeGeneratorVersionStrategy,
+  })
+  @Field(() => CodeGeneratorVersionStrategy, { nullable: false })
+  codeGeneratorStrategy!: CodeGeneratorVersionStrategy;
+}
+
+registerEnumType(CodeGeneratorVersionStrategy, {
+  name: "CodeGeneratorVersionStrategy",
+});
+
+export { GetCodeGeneratorVersionInput };

--- a/packages/data-service-generator-catalog/src/version/version.controller.ts
+++ b/packages/data-service-generator-catalog/src/version/version.controller.ts
@@ -3,6 +3,10 @@ import * as swagger from "@nestjs/swagger";
 import * as nestAccessControl from "nest-access-control";
 import { VersionService } from "./version.service";
 import { VersionControllerBase } from "./base/version.controller.base";
+import { GetCodeGeneratorVersionInput } from "./GetCodeGeneratorVersionInput";
+import { Public } from "../decorators/public.decorator";
+import * as errors from "../errors";
+import { Version } from "./base/Version";
 
 @swagger.ApiTags("versions")
 @common.Controller("versions")
@@ -13,5 +17,17 @@ export class VersionController extends VersionControllerBase {
     protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {
     super(service, rolesBuilder);
+  }
+
+  @Public()
+  @common.Post("/code-generator-version")
+  @swagger.ApiOkResponse({ type: [Version] })
+  @swagger.ApiForbiddenResponse({
+    type: errors.ForbiddenException,
+  })
+  async getCodeGeneratorVersion(
+    @common.Body() params: GetCodeGeneratorVersionInput
+  ): Promise<Version> {
+    return this.service.getCodeGeneratorVersion(params);
   }
 }

--- a/packages/data-service-generator-catalog/src/version/version.resolver.ts
+++ b/packages/data-service-generator-catalog/src/version/version.resolver.ts
@@ -6,6 +6,8 @@ import * as common from "@nestjs/common";
 import { VersionResolverBase } from "./base/version.resolver.base";
 import { Version } from "./base/Version";
 import { VersionService } from "./version.service";
+import { Public } from "../decorators/public.decorator";
+import { GetCodeGeneratorVersionInput } from "./GetCodeGeneratorVersionInput";
 
 @common.UseGuards(GqlDefaultAuthGuard, gqlACGuard.GqlACGuard)
 @graphql.Resolver(() => Version)
@@ -16,5 +18,15 @@ export class VersionResolver extends VersionResolverBase {
     protected readonly rolesBuilder: nestAccessControl.RolesBuilder
   ) {
     super(service, rolesBuilder);
+  }
+
+  @Public()
+  @graphql.Mutation(() => Version)
+  async getCodeGeneratorVersion(
+    @graphql.Args("GetCodeGeneratorVersionInput")
+    args: GetCodeGeneratorVersionInput
+  ): Promise<Version> {
+    const res = await this.service.getCodeGeneratorVersion(args);
+    return res;
   }
 }

--- a/packages/data-service-generator-catalog/src/version/version.service.spec.ts
+++ b/packages/data-service-generator-catalog/src/version/version.service.spec.ts
@@ -1,0 +1,140 @@
+import { ConfigService } from "@nestjs/config";
+import { Test, TestingModule } from "@nestjs/testing";
+import { CodeGeneratorVersionStrategy } from "@amplication/code-gen-types/models";
+import { VersionService } from "./version.service";
+import { PrismaService } from "../prisma/prisma.service";
+
+describe("VersionService", () => {
+  let service: VersionService;
+  const mockVersionFindMany = jest.fn();
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [],
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (variable) => {
+              switch (variable) {
+                default:
+                  return "";
+              }
+            },
+          },
+        },
+        {
+          provide: PrismaService,
+          useValue: {
+            version: {
+              findMany: mockVersionFindMany,
+            },
+          },
+        },
+        VersionService,
+      ],
+    }).compile();
+
+    service = module.get<VersionService>(VersionService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  it.each([
+    ["v1.0.1", CodeGeneratorVersionStrategy.Specific],
+    ["v2.1.1", CodeGeneratorVersionStrategy.LatestMajor],
+    ["v1.2.0", CodeGeneratorVersionStrategy.LatestMinor],
+  ])(
+    `should return version %s when %s is selected`,
+    async (
+      expected: string,
+      codeGeneratorStrategy: CodeGeneratorVersionStrategy
+    ) => {
+      const selectedVersion = "v1.0.1";
+
+      mockVersionFindMany.mockResolvedValue([{ name: expected }]);
+
+      const result = await service.getCodeGeneratorVersion({
+        codeGeneratorVersion: selectedVersion,
+        codeGeneratorStrategy,
+      });
+
+      expect(result).toEqual({ name: expected });
+    }
+  );
+
+  describe("getCodeGeneratorAvailableVersions", () => {
+    it("should return all available versions", async () => {
+      mockVersionFindMany.mockResolvedValue([
+        { name: "v1.0.0" },
+        { name: "v1.0.1" },
+        { name: "v0.8.1" },
+        { name: "v2.0.0" },
+        { name: "v1.1.0" },
+        { name: "v1.10.1" },
+        { name: "v2.2.0" },
+        { name: "v1.2.0" },
+      ]);
+
+      const versions = await service.findMany({});
+      expect(versions).toEqual([
+        { name: "v1.0.0" },
+        { name: "v1.0.1" },
+        { name: "v0.8.1" },
+        { name: "v2.0.0" },
+        { name: "v1.1.0" },
+        { name: "v1.10.1" },
+        { name: "v2.2.0" },
+        { name: "v1.2.0" },
+      ]);
+    });
+  });
+
+  describe("getLatestVersion", () => {
+    it("should return the latest minor version for a selected version", async () => {
+      const versions = [
+        "v1.0.0",
+        "v1.0.1",
+        "v0.8.1",
+        "v0.2.1",
+        "v2.0.0",
+        "v1.1.0",
+        "v1.10.0",
+        "v1.10.1",
+        "v2.2.0",
+        "v1.2.0",
+      ];
+
+      const selectedVersion = "v1.0.1";
+
+      const selected = await service["getLatestVersion"](
+        versions,
+        selectedVersion
+      );
+
+      expect(selected).toEqual("v1.10.1");
+    });
+    it("should return the latest version", async () => {
+      const versions = [
+        "v1.0.0",
+        "v1.0.1",
+        "v0.8.1",
+        "v0.2.1",
+        "v2.0.0",
+        "v1.1.0",
+        "v1.10.0",
+        "v1.10.1",
+        "v2.2.0",
+        "v1.2.0",
+      ];
+
+      const selected = await service["getLatestVersion"](versions);
+
+      expect(selected).toEqual("v2.2.0");
+    });
+  });
+});

--- a/packages/data-service-generator-catalog/src/version/version.service.ts
+++ b/packages/data-service-generator-catalog/src/version/version.service.ts
@@ -1,10 +1,118 @@
-import { Injectable } from "@nestjs/common";
+import { BadRequestException, Injectable } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service";
 import { VersionServiceBase } from "./base/version.service.base";
+import { CodeGeneratorVersionStrategy } from "@amplication/code-gen-types/models";
+import { Version } from "./base/Version";
+import { GetCodeGeneratorVersionInput } from "./GetCodeGeneratorVersionInput";
 
 @Injectable()
 export class VersionService extends VersionServiceBase {
   constructor(protected readonly prisma: PrismaService) {
     super(prisma);
+  }
+
+  private sortVersions(versions: string[]): string[] {
+    return versions.sort((version1: string, version2: string): number => {
+      const parseVersion = (version: string): number[] => {
+        const versionParts = version.replace("v", "").split(".");
+        return versionParts.map((part) => parseInt(part, 10));
+      };
+
+      const parsedVersion1 = parseVersion(version1);
+      const parsedVersion2 = parseVersion(version2);
+
+      for (
+        let i = 0;
+        i < Math.max(parsedVersion1.length, parsedVersion2.length);
+        i++
+      ) {
+        const part1 = parsedVersion1[i] || 0;
+        const part2 = parsedVersion2[i] || 0;
+
+        if (part1 < part2) {
+          return 1; // version2 is greater
+        } else if (part1 > part2) {
+          return -1; // version1 is greater
+        }
+      }
+
+      return 0; // versions are equal
+    });
+  }
+
+  private async getLatestVersion(
+    versions: string[],
+    specificVersion?: string
+  ): Promise<string> {
+    const sortedVersions = this.sortVersions(versions);
+    if (!specificVersion) {
+      // return the most recent version
+      return sortedVersions[0];
+    }
+    const specificVersionParts = specificVersion.replace("v", "").split(".");
+    const specificVersionMajor = specificVersionParts[0];
+
+    const latestMinorVersion = sortedVersions.find((version) => {
+      const versionParts = version.replace("v", "").split(".");
+      return versionParts[0] === specificVersionMajor;
+    });
+    if (!latestMinorVersion) {
+      throw new Error(
+        `Could not find latest minor version for ${specificVersion}`
+      );
+    }
+    return latestMinorVersion;
+  }
+
+  async getCodeGeneratorVersion(
+    args: GetCodeGeneratorVersionInput
+  ): Promise<Version | undefined> {
+    const { codeGeneratorVersion, codeGeneratorStrategy } = args;
+    if (
+      (!codeGeneratorVersion &&
+        (codeGeneratorStrategy === CodeGeneratorVersionStrategy.Specific ||
+          codeGeneratorStrategy ===
+            CodeGeneratorVersionStrategy.LatestMinor)) ||
+      !codeGeneratorStrategy
+    ) {
+      throw new BadRequestException();
+    }
+
+    if (codeGeneratorStrategy === CodeGeneratorVersionStrategy.Specific) {
+      return (
+        await this.findMany({
+          where: {
+            name: codeGeneratorVersion,
+          },
+          take: 1,
+        })
+      )[0];
+    }
+
+    const activeVersions = await this.findMany({
+      where: {
+        isActive: true,
+        deletedAt: null,
+      },
+    });
+
+    let selectedVersion: string;
+
+    switch (codeGeneratorStrategy) {
+      case CodeGeneratorVersionStrategy.LatestMinor:
+        selectedVersion = await this.getLatestVersion(
+          activeVersions.map((version) => version.name),
+          codeGeneratorVersion
+        );
+        break;
+      case CodeGeneratorVersionStrategy.LatestMajor:
+      default:
+        selectedVersion = await this.getLatestVersion(
+          activeVersions.map((version) => version.name)
+        );
+        break;
+    }
+
+    return activeVersions.find((version) => version.name === selectedVersion);
   }
 }


### PR DESCRIPTION

Close: https://github.com/amplication/amplication/issues/6736

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0d75f7f</samp>

### Summary
📄🧪🛠️

<!--
1.  📄 for adding new files and types
2.  🧪 for adding and updating tests
3.  🛠️ for improving error handling and logic
-->
This pull request adds a new feature to the data service generator catalog service that allows getting the version of a code generator by its name and version. It also updates the build manager service to use this feature and refactors some tests and code for better quality and consistency. The main changes are in the `version` module of the data service generator catalog service and the `code-generator` module of the build manager service. The pull request also introduces new types and enums in the `code-gen-types` and `common` packages.

> _We are the data service generator_
> _We use the `Version` interface and the `CodeGeneratorVersionStrategy` enum_
> _We handle errors and sort versions with the `version.service`_
> _We are the data service generator_

### Walkthrough
*  Add `version.interface.ts` file to define the `Version` interface for the data service generator catalog service ([link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-90e9bee39abb0f32ef0af961f27c2d4cb3da68e78f9cc0a191c1e91c12adef3aR1-R12))
*  Add `GetCodeGeneratorVersionInput.ts` file to define the input type for the `getCodeGeneratorVersion` method in the data service generator catalog service ([link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-415aac96ae56139fffb7d4ff03685ef35d6831bae2d74e041ca3aad225ab22d2R1-R29))
*  Modify the `getCodeGeneratorVersion` method in the code generator catalog service to use the `axios.post` method and the `Version` interface, and to handle errors ([link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-589b23ac0aa0af13d460a0e49556ed0df602063e7a078bd3c352788c44e00abeL87-R40), [link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-589b23ac0aa0af13d460a0e49556ed0df602063e7a078bd3c352788c44e00abeR7))
*  Modify the `getCodeGeneratorVersion` method in the version service of the data service generator catalog service to use the `GetCodeGeneratorVersionInput` type, the `CodeGeneratorVersionStrategy` enum, and the private methods `sortVersions` and `getLatestVersion`, and to validate and handle errors ([link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-af45d823ef78c43db0372051542a70d210569bbddc09b3070912fdf097ef88efR13-R117), [link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-af45d823ef78c43db0372051542a70d210569bbddc09b3070912fdf097ef88efL1-R6))
*  Add the `getCodeGeneratorVersion` method to the version controller and the version resolver of the data service generator catalog service, using the `Public` decorator, the `GetCodeGeneratorVersionInput` type, and the `Version` type ([link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-df669d9f0a625e7933beb32d300102ef9c9e217a17cb167b106065cba412752fR21-R32), [link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-df669d9f0a625e7933beb32d300102ef9c9e217a17cb167b106065cba412752fR6-R9), [link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-c907d1f8dbaf402275bb1430bea404a381317dcd336bc9e29b49496580c6d2b8R22-R31), [link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-c907d1f8dbaf402275bb1430bea404a381317dcd336bc9e29b49496580c6d2b8R9-R10))
*  Add the `version.service.spec.ts` file to define the unit tests for the version service of the data service generator catalog service, using the `CodeGeneratorVersionStrategy` enum and the `Version` type ([link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-6ffa846727f75044914cb18ebe994d12a4a56aad0bde64b034316e1ca952ef3cR1-R140))
*  Modify the `build-runner.controller.spec.ts` file to use the `expectedCodeGeneratorVersion` variable instead of hard-coded values, and to mock the `getCodeGeneratorVersion` method ([link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-0c8c0049207f0f2eb216ff7ef2a0a4279eb08309a6e955af38cb23024977790bR311), [link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-0c8c0049207f0f2eb216ff7ef2a0a4279eb08309a6e955af38cb23024977790bL320-R321), [link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-0c8c0049207f0f2eb216ff7ef2a0a4279eb08309a6e955af38cb23024977790bL332-R333), [link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-0c8c0049207f0f2eb216ff7ef2a0a4279eb08309a6e955af38cb23024977790bL341-R340))
*  Modify the `code-generator-catalog.service.spec.ts` file to use the `Version` interface and the `axios.post` method, and to remove the tests for the unused methods ([link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-fdd9f332fd6828b98bea1e11a120c71addf9451d66c6a1a1e5b1892bd22d5fe5R7), [link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-fdd9f332fd6828b98bea1e11a120c71addf9451d66c6a1a1e5b1892bd22d5fe5L26-R27), [link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-fdd9f332fd6828b98bea1e11a120c71addf9451d66c6a1a1e5b1892bd22d5fe5L50-R71), [link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-fdd9f332fd6828b98bea1e11a120c71addf9451d66c6a1a1e5b1892bd22d5fe5L67-L141))
*  Modify the `build-runner.controller.ts` file to move the `containerImageTag` variable declaration, to handle the error from the `axios.post` call to the data service generator runner service, and to use the nullish coalescing operator for the code generation failure event ([link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-5c940f381b508c980f52d86bfc5418d7aa34d5c60f43628bfbd5a3459cf40d17L100-R112), [link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-5c940f381b508c980f52d86bfc5418d7aa34d5c60f43628bfbd5a3459cf40d17L120-R134), [link](https://github.com/amplication/amplication/pull/6865/files?diff=unified&w=0#diff-5c940f381b508c980f52d86bfc5418d7aa34d5c60f43628bfbd5a3459cf40d17L133-R143))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
