### PR TITLE
fix(ci): release workflow tag check

### DIFF
--- a/.github/workflows/release.production.yml
+++ b/.github/workflows/release.production.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Check version is unique
         id: validate-version-unique
         run: |
-          if git tag --list | grep -q -p "^${{ github.event.inputs.version }}"; then
+          if git tag --list | grep -q "^${{ github.event.inputs.version }}"; then
             echo "Version '${{ github.event.inputs.version }}' already exists."
             echo "Please use a different version."
             exit 1


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6964 
## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 33d5c2c</samp>

### Summary
:wastebasket::bug::runner:

<!--
1.  :wastebasket: This emoji can be used to indicate that something was removed or deleted, such as a flag or an option.
2.  :bug: This emoji can be used to indicate that something was fixed or resolved, such as an error or a bug.
3.  :runner: This emoji can be used to indicate that something was related to GitHub Actions or workflows, such as a runner or a step.
-->
Fixed a bug in the release production workflow that prevented creating new version tags. Removed an unsupported flag from the `grep` command in `.github/workflows/release.production.yml`.

> _`grep` without `-p`_
> _Fixes error on runners_
> _Autumn leaves falling_

### Walkthrough
* Remove the `-p` flag from the `grep` command to avoid errors on GitHub Actions runners ([link](https://github.com/amplication/amplication/pull/6965/files?diff=unified&w=0#diff-01085e43c580feab2b4853d3f444ec18378cb427dbf2590633938157ad97c773L68-R68))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
