### PR TITLE
chore(ci): improve nx template performances by 10x

### DIFF
--- a/.github/workflows/nx.template.yml
+++ b/.github/workflows/nx.template.yml
@@ -60,10 +60,11 @@ jobs:
       affected-deploy-static: ${{ steps.configure-nx.outputs.affected-deploy-static }}
       affected-deploy-container: ${{ steps.configure-nx.outputs.affected-deploy-container }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ inputs.nx-head }}
+          filter: blob:none
 
       - uses: nrwl/nx-set-shas@v3
         if: inputs.nx-force-all == false
@@ -76,18 +77,22 @@ jobs:
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
 
-      - name: Cache global node modules
-        id: cache-node-modules
+      - name: Setup Bun Runtime
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        uses: oven-sh/setup-bun@v1
+
+      - name: Cache
+        id: cache
         uses: actions/cache@v3
         env:
-          cache-name: cache-node-modules
+          cache-name: cache
         with:
-          path: node_modules
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('package-lock.json') }}
+          path: |
+            ~/.bun/install/cache
 
-      - name: Install dependencies
-        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-        run: npm ci
+      - name: Install Dependencies
+        run: bun i --lockfile package-lock.json
 
       - name: Evaluate affected projects
         id: configure-nx

--- a/.github/workflows/nx.template.yml
+++ b/.github/workflows/nx.template.yml
@@ -71,12 +71,6 @@ jobs:
         with:
           main-branch-name: ${{ inputs.nx-base }}
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: "package.json"
-          cache: "npm"
-          cache-dependency-path: "**/package-lock.json"
-
       - name: Setup Bun Runtime
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         uses: oven-sh/setup-bun@v1
@@ -97,10 +91,10 @@ jobs:
       - name: Evaluate affected projects
         id: configure-nx
         run: |
-          echo affected-apps=$(npx nx print-affected --type=app $NX_FORCE_ALL | jq -c .projects) >> $GITHUB_OUTPUT
-          echo affected-lib=$(npx nx print-affected --type=lib $NX_FORCE_ALL | jq -c .projects) >> $GITHUB_OUTPUT
-          echo affected-e2e=$(npx nx print-affected --target=e2e $NX_FORCE_ALL | jq -c .projects) >> $GITHUB_OUTPUT
-          echo affected-package-container=$(npx nx print-affected --target=package:container --type=app $NX_FORCE_ALL | jq -c .projects) >> $GITHUB_OUTPUT
-          echo affected-deploy-static=$(npx nx print-affected --target=deploy:static --type=app $NX_FORCE_ALL  | jq -c .projects) >> $GITHUB_OUTPUT
-          echo affected-deploy-container=$(npx nx print-affected --target=deploy:container --type=app $NX_FORCE_ALL  | jq -c .projects) >> $GITHUB_OUTPUT
+          echo affected-apps=$(bunx nx print-affected --type=app $NX_FORCE_ALL | jq -c .projects) >> $GITHUB_OUTPUT
+          echo affected-lib=$(bunx nx print-affected --type=lib $NX_FORCE_ALL | jq -c .projects) >> $GITHUB_OUTPUT
+          echo affected-e2e=$(bunx nx print-affected --target=e2e $NX_FORCE_ALL | jq -c .projects) >> $GITHUB_OUTPUT
+          echo affected-package-container=$(bunx nx print-affected --target=package:container --type=app $NX_FORCE_ALL | jq -c .projects) >> $GITHUB_OUTPUT
+          echo affected-deploy-static=$(bunx nx print-affected --target=deploy:static --type=app $NX_FORCE_ALL  | jq -c .projects) >> $GITHUB_OUTPUT
+          echo affected-deploy-container=$(bunx nx print-affected --target=deploy:container --type=app $NX_FORCE_ALL  | jq -c .projects) >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT | grep affected


### PR DESCRIPTION
Closes: #7105

## PR Details

This PR improves nx.template performance by leveraging `bun install` instead of `npm install`. 
The nx.template is used by most of amplication monorepo github workflow

### Before this PR:
#### **WITHOUT CACHE AVAILABLE**
<img width="1415" alt="image" src="https://github.com/amplication/amplication/assets/2861984/900d3b65-709a-42df-9de9-c7bc3ab8624d">

#### **WITH CACHE AVAILABLE**
<img width="1413" alt="image" src="https://github.com/amplication/amplication/assets/2861984/5cada57c-8e11-43ec-a05d-b28ed4e1a9ff">

### After this PR:
#### **WITHOUT CACHE AVAILABLE**
<img width="1415" alt="image" src="https://github.com/amplication/amplication/assets/2861984/3b672d3c-780a-4cc1-9866-5e7b3d9fabcd">

#### **WITH CACHE AVAILABLE**
<img width="1408" alt="image" src="https://github.com/amplication/amplication/assets/2861984/7dd410e1-4897-4d34-9ac0-b9add24191af">

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0f39fff</samp>

### Summary
🆙🚀🔄

<!--
1.  🆙 - This emoji can be used to indicate that something was updated or upgraded, such as the `actions/checkout` action in this case.
2.  🚀 - This emoji can be used to indicate that something was improved in terms of speed or performance, such as the `bun` tool in this case.
3.  🔄 - This emoji can be used to indicate that something was changed or replaced, such as the `npm` tool in this case.
-->
Update GitHub workflow to improve performance and reliability. Use `actions/checkout@v2` and `bun` instead of `npm` in `.github/workflows/nx.template.yml`.

> _We're breaking free from the old ways_
> _We're using `bun` to speed up our days_
> _We're checking out the latest action_
> _We're the masters of our own creation_

### Walkthrough
* Update the `actions/checkout` action to version 4 and filter out large files from the repository ([link](https://github.com/amplication/amplication/pull/7042/files?diff=unified&w=0#diff-a2765f0b0f4f04930dda074571e9f5477116139d7b151bd33d9029fc65812559L63-R66))
* Use the `bun` tool and the `oven-sh/setup-bun` action to manage node modules and improve dependency installation and caching ([link](https://github.com/amplication/amplication/pull/7042/files?diff=unified&w=0#diff-a2765f0b0f4f04930dda074571e9f5477116139d7b151bd33d9029fc65812559L78-R94))
* Replace the `npm ci` command with the `bun i` command in the `install dependencies` step ([link](https://github.com/amplication/amplication/pull/7042/files?diff=unified&w=0#diff-a2765f0b0f4f04930dda074571e9f5477116139d7b151bd33d9029fc65812559L78-R94))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
