### PR TITLE
fix(client): Text design on select org git dropdwn

### DIFF
--- a/packages/amplication-client/src/Resource/git/GitActions/ExistingConnectionsMenu.scss
+++ b/packages/amplication-client/src/Resource/git/GitActions/ExistingConnectionsMenu.scss
@@ -33,6 +33,7 @@
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
+        color: var(--menu-item-active-color)
       }
     }
 
@@ -79,7 +80,7 @@
     background-color: var(--gray-80);
     height: 34px;
     display: flex;
-    color: var(--gray-20);
+    color: var(--menu-item-active-color);
 
     align-items: center;
     & i {


### PR DESCRIPTION
Close: #6011 

## PR Details

This PR change font color in white for dropdown which select git organization

copilot:all

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

