### PR TITLE
fix(server): Now warning is being logged instead of error upon rebuilding

### DIFF
--- a/libs/util/git/src/providers/github/github.service.ts
+++ b/libs/util/git/src/providers/github/github.service.ts
@@ -455,7 +455,7 @@ export class GithubService implements GitProvider {
       return { url: pullRequest.html_url, number: pullRequest.number };
     } catch (error) {
       if (error.status === 422) {
-        throw new Error(
+        this.logger.warn(
           `Hey there! Looks like your code hasn't changed since the last build. We skipped creating a new pull request to keep things tidy.`
         );
       }


### PR DESCRIPTION
Close: #7263

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

Currently Warning will be logged instead of error when we press "Rebuild" again without making any new changes. 

## PR Checklist

- [X] Tests for the changes have been added
- [X] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
