### PR TITLE
fix: Removed the "The selected repository must not be empty" notification from the service wizard

### DIFF
--- a/packages/amplication-client/src/Resource/git/GitSyncNotes.tsx
+++ b/packages/amplication-client/src/Resource/git/GitSyncNotes.tsx
@@ -13,10 +13,6 @@ export default function GitSyncNotes() {
           You can connect multiple services to the same repository, next you
           will see the option to select the destination folder
         </li>
-        <li>
-          <Icon icon="check_square" size="xsmall" />
-          The selected repository must not be empty
-        </li>
       </ul>
     </div>
   );


### PR DESCRIPTION
Issue: #7235 