### PR TITLE
Feat(server): project limitation

### DIFF
--- a/packages/amplication-server/src/core/billing/billing.service.spec.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.spec.ts
@@ -143,29 +143,11 @@ describe("BillingService", () => {
       workspaceId,
       BillingFeature.IgnoreValidationCodeGeneration
     );
-    await expect(
-      service.getBooleanEntitlement(
-        workspaceId,
-        BillingFeature.IgnoreValidationCodeGeneration
-      )
-    ).resolves.toEqual(
-      expect.objectContaining({
-        hasAccess: false,
-      })
-    );
-
     expect(spyOnServiceGetMeteredEntitlement).toHaveBeenCalledTimes(1);
     expect(spyOnServiceGetMeteredEntitlement).toHaveBeenNthCalledWith(
       1,
       workspaceId,
       BillingFeature.Projects
-    );
-    await expect(
-      service.getMeteredEntitlement(workspaceId, BillingFeature.Projects)
-    ).resolves.toEqual(
-      expect.objectContaining({
-        hasAccess: false,
-      })
     );
   });
 

--- a/packages/amplication-server/src/core/billing/billing.service.spec.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.spec.ts
@@ -113,7 +113,7 @@ describe("BillingService", () => {
       {
         id: projectId,
         name: "project-1",
-        workspaceId: "workspace-id",
+        workspaceId: workspaceId,
         useDemoRepo: false,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -221,7 +221,7 @@ describe("BillingService", () => {
       {
         id: projectId,
         name: "project-1",
-        workspaceId: "workspace-id",
+        workspaceId: workspaceId,
         useDemoRepo: false,
         createdAt: new Date(),
         updatedAt: new Date(),

--- a/packages/amplication-server/src/core/billing/billing.service.spec.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.spec.ts
@@ -75,6 +75,100 @@ describe("BillingService", () => {
     );
   });
 
+  it("should throw exceptions on number of projects if the workspace has no entitlement to bypass code generation limitation and the current project is out of the limitation based on the number of allowed projects and its creation date", async () => {
+    const workspaceId = "id";
+    const projectsPerWorkspaceLimit = 1;
+
+    const spyOnServiceGetBooleanEntitlement = jest
+      .spyOn(service, "getBooleanEntitlement")
+      .mockResolvedValue({
+        hasAccess: false,
+      } as BooleanEntitlement);
+
+    const spyOnServiceGetMeteredEntitlement = jest
+      .spyOn(service, "getMeteredEntitlement")
+      .mockResolvedValue({
+        hasAccess: false,
+        usageLimit: projectsPerWorkspaceLimit,
+      } as MeteredEntitlement);
+
+    const user: User = {
+      id: "user-id",
+      account: {
+        id: "account-id",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        email: "email",
+        firstName: "first-name",
+        lastName: "last-name",
+        password: "password",
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      isOwner: true,
+    };
+
+    const projects: Project[] = [
+      {
+        id: "project-id-1",
+        name: "project-1",
+        workspaceId: workspaceId,
+        useDemoRepo: false,
+        createdAt: new Date("2023-01-01"),
+        updatedAt: new Date(),
+      },
+      {
+        id: "project-id-2",
+        name: "project-2",
+        workspaceId: workspaceId,
+        useDemoRepo: false,
+        createdAt: new Date("2023-01-02"),
+        updatedAt: new Date(),
+      },
+    ];
+
+    await expect(
+      service.validateSubscriptionPlanLimitationsForWorkspace(
+        workspaceId,
+        user,
+        "project-id-2",
+        projects
+      )
+    ).rejects.toThrow(
+      new ValidationError("LimitationError: Allowed projects per workspace: 1")
+    );
+
+    expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledTimes(1);
+    expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledWith(
+      workspaceId,
+      BillingFeature.IgnoreValidationCodeGeneration
+    );
+    await expect(
+      service.getBooleanEntitlement(
+        workspaceId,
+        BillingFeature.IgnoreValidationCodeGeneration
+      )
+    ).resolves.toEqual(
+      expect.objectContaining({
+        hasAccess: false,
+      })
+    );
+
+    expect(spyOnServiceGetMeteredEntitlement).toHaveBeenCalledTimes(1);
+    expect(spyOnServiceGetMeteredEntitlement).toHaveBeenNthCalledWith(
+      1,
+      workspaceId,
+      BillingFeature.Projects
+    );
+    await expect(
+      service.getMeteredEntitlement(workspaceId, BillingFeature.Projects)
+    ).resolves.toEqual(
+      expect.objectContaining({
+        hasAccess: false,
+      })
+    );
+  });
+
   it("should throw exceptions on number of services if the workspace has no entitlement to bypass code generation limitation", async () => {
     const workspaceId = "id";
     const projectId = "project-id-1";

--- a/packages/amplication-server/src/core/billing/billing.service.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.ts
@@ -374,6 +374,12 @@ export class BillingService {
     if (this.isBillingEnabled) {
       await this.setUsage(
         workspaceId,
+        BillingFeature.Projects,
+        currentUsage.projects
+      );
+
+      await this.setUsage(
+        workspaceId,
         BillingFeature.Services,
         currentUsage.services
       );

--- a/packages/amplication-server/src/core/billing/billing.service.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.ts
@@ -21,7 +21,7 @@ import { ProvisionSubscriptionResult } from "../workspace/dto/ProvisionSubscript
 import { ValidationError } from "../../errors/ValidationError";
 import { FeatureUsageReport } from "../project/FeatureUsageReport";
 import { ProvisionSubscriptionInput } from "../workspace/dto/ProvisionSubscriptionInput";
-import { User } from "../../models";
+import { Project, User } from "../../models";
 
 @Injectable()
 export class BillingService {
@@ -279,7 +279,9 @@ export class BillingService {
   //todo: wrap with a try catch and return an object with the details about the limitations
   async validateSubscriptionPlanLimitationsForWorkspace(
     workspaceId: string,
-    currentUser: User
+    currentUser: User,
+    currentProjectId: string,
+    projects: Project[]
   ): Promise<void> {
     if (this.isBillingEnabled) {
       const isIgnoreValidationCodeGeneration = await this.getBooleanEntitlement(
@@ -289,6 +291,34 @@ export class BillingService {
 
       //check whether the workspace has entitlement to bypass code generation limitation
       if (!isIgnoreValidationCodeGeneration.hasAccess) {
+        const projectsEntitlement = await this.getMeteredEntitlement(
+          workspaceId,
+          BillingFeature.Projects
+        );
+
+        const projectsUnderLimitation = projects.slice(
+          0,
+          projectsEntitlement.usageLimit
+        );
+        const canCurrentProjectCommit = projectsUnderLimitation.some(
+          (project) => project.id === currentProjectId
+        );
+
+        if (!projectsEntitlement.hasAccess && !canCurrentProjectCommit) {
+          const message = `Allowed projects per workspace: ${projectsEntitlement.usageLimit}`;
+
+          await this.analytics.track({
+            userId: currentUser.account.id,
+            properties: {
+              workspaceId,
+              reason: message,
+            },
+            event: EnumEventType.SubscriptionLimitPassed,
+          });
+
+          throw new ValidationError(`LimitationError: ${message}`);
+        }
+
         const servicesEntitlement = await this.getMeteredEntitlement(
           workspaceId,
           BillingFeature.Services

--- a/packages/amplication-server/src/core/billing/billing.types.ts
+++ b/packages/amplication-server/src/core/billing/billing.types.ts
@@ -12,6 +12,7 @@ export enum BillingFeature {
   HideNotifications = "feature-ignore-validation-code-generation-hide-notifications",
   IgnoreValidationCodeGeneration = "feature-ignore-validation-code-generation",
   Services = "feature-services",
+  Projects = "feature-projects",
   ServicesAboveEntitiesPerServiceLimit = "feature-services-above-entities-per-service-limit",
   ServicesWithManyEntities = "feature-services-wth-many-entities",
   SmartGitSync = "feature-smart-git-sync",

--- a/packages/amplication-server/src/core/project/FeatureUsageReport.ts
+++ b/packages/amplication-server/src/core/project/FeatureUsageReport.ts
@@ -1,4 +1,5 @@
 export type FeatureUsageReport = {
+  projects: number;
   services: number;
   servicesAboveEntityPerServiceLimit: number;
 };

--- a/packages/amplication-server/src/core/project/project.service.ts
+++ b/packages/amplication-server/src/core/project/project.service.ts
@@ -228,6 +228,7 @@ export class ProjectService {
     }
 
     return {
+      projects: workspace.projects.length,
       services: workspaceServices.length,
       servicesAboveEntityPerServiceLimit:
         servicesAboveEntityPerServiceLimitCount,

--- a/packages/amplication-server/src/core/project/project.service.ts
+++ b/packages/amplication-server/src/core/project/project.service.ts
@@ -74,10 +74,16 @@ export class ProjectService {
         },
       },
     });
+
     await this.resourceService.createProjectConfiguration(
       project.id,
       project?.name,
       userId
+    );
+
+    await this.billingService.reportUsage(
+      project.workspaceId,
+      BillingFeature.Projects
     );
 
     return project;
@@ -103,6 +109,12 @@ export class ProjectService {
       project.workspace.id,
       BillingFeature.Services,
       -archivedServiceCount
+    );
+
+    await this.billingService.reportUsage(
+      project.workspaceId,
+      BillingFeature.Projects,
+      -1
     );
 
     return this.prisma.project.update({
@@ -252,9 +264,21 @@ export class ProjectService {
       const usageReport = await this.calculateMeteredUsage(project.workspaceId);
       await this.billingService.resetUsage(project.workspaceId, usageReport);
 
+      const projects = await this.prisma.project.findMany({
+        where: {
+          workspaceId: project.workspaceId,
+          deletedAt: null,
+        },
+        orderBy: {
+          createdAt: "asc",
+        },
+      });
+
       await this.billingService.validateSubscriptionPlanLimitationsForWorkspace(
         project.workspaceId,
-        currentUser
+        currentUser,
+        project.id,
+        projects
       );
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: https://github.com/amplication/private-issues/issues/40

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2699bf7</samp>

### Summary
🆕🧾🏗️

<!--
1.  🆕 - This emoji can be used to indicate that a new feature or value was added to the codebase. It can be associated with the `BillingFeature.Projects` enum value and the `projects` property of the `FeatureUsageReport` type.
2.  🧾 - This emoji can be used to indicate that some validation or usage tracking logic was added or modified in the codebase. It can be associated with the changes in the `BillingService` class and the `validateSubscriptionPlanLimitationsForWorkspace` and `resetUsage` methods.
3.  🏗️ - This emoji can be used to indicate that some integration or construction work was done in the codebase. It can be associated with the changes in the `ProjectService` class and the integration of the `BillingService` class.
-->
This pull request implements the billing logic for the number of projects per workspace feature. It adds the `BillingFeature.Projects` enum value, the `projects` property in the `FeatureUsageReport` type, and modifies the `BillingService` and `ProjectService` classes to validate and report the usage and limitations of this feature.

> _Oh we are the coders of the billing service_
> _We track and validate the features we give_
> _We heave and we ho on the `BillingFeature.Projects`_
> _And we hope that our customers will pay and live_

### Walkthrough
*  Add `BillingFeature.Projects` enum value to represent the feature of having a certain number of projects per workspace in the subscription plan ([link](https://github.com/amplication/amplication/pull/7274/files?diff=unified&w=0#diff-dfa68e574b49dfe97f85d13ffe12404f479236a77840b9f720e05faf5902dabbR15))
*  Add `projects` property to `FeatureUsageReport` type to indicate the current number of projects in the workspace ([link](https://github.com/amplication/amplication/pull/7274/files?diff=unified&w=0#diff-3045b61429f2488e836512bb802813d83c7e4bec930f53233947d29e0df26858R2))
  *  Import `Project` model from `../../models` to use it as a type for the `projects` parameter in the `validateSubscriptionPlanLimitationsForWorkspace` method ([link](https://github.com/amplication/amplication/pull/7274/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L24-R24))
  *  Add `currentProjectId` and `projects` parameters to the `validateSubscriptionPlanLimitationsForWorkspace` method to check if the current project can be committed under the subscription plan limitations for the number of projects per workspace ([link](https://github.com/amplication/amplication/pull/7274/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L282-R284))
  *  Add code to the `validateSubscriptionPlanLimitationsForWorkspace` method to get the metered entitlement for the `BillingFeature.Projects` feature, slice the `projects` array to get the projects that are under the usage limit, and throw a `ValidationError` if the access flag is false and the current project is not among the projects under the limit. Also, track the event of passing the subscription limit using the `analytics` service ([link](https://github.com/amplication/amplication/pull/7274/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1R294-R321))
  *  Add code to the `resetUsage` method to set the usage of the `BillingFeature.Projects` feature to the current number of projects in the workspace ([link](https://github.com/amplication/amplication/pull/7274/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1R377-R382))
  *  Add code to the `createOne` method to call the `reportUsage` method of the `BillingService` class with the `workspaceId` and the `BillingFeature.Projects` feature when a new project is created ([link](https://github.com/amplication/amplication/pull/7274/files?diff=unified&w=0#diff-cd946c1c9f9271b6dd02f554735fae66c53c2516f9b097daf8f798c2154118ffR77))
  *  Add code to the `delete` method to call the `reportUsage` method of the `BillingService` class with the `workspaceId`, the `BillingFeature.Projects` feature, and a negative value to indicate a decrease in usage when a project is deleted ([link](https://github.com/amplication/amplication/pull/7274/files?diff=unified&w=0#diff-cd946c1c9f9271b6dd02f554735fae66c53c2516f9b097daf8f798c2154118ffR84-R88))
  *  Add code to the `restore` method to call the `reportUsage` method of the `BillingService` class with the `workspaceId` and the `BillingFeature.Projects` feature when a project is restored ([link](https://github.com/amplication/amplication/pull/7274/files?diff=unified&w=0#diff-cd946c1c9f9271b6dd02f554735fae66c53c2516f9b097daf8f798c2154118ffR114-R119))
  *  Add code to the `getFeatureUsageReport` method to assign the `projects` property to the length of the `projects` array in the `workspace` object, which contains all the projects in the workspace ([link](https://github.com/amplication/amplication/pull/7274/files?diff=unified&w=0#diff-cd946c1c9f9271b6dd02f554735fae66c53c2516f9b097daf8f798c2154118ffR231))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
