### PR TITLE
chore(dsg): fix docker build args

### DIFF
--- a/packages/data-service-generator/project.json
+++ b/packages/data-service-generator/project.json
@@ -113,7 +113,7 @@
       "options": {
         "push": false,
         "tags": ["amplication/data-service-generator:latest"],
-        "build-args": ["GIT_REF_NAME=latest-local", "GIT_SHA=🦄-sha"]
+        "build-args": ["GIT_REF_NAME=${GIT_REF_NAME}", "GIT_SHA=${GIT_SHA}"]
       },
       "configurations": {
         "production": {

--- a/packages/data-service-generator/scripts/package-container.sh
+++ b/packages/data-service-generator/scripts/package-container.sh
@@ -6,6 +6,9 @@ ROOT_DIR=$SCRIPT_DIR/../../../
 
 cd $ROOT_DIR
 
+export GIT_REF_NAME=${GIT_REF_NAME:-"latest-local"}
+export GIT_SHA=${GIT_SHA:-"🦄-sha"}
+
 if [[ $PRODUCTION_TAGS = "true" ]]; then
     echo "Production deployment detected"
     echo "Overriding INPUT_TAGS with data-service-generator package version"
@@ -14,7 +17,7 @@ if [[ $PRODUCTION_TAGS = "true" ]]; then
     # prefix with `v` to match other container image tags
     IMAGE_TAG="v$PACKAGE_VERSION"
     export INPUT_TAGS="$IMAGE_REPO:$IMAGE_TAG,$IMAGE_REPO:sha-$GIT_SHA"
-    
+
     npx nx internal:package:container data-service-generator --prod
 else
     npx nx internal:package:container data-service-generator 


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close:  #6785

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fd093dd</samp>

### Summary
🏗️🌎🐛

<!--
1.  🏗️ This emoji represents building or construction, and can be used to indicate changes related to the container build process or the build-args.
2.  🌎 This emoji represents the earth or the global scope, and can be used to indicate changes related to environment variables or configuration options that affect different contexts or environments.
3.  🐛 This emoji represents a bug or an issue, and can be used to indicate changes that fix or improve something that was not working as expected or intended.
-->
Improved the flexibility and reliability of the `data-service-generator` container build process by using environment variables for the `build-args` and fixing the `package-container.sh` script.

> _Sing, O Muse, of the cunning code review_
> _That changed the `build-args` of the container_
> _Which generates the data service, swift and true,_
> _From various git refs, like a skilled hunter._

### Walkthrough
*  Use environment variables for `build-args` of `data-service-generator` container ([link](https://github.com/amplication/amplication/pull/6950/files?diff=unified&w=0#diff-1516d412c4cb5830f51541422e3b6fc06c855126c307ec0cc2d763baac4702aaL116-R116), [link](https://github.com/amplication/amplication/pull/6950/files?diff=unified&w=0#diff-e37a309b8feb6cd04052ae0d5337d5692bcf87f202892b1e4f09407dbe153079R9-R11))
  - Export `GIT_REF_NAME` and `GIT_SHA` with default values in `package-container.sh` ([link](https://github.com/amplication/amplication/pull/6950/files?diff=unified&w=0#diff-e37a309b8feb6cd04052ae0d5337d5692bcf87f202892b1e4f09407dbe153079R9-R11))
  - Pass them as `build-args` to `internal:package:container` command in `project.json` ([link](https://github.com/amplication/amplication/pull/6950/files?diff=unified&w=0#diff-1516d412c4cb5830f51541422e3b6fc06c855126c307ec0cc2d763baac4702aaL116-R116))
* Use `INPUT_TAGS` environment variable for `tags` option of `internal:package:container` command ([link](https://github.com/amplication/amplication/pull/6950/files?diff=unified&w=0#diff-e37a309b8feb6cd04052ae0d5337d5692bcf87f202892b1e4f09407dbe153079L17-R24))
  - Fix `package-container.sh` to use `INPUT_TAGS` instead of hard-coded value ([link](https://github.com/amplication/amplication/pull/6950/files?diff=unified&w=0#diff-e37a309b8feb6cd04052ae0d5337d5692bcf87f202892b1e4f09407dbe153079L17-R24))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
