### PR TITLE
Refactor(server): import schema with multiple relations

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -2722,6 +2722,176 @@ describe("prismaSchemaParser", () => {
           expect(result).toEqual(expectedEntitiesWithFields);
         });
 
+        it("should create the models and fields properly when the models have more than one related field to the same model", async () => {
+          const prismaSchema = `datasource db {
+            provider = "postgresql"
+            url      = env("DB_URL")
+          }
+          
+          generator client {
+            provider = "prisma-client-js"
+          }
+          
+          model Event {
+            id          String   @id @default(uuid())
+            event2Id    String?  @unique
+            test789     Test[]    @relation("event3")
+            tests       Test[]    @relation("event1")
+            test456     Test?   @relation(references: [id], fields: [event2Id], map: "FK_event4_event_id")
+            test123     Test?    @relation("event2", fields: [event2Id], references: [id])
+          }
+          
+          
+          model Test {
+            id          String  @id @default(uuid())
+            event2      Event[]  @relation("event2")
+            event4      Event[]
+            event1      Event?  @relation("event1", fields: [event1Id], references: [id])
+            event3      Event?  @relation("event3", fields: [event1Id], references: [id], map: "FK_event3_event_id")
+            event1Id    String? @unique
+          }`;
+
+          const existingEntities: ExistingEntitySelect[] = [];
+          const customerFieldPermanentId = expect.any(String);
+          const result = await service.convertPrismaSchemaForImportObjects(
+            prismaSchema,
+            existingEntities,
+            actionContext
+          );
+
+          const expectedEntitiesWithFields: CreateBulkEntitiesInput[] = [
+            {
+              id: expect.any(String),
+              name: "Event",
+              displayName: "Event",
+              pluralDisplayName: "Events",
+              description: "",
+              customAttributes: "",
+              fields: [
+                {
+                  permanentId: expect.any(String),
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: false,
+                  searchable: true,
+                  description: "",
+                  properties: {
+                    idType: "UUID",
+                  },
+                  customAttributes: "@id @default(uuid())",
+                },
+                {
+                  permanentId: customerFieldPermanentId,
+                  name: "test456",
+                  displayName: "Test456",
+                  dataType: EnumDataType.Lookup,
+                  required: false,
+                  unique: false,
+                  searchable: true,
+                  description: "",
+                  properties: {
+                    relatedEntityId: expect.any(String),
+                    allowMultipleSelection: false,
+                    fkHolder: customerFieldPermanentId,
+                    fkFieldName: "event2Id",
+                  },
+                  customAttributes: "",
+                  relatedFieldAllowMultipleSelection: true,
+                  relatedFieldDisplayName: "Event4",
+                  relatedFieldName: "event4",
+                },
+                {
+                  permanentId: customerFieldPermanentId,
+                  name: "test123",
+                  displayName: "Test123",
+                  dataType: EnumDataType.Lookup,
+                  required: false,
+                  unique: false,
+                  searchable: true,
+                  description: "",
+                  properties: {
+                    relatedEntityId: expect.any(String),
+                    allowMultipleSelection: false,
+                    fkHolder: customerFieldPermanentId,
+                    fkFieldName: "event2Id",
+                  },
+                  customAttributes: "",
+                  relatedFieldAllowMultipleSelection: true,
+                  relatedFieldDisplayName: "Event2",
+                  relatedFieldName: "event2",
+                },
+              ],
+            },
+            {
+              id: expect.any(String),
+              name: "Test",
+              displayName: "Test",
+              pluralDisplayName: "Tests",
+              description: "",
+              customAttributes: "",
+              fields: [
+                {
+                  permanentId: expect.any(String),
+                  name: "id",
+                  displayName: "Id",
+                  dataType: EnumDataType.Id,
+                  required: true,
+                  unique: false,
+                  searchable: true,
+                  description: "",
+                  properties: {
+                    idType: "UUID",
+                  },
+                  customAttributes: "@id @default(uuid())",
+                },
+                {
+                  permanentId: customerFieldPermanentId,
+                  name: "event1",
+                  displayName: "Event1",
+                  dataType: EnumDataType.Lookup,
+                  required: false,
+                  unique: false,
+                  searchable: true,
+                  description: "",
+                  properties: {
+                    relatedEntityId: expect.any(String),
+                    allowMultipleSelection: false,
+                    fkHolder: customerFieldPermanentId,
+                    fkFieldName: "event1Id",
+                  },
+                  customAttributes: "",
+                  relatedFieldAllowMultipleSelection: true,
+                  relatedFieldDisplayName: "Tests",
+                  relatedFieldName: "tests",
+                },
+                {
+                  permanentId: customerFieldPermanentId,
+                  name: "event3",
+                  displayName: "Event3",
+                  dataType: EnumDataType.Lookup,
+                  required: false,
+                  unique: false,
+                  searchable: true,
+                  description: "",
+                  properties: {
+                    relatedEntityId: expect.any(String),
+                    allowMultipleSelection: false,
+                    fkHolder: customerFieldPermanentId,
+                    fkFieldName: "event1Id",
+                  },
+                  customAttributes: "",
+                  relatedFieldAllowMultipleSelection: true,
+                  relatedFieldDisplayName: "Test789",
+                  relatedFieldName: "test789",
+                },
+              ],
+            },
+          ];
+          expect(result).toEqual(expectedEntitiesWithFields);
+        });
+
         describe("when the relation is many to many", () => {
           it("should rename the field but it should NOT add the @map attribute", async () => {
             // arrange

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -2735,7 +2735,7 @@ describe("prismaSchemaParser", () => {
           model Event {
             id          String   @id @default(uuid())
             event2Id    String?  @unique
-            test789     Test[]    @relation("event3")
+            test789     Test[]    @relation(name: "event3")
             tests       Test[]    @relation("event1")
             test456     Test?   @relation(references: [id], fields: [event2Id], map: "FK_event4_event_id")
             test123     Test?    @relation("event2", fields: [event2Id], references: [id])
@@ -2744,10 +2744,10 @@ describe("prismaSchemaParser", () => {
           
           model Test {
             id          String  @id @default(uuid())
-            event2      Event[]  @relation("event2")
+            event2      Event[]  @relation(name: "event2")
             event4      Event[]
             event1      Event?  @relation("event1", fields: [event1Id], references: [id])
-            event3      Event?  @relation("event3", fields: [event1Id], references: [id], map: "FK_event3_event_id")
+            event3      Event?  @relation(name: "event3", fields: [event1Id], references: [id], map: "FK_event3_event_id")
             event1Id    String? @unique
           }`;
 

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.ts
@@ -1181,15 +1181,6 @@ export class PrismaSchemaParserService {
       )
     );
 
-    if (relationFiledWithReference.length > 1) {
-      this.logger.error(
-        `Field ${field.name} on model ${model.name} has more than one relation field`
-      );
-      this.logger.error(
-        `Field ${field.name} on model ${model.name} has more than one relation field`
-      );
-    }
-
     return !!(relationFiledWithReference.length === 1);
   }
 

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.spec.ts
@@ -346,25 +346,6 @@ describe("schema-utils", () => {
   });
 
   describe("findFkFieldNameOnAnnotatedField", () => {
-    it("should throw error if no relation attribute is found", () => {
-      const field = {
-        type: "field",
-        name: "testField",
-        attributes: [
-          {
-            type: "attribute-type",
-            kind: "kind",
-            name: "attribute",
-            args: [],
-          },
-        ],
-      } as unknown as Field;
-
-      expect(() => {
-        findFkFieldNameOnAnnotatedField(field);
-      }).toThrow(`Missing relation attribute on field ${field.name}`);
-    });
-
     it("should throw error if no fields attribute is found on relation attribute", () => {
       const field = {
         name: "testField",

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
@@ -229,8 +229,10 @@ export function findRelationAttributeName(
     );
   }
 
-  const keyRelationAttributeName = relationAttribute.args.find(
-    (arg) => (arg.value as KeyValue)?.key === "name"
+  const keyRelationAttributeName = (
+    relationAttribute.args.find(
+      (arg) => (arg.value as KeyValue)?.key === "name"
+    )?.value as KeyValue
   )?.value as string;
 
   const valueRelationAttributeName = relationAttribute.args.find(

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
@@ -294,14 +294,18 @@ export function findRemoteRelatedModelAndField(
       );
     });
   } else {
+    // in this block the current field is a relation field that doesn't have a relation attribute with name
+    // but, because there could be more than one field in the remote model that reference the current model
+    // we still need to find the field that reference the current model and *doesn't* have a relation attribute with name
+    // it can still have a relation attribute *without* a name (for one to one relation for example) and this case is still valid,
+    // meaning it can be the remote field we are looking for
     const remoteRelatedFields = remoteModelFields.filter(
       (fieldOnRelatedModel: Field) =>
         formatModelName(fieldOnRelatedModel.fieldType as string) ===
         formatModelName(model.name)
     );
 
-    remoteRelatedFields.find((fieldOnRelatedModel: Field) => {
-      // find the field that doesn't have the relation attribute with the name we found
+    remoteField = remoteRelatedFields.find((fieldOnRelatedModel: Field) => {
       const relationAttribute = fieldOnRelatedModel.attributes?.find(
         (attr) => attr.name === RELATION_ATTRIBUTE_NAME
       );
@@ -309,7 +313,7 @@ export function findRemoteRelatedModelAndField(
         !relationAttribute ||
         (relationAttribute && !findRelationAttributeName(relationAttribute))
       ) {
-        remoteField = fieldOnRelatedModel;
+        return fieldOnRelatedModel;
       }
     });
   }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6977

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3f08891</samp>

### Summary
🗑️🐛♻️

<!--
1.  🗑️ for removing a test case
2.  🐛 for fixing a bug
3.  ♻️ for refactoring and improving code
-->
This pull request enhances the Prisma schema parser by fixing a bug in many-to-many relations, simplifying the field validation logic, adding a function to extract relation names, and updating the variable names and test cases accordingly. It affects the files `prismaSchemaParser.service.ts`, `schema-utils.ts`, and `schema-utils.spec.ts`.

> _`PrismaSchemaParser`_
> _Refines and fixes relations_
> _Autumn of bug squash_

### Walkthrough
*  Extract the relation name from a relation attribute in a field using the new function `findRelationAttributeName` ([link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R223-R242), [link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R51), [link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1031-R1045), [link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L236-R265))
* Simplify the logic of checking if a field is a lookup field based on its type, relation attribute, and reference field, and add a comment to explain it ([link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3R263-R266), [link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1058-R1059))
* Handle the case where there are multiple remote related fields that reference the current model, by finding the matching relation name and field type ([link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1102-R1155), [link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L281-R318))
* Refactor the `isNotAnnotatedRelationField` function to use more descriptive and accurate variable names, and change the condition of checking if the remote related fields exist ([link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1068-R1074), [link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1090-R1096), [link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1096-R1102))
* Use the `find` method instead of the `filter` method to find the relation field with reference, and remove the redundant error logging and throwing ([link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1122-R1171), [link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-101d4943af6514d1fdfefcb8ee7be3d2c6e0f28cb7621a0d41bc39a06d0f7bd3L1136-R1184))
* Make the relation attribute optional in the `findFkFieldNameOnAnnotatedField` function, and return undefined if it is not found ([link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697L330-R335), [link](https://github.com/amplication/amplication/pull/6978/files?diff=unified&w=0#diff-729822b2dc6d7e1d96b58a6a13873902a54700227afd424960f528b4ea4ff09fL349-L367))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
