### PR TITLE
fix(client): filter null resources from the commits list

### DIFF
--- a/packages/amplication-client/src/Resource/code-view/CodeViewExplorer.tsx
+++ b/packages/amplication-client/src/Resource/code-view/CodeViewExplorer.tsx
@@ -49,9 +49,10 @@ const CodeViewExplorer: React.FC<Props> = ({ onFileSelected }) => {
   }, [resources]);
 
   const selectedBuild = useMemo(() => {
-    return selectedCommit?.builds?.find(
-      (b) => b.resource.id === selectedResource?.id
+    const filteredBuilds = selectedCommit?.builds?.filter(
+      (b) => b.resource !== null
     );
+    return filteredBuilds?.find((b) => b.resource.id === selectedResource?.id);
   }, [selectedCommit, selectedResource]);
 
   return (


### PR DESCRIPTION

Close: #[issue-number]

## PR Details

code-view page fails when there is a deleted resource in the commits list => 
filter null resources from the commits list to prevent it. 

copilot:all

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
