### PR TITLE
feat(server):expose project description

### DIFF
--- a/ee/packages/git-sync-manager/src/models.ts
+++ b/ee/packages/git-sync-manager/src/models.ts
@@ -1513,6 +1513,7 @@ export type PluginSetOrderInput = {
 export type Project = {
   createdAt: Scalars['DateTime']['output'];
   demoRepoName?: Maybe<Scalars['String']['output']>;
+  description: Scalars['String']['output'];
   id: Scalars['String']['output'];
   name: Scalars['String']['output'];
   resources?: Maybe<Array<Resource>>;

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -1513,6 +1513,7 @@ export type PluginSetOrderInput = {
 export type Project = {
   createdAt: Scalars['DateTime']['output'];
   demoRepoName?: Maybe<Scalars['String']['output']>;
+  description: Scalars['String']['output'];
   id: Scalars['String']['output'];
   name: Scalars['String']['output'];
   resources?: Maybe<Array<Resource>>;

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -1516,6 +1516,7 @@ export type PluginSetOrderInput = {
 export type Project = {
   createdAt: Scalars['DateTime']['output'];
   demoRepoName?: Maybe<Scalars['String']['output']>;
+  description: Scalars['String']['output'];
   id: Scalars['String']['output'];
   name: Scalars['String']['output'];
   resources?: Maybe<Array<Resource>>;

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -1513,6 +1513,7 @@ export type PluginSetOrderInput = {
 export type Project = {
   createdAt: Scalars['DateTime']['output'];
   demoRepoName?: Maybe<Scalars['String']['output']>;
+  description: Scalars['String']['output'];
   id: Scalars['String']['output'];
   name: Scalars['String']['output'];
   resources?: Maybe<Array<Resource>>;

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -1513,6 +1513,7 @@ export type PluginSetOrderInput = {
 export type Project = {
   createdAt: Scalars['DateTime']['output'];
   demoRepoName?: Maybe<Scalars['String']['output']>;
+  description: Scalars['String']['output'];
   id: Scalars['String']['output'];
   name: Scalars['String']['output'];
   resources?: Maybe<Array<Resource>>;

--- a/packages/amplication-server/src/core/project/project.resolver.ts
+++ b/packages/amplication-server/src/core/project/project.resolver.ts
@@ -29,6 +29,7 @@ import {
   PendingChange,
 } from "../resource/dto";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
+import { EnumResourceType } from "../resource/dto/EnumResourceType";
 
 @Resolver(() => Project)
 @UseFilters(GqlResolverExceptionsFilter)
@@ -81,6 +82,17 @@ export class ProjectResolver {
   @Roles("ORGANIZATION_ADMIN")
   async updateProject(@Args() args: UpdateProjectArgs): Promise<Project> {
     return this.projectService.updateProject(args);
+  }
+
+  @ResolveField(() => String)
+  async description(@Parent() project: Project): Promise<string> {
+    const [configuration] = await this.resourceService.resources({
+      where: {
+        project: { id: project.id },
+        resourceType: { equals: EnumResourceType.ProjectConfiguration },
+      },
+    });
+    return configuration?.description;
   }
 
   @ResolveField(() => [Resource])

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -1105,6 +1105,7 @@ input PluginSetOrderInput {
 type Project {
   createdAt: DateTime!
   demoRepoName: String
+  description: String!
   id: String!
   name: String!
   resources: [Resource!]

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -1513,6 +1513,7 @@ export type PluginSetOrderInput = {
 export type Project = {
   createdAt: Scalars['DateTime']['output'];
   demoRepoName?: Maybe<Scalars['String']['output']>;
+  description: Scalars['String']['output'];
   id: Scalars['String']['output'];
   name: Scalars['String']['output'];
   resources?: Maybe<Array<Resource>>;


### PR DESCRIPTION


Close: #7022 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b3646d7</samp>

### Summary
🆕📝🎨

<!--
1.  🆕 - This emoji indicates that a new feature or functionality was added to the project. In this case, the new field `description` is a new feature that enhances the project type and its usage in different packages and interfaces.
2. 📝 - This emoji indicates that some documentation or comments were added or updated. In this case, the new field `description` is documented in the type definitions and the GraphQL schema, and also used to generate documentation in the pull request and the code templates.
3. 🎨 - This emoji indicates that some improvements or refinements were made to the code style or structure. In this case, the new field `description` is added in a consistent way across different packages and modules, and also uses an existing enum to query the resource type.
-->
This pull request adds a new field `description` to the `Project` type across multiple packages and files. This field allows storing and displaying the project description in various interfaces and services.

> _`description` field_
> _added to project type in_
> _many packages_

### Walkthrough
*  Add a new field `description` to the type `Project` in various packages and modules to store, display, and generate the project description for each project ([link](https://github.com/amplication/amplication/pull/7023/files?diff=unified&w=0#diff-aebcd788f7feb9ebc4bbfd2b35aeee1153419a772551daa1cedb30b6735d5442R1516), [link](https://github.com/amplication/amplication/pull/7023/files?diff=unified&w=0#diff-8e34f7703a0b39fa5e612bb39ad750167d90a6b75df578f54f35a9348dd0a509R1516), [link](https://github.com/amplication/amplication/pull/7023/files?diff=unified&w=0#diff-b9ccc53c48e521fb7c98b07ad7f4761ba0ea91eb649e157d159b065ac2487c1dR1519), [link](https://github.com/amplication/amplication/pull/7023/files?diff=unified&w=0#diff-3860f234d2c5629bf7aeb4e7439fe3b357be4e00c08a9f008b56d3610bb017c0R1516), [link](https://github.com/amplication/amplication/pull/7023/files?diff=unified&w=0#diff-6137baa91c68c17d5e3716428198a16a3cb5cdd263e22998503daa29c86a296eR1516), [link](https://github.com/amplication/amplication/pull/7023/files?diff=unified&w=0#diff-a54fca1e77b31822272d37bef66289ad466ba9d835ac76a5474a6808d4bcaaabR1516))
*  Import the `EnumResourceType` enum from the `resource` module in the `project` resolver to query the project configuration resource from the database ([link](https://github.com/amplication/amplication/pull/7023/files?diff=unified&w=0#diff-a8504de7905962c55dec9c14d3819a451e86722b779bc9d9ac8ce323ceb2d76eR32))
*  Add a new resolver field `description` to the `ProjectResolver` class in the `project.resolver.ts` file to return the project description from the project configuration resource using the `resourceService` ([link](https://github.com/amplication/amplication/pull/7023/files?diff=unified&w=0#diff-a8504de7905962c55dec9c14d3819a451e86722b779bc9d9ac8ce323ceb2d76eR87-R97))
*  Add the same field `description` to the type `Project` in the `schema.graphql` file to expose the project description in the GraphQL schema ([link](https://github.com/amplication/amplication/pull/7023/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75R1108))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
