### PR TITLE
fix: empty state image misalignment on commits page

### DIFF
--- a/packages/amplication-client/src/Components/EmptyState.scss
+++ b/packages/amplication-client/src/Components/EmptyState.scss
@@ -9,6 +9,7 @@ $svg-img-height: 200px;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  height: 100%;
 
   p {
     @include regular-12;


### PR DESCRIPTION
Close: #7275 

## PR Details

This PR fixes the empty state image misalignment issue on the commits page.
