### PR TITLE
fix(server): id properties

### DIFF
--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -152,10 +152,9 @@ const RELATED_FIELD_ID_UNDEFINED_AND_NAMES_UNDEFINED_ERROR_MESSAGE =
 const RELATED_FIELD_NAMES_SHOULD_BE_UNDEFINED_ERROR_MESSAGE =
   "When data.dataType is not Lookup, relatedFieldName and relatedFieldDisplayName must be null";
 
-const UPDATED_AT = "updatedAt";
-const CREATED_AT = "createdAt";
-const PROPERTIES = "properties";
-const CUSTOM_ATTRIBUTES = "customAttributes";
+const NAME = "name";
+const DATA_TYPE = "dataType";
+const SEARCHABLE = "searchable";
 
 const BASE_FIELD: Pick<
   EntityField,
@@ -2771,25 +2770,21 @@ function isUserEntity(entity: Entity): boolean {
 function isBasePropertyIdFieldPayloadChanged(
   data: EntityFieldUpdateInput
 ): boolean {
+  const PROPERTIES_TO_VALIDATE = [NAME, DATA_TYPE, SEARCHABLE];
+
   const idTypeData = {
     ...INITIAL_ID_TYPE_FIELDS,
     createdAt: undefined,
     updatedAt: undefined,
   };
-  const idTypeDataWithoutProperties = omit(idTypeData, [
-    PROPERTIES,
-    CREATED_AT,
-    UPDATED_AT,
-    CUSTOM_ATTRIBUTES,
-  ]);
-  const dataWithoutProperties = omit(data, [
-    PROPERTIES,
-    CREATED_AT,
-    UPDATED_AT,
-    CUSTOM_ATTRIBUTES,
-  ]);
 
-  return !isEqual(dataWithoutProperties, idTypeDataWithoutProperties);
+  const idTypeDataWithSelectedProperties = pick(
+    idTypeData,
+    PROPERTIES_TO_VALIDATE
+  );
+  const dataWithSelectedProperties = pick(data, PROPERTIES_TO_VALIDATE);
+
+  return !isEqual(dataWithSelectedProperties, idTypeDataWithSelectedProperties);
 }
 
 export function createEntityNamesWhereInput(

--- a/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/prismaSchemaParser.service.spec.ts
@@ -123,10 +123,10 @@ describe("prismaSchemaParser", () => {
               {
                 permanentId: expect.any(String),
                 name: "id",
-                displayName: "Id",
+                displayName: "ID",
                 dataType: EnumDataType.Id,
                 required: true,
-                unique: false,
+                unique: true,
                 searchable: true,
                 description: "",
                 properties: {
@@ -215,10 +215,10 @@ describe("prismaSchemaParser", () => {
               {
                 permanentId: expect.any(String),
                 name: "id",
-                displayName: "Id",
+                displayName: "ID",
                 dataType: EnumDataType.Id,
                 required: true,
-                unique: false,
+                unique: true,
                 searchable: true,
                 description: "",
                 properties: {
@@ -347,10 +347,10 @@ describe("prismaSchemaParser", () => {
               {
                 permanentId: expect.any(String),
                 name: "id",
-                displayName: "Id",
+                displayName: "ID",
                 dataType: EnumDataType.Id,
                 required: true,
-                unique: false,
+                unique: true,
                 searchable: true,
                 description: "",
                 properties: {
@@ -465,10 +465,10 @@ describe("prismaSchemaParser", () => {
               {
                 permanentId: expect.any(String),
                 name: "id",
-                displayName: "Id",
+                displayName: "ID",
                 dataType: EnumDataType.Id,
                 required: true,
-                unique: false,
+                unique: true,
                 searchable: true,
                 description: "",
                 properties: {
@@ -631,10 +631,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -684,7 +684,7 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
                   unique: true,
@@ -761,7 +761,7 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
                   unique: true,
@@ -837,7 +837,7 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
                   unique: true,
@@ -918,7 +918,7 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
                   unique: true,
@@ -1017,10 +1017,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -1098,10 +1098,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -1170,10 +1170,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -1209,10 +1209,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -1279,10 +1279,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -1363,10 +1363,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -1447,10 +1447,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -1530,10 +1530,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -1613,10 +1613,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -1664,10 +1664,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -1715,10 +1715,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -1766,10 +1766,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -1852,10 +1852,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -1908,10 +1908,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2016,10 +2016,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2069,10 +2069,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2130,10 +2130,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2236,10 +2236,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2297,10 +2297,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2385,10 +2385,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2460,10 +2460,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2504,10 +2504,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2593,10 +2593,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2637,10 +2637,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2727,10 +2727,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2813,10 +2813,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2877,10 +2877,10 @@ describe("prismaSchemaParser", () => {
                 {
                   permanentId: expect.any(String),
                   name: "id",
-                  displayName: "Id",
+                  displayName: "ID",
                   dataType: EnumDataType.Id,
                   required: true,
-                  unique: false,
+                  unique: true,
                   searchable: true,
                   description: "",
                   properties: {
@@ -2975,10 +2975,10 @@ describe("prismaSchemaParser", () => {
                   {
                     permanentId: expect.any(String),
                     name: "id",
-                    displayName: "Id",
+                    displayName: "ID",
                     dataType: EnumDataType.Id,
                     required: true,
-                    unique: false,
+                    unique: true,
                     searchable: true,
                     description: "",
                     properties: {
@@ -3019,10 +3019,10 @@ describe("prismaSchemaParser", () => {
                   {
                     permanentId: expect.any(String),
                     name: "id",
-                    displayName: "Id",
+                    displayName: "ID",
                     dataType: EnumDataType.Id,
                     required: true,
-                    unique: false,
+                    unique: true,
                     searchable: true,
                     description: "",
                     properties: {
@@ -3076,10 +3076,10 @@ describe("prismaSchemaParser", () => {
                   {
                     permanentId: expect.any(String),
                     name: "id",
-                    displayName: "Id",
+                    displayName: "ID",
                     dataType: EnumDataType.Id,
                     required: true,
-                    unique: false,
+                    unique: true,
                     searchable: true,
                     description: "",
                     properties: {
@@ -3120,10 +3120,10 @@ describe("prismaSchemaParser", () => {
                   {
                     permanentId: expect.any(String),
                     name: "id",
-                    displayName: "Id",
+                    displayName: "ID",
                     dataType: EnumDataType.Id,
                     required: true,
-                    unique: false,
+                    unique: true,
                     searchable: true,
                     description: "",
                     properties: {

--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
@@ -56,9 +56,15 @@ export function createOneEntityFieldCommonProperties(
   field: Field,
   fieldDataType: EnumDataType
 ): CreateBulkFieldsInput {
-  const fieldDisplayName = formatDisplayName(field.name);
+  const fieldDisplayName =
+    field.name === ID_FIELD_NAME
+      ? field.name.toUpperCase()
+      : formatDisplayName(field.name);
+
+  // in Amplication id fields are uniques and from prisma schema perspective unique field is a field that has the @unique attribute
   const isUniqueField =
-    field.attributes?.some((attr) => attr.name === UNIQUE_ATTRIBUTE_NAME) ??
+    (fieldDataType === EnumDataType.Id ||
+      field.attributes?.some((attr) => attr.name === UNIQUE_ATTRIBUTE_NAME)) ??
     false;
 
   const fieldAttributes = filterOutAmplicationAttributes(


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Close: #7164

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9ab8e4d</samp>

### Summary
🔠🛠️🧪

<!--
1.  🔠 - This emoji represents the change from "Id" to "ID" as the display name for the id field, which is a change in the capitalization of a word.
2.  🛠️ - This emoji represents the refactoring and improvement of the validation logic for the id field, which is a change in the quality and functionality of the code.
3.  🧪 - This emoji represents the modification of the test cases to match the expected output, which is a change in the testing and verification of the code.
-->
Refactored and improved the handling and testing of the id field of entities in the server package. This includes using clearer constants and functions for validation, updating the unit tests to match the expected output, and following the conventions for display name and uniqueness of the id field.

> _Sing, O Muse, of the skillful coder who refined the schema parser_
> _And made the ID field more consistent and unique in its display_
> _Heeding the conventions and validations of Amplication, the builder of apps_
> _And updating the tests with diligence, to match the changes he made_

### Walkthrough
*  Change the display name and the unique attribute of the id field in the prisma schema parser service tests to match the conventions and validations of Amplication ([link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL126-R129), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL218-R221), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL350-R353), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL468-R471), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL634-R637), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL687-R687), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL764-R764), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL840-R840), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL921-R921), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1020-R1023), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1101-R1104), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1173-R1176), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1212-R1215), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1282-R1285), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1366-R1369), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1450-R1453), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1533-R1536), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1616-R1619), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1667-R1670), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1718-R1721), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1769-R1772), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1855-R1858), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL1911-R1914), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2019-R2022), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2072-R2075), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2133-R2136), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2239-R2242), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2300-R2303), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2388-R2391), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2463-R2466), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2507-R2510), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2596-R2599), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2640-R2643), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2730-R2733), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2816-R2819), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2880-R2883), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL2978-R2981), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL3022-R3025), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL3079-R3082), [link](https://github.com/amplication/amplication/pull/7167/files?diff=unified&w=0#diff-15585c73ba81eb439d9e2cfcec6fb58e527c258cb4f9c064eb971f971d890b3aL3123-R3126)) in file `prismaSchemaParser.service.spec.ts`



## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
