### PR TITLE
fix(client): GitHub icon used when not connected to a git provider instead of the generic Git icon.

### DIFF
--- a/packages/amplication-client/src/Resource/git/git-provider-icon-map.ts
+++ b/packages/amplication-client/src/Resource/git/git-provider-icon-map.ts
@@ -1,6 +1,6 @@
 import { EnumGitProvider } from "../../models";
 import BitbucketLogo from "../../assets/images/bitbucket.svg";
-import GithubLogo from "../../assets/images/github.svg";
+import GenericGithubIcon from "../../assets/images/272531990-8b84b9aa-6a62-4168-80a9-9a8982033da7.png";
 import AwsCodeCommit from "../../assets/images/awscodecommit.svg";
 
 export const gitProviderIconMap = {
@@ -11,6 +11,6 @@ export const gitProviderIconMap = {
 
 export const gitLogoMap = {
   [EnumGitProvider.Bitbucket]: BitbucketLogo,
-  [EnumGitProvider.Github]: GithubLogo,
+  [EnumGitProvider.Github]: GenericGithubIcon,
   [EnumGitProvider.AwsCodeCommit]: AwsCodeCommit,
 };


### PR DESCRIPTION
issue-:#7151


