### PR TITLE
change notification entitlement

### DIFF
--- a/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
@@ -118,7 +118,7 @@ const WorkspaceHeader: React.FC<{}> = () => {
   ]);
 
   const canShowNotification = stigg.getBooleanEntitlement({
-    featureId: BillingFeature.ImportDBSchema,
+    featureId: BillingFeature.Notification,
   }).hasAccess;
 
   const [showProfileFormDialog, setShowProfileFormDialog] =

--- a/packages/amplication-server/src/core/user/user.service.ts
+++ b/packages/amplication-server/src/core/user/user.service.ts
@@ -156,7 +156,7 @@ export class UserService {
     const booleanEntityUserNotification =
       await this.billingService.getBooleanEntitlement(
         user.workspace.id,
-        BillingFeature.ChangeGitBaseBranch
+        BillingFeature.Notification
       );
     const canShowUserNotification = booleanEntityUserNotification.hasAccess;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6534 
## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5b552df</samp>

### Summary
🔧💰🔔

<!--
1.  🔧 - This emoji represents a wrench or a tool, and it can be used to indicate a refactor or an improvement of the codebase. The changes made to the `canShowNotification` and `canShowUserNotification` variables are examples of refactoring, as they simplify and unify the logic for checking the billing features and the notification system.
2.  💰 - This emoji represents money or a currency, and it can be used to indicate a change related to the billing system or the subscription plan. The changes made to the `canShowNotification` and `canShowUserNotification` variables are also examples of billing-related changes, as they affect the features that the users can access depending on their payment status and plan.
3.  🔔 - This emoji represents a bell or a notification, and it can be used to indicate a change related to the notification system or the user interface. The changes made to the `canShowNotification` and `canShowUserNotification` variables are also examples of notification-related changes, as they affect the way that the users receive and manage the notifications from the application.
-->
Refactor the notification and billing systems to use a common feature id for notifications. Update the `canShowNotification` variable in `WorkspaceHeader.tsx` and the `canShowUserNotification` variable in `user.service.ts` to use the `BillingFeature.Notification` feature id.

> _`canShowNotification`_
> _Unified with billing plan_
> _A winter refactor_

### Walkthrough
*  Refactor the notification and billing systems to use a common feature id for notifications ([link](https://github.com/amplication/amplication/pull/6888/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L121-R121), [link](https://github.com/amplication/amplication/pull/6888/files?diff=unified&w=0#diff-091d0dcf087febea1710927b3f51327d41fac7c82995b71581447f4052ca6864L159-R159))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
