### PR TITLE
chore(server): code gen version server entitlement

### DIFF
--- a/packages/amplication-server/src/core/billing/billing.types.ts
+++ b/packages/amplication-server/src/core/billing/billing.types.ts
@@ -21,4 +21,5 @@ export enum BillingFeature {
   ChangeGitBaseBranch = "feature-change-git-base-branch",
   Notification = "feature-notifications",
   BranchPerResource = "feature-branch-per-resource",
+  CodeGeneratorVersion = "feature-code-generator-version",
 }

--- a/packages/amplication-server/src/core/resource/resource.resolver.ts
+++ b/packages/amplication-server/src/core/resource/resource.resolver.ts
@@ -164,9 +164,10 @@ export class ResourceResolver {
   })
   @AuthorizeContext(AuthorizableOriginParameter.ResourceId, "where.id")
   async updateCodeGeneratorVersion(
-    @Args() args: UpdateCodeGeneratorVersionArgs
+    @Args() args: UpdateCodeGeneratorVersionArgs,
+    @UserEntity() user: User
   ): Promise<Resource | null> {
-    return this.resourceService.updateCodeGeneratorVersion(args);
+    return this.resourceService.updateCodeGeneratorVersion(args, user);
   }
 
   @ResolveField(() => GitRepository, { nullable: true })

--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -254,17 +254,8 @@ export class ResourceService {
       throw new Error(INVALID_RESOURCE_ID);
     }
 
-    const resourceWithProject = await this.prisma.resource.findUnique({
-      where: {
-        id: resource.id,
-      },
-      include: {
-        project: true,
-      },
-    });
-
     const codeGeneratorUpdate = await this.billingService.getBooleanEntitlement(
-      resourceWithProject.project.workspaceId,
+      user.workspace.id,
       BillingFeature.CodeGeneratorVersion
     );
 
@@ -277,8 +268,8 @@ export class ResourceService {
       userId: user.account.id,
       properties: {
         resourceId: resource.id,
-        projectId: resourceWithProject.projectId,
-        workspaceId: resourceWithProject.project.workspaceId,
+        projectId: resource.projectId,
+        workspaceId: user.workspace.id,
       },
       event: EnumEventType.CodeGeneratorVersionUpdate,
     });

--- a/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
+++ b/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
@@ -30,6 +30,8 @@ export enum EnumEventType {
 
   GitSyncError = "gitSyncError",
   CodeGenerationError = "codeGenerationError",
+
+  CodeGeneratorVersionUpdate = "codeGeneratorVersionUpdate",
 }
 
 export type IdentifyData = {


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6879

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0fb6d58</samp>

### Summary
🆕🛠️🚀

<!--
1.  🆕 - This emoji represents the addition of a new enum value to the `BillingFeature` type, as well as the new analytics event type for updating the code generator version.
2.  🛠️ - This emoji represents the modification of the `updateCodeGeneratorVersion` resolver method to accept a user parameter and the enhancement of the service method to enforce billing and track analytics.
3.  🚀 - This emoji represents the improvement of the user experience and the functionality of the code generator feature by allowing users to update the version of their resources.
-->
This pull request adds support for updating the code generator version of resources as a billing feature and tracks the analytics of this action. It modifies the `ResourceService`, `ResourceResolver`, `BillingFeature`, and `EnumEventType` types and methods accordingly.

> _Sing, O Muse, of the code that the clever developers wrought,_
> _Adding a new `BillingFeature` for the `CodeGeneratorVersion`,_
> _And how they changed the `ResourceResolver` with skill and thought,_
> _To pass the `user` parameter for the analytics event._

### Walkthrough
*  Add a new billing feature for updating the code generator version of resources ([link](https://github.com/amplication/amplication/pull/6880/files?diff=unified&w=0#diff-dfa68e574b49dfe97f85d13ffe12404f479236a77840b9f720e05faf5902dabbR24))
*  Modify the resolver and service methods for updating the code generator version to accept a user parameter and track the analytics event ([link](https://github.com/amplication/amplication/pull/6880/files?diff=unified&w=0#diff-aba72828b21f194a464efd83160cdd81aeab3bc79099b35f95045de1dcbb352fL167-R170), [link](https://github.com/amplication/amplication/pull/6880/files?diff=unified&w=0#diff-69e1f5c184f8ffa46def579dd2fb6e88ea5b228afc3ea64079b51134af116c80L244-R245))
*  Check the user's billing entitlement for the code generator version feature and throw an error if not allowed ([link](https://github.com/amplication/amplication/pull/6880/files?diff=unified&w=0#diff-69e1f5c184f8ffa46def579dd2fb6e88ea5b228afc3ea64079b51134af116c80R257-R285))
*  Add a new analytics event type for updating the code generator version ([link](https://github.com/amplication/amplication/pull/6880/files?diff=unified&w=0#diff-18685efac1e573e80e4297b774d6d17dae8ccbbcde9db01faa86aa7740526745R33-R34))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
