### PR TITLE
style(client):pending changes bar

### DIFF
--- a/libs/ui/design-system/src/lib/components/TextInput/TextInput.scss
+++ b/libs/ui/design-system/src/lib/components/TextInput/TextInput.scss
@@ -30,6 +30,10 @@
     &:disabled {
       @include textField--disabled;
     }
+
+    &::placeholder {
+      color: var(--gray-40);
+    }
   }
 
   textarea {

--- a/packages/amplication-client/src/Components/ClickableId.tsx
+++ b/packages/amplication-client/src/Components/ClickableId.tsx
@@ -1,4 +1,8 @@
-import { EnumTextStyle, Text } from "@amplication/ui/design-system";
+import {
+  EnumTextColor,
+  EnumTextStyle,
+  Text,
+} from "@amplication/ui/design-system";
 import classNames from "classnames";
 import { useCallback } from "react";
 import { Link, LinkProps } from "react-router-dom";
@@ -40,7 +44,7 @@ export const ClickableId = ({
       {label && <Text textStyle={EnumTextStyle.Tag}>{label} </Text>}
 
       <Link {...rest} to={to} onClick={handleClick}>
-        <Text textStyle={EnumTextStyle.Tag}>
+        <Text textStyle={EnumTextStyle.Tag} textColor={EnumTextColor.White}>
           <TruncatedId id={id} />
         </Text>
       </Link>

--- a/packages/amplication-client/src/VersionControl/LastCommit.tsx
+++ b/packages/amplication-client/src/VersionControl/LastCommit.tsx
@@ -1,6 +1,16 @@
 import { useContext } from "react";
 import classNames from "classnames";
-import { Button, EnumButtonStyle } from "@amplication/ui/design-system";
+import {
+  Button,
+  EnumButtonStyle,
+  EnumFlexDirection,
+  EnumFlexItemMargin,
+  EnumGapSize,
+  EnumItemsAlign,
+  EnumTextStyle,
+  FlexItem,
+  Text,
+} from "@amplication/ui/design-system";
 import { ClickableId } from "../Components/ClickableId";
 import "./LastCommit.scss";
 import { AppContext } from "../context/appContext";
@@ -43,17 +53,24 @@ const LastCommit = ({ lastCommit }: Props) => {
     >
       <hr className={`${CLASS_NAME}__divider`} />
       <div className={`${CLASS_NAME}__content`}>
-        <p className={`${CLASS_NAME}__title`}>
-          Last Commit
-          <CommitBuildsStatusIcon commitBuildStatus={commitStatus} />
-        </p>
+        <FlexItem
+          itemsAlign={EnumItemsAlign.Center}
+          end={<CommitBuildsStatusIcon commitBuildStatus={commitStatus} />}
+        >
+          <Text textStyle={EnumTextStyle.H4}>Last Commit</Text>
+        </FlexItem>
 
-        <div className={`${CLASS_NAME}__status`}>
-          <div>{ClickableCommitId}</div>
-          <span className={classNames("clickable-id")}>
+        <FlexItem
+          direction={EnumFlexDirection.Column}
+          margin={EnumFlexItemMargin.Both}
+          gap={EnumGapSize.Small}
+        >
+          {ClickableCommitId}
+          <Text textStyle={EnumTextStyle.Tag}>
             {formatTimeToNow(lastCommit?.createdAt)}
-          </span>
-        </div>
+          </Text>
+        </FlexItem>
+
         {lastCommit && (
           <Link
             to={`/${currentWorkspace?.id}/${currentProject?.id}/code-view`}

--- a/packages/amplication-client/src/VersionControl/PendingChangeContent.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChangeContent.tsx
@@ -2,6 +2,11 @@ import * as models from "../models";
 import React, { useContext } from "react";
 import { Link } from "react-router-dom";
 import { AppContext } from "../context/appContext";
+import {
+  EnumTextColor,
+  EnumTextStyle,
+  Text,
+} from "@amplication/ui/design-system";
 
 type Props = {
   change: models.PendingChange;
@@ -20,6 +25,16 @@ const PendingChangeContent = ({
 
   const url = `/${currentWorkspace?.id}/${currentProject?.id}/${change.resource.id}/${relativeUrl}`;
 
-  return linkToOrigin ? <Link to={url}>{name}</Link> : <span>{name}</span>;
+  const nameElement = (
+    <Text textStyle={EnumTextStyle.Tag} textColor={EnumTextColor.White}>
+      {name}
+    </Text>
+  );
+
+  return linkToOrigin ? (
+    <Link to={url}>{nameElement}</Link>
+  ) : (
+    <span>{nameElement}</span>
+  );
 };
 export default PendingChangeContent;

--- a/packages/amplication-client/src/VersionControl/PendingChanges.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChanges.tsx
@@ -6,7 +6,15 @@ import PendingChange from "./PendingChange";
 import { Button, EnumButtonStyle } from "../Components/Button";
 import {
   CircularProgress,
+  EnumContentAlign,
+  EnumFlexDirection,
+  EnumFlexItemMargin,
+  EnumGapSize,
+  EnumItemsAlign,
+  EnumTextStyle,
+  FlexItem,
   Snackbar,
+  Text,
   Tooltip,
 } from "@amplication/ui/design-system";
 import Commit from "./Commit";
@@ -61,82 +69,90 @@ const PendingChanges = ({ projectId }: Props) => {
 
   return (
     <div className={CLASS_NAME}>
-      <h5 className={`${CLASS_NAME}__title`}>Pending changes</h5>
-      <Commit projectId={projectId} noChanges={noChanges} />
+      <Text textStyle={EnumTextStyle.H4}>Pending changes</Text>
+      <FlexItem
+        itemsAlign={EnumItemsAlign.Stretch}
+        direction={EnumFlexDirection.Column}
+        margin={EnumFlexItemMargin.Top}
+        gap={EnumGapSize.Small}
+      >
+        <Commit projectId={projectId} noChanges={noChanges} />
 
-      <DiscardChanges
-        isOpen={discardDialogOpen}
-        projectId={projectId}
-        onComplete={handleDiscardDialogCompleted}
-        onDismiss={handleToggleDiscardDialog}
-      />
+        <DiscardChanges
+          isOpen={discardDialogOpen}
+          projectId={projectId}
+          onComplete={handleDiscardDialogCompleted}
+          onDismiss={handleToggleDiscardDialog}
+        />
 
-      <div className={`${CLASS_NAME}__changes-wrapper`}>
-        {pendingChangesDataLoading ? (
-          <CircularProgress centerToParent />
-        ) : isEmpty(pendingChanges) && !pendingChangesDataLoading ? (
-          <div className={`${CLASS_NAME}__empty-state`}>
-            <SvgThemeImage image={EnumImages.NoChanges} />
-            <div className={`${CLASS_NAME}__empty-state__title`}>
-              No pending changes! keep working.
-            </div>
-          </div>
-        ) : (
-          <div className={`${CLASS_NAME}__changes`}>
-            {pendingChangesByResource.map((group) => (
-              <div key={group.resource.id}>
-                <div className={`${CLASS_NAME}__changes__resource`}>
-                  <ResourceCircleBadge
-                    type={group.resource.resourceType}
-                    size="xsmall"
-                  />
-                  <span>{group.resource.name}</span>
-                </div>
-                {group.changes.map((change) => (
-                  <PendingChange
-                    key={change.originId}
-                    change={change}
-                    linkToOrigin
-                  />
-                ))}
+        <div className={`${CLASS_NAME}__changes-wrapper`}>
+          {pendingChangesDataLoading ? (
+            <CircularProgress centerToParent />
+          ) : isEmpty(pendingChanges) && !pendingChangesDataLoading ? (
+            <div className={`${CLASS_NAME}__empty-state`}>
+              <SvgThemeImage image={EnumImages.NoChanges} />
+              <div className={`${CLASS_NAME}__empty-state__title`}>
+                No pending changes! keep working.
               </div>
-            ))}
-          </div>
-        )}
-        <hr className={`${CLASS_NAME}__divider`} />
-        <div className={`${CLASS_NAME}__changes-header`}>
-          <span>Changes</span>
-          <span
-            className={
-              pendingChanges.length
-                ? `${CLASS_NAME}__changes-count-warning`
-                : `${CLASS_NAME}__changes-count`
-            }
-          >
-            {pendingChanges.length}
-          </span>
-          <div className="spacer" />
-          <Tooltip aria-label={"Compare Changes"} direction="nw">
-            <Link
-              to={`/${currentWorkspace?.id}/${currentProject?.id}/pending-changes`}
+            </div>
+          ) : (
+            <div className={`${CLASS_NAME}__changes`}>
+              {pendingChangesByResource.map((group) => (
+                <div key={group.resource.id}>
+                  <div className={`${CLASS_NAME}__changes__resource`}>
+                    <ResourceCircleBadge
+                      type={group.resource.resourceType}
+                      size="xsmall"
+                    />
+                    <span>{group.resource.name}</span>
+                  </div>
+                  {group.changes.map((change) => (
+                    <PendingChange
+                      key={change.originId}
+                      change={change}
+                      linkToOrigin
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
+          )}
+          <hr className={`${CLASS_NAME}__divider`} />
+          <div className={`${CLASS_NAME}__changes-header`}>
+            <span>Changes</span>
+            <span
+              className={
+                pendingChanges.length
+                  ? `${CLASS_NAME}__changes-count-warning`
+                  : `${CLASS_NAME}__changes-count`
+              }
             >
+              {pendingChanges.length}
+            </span>
+            <div className="spacer" />
+            <Tooltip aria-label={"Compare Changes"} direction="nw">
+              <Link
+                to={`/${currentWorkspace?.id}/${currentProject?.id}/pending-changes`}
+              >
+                <Button
+                  buttonStyle={EnumButtonStyle.Text}
+                  disabled={pendingChangesDataLoading || noChanges}
+                  icon="compare"
+                />
+              </Link>
+            </Tooltip>
+            <Tooltip aria-label={"Discard Pending Changes"} direction="nw">
               <Button
                 buttonStyle={EnumButtonStyle.Text}
+                onClick={handleToggleDiscardDialog}
                 disabled={pendingChangesDataLoading || noChanges}
-                icon="compare"
+                icon="trash_2"
               />
-            </Link>
-          </Tooltip>
-          <Tooltip aria-label={"Discard Pending Changes"} direction="nw">
-            <Button
-              buttonStyle={EnumButtonStyle.Text}
-              onClick={handleToggleDiscardDialog}
-              disabled={pendingChangesDataLoading || noChanges}
-              icon="trash_2"
-            />
-          </Tooltip>
+            </Tooltip>
+          </div>
         </div>
-      </div>
+      </FlexItem>
+
       <Snackbar open={Boolean(pendingChangesIsError)} message={errorMessage} />
     </div>
   );

--- a/packages/amplication-client/src/Workspaces/WorkspaceFooter.scss
+++ b/packages/amplication-client/src/Workspaces/WorkspaceFooter.scss
@@ -31,20 +31,6 @@
     align-items: center;
   }
 
-  &__right {
-    .truncated-id {
-      @include regular-12;
-      color: var(--gray-base);
-    }
-
-    .clickable-id {
-      color: var(--gray-20);
-      a {
-        color: var(--gray-base);
-      }
-    }
-  }
-
   &__git-connection {
     color: var(--gray-20);
     display: flex;


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #7097

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ed3901d</samp>

### Summary
🎨🔥🌈

<!--
1.  🎨 - This emoji is often used for changes related to UI design, styling, or appearance. It could be used for the first, fourth, fifth, and sixth changes in the list, as they all involve modifying the visual aspects of the components using the design-system library.
2.  🔥 - This emoji is often used for changes related to removing code or files that are no longer needed or used. It could be used for the second change in the list, as it removes the unused CSS classes from the WorkspaceFooter component.
3.  🌈 - This emoji is often used for changes related to improving accessibility, usability, or user experience. It could be used for the third change in the list, as it changes the text color of the ClickableId component to white, which improves the contrast and visibility of the component.
-->
This pull request updates several components in the amplication-client package to use the design-system library for styling and layout. It also adds a placeholder style for the TextInput component in the design-system library and removes some unused CSS classes.

> _We're heaving on the ropes, me hearties, one, two, three_
> _We're making our components look so fine and dandy_
> _We're using the `design-system` library, oh, aye, oh_
> _We're styling with the enums and the props, you know_

### Walkthrough
*  Add placeholder style for TextInput component in design-system library ([link](https://github.com/amplication/amplication/pull/7098/files?diff=unified&w=0#diff-d93bfa95eaeded53c44dd95c0f6a6b21e12c3de8b2c8d36e1f1cfd111d5ad994R33-R36))
*  Use design-system components and props to replace HTML elements and classes in LastCommit, PendingChangeContent, and PendingChanges components ([link](https://github.com/amplication/amplication/pull/7098/files?diff=unified&w=0#diff-047889aa3c50ee4f2d0bdf5b0c5182948a3e492c318728867393bd36a1d52d53L46-R73), [link](https://github.com/amplication/amplication/pull/7098/files?diff=unified&w=0#diff-3ea8414e3b80b4a760abb54edb197610380105f60a497fc0844a9aef80cb82d7L23-R38), [link](https://github.com/amplication/amplication/pull/7098/files?diff=unified&w=0#diff-4e7567cc25712fceb44e62bb78b2835cc2f13078e7e8babdc7214b6ae0ea69e6L64-R155))
*  Import enums for text color, text style, flex layout, and gap size from design-system library in ClickableId, LastCommit, PendingChangeContent, and PendingChanges components ([link](https://github.com/amplication/amplication/pull/7098/files?diff=unified&w=0#diff-a89da1a0a9d2d6cf24eee429715163bfdd253fbdd4ab0f67b1065bb2ac36c4e5L1-R5), [link](https://github.com/amplication/amplication/pull/7098/files?diff=unified&w=0#diff-047889aa3c50ee4f2d0bdf5b0c5182948a3e492c318728867393bd36a1d52d53L3-R13), [link](https://github.com/amplication/amplication/pull/7098/files?diff=unified&w=0#diff-3ea8414e3b80b4a760abb54edb197610380105f60a497fc0844a9aef80cb82d7R5-R9), [link](https://github.com/amplication/amplication/pull/7098/files?diff=unified&w=0#diff-4e7567cc25712fceb44e62bb78b2835cc2f13078e7e8babdc7214b6ae0ea69e6L9-R17))
*  Apply white text color to ClickableId and PendingChangeContent components using EnumTextColor.White ([link](https://github.com/amplication/amplication/pull/7098/files?diff=unified&w=0#diff-a89da1a0a9d2d6cf24eee429715163bfdd253fbdd4ab0f67b1065bb2ac36c4e5L43-R47), [link](https://github.com/amplication/amplication/pull/7098/files?diff=unified&w=0#diff-3ea8414e3b80b4a760abb54edb197610380105f60a497fc0844a9aef80cb82d7L23-R38))
*  Render commit status icon using CommitBuildsStatusIcon component from design-system library in LastCommit component ([link](https://github.com/amplication/amplication/pull/7098/files?diff=unified&w=0#diff-047889aa3c50ee4f2d0bdf5b0c5182948a3e492c318728867393bd36a1d52d53L46-R73))
*  Remove unused CSS classes for truncated-id and clickable-id elements in `WorkspaceFooter.scss` ([link](https://github.com/amplication/amplication/pull/7098/files?diff=unified&w=0#diff-90c08b2f5d2c905474fb60f8a1855a15cbe14d25e8e106cc421dc3e94cdc7119L34-L47))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
