### PR TITLE
fix(dsg-catalog): issue of LatestMinor returning the dev version if available instead of proper latest minor

### DIFF
--- a/packages/data-service-generator-catalog/src/version/version.resolver.ts
+++ b/packages/data-service-generator-catalog/src/version/version.resolver.ts
@@ -22,7 +22,7 @@ export class VersionResolver extends VersionResolverBase {
   }
 
   @Public()
-  @graphql.Mutation(() => Version)
+  @graphql.Query(() => Version)
   async getCodeGeneratorVersion(
     @graphql.Args("GetCodeGeneratorVersionInput")
     args: GetCodeGeneratorVersionInput
@@ -32,7 +32,7 @@ export class VersionResolver extends VersionResolverBase {
   }
 
   @Public()
-  @graphql.Query(() => Boolean)
+  @graphql.Mutation(() => Boolean)
   async sync(): Promise<boolean> {
     await this.service.syncVersions();
     return true;

--- a/packages/data-service-generator-catalog/src/version/version.service.spec.ts
+++ b/packages/data-service-generator-catalog/src/version/version.service.spec.ts
@@ -9,6 +9,7 @@ import { MockedAmplicationLoggerProvider } from "@amplication/util/nestjs/loggin
 
 describe("VersionService", () => {
   let service: VersionService;
+  const mockVersionFindUnique = jest.fn();
   const mockVersionFindMany = jest.fn();
   const mockVersionCreateMany = jest.fn();
   const mockAwsEcrServiceGetTags = jest
@@ -39,6 +40,7 @@ describe("VersionService", () => {
           useValue: {
             version: {
               findMany: mockVersionFindMany,
+              findUnique: mockVersionFindUnique,
               createMany: mockVersionCreateMany,
               updateMany: jest.fn(),
             },
@@ -74,6 +76,12 @@ describe("VersionService", () => {
     ) => {
       const selectedVersion = "v1.0.1";
 
+      mockVersionFindUnique.mockImplementationOnce((args) => {
+        if (args.where.id === selectedVersion) {
+          return { name: selectedVersion };
+        }
+        return null;
+      });
       mockVersionFindMany.mockResolvedValue([{ name: expected }]);
 
       const result = await service.getCodeGeneratorVersion({

--- a/packages/data-service-generator-catalog/src/version/version.service.ts
+++ b/packages/data-service-generator-catalog/src/version/version.service.ts
@@ -90,18 +90,23 @@ export class VersionService extends VersionServiceBase {
             CodeGeneratorVersionStrategy.LatestMinor)) ||
       !codeGeneratorStrategy
     ) {
-      throw new BadRequestException();
+      throw new BadRequestException(
+        "codeGeneratorVersion is required when codeGeneratorStrategy is 'Specific' or 'LatestMinor'"
+      );
     }
 
     if (codeGeneratorStrategy === CodeGeneratorVersionStrategy.Specific) {
-      return (
-        await this.findMany({
-          where: {
-            name: codeGeneratorVersion,
-          },
-          take: 1,
-        })
-      )[0];
+      const foundVersion = await this.findOne({
+        where: {
+          id: codeGeneratorVersion,
+        },
+      });
+      if (foundVersion?.name !== codeGeneratorVersion) {
+        throw new BadRequestException(
+          `Version ${codeGeneratorVersion} not found`
+        );
+      }
+      return foundVersion;
     }
 
     const activeVersions = await this.findMany({


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6775

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fcbe28f</samp>

### Summary
🚨🛠️🔄

<!--
1.  🚨 - This emoji represents the improved error handling and validation of the input arguments, which can alert the user of any problems with their request and prevent unexpected behavior.
2.  🛠️ - This emoji represents the use of the `findOne` method instead of the `findMany` method, which is a more efficient and appropriate way to query a single record by its unique identifier, and the comparison of the `name` property to ensure consistency. This emoji can also represent the general improvement and refinement of the method's logic and functionality.
3.  🔄 - This emoji represents the change of the GraphQL types of the methods, which follows the convention of using queries for read operations and mutations for write operations. This emoji can also indicate the synchronization of the code generator versions with the external service, which is the purpose of the `sync` method.
-->
Refactored the `version.resolver.ts` and `version.service.ts` files in the `data-service-generator-catalog` package to follow GraphQL conventions and improve error handling. Changed the GraphQL types of `getCodeGeneratorVersion` and `sync` methods, and added validation and exception logic to `getCodeGeneratorVersion`.

> _`getCodeGeneratorVersion`_
> _Validates inputs, throws errors_
> _Better consistency_

### Walkthrough
*  Change `getCodeGeneratorVersion` from a mutation to a query to follow GraphQL convention ([link](https://github.com/amplication/amplication/pull/6890/files?diff=unified&w=0#diff-c907d1f8dbaf402275bb1430bea404a381317dcd336bc9e29b49496580c6d2b8L25-R25))
*  Change `sync` from a query to a mutation to follow GraphQL convention ([link](https://github.com/amplication/amplication/pull/6890/files?diff=unified&w=0#diff-c907d1f8dbaf402275bb1430bea404a381317dcd336bc9e29b49496580c6d2b8L35-R35))
*  Add validation and error handling to `getCodeGeneratorVersion` in `version.service.ts` ([link](https://github.com/amplication/amplication/pull/6890/files?diff=unified&w=0#diff-af45d823ef78c43db0372051542a70d210569bbddc09b3070912fdf097ef88efL93-R109))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
