### PR TITLE
feat(client): select repo automatically pops up after user connect to git

### DIFF
--- a/packages/amplication-client/src/Resource/git/AuthWithGitProvider.tsx
+++ b/packages/amplication-client/src/Resource/git/AuthWithGitProvider.tsx
@@ -117,6 +117,7 @@ const AuthWithGitProvider: React.FC<AuthWithGitProviderProps> = ({
             onDone={onDone}
             setPopupFailed={setPopupFailed}
             onProviderSelect={closeSelectOrganizationDialog}
+            onSelectRepository={openSelectRepoDialog}
           />
         </Dialog>
       )}

--- a/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnectionList.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnectionList.tsx
@@ -25,6 +25,7 @@ export type Props = {
   onDone: () => void;
   setPopupFailed: (status: boolean) => void;
   onProviderSelect?: (data: any) => any;
+  onSelectRepository?: () => void;
 };
 
 const CLASS_NAME = "git-provider-connection-list";
@@ -33,6 +34,7 @@ export const GitProviderConnectionList: React.FC<Props> = ({
   onDone,
   setPopupFailed,
   onProviderSelect,
+  onSelectRepository,
 }) => {
   const { trackEvent } = useTracking();
   const { stigg } = useStiggContext();
@@ -73,7 +75,11 @@ export const GitProviderConnectionList: React.FC<Props> = ({
         variables: {
           gitProvider: provider,
         },
-      }).catch(console.error);
+      })
+        .then(() => {
+          onSelectRepository();
+        })
+        .catch(console.error);
       onProviderSelect && onProviderSelect(provider);
     },
     [authWithGit, trackEvent, onProviderSelect]


### PR DESCRIPTION
Close: #7072

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

Now in the client, after a user connects to his/her git provider, the select repo page will automatically pops up for him/her to select the repo, so he/she doesn't have to manually click twice. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.


