### PR TITLE
Feat: Add coupons

### DIFF
--- a/ee/packages/git-sync-manager/src/models.ts
+++ b/ee/packages/git-sync-manager/src/models.ts
@@ -304,6 +304,14 @@ export type ConnectGitRepositoryInput = {
   resourceId: Scalars['String']['input'];
 };
 
+export type Coupon = {
+  code: Scalars['String']['output'];
+  couponType?: Maybe<Scalars['String']['output']>;
+  durationMonths: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
+  subscriptionPlan: EnumSubscriptionPlan;
+};
+
 export type CreateGitRepositoryBaseInput = {
   gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
@@ -966,6 +974,7 @@ export type Mutation = {
   lockEntity?: Maybe<Entity>;
   login: Auth;
   provisionSubscription?: Maybe<ProvisionSubscriptionResult>;
+  redeemCoupon: Coupon;
   resendInvitation?: Maybe<Invitation>;
   revokeInvitation?: Maybe<Invitation>;
   setCurrentWorkspace: Auth;
@@ -1236,6 +1245,11 @@ export type MutationLoginArgs = {
 
 export type MutationProvisionSubscriptionArgs = {
   data: ProvisionSubscriptionInput;
+};
+
+
+export type MutationRedeemCouponArgs = {
+  data: RedeemCouponInput;
 };
 
 
@@ -1813,6 +1827,10 @@ export enum QueryMode {
   Default = 'Default',
   Insensitive = 'Insensitive'
 }
+
+export type RedeemCouponInput = {
+  code: Scalars['String']['input'];
+};
 
 export type RemoteGitRepos = {
   pagination: Pagination;

--- a/libs/ui/design-system/src/lib/components/PlanUpgradeConfirmation/PlanUpgradeConfirmation.scss
+++ b/libs/ui/design-system/src/lib/components/PlanUpgradeConfirmation/PlanUpgradeConfirmation.scss
@@ -25,6 +25,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    text-align: center;
 
     &__header {
       font-size: 24px;
@@ -35,12 +36,16 @@
     &__animation {
       height: 200px;
       width: 200px;
+
+      img {
+        width: 100%;
+      }
     }
 
     &__description_purchase {
       font-size: 14px;
       font-weight: 600;
-      margin-bottom: 4px;
+      margin-bottom: var(--default-spacing);
     }
 
     &__description_details {

--- a/libs/ui/design-system/src/lib/components/PlanUpgradeConfirmation/PlanUpgradeConfirmation.tsx
+++ b/libs/ui/design-system/src/lib/components/PlanUpgradeConfirmation/PlanUpgradeConfirmation.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import { Dialog, Props as DialogProps } from "../Dialog/Dialog";
 import { Button, EnumButtonStyle } from "../Button/Button";
 
@@ -17,6 +17,7 @@ export type Props = DialogProps & {
   subTitle?: string;
   message?: string;
   ctaText?: string;
+  graphics?: ReactNode;
 };
 
 export const PlanUpgradeConfirmation = ({
@@ -27,12 +28,15 @@ export const PlanUpgradeConfirmation = ({
   subTitle,
   message,
   ctaText,
+  graphics,
 }: Props) => {
   const defaultTitle = "Your workspace was upgraded";
   const defaultSubTitle = "Thank you for your purchase!";
   const defaultMessage =
     "An email with your order confirmation and order details is on its way to you";
   const defaultCtaText = "Back to work";
+
+  const defaultGraphics = <Lottie animationData={animationFull} />;
 
   return (
     <Dialog
@@ -47,7 +51,7 @@ export const PlanUpgradeConfirmation = ({
           {title || defaultTitle}
         </div>
         <div className={`${CLASS_NAME}__message__animation`}>
-          <Lottie animationData={animationFull} />
+          {graphics || defaultGraphics}
         </div>
         <div className={`${CLASS_NAME}__message__description_purchase`}>
           {subTitle || defaultSubTitle}

--- a/libs/ui/design-system/src/lib/components/PlanUpgradeConfirmation/PlanUpgradeConfirmation.tsx
+++ b/libs/ui/design-system/src/lib/components/PlanUpgradeConfirmation/PlanUpgradeConfirmation.tsx
@@ -13,13 +13,27 @@ export type Props = DialogProps & {
   isOpen: boolean;
   onConfirm: () => void;
   onDismiss: () => void;
+  title?: string;
+  subTitle?: string;
+  message?: string;
+  ctaText?: string;
 };
 
 export const PlanUpgradeConfirmation = ({
   isOpen,
   onConfirm,
   onDismiss,
+  title,
+  subTitle,
+  message,
+  ctaText,
 }: Props) => {
+  const defaultTitle = "Your workspace was upgraded";
+  const defaultSubTitle = "Thank you for your purchase!";
+  const defaultMessage =
+    "An email with your order confirmation and order details is on its way to you";
+  const defaultCtaText = "Back to work";
+
   return (
     <Dialog
       title=""
@@ -30,17 +44,16 @@ export const PlanUpgradeConfirmation = ({
     >
       <div className={`${CLASS_NAME}__message`}>
         <div className={`${CLASS_NAME}__message__header`}>
-          Your workspace was upgraded
+          {title || defaultTitle}
         </div>
         <div className={`${CLASS_NAME}__message__animation`}>
           <Lottie animationData={animationFull} />
         </div>
         <div className={`${CLASS_NAME}__message__description_purchase`}>
-          Thank you for your purchase!
+          {subTitle || defaultSubTitle}
         </div>
         <div className={`${CLASS_NAME}__message__description_details`}>
-          An email with your order confirmation and order details is on its way
-          to you
+          {message || defaultMessage}
         </div>
       </div>
       <Button
@@ -48,7 +61,7 @@ export const PlanUpgradeConfirmation = ({
         buttonStyle={EnumButtonStyle.Primary}
         onClick={onConfirm}
       >
-        Back to work
+        {ctaText || defaultCtaText}
       </Button>
     </Dialog>
   );

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -304,6 +304,14 @@ export type ConnectGitRepositoryInput = {
   resourceId: Scalars['String']['input'];
 };
 
+export type Coupon = {
+  code: Scalars['String']['output'];
+  couponType?: Maybe<Scalars['String']['output']>;
+  durationMonths: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
+  subscriptionPlan: EnumSubscriptionPlan;
+};
+
 export type CreateGitRepositoryBaseInput = {
   gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
@@ -966,6 +974,7 @@ export type Mutation = {
   lockEntity?: Maybe<Entity>;
   login: Auth;
   provisionSubscription?: Maybe<ProvisionSubscriptionResult>;
+  redeemCoupon: Coupon;
   resendInvitation?: Maybe<Invitation>;
   revokeInvitation?: Maybe<Invitation>;
   setCurrentWorkspace: Auth;
@@ -1236,6 +1245,11 @@ export type MutationLoginArgs = {
 
 export type MutationProvisionSubscriptionArgs = {
   data: ProvisionSubscriptionInput;
+};
+
+
+export type MutationRedeemCouponArgs = {
+  data: RedeemCouponInput;
 };
 
 
@@ -1813,6 +1827,10 @@ export enum QueryMode {
   Default = 'Default',
   Insensitive = 'Insensitive'
 }
+
+export type RedeemCouponInput = {
+  code: Scalars['String']['input'];
+};
 
 export type RemoteGitRepos = {
   pagination: Pagination;

--- a/packages/amplication-client/src/App.tsx
+++ b/packages/amplication-client/src/App.tsx
@@ -24,6 +24,7 @@ declare global {
 }
 
 export const LOCAL_STORAGE_KEY_INVITATION_TOKEN = "invitationToken";
+export const LOCAL_STORAGE_KEY_COUPON_CODE = "couponCode";
 
 const GeneratedRoutes = routesGenerator(Routes);
 const context = {
@@ -61,15 +62,29 @@ function App() {
     undefined
   );
 
+  const [, setCouponCode] = useLocalStorage(
+    LOCAL_STORAGE_KEY_COUPON_CODE,
+    undefined
+  );
+
   useEffect(() => {
     const params = queryString.parse(location.search);
     if (params.invitation) {
       //save the invitation token in local storage to be validated by
       //<CompleteInvitation/> after signup or sign in
-      //we user local storage since github-passport does not support dynamic callback
+      //we use local storage since github-passport does not support dynamic callback
       setInvitationToken(params.invitation as string);
     }
   }, [setInvitationToken, location.search]);
+
+  useEffect(() => {
+    const params = queryString.parse(location.search);
+    if (params["coupon-code"]) {
+      //save the coupon code token in local storage to be validated by
+      //<CompleteCoupon/> after signup or sign in
+      setCouponCode(params["coupon-code"] as string);
+    }
+  }, [setCouponCode, location.search]);
 
   const [workspaceUpgradeConfirmation, setWorkspaceUpgradeConfirmation] =
     useState<boolean>(false);

--- a/packages/amplication-client/src/User/RedeemCoupon.tsx
+++ b/packages/amplication-client/src/User/RedeemCoupon.tsx
@@ -1,0 +1,94 @@
+import { gql, useMutation } from "@apollo/client";
+import { useCallback, useEffect, useState } from "react";
+import { useHistory } from "react-router-dom";
+import { isEmpty } from "lodash";
+import useLocalStorage from "react-use-localstorage";
+
+import { LOCAL_STORAGE_KEY_COUPON_CODE } from "../App";
+import { Dialog, PlanUpgradeConfirmation } from "@amplication/ui/design-system";
+import { formatError } from "../util/error";
+import e from "express";
+
+type TData = {
+  redeemCoupon: {
+    token: string;
+  };
+};
+
+/**
+ * Looks for coupon code in local storage, and send a redeemCoupon request to the server
+ */
+const RedeemCoupon = () => {
+  const history = useHistory();
+  const [couponCode, setCouponCode] = useLocalStorage(
+    LOCAL_STORAGE_KEY_COUPON_CODE,
+    undefined
+  );
+
+  const [redeemStarted, setRedeemStarted] = useState<boolean>(false);
+  const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
+  const [showError, setShowError] = useState<boolean>(false);
+
+  const onConfirmation = useCallback(() => {
+    setShowConfirmation(false);
+    history.replace("/");
+    window.location.reload();
+  }, []);
+
+  const [redeemCoupon, { loading, error }] = useMutation<TData>(REDEEM_COUPON, {
+    onCompleted: (data) => {
+      setCouponCode("");
+      setShowConfirmation(true);
+    },
+    onError: (error) => {
+      setCouponCode("");
+      setShowError(true);
+    },
+  });
+
+  useEffect(() => {
+    if (!isEmpty(couponCode) && !loading && !redeemStarted) {
+      setRedeemStarted(true);
+      redeemCoupon({
+        variables: {
+          code: couponCode,
+        },
+      }).catch(console.error);
+    }
+  }, [couponCode, history, redeemCoupon, loading]);
+
+  const errorMessage = error && formatError(error);
+
+  if (showError) {
+    return (
+      <Dialog
+        title="Error redeeming coupon"
+        isOpen={showError}
+        onDismiss={() => setShowError(false)}
+        showCloseButton={true}
+      >
+        {errorMessage}
+      </Dialog>
+    );
+  }
+
+  return !showConfirmation ? null : (
+    <PlanUpgradeConfirmation
+      isOpen={showConfirmation}
+      onConfirm={onConfirmation}
+      onDismiss={onConfirmation}
+      title="Congratulations!"
+      subTitle="You have successfully redeemed your Hacktoberfest coupon"
+      message="We appreciate your open-source contribution. You can now enjoy all the benefits of the Amplication Pro plan"
+      ctaText="Let's start building"
+    />
+  );
+};
+
+export default RedeemCoupon;
+
+const REDEEM_COUPON = gql`
+  mutation redeemCoupon($code: String!) {
+    redeemCoupon(data: { code: $code })
+  }
+`;

--- a/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
@@ -25,6 +25,7 @@ import WorkspaceFooter from "./WorkspaceFooter";
 import WorkspaceHeader from "./WorkspaceHeader/WorkspaceHeader";
 import "./WorkspaceLayout.scss";
 import useCommits from "../VersionControl/hooks/useCommits";
+import RedeemCoupon from "../User/RedeemCoupon";
 
 const MobileMessage = lazy(() => import("../Layout/MobileMessage"));
 
@@ -195,6 +196,7 @@ const WorkspaceLayout: React.FC<Props> = ({ innerRoutes, moduleClass }) => {
             <div className={moduleClass}>
               <WorkspaceHeader />
               <CompleteInvitation />
+              <RedeemCoupon />
               <div className={`${moduleClass}__page_content`}>
                 <div className={`${moduleClass}__main_content`}>
                   {projectsList.length ? innerRoutes : <ProjectEmptyState />}

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -307,6 +307,14 @@ export type ConnectGitRepositoryInput = {
   resourceId: Scalars['String']['input'];
 };
 
+export type Coupon = {
+  code: Scalars['String']['output'];
+  couponType?: Maybe<Scalars['String']['output']>;
+  durationMonths: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
+  subscriptionPlan: EnumSubscriptionPlan;
+};
+
 export type CreateGitRepositoryBaseInput = {
   gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
@@ -969,6 +977,7 @@ export type Mutation = {
   lockEntity?: Maybe<Entity>;
   login: Auth;
   provisionSubscription?: Maybe<ProvisionSubscriptionResult>;
+  redeemCoupon: Coupon;
   resendInvitation?: Maybe<Invitation>;
   revokeInvitation?: Maybe<Invitation>;
   setCurrentWorkspace: Auth;
@@ -1239,6 +1248,11 @@ export type MutationLoginArgs = {
 
 export type MutationProvisionSubscriptionArgs = {
   data: ProvisionSubscriptionInput;
+};
+
+
+export type MutationRedeemCouponArgs = {
+  data: RedeemCouponInput;
 };
 
 
@@ -1816,6 +1830,10 @@ export enum QueryMode {
   Default = 'Default',
   Insensitive = 'Insensitive'
 }
+
+export type RedeemCouponInput = {
+  code: Scalars['String']['input'];
+};
 
 export type RemoteGitRepos = {
   pagination: Pagination;

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -304,6 +304,14 @@ export type ConnectGitRepositoryInput = {
   resourceId: Scalars['String']['input'];
 };
 
+export type Coupon = {
+  code: Scalars['String']['output'];
+  couponType?: Maybe<Scalars['String']['output']>;
+  durationMonths: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
+  subscriptionPlan: EnumSubscriptionPlan;
+};
+
 export type CreateGitRepositoryBaseInput = {
   gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
@@ -966,6 +974,7 @@ export type Mutation = {
   lockEntity?: Maybe<Entity>;
   login: Auth;
   provisionSubscription?: Maybe<ProvisionSubscriptionResult>;
+  redeemCoupon: Coupon;
   resendInvitation?: Maybe<Invitation>;
   revokeInvitation?: Maybe<Invitation>;
   setCurrentWorkspace: Auth;
@@ -1236,6 +1245,11 @@ export type MutationLoginArgs = {
 
 export type MutationProvisionSubscriptionArgs = {
   data: ProvisionSubscriptionInput;
+};
+
+
+export type MutationRedeemCouponArgs = {
+  data: RedeemCouponInput;
 };
 
 
@@ -1813,6 +1827,10 @@ export enum QueryMode {
   Default = 'Default',
   Insensitive = 'Insensitive'
 }
+
+export type RedeemCouponInput = {
+  code: Scalars['String']['input'];
+};
 
 export type RemoteGitRepos = {
   pagination: Pagination;

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -304,6 +304,14 @@ export type ConnectGitRepositoryInput = {
   resourceId: Scalars['String']['input'];
 };
 
+export type Coupon = {
+  code: Scalars['String']['output'];
+  couponType?: Maybe<Scalars['String']['output']>;
+  durationMonths: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
+  subscriptionPlan: EnumSubscriptionPlan;
+};
+
 export type CreateGitRepositoryBaseInput = {
   gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
@@ -966,6 +974,7 @@ export type Mutation = {
   lockEntity?: Maybe<Entity>;
   login: Auth;
   provisionSubscription?: Maybe<ProvisionSubscriptionResult>;
+  redeemCoupon: Coupon;
   resendInvitation?: Maybe<Invitation>;
   revokeInvitation?: Maybe<Invitation>;
   setCurrentWorkspace: Auth;
@@ -1236,6 +1245,11 @@ export type MutationLoginArgs = {
 
 export type MutationProvisionSubscriptionArgs = {
   data: ProvisionSubscriptionInput;
+};
+
+
+export type MutationRedeemCouponArgs = {
+  data: RedeemCouponInput;
 };
 
 
@@ -1813,6 +1827,10 @@ export enum QueryMode {
   Default = 'Default',
   Insensitive = 'Insensitive'
 }
+
+export type RedeemCouponInput = {
+  code: Scalars['String']['input'];
+};
 
 export type RemoteGitRepos = {
   pagination: Pagination;

--- a/packages/amplication-prisma-db/prisma/migrations/20230918182036_/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20230918182036_/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "Coupon" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "newUserId" TEXT,
+    "code" TEXT NOT NULL,
+    "expiration" TIMESTAMP(3) NOT NULL,
+    "subscriptionPlan" "EnumSubscriptionPlan" NOT NULL DEFAULT 'Pro',
+    "durationMonths" INTEGER NOT NULL DEFAULT 1,
+    "redemptionAt" TIMESTAMP(3),
+
+    CONSTRAINT "Coupon_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Coupon_newUserId_key" ON "Coupon"("newUserId");
+
+-- AddForeignKey
+ALTER TABLE "Coupon" ADD CONSTRAINT "Coupon_newUserId_fkey" FOREIGN KEY ("newUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/amplication-prisma-db/prisma/migrations/20230919083101_/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20230919083101_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Coupon" ADD COLUMN     "couponType" TEXT;

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -107,6 +107,7 @@ model User {
   userRoles             UserRole[]
   sentInvitations       Invitation[] @relation("InvitedByUserOnInvitation")
   createdFromInvitation Invitation?
+  createdFromCoupon     Coupon?
   deletedAt             DateTime?
   userAction            UserAction[]
   lastActive            DateTime?    @default(now())
@@ -535,6 +536,19 @@ model Invitation {
   tokenExpiration DateTime
 
   @@unique([workspaceId, email], map: "Invitation.workspaceId_email_unique")
+}
+
+model Coupon {
+  id               String               @id @default(cuid())
+  createdAt        DateTime             @default(now())
+  updatedAt        DateTime             @updatedAt
+  newUserId        String?              @unique()
+  newUser          User?                @relation(fields: [newUserId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  code             String               @default(cuid())
+  expiration       DateTime
+  subscriptionPlan EnumSubscriptionPlan @default(Pro)
+  durationMonths   Int                  @default(1)
+  redemptionAt     DateTime?
 }
 
 enum EnumSubscriptionPlan {

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -549,6 +549,7 @@ model Coupon {
   subscriptionPlan EnumSubscriptionPlan @default(Pro)
   durationMonths   Int                  @default(1)
   redemptionAt     DateTime?
+  couponType       String?
 }
 
 enum EnumSubscriptionPlan {

--- a/packages/amplication-server/src/core/billing/billing.service.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.ts
@@ -381,6 +381,8 @@ export class BillingService {
         return EnumSubscriptionPlan.Free;
       case BillingPlan.Pro:
         return EnumSubscriptionPlan.Pro;
+      case BillingPlan.ProWithTrial:
+        return EnumSubscriptionPlan.Pro;
       case BillingPlan.Enterprise:
         return EnumSubscriptionPlan.Enterprise;
       default:

--- a/packages/amplication-server/src/core/billing/billing.types.ts
+++ b/packages/amplication-server/src/core/billing/billing.types.ts
@@ -2,6 +2,7 @@ export enum BillingPlan {
   Free = "plan-amplication-free",
   Pro = "plan-amplication-pro",
   Enterprise = "plan-amplication-enterprise",
+  ProWithTrial = "plan-amplication-pro-with-trial",
 }
 
 export enum BillingFeature {

--- a/packages/amplication-server/src/core/subscription/subscription.service.ts
+++ b/packages/amplication-server/src/core/subscription/subscription.service.ts
@@ -48,17 +48,34 @@ export class SubscriptionService {
   ): Promise<Subscription | null> {
     const sub = await this.prisma.subscription.findFirst({
       where: {
-        workspaceId: workspaceId,
-        status: PrismaEnumSubscriptionStatus.Active,
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        OR: [
+        AND: [
           {
-            cancellationEffectiveDate: {
-              gt: new Date(),
-            },
+            workspaceId: workspaceId,
           },
           {
-            cancellationEffectiveDate: null,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            OR: [
+              {
+                status: PrismaEnumSubscriptionStatus.Active,
+              },
+              {
+                status: PrismaEnumSubscriptionStatus.Trailing,
+              },
+            ],
+          },
+          {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            OR: [
+              {
+                cancellationEffectiveDate: {
+                  gt: new Date(),
+                },
+              },
+              {
+                cancellationEffectiveDate: null,
+              },
+            ],
           },
         ],
       },

--- a/packages/amplication-server/src/core/user/user.service.ts
+++ b/packages/amplication-server/src/core/user/user.service.ts
@@ -158,7 +158,7 @@ export class UserService {
         user.workspace.id,
         BillingFeature.Notification
       );
-    const canShowUserNotification = booleanEntityUserNotification.hasAccess;
+    const canShowUserNotification = booleanEntityUserNotification?.hasAccess;
 
     this.kafkaProducerService
       .emitMessage(KAFKA_TOPICS.USER_ACTION_TOPIC, <UserAction.KafkaEvent>{

--- a/packages/amplication-server/src/core/workspace/dto/Coupon.ts
+++ b/packages/amplication-server/src/core/workspace/dto/Coupon.ts
@@ -1,0 +1,36 @@
+import { Field, Int, ObjectType } from "@nestjs/graphql";
+import { EnumSubscriptionPlan } from "../../subscription/dto";
+
+@ObjectType({
+  isAbstract: true,
+})
+export class Coupon {
+  @Field(() => String, {
+    nullable: false,
+  })
+  id!: string;
+
+  createdAt!: Date;
+
+  updatedAt!: Date;
+
+  @Field(() => String, {
+    nullable: false,
+  })
+  code!: string;
+
+  @Field(() => EnumSubscriptionPlan, {
+    nullable: false,
+  })
+  subscriptionPlan!: keyof typeof EnumSubscriptionPlan;
+
+  @Field(() => Int, {
+    nullable: false,
+  })
+  durationMonths: number;
+
+  @Field(() => String, {
+    nullable: true,
+  })
+  couponType: string;
+}

--- a/packages/amplication-server/src/core/workspace/dto/RedeemCouponArgs.ts
+++ b/packages/amplication-server/src/core/workspace/dto/RedeemCouponArgs.ts
@@ -1,0 +1,8 @@
+import { ArgsType, Field } from "@nestjs/graphql";
+import { RedeemCouponInput } from "./RedeemCouponInput";
+
+@ArgsType()
+export class RedeemCouponArgs {
+  @Field(() => RedeemCouponInput, { nullable: false })
+  data!: RedeemCouponInput;
+}

--- a/packages/amplication-server/src/core/workspace/dto/RedeemCouponInput.ts
+++ b/packages/amplication-server/src/core/workspace/dto/RedeemCouponInput.ts
@@ -1,0 +1,11 @@
+import { Field, InputType } from "@nestjs/graphql";
+
+@InputType({
+  isAbstract: true,
+})
+export class RedeemCouponInput {
+  @Field(() => String, {
+    nullable: false,
+  })
+  code: string;
+}

--- a/packages/amplication-server/src/core/workspace/workspace.resolver.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.resolver.ts
@@ -39,6 +39,7 @@ import {
   SegmentAnalyticsService,
 } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { RedeemCouponArgs } from "./dto/RedeemCouponArgs";
+import { Coupon } from "./dto/Coupon";
 
 @Resolver(() => Workspace)
 @UseFilters(GqlResolverExceptionsFilter)
@@ -193,12 +194,12 @@ export class WorkspaceResolver {
     });
   }
 
-  @Mutation(() => Boolean)
+  @Mutation(() => Coupon)
   @UseGuards(GqlAuthGuard)
   async redeemCoupon(
     @UserEntity() user: User,
     @Args() args: RedeemCouponArgs
-  ): Promise<boolean> {
+  ): Promise<Coupon> {
     return this.workspaceService.redeemCoupon(user, args);
   }
 }

--- a/packages/amplication-server/src/core/workspace/workspace.resolver.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.resolver.ts
@@ -38,6 +38,7 @@ import {
   EnumEventType,
   SegmentAnalyticsService,
 } from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { RedeemCouponArgs } from "./dto/RedeemCouponArgs";
 
 @Resolver(() => Workspace)
 @UseFilters(GqlResolverExceptionsFilter)
@@ -190,5 +191,14 @@ export class WorkspaceResolver {
       ...args.data,
       userId: currentUser.account.id,
     });
+  }
+
+  @Mutation(() => Boolean)
+  @UseGuards(GqlAuthGuard)
+  async redeemCoupon(
+    @UserEntity() user: User,
+    @Args() args: RedeemCouponArgs
+  ): Promise<boolean> {
+    return this.workspaceService.redeemCoupon(user, args);
   }
 }

--- a/packages/amplication-server/src/core/workspace/workspace.service.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.service.ts
@@ -380,10 +380,10 @@ export class WorkspaceService {
     //use stigg API to provision a new trial subscription
     await this.billingService.provisionSubscription({
       workspaceId: currentUser.workspace.id,
-      planId: "plan-amplication-pro-with-trial",
+      planId: BillingPlan.ProWithTrial,
       cancelUrl: "",
       successUrl: "",
-      userId: currentUser.account.id,
+      userId: account.id,
       billingPeriod: BillingPeriod.Monthly,
       intentionType: "UPGRADE_PLAN",
     });

--- a/packages/amplication-server/src/core/workspace/workspace.service.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.service.ts
@@ -1,36 +1,39 @@
-import { Injectable, ConflictException } from "@nestjs/common";
-import { Workspace, User } from "../../models";
+import { ConflictException, Injectable } from "@nestjs/common";
+import { User, Workspace } from "../../models";
 import { Prisma, PrismaService } from "../../prisma";
-import { Invitation } from "./dto/Invitation";
 import {
-  FindManyWorkspaceArgs,
-  UpdateOneWorkspaceArgs,
-  InviteUserArgs,
   CompleteInvitationArgs,
-  WorkspaceMember,
   DeleteUserArgs,
-  RevokeInvitationArgs,
+  FindManyWorkspaceArgs,
+  InviteUserArgs,
   ResendInvitationArgs,
+  RevokeInvitationArgs,
+  UpdateOneWorkspaceArgs,
+  WorkspaceMember,
 } from "./dto";
+import { Invitation } from "./dto/Invitation";
 
-import { FindOneArgs } from "../../dto";
-import { Role } from "../../enums/Role";
-import { UserService } from "../user/user.service";
-import { MailService } from "../mail/mail.service";
-import { SubscriptionService } from "../subscription/subscription.service";
 import cuid from "cuid";
 import { addDays } from "date-fns";
 import { isEmpty } from "lodash";
-import { EnumWorkspaceMemberType } from "./dto/EnumWorkspaceMemberType";
-import { Subscription } from "../subscription/dto/Subscription";
+import { FindOneArgs } from "../../dto";
+import { Role } from "../../enums/Role";
 import { GitOrganization } from "../../models/GitOrganization";
-import { ProjectService } from "../project/project.service";
-import { BillingService } from "../billing/billing.service";
-import { BillingPlan } from "../billing/billing.types";
 import {
   EnumEventType,
   SegmentAnalyticsService,
 } from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { BillingService } from "../billing/billing.service";
+import { BillingPlan } from "../billing/billing.types";
+import { MailService } from "../mail/mail.service";
+import { ProjectService } from "../project/project.service";
+import { EnumSubscriptionPlan } from "../subscription/dto";
+import { Subscription } from "../subscription/dto/Subscription";
+import { SubscriptionService } from "../subscription/subscription.service";
+import { UserService } from "../user/user.service";
+import { EnumWorkspaceMemberType } from "./dto/EnumWorkspaceMemberType";
+import { RedeemCouponArgs } from "./dto/RedeemCouponArgs";
+import { BillingPeriod } from "@stigg/node-server-sdk";
 
 const INVITATION_EXPIRATION_DAYS = 7;
 
@@ -337,6 +340,77 @@ export class WorkspaceService {
     });
 
     return updatedInvitation;
+  }
+
+  async redeemCoupon(
+    currentUser: User,
+    args: RedeemCouponArgs
+  ): Promise<boolean> {
+    const { account } = currentUser;
+
+    const coupons = await this.prisma.coupon.findMany({
+      where: {
+        code: args.data.code,
+        newUser: null,
+        redemptionAt: null,
+      },
+    });
+
+    if (!(coupons && coupons.length === 1)) {
+      throw new ConflictException(`coupon cannot be found or it has expired`);
+    }
+
+    const [coupon] = coupons;
+
+    if (coupon.expiration < new Date()) {
+      throw new ConflictException(`coupon is expired`);
+    }
+
+    const subscription = await this.subscriptionService.resolveSubscription(
+      currentUser.workspace.id
+    );
+
+    if (subscription.subscriptionPlan !== EnumSubscriptionPlan.Free) {
+      throw new ConflictException(
+        `The coupon cannot be applied on the current subscription`
+      );
+    }
+
+    //use stigg API to provision a new trial subscription
+    await this.billingService.provisionSubscription({
+      workspaceId: currentUser.workspace.id,
+      planId: "plan-amplication-pro-with-trial",
+      cancelUrl: "",
+      successUrl: "",
+      userId: currentUser.account.id,
+      billingPeriod: BillingPeriod.Monthly,
+      intentionType: "UPGRADE_PLAN",
+    });
+    await this.prisma.coupon.update({
+      where: {
+        id: coupon.id,
+      },
+      data: {
+        redemptionAt: new Date(),
+        newUser: {
+          connect: {
+            id: currentUser.id,
+          },
+        },
+      },
+    });
+
+    await this.analytics.track({
+      userId: account.id,
+      event: EnumEventType.RedeemCoupon,
+      properties: {
+        workspaceId: currentUser.workspace.id,
+        subscriptionPlan: coupon.subscriptionPlan,
+        durationMonths: coupon.durationMonths,
+      },
+    });
+
+    return true;
   }
 
   async findMembers(args: FindOneArgs): Promise<WorkspaceMember[]> {

--- a/packages/amplication-server/src/core/workspace/workspace.service.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.service.ts
@@ -34,6 +34,7 @@ import { UserService } from "../user/user.service";
 import { EnumWorkspaceMemberType } from "./dto/EnumWorkspaceMemberType";
 import { RedeemCouponArgs } from "./dto/RedeemCouponArgs";
 import { BillingPeriod } from "@stigg/node-server-sdk";
+import { Coupon } from "./dto/Coupon";
 
 const INVITATION_EXPIRATION_DAYS = 7;
 
@@ -345,7 +346,7 @@ export class WorkspaceService {
   async redeemCoupon(
     currentUser: User,
     args: RedeemCouponArgs
-  ): Promise<boolean> {
+  ): Promise<Coupon> {
     const { account } = currentUser;
 
     const coupons = await this.prisma.coupon.findMany({
@@ -410,7 +411,7 @@ export class WorkspaceService {
       },
     });
 
-    return true;
+    return coupon;
   }
 
   async findMembers(args: FindOneArgs): Promise<WorkspaceMember[]> {

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -274,6 +274,14 @@ input ConnectGitRepositoryInput {
   resourceId: String!
 }
 
+type Coupon {
+  code: String!
+  couponType: String
+  durationMonths: Int!
+  id: String!
+  subscriptionPlan: EnumSubscriptionPlan!
+}
+
 input CreateGitRepositoryBaseInput {
   gitOrganizationId: String!
   gitOrganizationType: EnumGitOrganizationType!
@@ -936,6 +944,7 @@ type Mutation {
   lockEntity(where: WhereUniqueInput!): Entity
   login(data: LoginInput!): Auth!
   provisionSubscription(data: ProvisionSubscriptionInput!): ProvisionSubscriptionResult
+  redeemCoupon(data: RedeemCouponInput!): Coupon!
   resendInvitation(where: WhereUniqueInput!): Invitation
   revokeInvitation(where: WhereUniqueInput!): Invitation
   setCurrentWorkspace(data: WhereUniqueInput!): Auth!
@@ -1215,6 +1224,10 @@ type Query {
 enum QueryMode {
   Default
   Insensitive
+}
+
+input RedeemCouponInput {
+  code: String!
 }
 
 type RemoteGitRepos {

--- a/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
+++ b/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
@@ -32,6 +32,8 @@ export enum EnumEventType {
   CodeGenerationError = "codeGenerationError",
 
   CodeGeneratorVersionUpdate = "codeGeneratorVersionUpdate",
+
+  RedeemCoupon = "RedeemCoupon",
 }
 
 export type IdentifyData = {

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -304,6 +304,14 @@ export type ConnectGitRepositoryInput = {
   resourceId: Scalars['String']['input'];
 };
 
+export type Coupon = {
+  code: Scalars['String']['output'];
+  couponType?: Maybe<Scalars['String']['output']>;
+  durationMonths: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
+  subscriptionPlan: EnumSubscriptionPlan;
+};
+
 export type CreateGitRepositoryBaseInput = {
   gitOrganizationId: Scalars['String']['input'];
   gitOrganizationType: EnumGitOrganizationType;
@@ -966,6 +974,7 @@ export type Mutation = {
   lockEntity?: Maybe<Entity>;
   login: Auth;
   provisionSubscription?: Maybe<ProvisionSubscriptionResult>;
+  redeemCoupon: Coupon;
   resendInvitation?: Maybe<Invitation>;
   revokeInvitation?: Maybe<Invitation>;
   setCurrentWorkspace: Auth;
@@ -1236,6 +1245,11 @@ export type MutationLoginArgs = {
 
 export type MutationProvisionSubscriptionArgs = {
   data: ProvisionSubscriptionInput;
+};
+
+
+export type MutationRedeemCouponArgs = {
+  data: RedeemCouponInput;
 };
 
 
@@ -1813,6 +1827,10 @@ export enum QueryMode {
   Default = 'Default',
   Insensitive = 'Insensitive'
 }
+
+export type RedeemCouponInput = {
+  code: Scalars['String']['input'];
+};
 
 export type RemoteGitRepos = {
   pagination: Pagination;


### PR DESCRIPTION
Close: #6962 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fbf348b</samp>

### Summary
🎁🚀💸

<!--
1.  🎁 - This emoji represents the gift of a coupon code that users can redeem for a trial subscription. It also conveys the idea of a reward or a benefit that the feature provides.
2.  🚀 - This emoji represents the launch of a new feature that enhances the user experience and the value proposition of the app. It also conveys the idea of speed and innovation that the feature brings.
3.  💸 - This emoji represents the money that users can save by using the coupon code. It also conveys the idea of a discount or a deal that the feature offers.
-->
This pull request adds a feature to allow users to redeem coupons for trial subscriptions to the Pro plan. It modifies the UI, the database, the server, and the analytics services to handle the coupon code tokens, the coupon redemption logic, and the subscription status. It also fixes a minor bug in the user creation logic. The main files involved are `RedeemCoupon.tsx`, `PlanUpgradeConfirmation.tsx`, `schema.prisma`, `workspace.resolver.ts`, `workspace.service.ts`, and `billing.service.ts`.

> _Oh, we're the coupon crew and we're here to say_
> _We've added a feature to redeem them today_
> _With `RedeemCoupon` and `BillingPlan` we'll make it work_
> _So heave away, me hearties, heave away with a jerk_

### Walkthrough
*  Add a new component `RedeemCoupon` that handles the coupon redemption logic and UI ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-a6a92b036ad63a4baeb39caf47e6ceec3262b594be431f03d9ef7dc0fff31e14R1-R94))
*  Render the `RedeemCoupon` component in the `WorkspaceLayout` component to execute the coupon redemption logic whenever the user is in a workspace context ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-03267d3c067a6a362b6fbfa605791ab35df55bd9a6243e3e24fb53de9b1e5b35R28), [link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-03267d3c067a6a362b6fbfa605791ab35df55bd9a6243e3e24fb53de9b1e5b35R199))
*  Add a hook to get and set the coupon code token from the local storage using a constant key ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-198ffbfbb5bab3fdde83f3d781decd2c3780f95802b97a439edfaa4310ec21d7R27), [link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-198ffbfbb5bab3fdde83f3d781decd2c3780f95802b97a439edfaa4310ec21d7R65-R69))
*  Parse the coupon code token from the query string and store it in the local storage if it exists ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-198ffbfbb5bab3fdde83f3d781decd2c3780f95802b97a439edfaa4310ec21d7L69-R88))
*  Add a new GraphQL mutation `redeemCoupon` that takes the coupon code as an argument and calls the `redeemCoupon` method of the `WorkspaceService` class ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-1cb226bf6e90c823b799286689bcc7b8adce3fecf71b6a9187f008bce747cb76R41), [link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-1cb226bf6e90c823b799286689bcc7b8adce3fecf71b6a9187f008bce747cb76R195-R203))
*  Add a new table `Coupon` to the database that stores the coupon information and relation to the user ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-0f5d78c79d7a502ef296c20c972123c10bb78ce59e339a2b7820c21b14e79d38R1-R20), [link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-f83d54c896f6ae6f938ed753a6856094bef91365a576da08c393e51868d3ce76R541-R553))
*  Add a new optional field `createdFromCoupon` to the `User` model that references the `Coupon` model ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-f83d54c896f6ae6f938ed753a6856094bef91365a576da08c393e51868d3ce76R110))
*  Add a new enum value `ProWithTrial` to the `BillingPlan` type that represents the billing plan for trial subscriptions ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-dfa68e574b49dfe97f85d13ffe12404f479236a77840b9f720e05faf5902dabbR5))
*  Add a new case to the `resolveSubscriptionPlan` method of the `BillingService` class that maps the `ProWithTrial` billing plan to the `Pro` subscription plan ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1R384-R385))
*  Modify the `resolveSubscription` method of the `SubscriptionService` class to include subscriptions with the `Trailing` status in the query ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-1bb5e6555393081d4d962a67f77ac16986440f9a0aeb724bc848542a7c5f12dbL51-R79))
*  Add a null check to the `canShowUserNotification` variable in the `createUser` method of the `UserService` class ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-091d0dcf087febea1710927b3f51327d41fac7c82995b71581447f4052ca6864L161-R161))
*  Add four optional fields to the `Props` type of the `PlanUpgradeConfirmation` component that allow customizing the confirmation dialog text ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-1e7162ef7c4be6fbab066dd296de141458ba32495669b5a03b04190dcad55214R16-R19))
*  Destructure the four new fields from the `Props` object and assign them default values in the `PlanUpgradeConfirmation` component ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-1e7162ef7c4be6fbab066dd296de141458ba32495669b5a03b04190dcad55214L22-R36))
*  Replace the hardcoded strings in the confirmation dialog with the props or the default values ([link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-1e7162ef7c4be6fbab066dd296de141458ba32495669b5a03b04190dcad55214L33-R47), [link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-1e7162ef7c4be6fbab066dd296de141458ba32495669b5a03b04190dcad55214L39-R56), [link](https://github.com/amplication/amplication/pull/6961/files?diff=unified&w=0#diff-1e7162ef7c4be6fbab066dd296de141458ba32495669b5a03b04190dcad55214L51-R64))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
