### PR TITLE
fix: workflow input propagation

### DIFF
--- a/.github/workflows/release.dsg.production.yml
+++ b/.github/workflows/release.dsg.production.yml
@@ -47,8 +47,13 @@ jobs:
         id: check-tag
         run: |
           DSG_VERSION=v$(cat $DSG_PACKAGE_JSON  | jq -r '.version')
-          NEW_TAG=dsg/$DSG_VERSION
+          NEW_TAG=dsg/${{ inputs.version }}
           echo "🏷️ NEW_TAG=$NEW_TAG (based on $DSG_PACKAGE_JSON DSG_VERSION=$DSG_VERSION)"
+
+          if [[${{ inputs.version }} == $DSG_VERSION]]; then
+            echo -e  "$ECHO_RED 🚨 The chosen version '${{ inputs.version }}' already defined in data-service-generator package.json. 🚨"
+            exit 1
+          fi
 
           # If the tag already exists, it means that was already released. So we skip it. 
           if git tag --list | grep -q "^$NEW_TAG"; then


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #7224

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f3c09cd</samp>

### Summary
🚀🔒🛠️

<!--
1.  🚀 - This emoji represents the feature of allowing manual control over the versioning of the data-service-generator, and the ability to trigger a release from the GitHub UI. It conveys the idea of launching or deploying something new.
2.  🔒 - This emoji represents the validation step that checks if the input version matches the package.json version, and exits with an error if so. It conveys the idea of security, protection, or prevention of unwanted outcomes.
3.  🛠️ - This emoji represents the modification of the logic of creating a new tag for the data-service-generator release. It conveys the idea of fixing, improving, or updating something.
-->
This change enables manual versioning of the `data-service-generator` release by using a workflow input parameter instead of the `package.json` version. It also adds a validation step to prevent duplicate versions.

> _`data-service-generator`_
> _Version from input, not file_
> _Autumn leaves falling_

### Walkthrough
* Add a validation step to the release workflow for data-service-generator to check if the input version matches the package.json version, and exit with an error if so ([link](https://github.com/amplication/amplication/pull/7226/files?diff=unified&w=0#diff-51fcfb90d295dbd552e9d5728a5b1d1229730d83289a9505cd3b64379f4bf319L50-R57))
* Modify the tag creation step to use the input version instead of the package.json version ([link](https://github.com/amplication/amplication/pull/7226/files?diff=unified&w=0#diff-51fcfb90d295dbd552e9d5728a5b1d1229730d83289a9505cd3b64379f4bf319L50-R57))
* Add an input parameter `version` to the workflow dispatch event, and pass it to the validation and tag creation steps ([link](https://github.com/amplication/amplication/pull/7226/files?diff=unified&w=0#diff-51fcfb90d295dbd552e9d5728a5b1d1229730d83289a9505cd3b64379f4bf319L50-R57))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
