### PR TITLE
fix(dsg): seed data object/ fk true for relation scalar field.

### DIFF
--- a/packages/data-service-generator/src/server/prisma/create-prisma-schema-fields.ts
+++ b/packages/data-service-generator/src/server/prisma/create-prisma-schema-fields.ts
@@ -339,7 +339,7 @@ export const createPrismaSchemaFieldsHandlers: {
         undefined,
         undefined,
         undefined,
-        undefined,
+        true,
         field.customAttributes
       ),
     ];

--- a/packages/data-service-generator/src/server/seed/create-seed.spec.ts
+++ b/packages/data-service-generator/src/server/seed/create-seed.spec.ts
@@ -64,13 +64,13 @@ const EXAMPLE_ENTITY: Entity = {
   permissions: [],
 };
 
-describe("createUserObjectCustomProperties", () => {
-  test("creates custom object properties", () => {
+describe("createAuthEntityObjectCustomProperties", () => {
+  test("creates custom object properties", async () => {
     const userEntity = {
       ...DEFAULT_USER_ENTITY,
       fields: [...DEFAULT_USER_ENTITY.fields, EXAMPLE_SINGLE_LINE_TEXT_FIELD],
     };
-    expect(createAuthEntityObjectCustomProperties(userEntity)).toEqual([
+    expect(await createAuthEntityObjectCustomProperties(userEntity)).toEqual([
       builders.objectProperty(
         builders.identifier(EXAMPLE_ENTITY_FIELD_NAME),
         // @ts-ignore

--- a/packages/data-service-generator/src/server/seed/create-seed.spec.ts
+++ b/packages/data-service-generator/src/server/seed/create-seed.spec.ts
@@ -70,7 +70,7 @@ describe("createAuthEntityObjectCustomProperties", () => {
       ...DEFAULT_USER_ENTITY,
       fields: [...DEFAULT_USER_ENTITY.fields, EXAMPLE_SINGLE_LINE_TEXT_FIELD],
     };
-    expect(await createAuthEntityObjectCustomProperties(userEntity)).toEqual([
+    expect(createAuthEntityObjectCustomProperties(userEntity)).toEqual([
       builders.objectProperty(
         builders.identifier(EXAMPLE_ENTITY_FIELD_NAME),
         // @ts-ignore

--- a/packages/data-service-generator/src/server/seed/create-seed.spec.ts
+++ b/packages/data-service-generator/src/server/seed/create-seed.spec.ts
@@ -2,7 +2,7 @@ import { builders, namedTypes } from "ast-types";
 import { EntityField, EnumDataType, Entity } from "@amplication/code-gen-types";
 import {
   createDefaultValue,
-  createUserObjectCustomProperties,
+  createAuthEntityObjectCustomProperties,
   DEFAULT_ADDRESS_LITERAL,
   DEFAULT_BOOLEAN_LITERAL,
   DEFAULT_EMAIL_LITERAL,
@@ -70,7 +70,7 @@ describe("createUserObjectCustomProperties", () => {
       ...DEFAULT_USER_ENTITY,
       fields: [...DEFAULT_USER_ENTITY.fields, EXAMPLE_SINGLE_LINE_TEXT_FIELD],
     };
-    expect(createUserObjectCustomProperties(userEntity)).toEqual([
+    expect(createAuthEntityObjectCustomProperties(userEntity)).toEqual([
       builders.objectProperty(
         builders.identifier(EXAMPLE_ENTITY_FIELD_NAME),
         // @ts-ignore

--- a/packages/data-service-generator/src/server/seed/create-seed.spec.ts
+++ b/packages/data-service-generator/src/server/seed/create-seed.spec.ts
@@ -65,7 +65,7 @@ const EXAMPLE_ENTITY: Entity = {
 };
 
 describe("createAuthEntityObjectCustomProperties", () => {
-  test("creates custom object properties", async () => {
+  test("creates custom object properties", () => {
     const userEntity = {
       ...DEFAULT_USER_ENTITY,
       fields: [...DEFAULT_USER_ENTITY.fields, EXAMPLE_SINGLE_LINE_TEXT_FIELD],

--- a/packages/data-service-generator/src/server/seed/create-seed.ts
+++ b/packages/data-service-generator/src/server/seed/create-seed.ts
@@ -92,12 +92,12 @@ export async function createSeed(): Promise<ModuleMap> {
   const fileDir = serverDirectories.scriptsDirectory;
   const outputFileName = "seed.ts";
 
-  const userEntity = entities.find(
+  const authEntity = entities.find(
     (entity) => entity.name === resourceInfo.settings.authEntityName
   );
   const customProperties =
-    userEntity &&
-    (await createUserObjectCustomProperties(userEntity as Entity));
+    authEntity &&
+    (await createAuthEntityObjectCustomProperties(authEntity as Entity));
 
   const template = await readFile(seedTemplatePath);
   const seedingProperties = customProperties
@@ -153,17 +153,17 @@ async function createSeedInternal({
   return moduleMap;
 }
 
-export async function createUserObjectCustomProperties(
-  userEntity: Entity
+export async function createAuthEntityObjectCustomProperties(
+  authEntity: Entity
 ): Promise<namedTypes.ObjectProperty[]> {
   const { logger } = DsgContext.getInstance;
 
   try {
-    return userEntity.fields
+    return authEntity.fields
       .filter((field) => field.required)
       .map((field): [EntityField, namedTypes.Expression | null] => [
         field,
-        createDefaultValue(field, userEntity),
+        createDefaultValue(field, authEntity),
       ])
       .filter(([field, value]) => !AUTH_FIELD_NAMES.has(field.name) && value)
       .map(([field, value]) =>

--- a/packages/data-service-generator/src/server/seed/create-seed.ts
+++ b/packages/data-service-generator/src/server/seed/create-seed.ts
@@ -96,8 +96,7 @@ export async function createSeed(): Promise<ModuleMap> {
     (entity) => entity.name === resourceInfo.settings.authEntityName
   );
   const customProperties =
-    authEntity &&
-    (await createAuthEntityObjectCustomProperties(authEntity as Entity));
+    authEntity && createAuthEntityObjectCustomProperties(authEntity as Entity);
 
   const template = await readFile(seedTemplatePath);
   const seedingProperties = customProperties
@@ -153,29 +152,23 @@ async function createSeedInternal({
   return moduleMap;
 }
 
-export async function createAuthEntityObjectCustomProperties(
+export function createAuthEntityObjectCustomProperties(
   authEntity: Entity
-): Promise<namedTypes.ObjectProperty[]> {
-  const { logger } = DsgContext.getInstance;
-
-  try {
-    return authEntity.fields
-      .filter((field) => field.required)
-      .map((field): [EntityField, namedTypes.Expression | null] => [
-        field,
-        createDefaultValue(field, authEntity),
-      ])
-      .filter(([field, value]) => !AUTH_FIELD_NAMES.has(field.name) && value)
-      .map(([field, value]) =>
-        builders.objectProperty(
-          builders.identifier(field.name),
-          // @ts-ignore
-          value
-        )
-      );
-  } catch (error) {
-    await logger.info(error.message);
-  }
+): namedTypes.ObjectProperty[] {
+  return authEntity.fields
+    .filter((field) => field.required)
+    .map((field): [EntityField, namedTypes.Expression | null] => [
+      field,
+      createDefaultValue(field, authEntity),
+    ])
+    .filter(([field, value]) => !AUTH_FIELD_NAMES.has(field.name) && value)
+    .map(([field, value]) =>
+      builders.objectProperty(
+        builders.identifier(field.name),
+        // @ts-ignore
+        value
+      )
+    );
 }
 
 export function createDefaultValue(

--- a/packages/data-service-generator/tests/e2e/data/base/resourceInfo.ts
+++ b/packages/data-service-generator/tests/e2e/data/base/resourceInfo.ts
@@ -29,5 +29,6 @@ export const resourceInfo: AppInfo = {
       generateAdminUI: true,
       adminUIPath: "",
     },
+    authEntityName: "User",
   },
 };


### PR DESCRIPTION
Close: #6902

## PR Details

- Fix the seed script data object by the auth entity and not by the User entity.
- Create a data object even if you have a relation-required field. 
- When create a relation scalar field - send true for FK. 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 083912a</samp>

### Summary
🔑🌱🐛

<!--
1.  🔑 - This emoji represents the primary key concept, and can be used to indicate the change to the `isId` parameter for the `id` field.
2. 🌱 - This emoji represents the seed data concept, and can be used to indicate the improvement to the seed generation for the user entity.
3. 🐛 - This emoji represents the bug fix concept, and can be used to indicate the error handling and logging added to the `createUserObjectCustomProperties` function.
-->
This pull request enhances the data service generator to handle user entities and lookup fields better. It improves the seed generation logic in `create-seed.ts` and ensures the `id` field is the primary key in `create-prisma-schema-fields.ts`.

> _`id` field is key_
> _Prisma schema updated_
> _Autumn of refactor_

### Walkthrough
*  Mark the `id` field as the primary key in the Prisma schema ([link](https://github.com/amplication/amplication/pull/6903/files?diff=unified&w=0#diff-e0c9406d56a2f2510ab9debb49fae0df71bc5ff8f8f656a6354d90f3133abfb0L342-R342))
*  Use the `resourceInfo` parameter to access the user entity name and settings ([link](https://github.com/amplication/amplication/pull/6903/files?diff=unified&w=0#diff-8263b2694b12e2b38aec9cf8c0de56f5b5b4b6a029152c9f22d5462bf3a5ad03L86-R89), [link](https://github.com/amplication/amplication/pull/6903/files?diff=unified&w=0#diff-8263b2694b12e2b38aec9cf8c0de56f5b5b4b6a029152c9f22d5462bf3a5ad03L95-R100))
*  Make the `createUserObjectCustomProperties` function async and handle errors ([link](https://github.com/amplication/amplication/pull/6903/files?diff=unified&w=0#diff-8263b2694b12e2b38aec9cf8c0de56f5b5b4b6a029152c9f22d5462bf3a5ad03L153-R178))
*  Return `null` instead of throwing an error for lookup fields in the `createDefaultValue` function ([link](https://github.com/amplication/amplication/pull/6903/files?diff=unified&w=0#diff-8263b2694b12e2b38aec9cf8c0de56f5b5b4b6a029152c9f22d5462bf3a5ad03L222-R231))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
