### PR TITLE
Fixed period typo in the service wizard for MySQL, Issue #7405

### DIFF
--- a/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceDatabase.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceDatabase.tsx
@@ -65,7 +65,7 @@ const CreateServiceDatabase: React.FC<Props> = ({
             image={MysqlPng}
             imageSize="large"
             label="MySQL"
-            description="Use MySQL database in Amplication service.."
+            description="Use MySQL database in Amplication service."
             onClick={handleDatabaseSelect}
             currentValue={formik.values.databaseType}
           />


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #[issue-number]

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f7d101c</samp>

### Summary
🖋️🗑️🧹

<!--
1.  🖋️ - This emoji represents a pen or writing, and can be used to indicate that the change involved editing some text.
2.  🗑️ - This emoji represents a trash can or deleting, and can be used to indicate that the change involved removing something unnecessary or unwanted.
3.  🧹 - This emoji represents a broom or cleaning, and can be used to indicate that the change involved improving the quality or appearance of something.
-->
This pull request fixes a minor typo in the create service wizard UI. It removes an extra dot from the description of the `MySQL` option in the file `CreateServiceDatabase.tsx`.

> _`MySQL` option_
> _Edited for clarity_
> _A dot falls in autumn_

### Walkthrough
* Remove extra dot from MySQL option description ([link](https://github.com/amplication/amplication/pull/7078/files?diff=unified&w=0#diff-da2c23b22bced2188db3fb12ce981b6931828e6660f7b45f0889198dc4ef296cL68-R68))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
