### PR TITLE
feat(client): add a link to create message broker in service connections page

### DIFF
--- a/packages/amplication-client/src/Components/EmptyState.tsx
+++ b/packages/amplication-client/src/Components/EmptyState.tsx
@@ -4,15 +4,17 @@ import "./EmptyState.scss";
 
 type Props = SvgThemeImageProps & {
   message: string;
+  children?: React.ReactNode;
 };
 
 const CLASS_NAME = "empty-state";
 
-export const EmptyState = ({ message, ...rest }: Props) => {
+export const EmptyState = ({ message, children, ...rest }: Props) => {
   return (
     <div className={`${CLASS_NAME}`}>
       <SvgThemeImage {...rest} />
       <p>{message}</p>
+      {!!children && children}
     </div>
   );
 };

--- a/packages/amplication-client/src/ServiceConnections/ServiceConnectionsPage.scss
+++ b/packages/amplication-client/src/ServiceConnections/ServiceConnectionsPage.scss
@@ -1,0 +1,9 @@
+@import "../style/index.scss";
+
+.topics {
+  .add-broker {
+    &__label {
+      color: var(--black100);
+    }
+  }
+}

--- a/packages/amplication-client/src/ServiceConnections/ServiceConnectionsPage.tsx
+++ b/packages/amplication-client/src/ServiceConnections/ServiceConnectionsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useMemo } from "react";
-import { match } from "react-router-dom";
+import { match, useHistory } from "react-router-dom";
 import * as models from "../models";
 import { EmptyState } from "../Components/EmptyState";
 import { EnumImages } from "../Components/SvgThemeImage";
@@ -10,6 +10,11 @@ import { AppRouteProps } from "../routes/routesUtil";
 import useServiceConnection from "./hooks/useServiceConnection";
 import { ServiceConnectionsList } from "./ServiceConnectionsList";
 import { isEmpty } from "lodash";
+import {
+  Button,
+  EnumButtonStyle,
+  EnumIconPosition,
+} from "@amplication/ui/design-system";
 
 type MessageBrokerListItem = {
   resource: models.Resource;
@@ -32,7 +37,10 @@ const TopicsPage: React.FC<Props> = ({ match, innerRoutes }: Props) => {
     errorServiceTopics: error,
   } = useServiceConnection(resourceId);
 
-  const { resources } = useContext(AppContext);
+  const history = useHistory();
+
+  const { resources, currentWorkspace, currentProject } =
+    useContext(AppContext);
 
   const messageBrokerList = useMemo((): MessageBrokerListItem[] => {
     return resources
@@ -74,7 +82,22 @@ const TopicsPage: React.FC<Props> = ({ match, innerRoutes }: Props) => {
         <EmptyState
           message="There is no message broker to show."
           image={EnumImages.MessageBrokerEmptyState}
-        />
+        >
+          <Button
+            onClick={() =>
+              history.push(
+                `/${currentWorkspace?.id}/${currentProject?.id}/create-broker`
+              )
+            }
+            type="button"
+            buttonStyle={EnumButtonStyle.Secondary}
+            icon="plus"
+            iconPosition={EnumIconPosition.Left}
+            iconSize="xsmall"
+          >
+            <span style={{ color: "var(--black100)" }}>Add Message Broker</span>
+          </Button>
+        </EmptyState>
       )}
     </PageContent>
   );

--- a/packages/amplication-client/src/ServiceConnections/ServiceConnectionsPage.tsx
+++ b/packages/amplication-client/src/ServiceConnections/ServiceConnectionsPage.tsx
@@ -15,6 +15,7 @@ import {
   EnumButtonStyle,
   EnumIconPosition,
 } from "@amplication/ui/design-system";
+import "./ServiceConnectionsPage.scss";
 
 type MessageBrokerListItem = {
   resource: models.Resource;
@@ -95,7 +96,7 @@ const TopicsPage: React.FC<Props> = ({ match, innerRoutes }: Props) => {
             iconPosition={EnumIconPosition.Left}
             iconSize="xsmall"
           >
-            <span style={{ color: "var(--black100)" }}>Add Message Broker</span>
+            <span className={"add-broker__label"}>Add Message Broker</span>
           </Button>
         </EmptyState>
       )}


### PR DESCRIPTION

<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6214 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 05d2dd4</samp>

### Summary
🆕🎨🚀

<!--
1.  🆕 - This emoji conveys the idea of adding something new, which is what the button does by creating a new message broker.
2.  🎨 - This emoji suggests the idea of customizing or enhancing something, which is what the `children` prop does by allowing rendering additional elements inside the empty state container.
3.  🚀 - This emoji implies the idea of launching or starting something, which is what the button does by navigating to the message broker creation page.
-->
Added a feature to create a new message broker from the service connections page. Modified the `EmptyState` component to support custom actions.

> _When the service connections are few_
> _The `EmptyState` component will do_
> _But to make it more nice_
> _We added a slice_
> _Of `children` with a button to view_

### Walkthrough
*  Add an optional `children` prop to the `EmptyState` component, which allows rendering additional elements inside the empty state container ([link](https://github.com/amplication/amplication/pull/6874/files?diff=unified&w=0#diff-3acd4b227dadf1a6d2acdeb18478c46d1b75247847b4af5a817ded2dde7e59b9L7-R17))
* Import the `useHistory` hook from `react-router-dom` in the `ServiceConnectionsPage` component, which allows navigating to different routes programmatically ([link](https://github.com/amplication/amplication/pull/6874/files?diff=unified&w=0#diff-02c2e232d5e66303434e92c2e77cd64605c3929643b6f553457884d3a0f9d719L2-R2))
* Import the `Button` component and its related enums from `@amplication/ui/design-system` in the `ServiceConnectionsPage` component, which allows rendering a styled button with an icon ([link](https://github.com/amplication/amplication/pull/6874/files?diff=unified&w=0#diff-02c2e232d5e66303434e92c2e77cd64605c3929643b6f553457884d3a0f9d719R13-R17))
* Add the `history`, `currentWorkspace`, and `currentProject` variables to the `ServiceConnectionsPage` component, using the `useHistory` hook and the `AppContext`, which store the current browser history object, the current workspace object, and the current project object, respectively ([link](https://github.com/amplication/amplication/pull/6874/files?diff=unified&w=0#diff-02c2e232d5e66303434e92c2e77cd64605c3929643b6f553457884d3a0f9d719L35-R44))
* Add the `Button` component as a child of the `EmptyState` component in the `ServiceConnectionsPage` component, with the appropriate props to render a secondary button with a plus icon and a text label, which encourages the user to create a new message broker from the empty state ([link](https://github.com/amplication/amplication/pull/6874/files?diff=unified&w=0#diff-02c2e232d5e66303434e92c2e77cd64605c3929643b6f553457884d3a0f9d719L77-R100))
* Add the `onClick` handler of the button, which uses the `history` variable to push the route for creating a new message broker from the empty state ([link](https://github.com/amplication/amplication/pull/6874/files?diff=unified&w=0#diff-02c2e232d5e66303434e92c2e77cd64605c3929643b6f553457884d3a0f9d719L77-R100))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
