### PR TITLE
Changed version number on workspace header to link to github releases

### DIFF
--- a/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
@@ -194,24 +194,25 @@ const WorkspaceHeader: React.FC<{}> = () => {
             />
           </div>
           <Tooltip
-            aria-label="Version number copied successfully"
-            direction="e"
-            noDelay
-            show={versionAlert}
+              aria-label="Click to view releases on GitHub"
+              direction="e"
+              noDelay
+              show={versionAlert}
           >
-            <Button
-              className={`${CLASS_NAME}__version`}
-              buttonStyle={EnumButtonStyle.Clear}
-              onClick={async () => {
-                setVersionAlert(true);
-                await navigator.clipboard.writeText(version);
-              }}
-              onMouseLeave={() => {
-                setVersionAlert(false);
-              }}
-            >
-              <span>v{version}</span>
-            </Button>
+              <a
+                href="https://github.com/amplication/amplication/releases"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`${CLASS_NAME}__version`}
+                onMouseEnter={() => {
+                  setVersionAlert(true);
+                }}
+                onMouseLeave={() => {
+                  setVersionAlert(false);
+                }}
+              >
+                <span>v{version}</span>
+              </a>
           </Tooltip>
         </div>
         <div className={`${CLASS_NAME}__center`}>


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #[issue-number]

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2a6fcb3</samp>

### Summary
:link::octocat::memo:

<!--
1.  :link: - This emoji represents the change from a button to a link that opens an external URL.
2.  :octocat: - This emoji represents the GitHub platform where the releases page is hosted and where users can find more information about Amplication.
3.  :memo: - This emoji represents the release notes and changelog that users can access from the releases page.
-->
Changed the version button in the workspace header to a link to the releases page on GitHub. This provides more information about Amplication versions and release notes.

> _`Version` button changed_
> _Opens GitHub releases page_
> _Winter of updates_

### Walkthrough
* Change the version button to a link that opens the releases page on GitHub in a new tab ([link](https://github.com/amplication/amplication/pull/7081/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L197-R215))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
