### PR TITLE
fix(dsg-catalog): sync logic to not activate new versions by default

### DIFF
--- a/packages/amplication-server/src/app.module.ts
+++ b/packages/amplication-server/src/app.module.ts
@@ -43,6 +43,7 @@ import { RequestContextModule } from "nestjs-request-context";
           sortSchema: true,
           debug: configService.get("GRAPHQL_DEBUG") === "1",
           playground: configService.get("PLAYGROUND_ENABLE") === "1",
+          introspection: configService.get("PLAYGROUND_ENABLE") === "1",
           context: ({ req }: { req: Request }) => ({
             req,
           }),

--- a/packages/data-service-generator-catalog/.env
+++ b/packages/data-service-generator-catalog/.env
@@ -9,7 +9,6 @@ DB_PASSWORD=admin
 DB_PORT=5432
 DB_NAME=data-service-generator-catalog
 
-INCLUDE_DEV_VERSIONS=1
-DEV_VERSIONS=next,master
+DEV_VERSION_TAG=latest-local
 
 PLAYGROUND_ENABLE=1

--- a/packages/data-service-generator-catalog/src/version/version.controller.ts
+++ b/packages/data-service-generator-catalog/src/version/version.controller.ts
@@ -5,7 +5,6 @@ import { VersionService } from "./version.service";
 import { VersionControllerBase } from "./base/version.controller.base";
 import { GetCodeGeneratorVersionInput } from "./dto/GetCodeGeneratorVersionInput";
 import { Public } from "../decorators/public.decorator";
-import * as errors from "../errors";
 import { Version } from "./base/Version";
 
 @swagger.ApiTags("versions")
@@ -31,7 +30,8 @@ export class VersionController extends VersionControllerBase {
   @Public()
   @common.Post("/sync")
   @swagger.ApiOkResponse({ type: [null] })
-  async sync(): Promise<void> {
-    return this.service.syncVersions();
+  async sync(): Promise<boolean> {
+    await this.service.syncVersions();
+    return true;
   }
 }

--- a/packages/data-service-generator-catalog/src/version/version.resolver.ts
+++ b/packages/data-service-generator-catalog/src/version/version.resolver.ts
@@ -32,7 +32,7 @@ export class VersionResolver extends VersionResolverBase {
   }
 
   @Public()
-  @graphql.Mutation(() => Boolean)
+  @graphql.Query(() => Boolean, {})
   async sync(): Promise<boolean> {
     await this.service.syncVersions();
     return true;

--- a/packages/data-service-generator-catalog/src/version/version.resolver.ts
+++ b/packages/data-service-generator-catalog/src/version/version.resolver.ts
@@ -32,7 +32,7 @@ export class VersionResolver extends VersionResolverBase {
   }
 
   @Public()
-  @graphql.Query(() => Boolean, {})
+  @graphql.Query(() => Boolean)
   async sync(): Promise<boolean> {
     await this.service.syncVersions();
     return true;

--- a/packages/data-service-generator-catalog/src/version/version.service.spec.ts
+++ b/packages/data-service-generator-catalog/src/version/version.service.spec.ts
@@ -5,6 +5,7 @@ import { VersionService } from "./version.service";
 import { PrismaService } from "../prisma/prisma.service";
 import { AwsEcrService } from "../aws/aws-ecr.service";
 import { AwsEcrModule } from "../aws/aws-ecr.module";
+import { MockedAmplicationLoggerProvider } from "@amplication/util/nestjs/logging/test-utils";
 
 describe("VersionService", () => {
   let service: VersionService;
@@ -49,6 +50,7 @@ describe("VersionService", () => {
             getTags: mockAwsEcrServiceGetTags,
           },
         },
+        MockedAmplicationLoggerProvider,
         VersionService,
       ],
     }).compile();
@@ -138,6 +140,7 @@ describe("VersionService", () => {
                 },
               },
             },
+            MockedAmplicationLoggerProvider,
             VersionService,
           ],
         }).compile();
@@ -242,7 +245,7 @@ describe("VersionService", () => {
           {
             id: "v1.0.0",
             name: "v1.0.0",
-            isActive: true,
+            isActive: false,
             createdAt: pushedDate,
             updatedAt: expect.anything(),
             changelog: "",
@@ -252,7 +255,7 @@ describe("VersionService", () => {
           {
             id: "v1.0.1",
             name: "v1.0.1",
-            isActive: true,
+            isActive: false,
             createdAt: pushedDate,
             updatedAt: expect.anything(),
             changelog: "",
@@ -262,7 +265,7 @@ describe("VersionService", () => {
           {
             id: "v2.0.0",
             name: "v2.0.0",
-            isActive: true,
+            isActive: false,
             createdAt: pushedDate,
             updatedAt: expect.anything(),
             changelog: "",


### PR DESCRIPTION
Fix: #6855 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e234764</samp>

### Summary
🚀🛠️🔍

<!--
1.  🚀 - This emoji represents the feature of enabling the GraphQL playground in the app module, which can be seen as a launchpad for developers to explore and test the GraphQL API.
2.  🛠️ - This emoji represents the update of the environment variables for the data service generator catalog, which can be seen as a tool for simplifying the configuration and avoiding conflicts.
3.  🔍 - This emoji represents the modification of the sync resolver in the version resolver, which can be seen as a magnifying glass for querying the sync operation instead of mutating it.
-->
This pull request improves the data service generator catalog by adding logging, error handling, configuration, and version management features. It uses the `AmplicationLogger` in the `version.controller.ts` file, updates the unit test and the environment variables in the `version.service.spec.ts` and `.env` files, and changes the GraphQL resolver and service logic in the `version.resolver.ts` and `version.service.ts` files.

> _`syncVersions` query_
> _GraphQL playground in spring_
> _`AmplicationLogger`_

### Walkthrough
*  Enable GraphQL playground in app module if PLAYGROUND_ENABLE is set to "1" ([link](https://github.com/amplication/amplication/pull/6877/files?diff=unified&w=0#diff-4e72dc01e875c6474e7255d4778cb9acef369010c0ae3f813255eeee5fabcc24R46))
*  Simplify environment variables for data service generator catalog ([link](https://github.com/amplication/amplication/pull/6877/files?diff=unified&w=0#diff-a1d58259b8a7ea2d34a8ca70e5b08119d4defcaad265eb27cbbbca0e320d9a03L12))
*  Use AmplicationLogger in version controller and log sync operation ([link](https://github.com/amplication/amplication/pull/6877/files?diff=unified&w=0#diff-df669d9f0a625e7933beb32d300102ef9c9e217a17cb167b106065cba412752fL8-R9), [link](https://github.com/amplication/amplication/pull/6877/files?diff=unified&w=0#diff-df669d9f0a625e7933beb32d300102ef9c9e217a17cb167b106065cba412752fL17-R18), [link](https://github.com/amplication/amplication/pull/6877/files?diff=unified&w=0#diff-df669d9f0a625e7933beb32d300102ef9c9e217a17cb167b106065cba412752fL35-R45))
*  Change sync resolver from mutation to query in `version.resolver.ts` ([link](https://github.com/amplication/amplication/pull/6877/files?diff=unified&w=0#diff-c907d1f8dbaf402275bb1430bea404a381317dcd336bc9e29b49496580c6d2b8L35-R35))
*  Set isActive to false for all versions fetched from Docker registry in `version.service.ts` ([link](https://github.com/amplication/amplication/pull/6877/files?diff=unified&w=0#diff-af45d823ef78c43db0372051542a70d210569bbddc09b3070912fdf097ef88efL157-R157))
*  Update unit tests for syncVersions method in `version.service.spec.ts` and set isActive to false for unsupported versions ([link](https://github.com/amplication/amplication/pull/6877/files?diff=unified&w=0#diff-6ffa846727f75044914cb18ebe994d12a4a56aad0bde64b034316e1ca952ef3cL245-R245), [link](https://github.com/amplication/amplication/pull/6877/files?diff=unified&w=0#diff-6ffa846727f75044914cb18ebe994d12a4a56aad0bde64b034316e1ca952ef3cL255-R255), [link](https://github.com/amplication/amplication/pull/6877/files?diff=unified&w=0#diff-6ffa846727f75044914cb18ebe994d12a4a56aad0bde64b034316e1ca952ef3cL265-R265))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
