### PR TITLE
fix(client): change icon color in RepositoryActions

### DIFF
--- a/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/RepositoryActions.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/RepositoryActions.tsx
@@ -47,7 +47,7 @@ export default function RepositoryActions({
                   direction={EnumFlexDirection.Row}
                   gap={EnumGapSize.Small}
                 >
-                  <Icon icon="info_circle" />
+                  <Icon icon="info_circle" color={EnumTextColor.White}/>
                   No repository was selected
                 </FlexItem>
               </Text>

--- a/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/RepositoryActions.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/RepositoryActions.tsx
@@ -47,7 +47,7 @@ export default function RepositoryActions({
                   direction={EnumFlexDirection.Row}
                   gap={EnumGapSize.Small}
                 >
-                  <Icon icon="info_circle" color={EnumTextColor.White}/>
+                  <Icon icon="info_circle" color={EnumTextColor.White} />
                   No repository was selected
                 </FlexItem>
               </Text>


### PR DESCRIPTION
Close: #7298

## PR Details

Changing color of "i" icon on RepositoryActions for adding a Git repo

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 507b4ba</samp>

### Summary
🎨🌟👁️

<!--
1.  🎨 - This emoji is often used to indicate changes related to the appearance or style of the user interface, such as colors, fonts, layouts, etc. In this case, the `Icon` component was given a different color to improve its visibility and contrast.
2.  🌟 - This emoji is often used to indicate changes that add or improve features or functionality, such as new components, props, hooks, etc. In this case, the `Icon` component was given a new prop to allow customization of its color.
3.  👁️ - This emoji is often used to indicate changes related to accessibility or user experience, such as adding labels, alt texts, keyboard navigation, etc. In this case, the `Icon` component was given a color that makes it easier for users to see and understand the message.
-->
Improved the visibility of the icon in the `RepositoryActions` component. Changed the `color` prop of the `Icon` component in `RepositoryActions.tsx` to white.

> _No repo chosen_
> _`Icon` shines white on dark `Flex`_
> _Winter moon in sky_

### Walkthrough
*  Add a `color` prop to the `Icon` component to make it more visible on the dark background ([link](https://github.com/amplication/amplication/pull/7300/files?diff=unified&w=0#diff-98edde0eb0fdf9420d94d090382c7ba88e7b6305bc88626ce46443ee7f4fc624L50-R50))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

