### PR TITLE
feat(client): hide code-generator version from menu

### DIFF
--- a/packages/amplication-client/src/Resource/resourceSettings/ServiceSettingsPage.tsx
+++ b/packages/amplication-client/src/Resource/resourceSettings/ServiceSettingsPage.tsx
@@ -11,9 +11,10 @@ const CLASS_NAME = "service-settings";
 const ServiceSettingsPage: React.FC<{}> = () => {
   const { currentWorkspace, currentProject, currentResource } =
     useContext(AppContext);
+
   const { stigg } = useStiggContext();
-  const canChooseCodeGeneratorVersion = stigg.getBooleanEntitlement({
-    featureId: BillingFeature.CodeGeneratorVersion,
+  const showCodeGeneratorVersion = stigg.getBooleanEntitlement({
+    featureId: BillingFeature.ShowCodeGeneratorVersion,
   }).hasAccess;
 
   return (
@@ -58,7 +59,7 @@ const ServiceSettingsPage: React.FC<{}> = () => {
           API Tokens
         </InnerTabLink>
       </div>
-      {canChooseCodeGeneratorVersion && (
+      {showCodeGeneratorVersion && (
         <div>
           <InnerTabLink
             to={`/${currentWorkspace?.id}/${currentProject?.id}/${currentResource?.id}/settings/code-generator-version/update`}

--- a/packages/amplication-client/src/Resource/resourceSettings/ServiceSettingsPage.tsx
+++ b/packages/amplication-client/src/Resource/resourceSettings/ServiceSettingsPage.tsx
@@ -2,6 +2,8 @@ import React, { useContext } from "react";
 import { AppContext } from "../../context/appContext";
 import InnerTabLink from "../../Layout/InnerTabLink";
 import "./ServiceSettingsPage.scss";
+import { BillingFeature } from "../../util/BillingFeature";
+import { useStiggContext } from "@stigg/react-sdk";
 
 const CLASS_NAME = "service-settings";
 
@@ -9,6 +11,10 @@ const CLASS_NAME = "service-settings";
 const ServiceSettingsPage: React.FC<{}> = () => {
   const { currentWorkspace, currentProject, currentResource } =
     useContext(AppContext);
+  const { stigg } = useStiggContext();
+  const canChooseCodeGeneratorVersion = stigg.getBooleanEntitlement({
+    featureId: BillingFeature.CodeGeneratorVersion,
+  }).hasAccess;
 
   return (
     <div className={CLASS_NAME}>
@@ -52,14 +58,16 @@ const ServiceSettingsPage: React.FC<{}> = () => {
           API Tokens
         </InnerTabLink>
       </div>
-      <div>
-        <InnerTabLink
-          to={`/${currentWorkspace?.id}/${currentProject?.id}/${currentResource?.id}/settings/code-generator-version/update`}
-          icon="code"
-        >
-          Code Generator Version
-        </InnerTabLink>
-      </div>
+      {canChooseCodeGeneratorVersion && (
+        <div>
+          <InnerTabLink
+            to={`/${currentWorkspace?.id}/${currentProject?.id}/${currentResource?.id}/settings/code-generator-version/update`}
+            icon="code"
+          >
+            Code Generator Version
+          </InnerTabLink>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/amplication-client/src/util/BillingFeature.ts
+++ b/packages/amplication-client/src/util/BillingFeature.ts
@@ -13,4 +13,5 @@ export enum BillingFeature {
   ChangeGitBaseBranch = "feature-change-git-base-branch",
   Notification = "feature-notifications",
   CodeGeneratorVersion = "feature-code-generator-version",
+  ShowCodeGeneratorVersion = "feature-show-dsg-versions",
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6953

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 969233f</samp>

### Summary
💳🔒⚙️

<!--
1.  💳 - This emoji represents the billing logic and the use of the Stigg SDK, which is a payment platform. It suggests that the code involves money and transactions.
2.  🔒 - This emoji represents the entitlement checks and the hiding of the code generator version option for users who do not have the required feature. It suggests that the code involves security and access control.
3.  ⚙️ - This emoji represents the service settings page and the code generator version option, which are both related to the configuration and functionality of the service. It suggests that the code involves settings and features.
-->
Add billing and feature-based access control to service settings page. Use `Stigg` SDK to check user entitlements and hide `code generator version` option for users without `CodeGeneratorVersion` feature.

> _`Stigg SDK` used_
> _Billing and features checked_
> _Code version hidden_

### Walkthrough
*  Import modules for billing features and Stigg SDK ([link](https://github.com/amplication/amplication/pull/6954/files?diff=unified&w=0#diff-cdee9b4f9fa826aab9c55634b4b9c61f0adcb33b32ab45662aec1c2b639d0081R5-R6))
*  Check user entitlement for code generator version feature using `stigg.getBooleanEntitlement` ([link](https://github.com/amplication/amplication/pull/6954/files?diff=unified&w=0#diff-cdee9b4f9fa826aab9c55634b4b9c61f0adcb33b32ab45662aec1c2b639d0081R14-R17))
*  Hide code generator version option in resource settings page if user does not have access ([link](https://github.com/amplication/amplication/pull/6954/files?diff=unified&w=0#diff-cdee9b4f9fa826aab9c55634b4b9c61f0adcb33b32ab45662aec1c2b639d0081L55-R70))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
