### PR TITLE
chore(ci): fix issue in e2e workflow that was not respecting the nx force all input

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,8 +44,8 @@ jobs:
     with:
       nx-head: ${{ github.head_ref || github.ref_name }}
       nx-base: ${{ github.base_ref || inputs.nx-base || github.event.repository.default_branch }}
-      nx-skip-cache: ${{ inputs.nx-force-all || false }} # This relies on type coercion, an implicit cast from boolean true to 1 or false to 0, which is then used as array index.
-      nx-force-all: ${{ inputs.nx-skip-cache || false }}
+      nx-skip-cache: ${{ inputs.nx-skip-cache || false }} # This relies on type coercion, an implicit cast from boolean true to 1 or false to 0, which is then used as array index.
+      nx-force-all: ${{ inputs.nx-force-all || false }}
 
   e2e:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6997

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0f781d9</samp>

### Summary
🐛🚀🧪

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change. By correcting the variable name, the input value is no longer ignored and the cache behavior is as expected.
2.  🚀 - This emoji represents a performance improvement, which is one of the benefits of this change. By using the input value, the workflow can skip the cache when needed and avoid unnecessary or outdated dependencies, which can speed up the installation and execution of the tests.
3.  🧪 - This emoji represents a test-related change, which is the context of this change. The end-to-end tests workflow is part of the testing suite for the project, and this change affects how the tests are set up and run.
-->
Fixed a bug in the end-to-end tests workflow that caused the cache to be always skipped. Renamed the input variable `nx-skip-cache` in `.github/workflows/e2e.yml` to match the expected name.

> _`nx-skip-cache` fixed_
> _Input was ignored before_
> _Faster tests in spring_

### Walkthrough
* Fix input name for nx-skip-cache in end-to-end tests workflow ([link](https://github.com/amplication/amplication/pull/6998/files?diff=unified&w=0#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eL47-R48)). This allows the workflow to use the input value instead of the default value, which can improve performance and reliability. The affected file is `.github/workflows/e2e.yml`.



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
