### PR TITLE
fix(client):resource header and name

### DIFF
--- a/packages/amplication-client/src/Resource/ResourceHome.scss
+++ b/packages/amplication-client/src/Resource/ResourceHome.scss
@@ -33,19 +33,6 @@ $circle-badge-border: 2px;
     justify-content: center;
     padding: 0 var(--default-spacing-small);
   }
-  &__header:hover::before {
-    z-index: 1;
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--white-overlay-background);
-  }
-  .circle-badge-container {
-    z-index: 10;
-  }
 
   .circle-badge {
     width: $application-badge-size-large;

--- a/packages/amplication-client/src/Resource/ResourceHome.tsx
+++ b/packages/amplication-client/src/Resource/ResourceHome.tsx
@@ -1,25 +1,24 @@
 import { EnumResourceType } from "@amplication/code-gen-types/models";
 import { CircleBadge } from "@amplication/ui/design-system";
 import { gql } from "@apollo/client";
-import React, { useContext } from "react";
+import { useContext } from "react";
 import { match } from "react-router-dom";
-import { AppContext } from "../context/appContext";
 import PageContent from "../Layout/PageContent";
+import { AppContext } from "../context/appContext";
 import { AppRouteProps } from "../routes/routesUtil";
-import { resourceThemeMap } from "./constants";
 import DocsTile from "./DocsTile";
 import EntitiesTile from "./EntitiesTile";
 import FeatureRequestTile from "./FeatureRequestTile";
 import OverviewTile from "./OverviewTile";
 import "./ResourceHome.scss";
 import ResourceMenu from "./ResourceMenu";
-import RolesTile from "./RolesTile";
-import SyncWithGithubTile from "./SyncWithGithubTile";
-import ViewCodeViewTile from "./ViewCodeViewTile";
-import { TopicsTile } from "./TopicsTile";
-import { ServicesTile } from "./ServicesTile";
-import EllipsisText from "../Components/EllipsisText";
 import ResourceNameField from "./ResourceNameField";
+import RolesTile from "./RolesTile";
+import { ServicesTile } from "./ServicesTile";
+import SyncWithGithubTile from "./SyncWithGithubTile";
+import { TopicsTile } from "./TopicsTile";
+import ViewCodeViewTile from "./ViewCodeViewTile";
+import { resourceThemeMap } from "./constants";
 
 type Props = AppRouteProps & {
   match: match<{
@@ -51,11 +50,6 @@ const ResourceHome = ({ match, innerRoutes }: Props) => {
                 resourceThemeMap[currentResource?.resourceType].color,
             }}
           >
-            <EllipsisText
-              text={currentResource?.name}
-              maxLength={30}
-              maxHeight={180}
-            />
             <CircleBadge
               name={currentResource?.name || ""}
               color={
@@ -67,15 +61,6 @@ const ResourceHome = ({ match, innerRoutes }: Props) => {
               currentResource={currentResource}
               resourceId={resourceId}
             />
-            <div className="circle-badge-container">
-              <CircleBadge
-                name={currentResource?.name || ""}
-                color={
-                  resourceThemeMap[currentResource?.resourceType].color ||
-                  "transparent"
-                }
-              />
-            </div>
           </div>
           <div className={`${CLASS_NAME}__tiles`}>
             {currentResource?.resourceType === EnumResourceType.Service && (

--- a/packages/amplication-client/src/Resource/ResourceNameField.tsx
+++ b/packages/amplication-client/src/Resource/ResourceNameField.tsx
@@ -1,14 +1,14 @@
-import React, { useCallback, useState } from "react";
-import { Field, Form, Formik } from "formik";
-import FormikAutoSave from "../util/formikAutoSave";
 import { Icon, Tooltip } from "@amplication/ui/design-system";
-import { validate } from "../util/formikValidateJsonSchema";
-import { AnalyticsEventNames } from "../util/analytics-events.types";
-import { useTracking } from "react-tracking";
 import { useMutation } from "@apollo/client";
-import { UPDATE_RESOURCE } from "../Workspaces/queries/resourcesQueries";
+import { Field, Form, Formik } from "formik";
+import { useCallback } from "react";
+import { useTracking } from "react-tracking";
 import { GET_PROJECTS } from "../Workspaces/queries/projectQueries";
+import { UPDATE_RESOURCE } from "../Workspaces/queries/resourcesQueries";
 import * as models from "../models";
+import { AnalyticsEventNames } from "../util/analytics-events.types";
+import FormikAutoSave from "../util/formikAutoSave";
+import { validate } from "../util/formikValidateJsonSchema";
 import "./ResourceNameField.scss";
 
 type Props = {
@@ -34,10 +34,6 @@ const FORM_SCHEMA = {
   },
 };
 const ResourceNameField = ({ currentResource, resourceId }: Props) => {
-  const [isEditing, setIsEditing] = useState(false);
-  const [showTick, setShowTick] = useState(false);
-  const [hovered, setHovered] = useState(false);
-
   const { trackEvent } = useTracking();
   const [updateResource] = useMutation<TData>(UPDATE_RESOURCE, {
     refetchQueries: [
@@ -46,14 +42,6 @@ const ResourceNameField = ({ currentResource, resourceId }: Props) => {
       },
     ],
   });
-
-  const handleBlur = (isValid: boolean) => {
-    if (isValid) {
-      setIsEditing(false);
-      setShowTick(false);
-      setHovered(false);
-    }
-  };
 
   const handleSubmit = useCallback(
     (data) => {
@@ -69,21 +57,10 @@ const ResourceNameField = ({ currentResource, resourceId }: Props) => {
           resourceId: resourceId,
         },
       }).catch(console.error);
-      setShowTick(true);
-      setTimeout(() => {
-        setShowTick(false);
-      }, 3000);
     },
     [updateResource, resourceId, trackEvent]
   );
 
-  const handleMouseEnter = () => {
-    setHovered(true);
-  };
-
-  const handleMouseLeave = () => {
-    setHovered(false);
-  };
   return (
     <div className={`${CLASS_NAME}__input__container`}>
       <Formik
@@ -95,56 +72,29 @@ const ResourceNameField = ({ currentResource, resourceId }: Props) => {
         {({ errors, isValid }) => {
           return (
             <div className={`${CLASS_NAME}__form`}>
-              {isEditing ? (
-                <Form>
-                  <FormikAutoSave debounceMS={1000} />
-                  <Field
-                    autoFocus={true}
-                    className={`${CLASS_NAME}__input`}
-                    name="name"
-                    as="input"
-                    onBlur={() => handleBlur(isValid)}
-                  />
-                  {isValid ? (
-                    showTick && (
-                      <Icon
-                        className={`${CLASS_NAME}__saved`}
-                        icon="check"
-                        size="medium"
-                      />
-                    )
-                  ) : (
-                    <Tooltip
-                      noDelay
-                      direction="nw"
-                      aria-label={"Error: Unsupported character"}
-                      className={`${CLASS_NAME}__tooltip_invalid`}
-                    >
-                      <Icon
-                        icon="info_circle"
-                        size="small"
-                        className={`${CLASS_NAME}__invalid`}
-                      />
-                    </Tooltip>
-                  )}
-                </Form>
-              ) : (
-                <div
-                  className={`${CLASS_NAME}__edit`}
-                  onMouseEnter={handleMouseEnter}
-                  onMouseLeave={handleMouseLeave}
-                >
-                  <span className={`${CLASS_NAME}__text`}>
-                    {currentResource?.name}
-                  </span>
-                  <div
-                    onClick={() => setIsEditing(true)}
-                    className={`${CLASS_NAME}__edit_icon`}
+              <Form>
+                <FormikAutoSave debounceMS={1000} />
+                <Field
+                  autoFocus={true}
+                  className={`${CLASS_NAME}__input`}
+                  name="name"
+                  as="input"
+                />
+                {!isValid && (
+                  <Tooltip
+                    noDelay
+                    direction="nw"
+                    aria-label={"Error: Unsupported character"}
+                    className={`${CLASS_NAME}__tooltip_invalid`}
                   >
-                    {hovered && <Icon icon="edit_2" size="medium" />}
-                  </div>
-                </div>
-              )}
+                    <Icon
+                      icon="info_circle"
+                      size="small"
+                      className={`${CLASS_NAME}__invalid`}
+                    />
+                  </Tooltip>
+                )}
+              </Form>
             </div>
           );
         }}


### PR DESCRIPTION
Close: #6915

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 450f736</samp>

### Summary
🎨♻️🔥

<!--
1.  🎨 - This emoji is often used to indicate changes related to UI design, layout, or appearance. It could be used for the first and second changes, which both involve updating the UI of the resource home page and the resource name field.
2.  ♻️ - This emoji is often used to indicate changes related to refactoring, code quality, or performance. It could be used for the second and third changes, which both involve improving the code quality and simplifying the logic of the ResourceHome and ResourceNameField components.
3.  🔥 - This emoji is often used to indicate changes related to removing or deleting code, features, or files. It could be used for the third change, which involves removing unnecessary state variables, functions, and UI elements from the ResourceNameField component.
-->
This pull request implements a new UI design for the resource home page that allows users to edit resource names in place. It also cleans up the code by removing unused or redundant components, state variables, and styles. The main files affected are `ResourceHome.tsx`, `ResourceNameField.tsx`, and `ResourceHome.scss`.

> _We're heaving away the old UI_
> _We're making it simple and clean_
> _We're editing names in the `ResourceHome`_
> _We're the best coders you've ever seen_

### Walkthrough
*  Remove hover and circle badge effects from resource header ([link](https://github.com/amplication/amplication/pull/6942/files?diff=unified&w=0#diff-5132c1e628369117ef39981acc9367a7c80b8b17a86fafda4000c9e5e9fc725aL36-L48), [link](https://github.com/amplication/amplication/pull/6942/files?diff=unified&w=0#diff-1b796664945ea9810e1092727a9e0320e9697e68cfaed66a2a68d5a1f773ec15L54-L58), [link](https://github.com/amplication/amplication/pull/6942/files?diff=unified&w=0#diff-1b796664945ea9810e1092727a9e0320e9697e68cfaed66a2a68d5a1f773ec15L70-L78))
*  Remove ellipsis text and make resource name editable in place ([link](https://github.com/amplication/amplication/pull/6942/files?diff=unified&w=0#diff-1b796664945ea9810e1092727a9e0320e9697e68cfaed66a2a68d5a1f773ec15L16-R21), [link](https://github.com/amplication/amplication/pull/6942/files?diff=unified&w=0#diff-1b796664945ea9810e1092727a9e0320e9697e68cfaed66a2a68d5a1f773ec15L54-L58), [link](https://github.com/amplication/amplication/pull/6942/files?diff=unified&w=0#diff-d14ce2186a15b8b46ecf5b88e7da383cae71947f5b352c44deddb9fd47f5f7bfL37-L40), [link](https://github.com/amplication/amplication/pull/6942/files?diff=unified&w=0#diff-d14ce2186a15b8b46ecf5b88e7da383cae71947f5b352c44deddb9fd47f5f7bfL50-L57), [link](https://github.com/amplication/amplication/pull/6942/files?diff=unified&w=0#diff-d14ce2186a15b8b46ecf5b88e7da383cae71947f5b352c44deddb9fd47f5f7bfL72-R63), [link](https://github.com/amplication/amplication/pull/6942/files?diff=unified&w=0#diff-d14ce2186a15b8b46ecf5b88e7da383cae71947f5b352c44deddb9fd47f5f7bfL98-R97))
*  Simplify JSX structure and remove unused icons from `ResourceNameField` component ([link](https://github.com/amplication/amplication/pull/6942/files?diff=unified&w=0#diff-d14ce2186a15b8b46ecf5b88e7da383cae71947f5b352c44deddb9fd47f5f7bfL98-R97))
*  Reorder import statements in `ResourceHome.tsx` and `ResourceNameField.tsx` files ([link](https://github.com/amplication/amplication/pull/6942/files?diff=unified&w=0#diff-1b796664945ea9810e1092727a9e0320e9697e68cfaed66a2a68d5a1f773ec15L4-R8), [link](https://github.com/amplication/amplication/pull/6942/files?diff=unified&w=0#diff-d14ce2186a15b8b46ecf5b88e7da383cae71947f5b352c44deddb9fd47f5f7bfL1-R11))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
