### PR TITLE
feat(server): Allow renaming of 'User' entity

### DIFF
--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -925,14 +925,6 @@ export class EntityService {
         throw new ReservedNameError(args.data?.name?.toLowerCase().trim());
       }
 
-      if (entity.name === USER_ENTITY_NAME) {
-        if (args.data.name && args.data.name !== USER_ENTITY_NAME) {
-          throw new ConflictException(
-            `The 'user' entity is a reserved entity and its name cannot be updated`
-          );
-        }
-      }
-
       const resourceWithProject = await this.prisma.resource.findUnique({
         where: {
           id: entity.resourceId,


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #7113 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->
This PR addresses the GitHub issue that allows users to rename the 'User' entity without restrictions while ensuring compatibility with existing authentication mechanisms and integrations. The code changes include modifications to the EntityService class. The following changes were made:
- Removed the code block for preventing to rename the 'User' entity





## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
