### PR TITLE
fix(server): add the default attr to the id field if it doesn't exist

### DIFF
--- a/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
+++ b/packages/amplication-server/src/core/prismaSchemaParser/schema-utils.ts
@@ -527,8 +527,7 @@ export function convertModelIdToFieldId(
   builder
     .model(model.name)
     .field(originalPKField.name)
-    .attribute(ID_ATTRIBUTE_NAME)
-    .attribute(DEFAULT_ATTRIBUTE_NAME, [idDefaultType]);
+    .attribute(ID_ATTRIBUTE_NAME);
 
   void actionContext.onEmitUserActionLog(
     `The field "${originalPKField.name}" on model "${model.name}" was converted to id field`,


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Part of: #https://github.com/amplication/amplication/issues/6989

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 02ded3b</samp>

### Summary
🛠️🧪📝

<!--
1.  🛠️ - This emoji represents the enhancement of the function and the addition of checks and logging, which can be seen as fixing or improving the existing code.
2.  🧪 - This emoji represents the testing of the function and the default values, which can be seen as adding or improving the quality assurance of the code.
3.  📝 - This emoji represents the documentation of the function and the expected behavior, which can be seen as adding or improving the communication of the code.
-->
Improve the conversion of primary key fields to `id` fields in Prisma schema models. Add validation and logging for the default values of the fields in `schema-utils.ts`.

> _`id` fields from keys_
> _Prisma schema refined_
> _with checks and logging_

### Walkthrough
*  Add a variable to check if the primary key field has a default value ([link](https://github.com/amplication/amplication/pull/7210/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R519-R523))
*  Add logic and logging to convert the primary key field to an `id` field and assign a default value if needed ([link](https://github.com/amplication/amplication/pull/7210/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R532-R549))
*  Use the `actionContext` parameter to emit user action logs and inform the user of the changes made to the schema ([link](https://github.com/amplication/amplication/pull/7210/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R532-R549))
*  Update the file `schema-utils.ts` in the `prismaSchemaParser` module, which is responsible for parsing and transforming Prisma schema files ([link](https://github.com/amplication/amplication/pull/7210/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R519-R523), [link](https://github.com/amplication/amplication/pull/7210/files?diff=unified&w=0#diff-2208539b1783548dd47981f73d1959caaef02a787bb9e5a1d8f79aba712a2697R532-R549))



## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
