### PR TITLE
fix(client): move pass current resource id to mutation to avoid race condition

### DIFF
--- a/packages/amplication-client/src/Resource/codeGeneratorVersionSettings/CodeGeneratorVersion.tsx
+++ b/packages/amplication-client/src/Resource/codeGeneratorVersionSettings/CodeGeneratorVersion.tsx
@@ -160,6 +160,7 @@ const CodeGeneratorVersion = () => {
         codeGeneratorStrategy,
         codeGeneratorVersion,
       },
+      resourceId: currentResource?.id,
     });
   }, []);
 

--- a/packages/amplication-client/src/Workspaces/hooks/useResources.ts
+++ b/packages/amplication-client/src/Workspaces/hooks/useResources.ts
@@ -27,6 +27,7 @@ export type TUpdateCodeGeneratorVersion = {
     codeGeneratorStrategy: models.CodeGeneratorVersionStrategy | null;
     codeGeneratorVersion: string | null;
   };
+  resourceId: string;
 };
 
 type TCreateMessageBroker = {
@@ -146,7 +147,7 @@ const useResources = (
           },
         },
         where: {
-          id: currentResource?.id,
+          id: input.resourceId,
         },
       },
     });


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6721

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7169673</samp>

### Summary
🆕🛠️🔄

<!--
1.  🆕 - This emoji represents the addition of a new property to the mutation input object, which is a new feature for the client.
2.  🛠️ - This emoji represents the bug fix for the `useResources` hook and the `TUpdateCodeGeneratorVersion` type, which is a maintenance or improvement task for the client.
3.  🔄 - This emoji represents the update of the code generator version of the resource, which is a change or refresh of the existing functionality.
-->
This pull request fixes a bug with updating the code generator version of a resource in the client. It passes the `resourceId` to the `updateCodeGeneratorVersion` mutation and uses it in the `useResources` hook.

> _Sing, O Muse, of the skillful coder who devised_
> _A subtle change to the `updateCodeGeneratorVersion` mutation,_
> _Passing the `resourceId` as a new input to the server,_
> _To fix the bug that plagued the resource's generation._

### Walkthrough
*  Add `resourceId` property to the input of `updateCodeGeneratorVersion` mutation ([link](https://github.com/amplication/amplication/pull/6952/files?diff=unified&w=0#diff-eec09c3db11c4f2c4d0e1d281377a0d0b4ed9a461d2533e082204df35efa1763R163), [link](https://github.com/amplication/amplication/pull/6952/files?diff=unified&w=0#diff-2065092160f88848185e6b01c48f1859541550228b9a41c877e6a589e1b0304fR30))
* Use `input.resourceId` instead of `currentResource?.id` in `useResources` hook ([link](https://github.com/amplication/amplication/pull/6952/files?diff=unified&w=0#diff-2065092160f88848185e6b01c48f1859541550228b9a41c877e6a589e1b0304fL149-R150))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
