### PR TITLE
fix(client): On Hover version number not displayed

### DIFF
--- a/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
@@ -163,27 +163,16 @@ const WorkspaceHeader: React.FC = () => {
               <Icon icon="logo" size="medium" />
             </Link>
           </div>
-          <Tooltip
-            aria-label="Version number copied successfully"
-            direction="e"
-            noDelay
-            show={versionAlert}
-          >
+          <span>
             <a
               href="https://github.com/amplication/amplication/releases"
               target="_blank"
               rel="noopener noreferrer"
               className={`${CLASS_NAME}__version`}
-              onMouseEnter={() => {
-                setVersionAlert(true);
-              }}
-              onMouseLeave={() => {
-                setVersionAlert(false);
-              }}
             >
-              <span>v{version}</span>
+              v{version}
             </a>
-          </Tooltip>
+          </span>
           <Breadcrumbs>
             {breadcrumbsContext.breadcrumbsItems.map((item, index) => (
               <Breadcrumbs.Item key={item.url} to={item.url}>


### PR DESCRIPTION
Close: #7222 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

Previously tooltip was used which showed the message on hover, currently that has been removed hence fixing the issue.
Screen Recording has been attached for reference.

https://github.com/amplication/amplication/assets/62256588/2bd031eb-79ed-42fe-b840-18b155f9d248


## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
