### PR TITLE
fix(dsg): issue where production builds where tagged correctly but setting the wrong reference

### DIFF
--- a/packages/data-service-generator/scripts/package-container.sh
+++ b/packages/data-service-generator/scripts/package-container.sh
@@ -17,6 +17,7 @@ if [[ $PRODUCTION_TAGS = "true" ]]; then
     # prefix with `v` to match other container image tags
     IMAGE_TAG="v$PACKAGE_VERSION"
     export INPUT_TAGS="$IMAGE_REPO:$IMAGE_TAG,$IMAGE_REPO:sha-${GIT_SHA:0:7}"
+    export GIT_REF_NAME=${IMAGE_TAG}
 
     npx nx internal:package:container data-service-generator --prod
 else


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #7006

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bb31829</samp>

### Summary
🏷️🌐🧪

<!--
1.  🏷️ - This emoji represents the concept of tagging, which is relevant for both the `GIT_REF_NAME` and `IMAGE_TAG` variables. It also conveys the idea of labeling or naming something, which is what the branch name does for the data service subdomain.
2.  🌐 - This emoji represents the concept of the web or the internet, which is relevant for the data service subdomain and the testing of the generated service. It also conveys the idea of connectivity or networking, which is what the data service does by exposing an API.
3.  🧪 - This emoji represents the concept of testing, which is the main purpose of this change. It also conveys the idea of experimentation or exploration, which is what the data service generator allows by creating different services from different branches.
-->
Set `GIT_REF_NAME` to `IMAGE_TAG` in `package-container.sh` to enable branch-specific subdomains for data service generator.

> _`GIT_REF_NAME` set_
> _To `IMAGE_TAG` value_
> _Branch subdomains / spring_

### Walkthrough
* Set the `GIT_REF_NAME` environment variable to the image tag name ([link](https://github.com/amplication/amplication/pull/7007/files?diff=unified&w=0#diff-e37a309b8feb6cd04052ae0d5337d5692bcf87f202892b1e4f09407dbe153079R20)). This passes the branch name to the data service generator, which uses it to create a unique subdomain for each branch.



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
