### PR TITLE
(amplication-server): allow system data type manipulation

### DIFF
--- a/packages/amplication-server/src/core/entity/constants.ts
+++ b/packages/amplication-server/src/core/entity/constants.ts
@@ -58,6 +58,12 @@ export const SYSTEM_DATA_TYPES: Set<EnumDataType> = new Set([
   EnumDataType.Roles,
 ]);
 
+export const MANIPULABLE_SYSTEM_DATA_TYPES: Set<EnumDataType> = new Set([
+  EnumDataType.Id,
+  EnumDataType.Roles,
+  EnumDataType.Password,
+]);
+
 export const INITIAL_ID_TYPE_FIELDS: EntityFieldData = {
   dataType: EnumDataType.Id,
   name: "id",

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -41,6 +41,7 @@ import {
   SYSTEM_DATA_TYPES,
   DATA_TYPE_TO_DEFAULT_PROPERTIES,
   INITIAL_ID_TYPE_FIELDS,
+  MANIPULABLE_SYSTEM_DATA_TYPES,
 } from "./constants";
 import {
   prepareDeletedItemName,
@@ -2209,7 +2210,7 @@ export class EntityService {
     // Validate the field's dataType is not a system data type
     if (
       isSystemDataType(data.dataType as EnumDataType) &&
-      data.dataType !== EnumDataType.Id
+      !isManipulableSystemDataType(data.dataType as EnumDataType)
     ) {
       throw new DataConflictError(
         `The data type ${data.dataType} cannot be used for non-system fields`
@@ -2515,7 +2516,7 @@ export class EntityService {
 
     if (
       isSystemDataType(field.dataType as EnumDataType) &&
-      field.dataType !== EnumDataType.Id
+      !isManipulableSystemDataType(field.dataType as EnumDataType)
     ) {
       throw new ConflictException(
         `Cannot update entity field ${field.name} because fields with data type ${field.dataType} cannot be updated`
@@ -2758,6 +2759,10 @@ function validateFieldName(name: string): void {
 
 function isSystemDataType(dataType: EnumDataType): boolean {
   return SYSTEM_DATA_TYPES.has(dataType);
+}
+
+function isManipulableSystemDataType(dataType: EnumDataType): boolean {
+  return MANIPULABLE_SYSTEM_DATA_TYPES.has(dataType);
 }
 
 function isReservedUserEntityFieldName(name: string): boolean {


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #7068

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

Here are the changes this PR introduces:
- new constant `MANIPULABLE_SYSTEM_DATA_TYPES` is added, which is a set containing the system data types that can be manipulated.
- the `isManipulableSystemDataType()` function is added to determine if a given data type is manipulable. It checks if the data type is present in the `MANIPULABLE_SYSTEM_DATA_TYPES` set.


## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
