### PR TITLE
chore(ci): fix release issue where the old git sha was used in the calculation

### DIFF
--- a/.github/workflows/release.dsg.production.yml
+++ b/.github/workflows/release.dsg.production.yml
@@ -90,6 +90,7 @@ jobs:
           cat $DSG_PACKAGE_JSON
           
       - name: Commit changes
+        id: commit-changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "chore(dsg): bump version to ${{ inputs.version }}"
@@ -103,7 +104,7 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v4
         with:
           fromTag: '${{ steps.check-tag.outputs.previous-tag }}'
-          toTag: '${{ github.sha }}'
+          toTag: '${{ steps.commit-changes.outputs.commit_hash }}'
           configurationJson: |
             {
               "ignore_labels": [
@@ -147,7 +148,7 @@ jobs:
           INPUT_PUSH: true
           # env variables substituted in the project.json docker target build-args
           GIT_REF_NAME: ${{ inputs.version }}
-          GIT_SHA: ${{ github.sha }}
+          GIT_SHA: ${{ steps.commit-changes.outputs.commit_hash }}
 
       - name: Create data-service-generator git tag
         run: |

--- a/.github/workflows/release.production.yml
+++ b/.github/workflows/release.production.yml
@@ -119,6 +119,7 @@ jobs:
 
       # Commit all changed files back to the repository
       - name: Commit changes
+        id: commit-changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "chore: update apps version.ts"
@@ -132,7 +133,7 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v4
         with:
           fromTag: "${{ steps.check-tag.outputs.previous-tag }}"
-          toTag: "${{ github.sha }}"
+          toTag: ${{ steps.commit-changes.outputs.commit_hash }}
           configurationJson: |
             {
               "template": "#{{CHANGELOG}}\n\n**Full Changelog**: [#{{FROM_TAG}}...${{ github.event.inputs.version }}](https://github.com/amplication/amplication/compare/#{{FROM_TAG}}...${{ github.event.inputs.version }})",


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #6908

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3e3477b</samp>

### Summary
🐛📝🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is appropriate for the first change that fixes the data-service-generator release workflow.
2.  📝 - This emoji represents documentation, which is appropriate for the second change that improves the amplication release notes.
3.  🚀 - This emoji represents a deployment or performance improvement, which is appropriate for the second change that also builds docker images.
-->
This pull request fixes and improves the release workflows for `data-service-generator` and `amplication` by using the correct commit hashes for generating release notes and building docker images. It also adds ids to the commit steps for better readability.

> _`commit` id added_
> _better release notes and builds_
> _autumn leaves falling_

### Walkthrough
*  Add ids to commit steps to access commit hashes in data-service-generator and amplication workflows ([link](https://github.com/amplication/amplication/pull/7024/files?diff=unified&w=0#diff-51fcfb90d295dbd552e9d5728a5b1d1229730d83289a9505cd3b64379f4bf319R93), [link](https://github.com/amplication/amplication/pull/7024/files?diff=unified&w=0#diff-01085e43c580feab2b4853d3f444ec18378cb427dbf2590633938157ad97c773R122))
*  Use commit hashes instead of github.sha to generate release notes and docker build arguments in data-service-generator workflow ([link](https://github.com/amplication/amplication/pull/7024/files?diff=unified&w=0#diff-51fcfb90d295dbd552e9d5728a5b1d1229730d83289a9505cd3b64379f4bf319L106-R107), [link](https://github.com/amplication/amplication/pull/7024/files?diff=unified&w=0#diff-51fcfb90d295dbd552e9d5728a5b1d1229730d83289a9505cd3b64379f4bf319L150-R151))
*  Use commit hash instead of github.sha to generate release notes in amplication workflow ([link](https://github.com/amplication/amplication/pull/7024/files?diff=unified&w=0#diff-01085e43c580feab2b4853d3f444ec18378cb427dbf2590633938157ad97c773L135-R136))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
