### PR TITLE
Fix(server): import schema self relation

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -1036,7 +1036,12 @@ export class PrismaSchemaParserService {
       field.attributes?.some(
         (attr) =>
           attr.name === RELATION_ATTRIBUTE_NAME &&
-          attr.args?.some((arg) => typeof arg.value === "string") &&
+          attr.args?.some(
+            (arg) =>
+              ((arg.value as KeyValue)?.key === "name" &&
+                typeof (arg.value as KeyValue)?.value === "string") ||
+              typeof arg.value === "string"
+          ) &&
           !attr.args?.find(
             (arg) => (arg.value as KeyValue).key === ARG_KEY_FIELD_NAME
           )

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -1730,8 +1730,8 @@ export class PrismaSchemaParserService {
       });
 
       void actionContext.onEmitUserActionLog(
-        EnumActionLogLevel.Error,
-        error.message
+        error.message,
+        EnumActionLogLevel.Error
       );
       throw error;
     }

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.spec.ts
@@ -106,21 +106,6 @@ describe("schema-utils", () => {
       expect(result.searchable).toEqual(true);
     });
 
-    it("should throw error if Lookup field has custom attributes", () => {
-      const field = {
-        name: "testField",
-        optional: false,
-        attributes: mockAttributes,
-      } as unknown as Field;
-      const dataType = EnumDataType.Lookup;
-
-      expect(() =>
-        createOneEntityFieldCommonProperties(field, dataType)
-      ).toThrowError(
-        "Custom attributes are not allowed on relation fields. Only @relation attribute is allowed"
-      );
-    });
-
     it("should add custom attributes for non-Lookup field", () => {
       const field = {
         name: "testField",

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
@@ -68,12 +68,6 @@ export function createOneEntityFieldCommonProperties(
     .filter((attr) => attr !== "@default()")
     .join(" ");
 
-  if (fieldDataType === EnumDataType.Lookup && fieldAttributes !== "") {
-    throw new Error(
-      `Custom attributes are not allowed on relation fields. Only @relation attribute is allowed`
-    );
-  }
-
   return {
     permanentId: cuid(),
     name: field.name,


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6732

## PR Details

- fix the creation of self-relation
- handle the relation name when it's an annotated field and when it's just a relation attribute with relation name

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1318091</samp>

### Summary
🐛🧹♻️

<!--
1.  🐛 for fixing a bug
2.  🧹 for removing an obsolete test case
3.  ♻️ for refactoring and improving the logic
-->
This pull request fixes a bug in the `PrismaSchemaParserService` and the `schema-utils.ts` file that prevented self relations from being parsed and generated correctly in Prisma schema files. It also improves the logic of finding relation names and fields, and the error logging in the service. It adds a new test case for self relations and removes an obsolete test case for custom attributes.

> _`PrismaSchemaParser`_
> _Fixes self relations bug_
> _Autumn of errors_

### Walkthrough
*  Fix self relation bug in PrismaSchemaParserService and refactor schema-utils functions ([link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR2651-R2724), [link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1039-R1044), [link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1733-R1739), [link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-729822b2dc6d7e1d96b58a6a13873902a54700227afd424960f528b4ea4ff09fL109-L123), [link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L71-L76), [link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L250-R255), [link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L277-R290), [link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L326-R337))
  * Add a test case in `prismaSchemaParser.service.spec.ts` to check if the service can handle self relations in a prisma schema ([link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aR2651-R2724))
  * Modify the condition in `prismaSchemaParser.service.ts` to check if a field has a relation attribute with a string or a named argument as the relation name ([link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1039-R1044))
  * Fix a typo in the order of the arguments passed to the `onEmitUserActionLog` method in `prismaSchemaParser.service.ts` ([link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1733-R1739))
  * Remove an obsolete test case in `schema-utils.spec.ts` that checked for custom attributes on lookup fields ([link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-729822b2dc6d7e1d96b58a6a13873902a54700227afd424960f528b4ea4ff09fL109-L123))
  * Remove the check for custom attributes on lookup fields from the `createOneEntityFieldCommonProperties` function in `schema-utils.ts` ([link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L71-L76))
  * Modify the logic in `schema-utils.ts` to find the relation name from the relation attribute of a field using either a string or a named argument ([link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L250-R255))
  * Modify the logic in `schema-utils.ts` to find the remote field in the remote model that has the same relation name as the current field and is not the same field in cases of self relations ([link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L277-R290))
  * Modify the logic in `schema-utils.ts` to find the foreign key field name from the relation attribute of a field using a key-value pair argument ([link](https://github.com/amplication/amplication/pull/6973/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L326-R337))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
