### PR TITLE
chore(server): improve devex by reducing test run time 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Test
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
-        run: npx nx affected --target=test --parallel=3 --coverage --coverageReporters=text-summary $NX_FORCE_ALL
+        run: npx nx affected --target=test --coverage --maxWorkers=${{ steps.cpu-cores.outputs.count }}  $NX_FORCE_ALL
       
   nx:
     name: Nx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,10 @@ jobs:
           npx nx affected --target=build --parallel=3 $NX_FORCE_ALL
           npx nx affected --target=postbuild --parallel=3 $NX_FORCE_ALL
 
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v1
+        id: cpu-cores
+        
       - name: Test
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Test
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
-        run: npx nx affected --target=test --coverage --maxWorkers=${{ steps.cpu-cores.outputs.count }}  $NX_FORCE_ALL
+        run: npx nx affected --target=test --coverage --maxWorkers=${{ steps.cpu-cores.outputs.count }} $NX_FORCE_ALL
       
   nx:
     name: Nx

--- a/nx.json
+++ b/nx.json
@@ -15,7 +15,9 @@
           "test:e2e",
           "e2e",
           "test:cov",
-          "build-storybook"
+          "build-storybook",
+          "graphql:schema:generate",
+          "graphql:models:generate"
         ],
         "accessToken": "ZjczM2RhYjEtYzdmOS00MDVhLThkYWEtMDU4MmJkMTQ1ZWZjfHJlYWQ="
       }

--- a/packages/amplication-server/project.json
+++ b/packages/amplication-server/project.json
@@ -22,7 +22,8 @@
       "dependsOn": ["graphql:schema:check"],
       "options": {
         "jestConfig": "packages/amplication-server/jest.config.ts",
-        "passWithNoTests": true
+        "passWithNoTests": true,
+        "maxWorkers": "50%"
       }
     },
     "e2e": {


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6911

## PR Details

Reduce server tests run time from

![image](https://github.com/amplication/amplication/assets/2861984/88aff7b9-8054-4d93-bac5-18b4815d57b0)
to 
![image](https://github.com/amplication/amplication/assets/2861984/345281e6-c815-4ee5-9079-1d11c9645d7c)

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3f693f5</samp>

### Summary
🚀🛠️🧪

<!--
1.  🚀 - This emoji represents the improvement in performance and stability of the test execution by using the `--maxWorkers` option in the GitHub workflow `ci.yml`.
2.  🛠️ - This emoji represents the addition of the tasks to generate the GraphQL schema and models for the `amplication-server` package in the `nx.json` file, which are necessary tools for the development and testing of the package.
3.  🧪 - This emoji represents the modification of the `test` target in the `project.json` file for the `amplication-server` package, which affects the testing environment and configuration of the package.
-->
This pull request improves the test performance and consistency for the `amplication-server` package. It uses the `--maxWorkers` option for Jest to adjust the parallelism based on the available CPU cores, and adds tasks to generate the GraphQL schema and models before running other tasks.

> _`ci.yml` changes_
> _Workers match CPU cores_
> _Faster tests in spring_

### Walkthrough
*  Adjust the parallelism of the test execution for the `amplication-server` package based on the available CPU cores ([link](https://github.com/amplication/amplication/pull/6912/files?diff=unified&w=0#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL95-R95), [link](https://github.com/amplication/amplication/pull/6912/files?diff=unified&w=0#diff-c5b682550310d16ccc0484158ea019afa825a387eae2d7f90208883b7e54d055L25-R26))
* Add tasks to generate the GraphQL schema and models for the `amplication-server` package before running other tasks that depend on them ([link](https://github.com/amplication/amplication/pull/6912/files?diff=unified&w=0#diff-15552e50b1b7c05b05b7ffe08ee47b5ed62b8d2039229c58972a42fd22a7381cL18-R20))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
