### PR TITLE
feat(client): select repo automatically pops up after user connect to…

### DIFF
--- a/packages/amplication-client/src/Resource/git/AuthWithGitProvider.tsx
+++ b/packages/amplication-client/src/Resource/git/AuthWithGitProvider.tsx
@@ -121,6 +121,7 @@ const AuthWithGitProvider: React.FC<AuthWithGitProviderProps> = ({
             onDone={onDone}
             setPopupFailed={setPopupFailed}
             onProviderSelect={closeSelectOrganizationDialog}
+            onSelectRepository={openSelectRepoDialog}
           />
         </Dialog>
       )}
@@ -128,6 +129,7 @@ const AuthWithGitProvider: React.FC<AuthWithGitProviderProps> = ({
         <GitProviderConnectionList
           onDone={onDone}
           setPopupFailed={setPopupFailed}
+          onSelectRepository={openSelectRepoDialog}
         />
       ) : (
         <>

--- a/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnectionList.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnectionList.tsx
@@ -4,7 +4,6 @@ import {
   EnumGitProvider,
 } from "../../../models";
 import { useTracking } from "../../../util/analytics";
-
 import "./GitProviderConnectionList.scss";
 import { useCallback } from "react";
 import { AnalyticsEventNames } from "../../../util/analytics-events.types";
@@ -25,6 +24,7 @@ export type Props = {
   onDone: () => void;
   setPopupFailed: (status: boolean) => void;
   onProviderSelect?: (data: any) => any;
+  onSelectRepository?: () => void;
 };
 
 const CLASS_NAME = "git-provider-connection-list";
@@ -33,6 +33,7 @@ export const GitProviderConnectionList: React.FC<Props> = ({
   onDone,
   setPopupFailed,
   onProviderSelect,
+  onSelectRepository,
 }) => {
   const { trackEvent } = useTracking();
   const { stigg } = useStiggContext();
@@ -67,7 +68,11 @@ export const GitProviderConnectionList: React.FC<Props> = ({
         variables: {
           gitProvider: provider,
         },
-      }).catch(console.error);
+      })
+        .then(() => {
+          onSelectRepository();
+        })
+        .catch(console.error);
       onProviderSelect && onProviderSelect(provider);
     },
     [authWithGit, trackEvent, onProviderSelect]


### PR DESCRIPTION


<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #7072

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

Now in the client, after a user connects to his/her git provider, the select repo page will automatically pops up for him/her to select the repo, so he/she doesn't have to manually click twice.


## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
