### PR TITLE
fix(server):import model plural name for 'noncount nouns'

### DIFF
--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -664,6 +664,10 @@ export class EntityService {
             field: field.name,
             entity: entity.name,
           });
+          void actionContext.onEmitUserActionLog(
+            `Failed to create entity field "${field.name}" on entity "${entity.name}". ${error.message}`,
+            EnumActionLogLevel.Error
+          );
         }
       }
     }

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -561,11 +561,6 @@ export class PrismaSchemaParserService {
               },
             };
 
-            void actionContext.onEmitUserActionLog(
-              `field type "${field.fieldType}" on model "${model.name}" was changed to "${newName}"`,
-              EnumActionLogLevel.Info
-            );
-
             builder
               .model(model.name)
               .field(field.name)

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -1181,7 +1181,10 @@ export class PrismaSchemaParserService {
       id: cuid(), // creating here the entity id because we need it for the relation
       name: model.name,
       displayName: modelDisplayName,
-      pluralDisplayName: entityPluralDisplayName,
+      pluralDisplayName:
+        entityPluralDisplayName === model.name
+          ? `${entityPluralDisplayName} Items`
+          : entityPluralDisplayName,
       description: "",
       customAttributes: entityAttributes,
       fields: [],


### PR DESCRIPTION


Close: #6931 

<img width="677" alt="image" src="https://github.com/amplication/amplication/assets/43705455/07465d01-a097-4375-bebe-6b58976c71c3">


## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ee6bd21</samp>

### Summary
📝🚸🧮

<!--
1.  📝 - This emoji can be used to indicate that the change modifies some text or documentation, such as the plural display name property.
2.  🚸 - This emoji can be used to indicate that the change improves the user experience or accessibility of the application, such as avoiding confusion or ambiguity.
3.  🧮 - This emoji can be used to indicate that the change affects some logic or calculation related to the data model, such as the pluralization rules.
-->
Modify the `pluralDisplayName` property of entities generated from Prisma models to avoid confusion when the model name is already plural or irregular. This change affects the file `prismaSchemaParser.service.ts` and aims to improve the user experience and clarity of the generated application.

> _`pluralDisplayName`_
> _Suffix added for clarity_
> _Autumn leaves no doubt_

### Walkthrough
*  Add `Items` suffix to plural display name of entity if it is the same as model name ([link](https://github.com/amplication/amplication/pull/6932/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1184-R1187))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
