### PR TITLE
fix(client): updated the generic Git icon

### DIFF
--- a/packages/amplication-client/src/Resource/SyncWithGithubTile.tsx
+++ b/packages/amplication-client/src/Resource/SyncWithGithubTile.tsx
@@ -30,7 +30,7 @@ function SyncWithGithubTile({ resourceId }: Props) {
 
   return (
     <OverviewSecondaryTile
-      icon="git-sync"
+      icon="pending_changes"
       title="Sync with Git provider"
       message="Push the Amplication-generated resource to your favorite Git provider. Track changes, track our code. You are in full control of your resource."
       footer={

--- a/packages/amplication-client/src/Resource/git/AppGitStatusPanel.tsx
+++ b/packages/amplication-client/src/Resource/git/AppGitStatusPanel.tsx
@@ -54,7 +54,7 @@ const AppGitStatusPanel = ({ resource, showDisconnectedMessage }: Props) => {
           >
             <Button
               buttonStyle={EnumButtonStyle.Secondary}
-              icon="git-sync"
+              icon="pending_changes"
               iconPosition={EnumIconPosition.Left}
               className={`${CLASS_NAME}__connect__button`}
             >

--- a/packages/amplication-client/src/Resource/resourceMenuUtils.ts
+++ b/packages/amplication-client/src/Resource/resourceMenuUtils.ts
@@ -28,7 +28,7 @@ export const linksMap = {
   },
   git: {
     title: "Sync with Git provider",
-    icon: "git-sync",
+    icon: "pending_changes",
     to: "/git-sync",
   },
   settings: {

--- a/packages/amplication-client/src/Workspaces/WorkspaceFooter.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceFooter.tsx
@@ -99,7 +99,7 @@ const WorkspaceFooter: React.FC<{ lastCommit: Commit }> = ({ lastCommit }) => {
         ) : (
           <div className={`${CLASS_NAME}__git-disconnected`}>
             <Icon
-              icon="git-sync"
+              icon="pending_changes"
               size="small"
               className={`${CLASS_NAME}__git-icon`}
             />


### PR DESCRIPTION
Close: #6592

Regarding issue no #6592, I have changed the "git-sync" icon with the "pending_changes" icon as mentioned in the issue.


<img width="327" alt="Screenshot 2023-09-15 at 20 13 25" src="https://github.com/amplication/amplication/assets/96016851/8e3563a4-15df-4ce6-8a8d-c08b18277d02">
<img width="188" alt="Screenshot 2023-09-15 at 20 14 10" src="https://github.com/amplication/amplication/assets/96016851/e8639a85-b231-4aa3-99db-feb2a1f05806">
<img width="406" alt="Screenshot 2023-09-15 at 20 15 24" src="https://github.com/amplication/amplication/assets/96016851/0a6e332a-0d1d-4bca-a6e4-61124dce284d">


Please review and suggest changes 