### PR TITLE
Fix/7054 load expand folder

### DIFF
--- a/packages/amplication-client/src/Resource/code-view/CodeViewExplorerTree.tsx
+++ b/packages/amplication-client/src/Resource/code-view/CodeViewExplorerTree.tsx
@@ -43,15 +43,34 @@ const CodeViewExplorerTree = ({
   const { error, isError } = useQuery<StorageResponseType, AxiosError>(
     ["storage-folderList", selectedBuild.id, selectedFolder?.path],
     async () => {
-      return await StorageBaseAxios.instance.folderList(
-        resourceId,
-        selectedBuild.id,
-        selectedFolder?.path
-      );
+      const currentFolder = selectedFolder;
+      currentFolder.children = [
+        {
+          type: NodeTypeEnum.File,
+          name: "Loading...",
+          path: "/",
+          children: [],
+          expanded: true,
+        },
+      ];
+      setRootFile({ ...rootFile });
+
+      try {
+        const responseData = await StorageBaseAxios.instance.folderList(
+          resourceId,
+          selectedBuild.id,
+          selectedFolder?.path
+        );
+
+        currentFolder.children = responseData.result;
+        return responseData;
+      } catch (error) {
+        console.error(error);
+      }
     },
     {
       onSuccess: (data) => {
-        selectedFolder.children = data.result;
+        // selectedFolder.children = data.result;
         setRootFile({ ...rootFile });
       },
     }
@@ -113,6 +132,8 @@ const CodeViewExplorerTree = ({
                   file={child}
                   key={child.path + JSON.stringify(child.children)}
                   onSelect={handleNodeClick}
+                  currentFolder={selectedFolder.path}
+                  isLoading={selectedFolder.path === child.path}
                 />
               ))}
             </TreeView>

--- a/packages/amplication-client/src/Resource/code-view/FileExplorerNode.tsx
+++ b/packages/amplication-client/src/Resource/code-view/FileExplorerNode.tsx
@@ -6,9 +6,16 @@ import { FileMeta } from "./CodeViewExplorer";
 export type FileExplorerNodeProps = {
   file: FileMeta;
   onSelect: (data: FileMeta) => void;
+  currentFolder: string;
+  isLoading: boolean;
 };
 
-export const FileExplorerNode = ({ file, onSelect }: FileExplorerNodeProps) => {
+export const FileExplorerNode = ({
+  file,
+  onSelect,
+  currentFolder,
+  isLoading,
+}: FileExplorerNodeProps) => {
   const handleNodeClick = useCallback(
     (id: string, file: FileMeta) => {
       file && onSelect(file);
@@ -24,12 +31,16 @@ export const FileExplorerNode = ({ file, onSelect }: FileExplorerNodeProps) => {
   const farIcon = useMemo(() => {
     if (file.type !== NodeTypeEnum.Folder) return null;
 
-    return file.expanded ? (
-      <Icon icon="chevron_down" />
-    ) : (
-      <Icon icon="chevron_right" />
+    return (
+      <div className={`folder-icon ${isLoading ? "spin" : ""}`}>
+        {file.expanded ? (
+          <Icon icon="chevron_down" />
+        ) : (
+          <Icon icon="chevron_right" />
+        )}
+      </div>
     );
-  }, [file.expanded, file.type]);
+  }, [isLoading, file.expanded, file.type]);
 
   return (
     <TreeItem
@@ -42,7 +53,13 @@ export const FileExplorerNode = ({ file, onSelect }: FileExplorerNodeProps) => {
     >
       {file.children?.map((child) => {
         return (
-          <FileExplorerNode file={child} key={child.path} onSelect={onSelect} />
+          <FileExplorerNode
+            file={child}
+            key={child.path}
+            onSelect={onSelect}
+            currentFolder={currentFolder}
+            isLoading={isLoading}
+          />
         );
       })}
     </TreeItem>

--- a/packages/amplication-client/src/Resource/code-view/FileExplorerNode.tsx
+++ b/packages/amplication-client/src/Resource/code-view/FileExplorerNode.tsx
@@ -2,6 +2,7 @@ import { Icon, TreeItem } from "@amplication/ui/design-system";
 import React, { useCallback, useMemo } from "react";
 import { NodeTypeEnum } from "./NodeTypeEnum";
 import { FileMeta } from "./CodeViewExplorer";
+import { CircularProgress } from "@mui/material";
 
 export type FileExplorerNodeProps = {
   file: FileMeta;
@@ -32,7 +33,7 @@ export const FileExplorerNode = ({
     if (file.type !== NodeTypeEnum.Folder) return null;
 
     return (
-      <div className={`folder-icon ${isLoading ? "spin" : ""}`}>
+      <div className={`folder-icon ${isLoading ? CircularProgress : ""}`}>
         {file.expanded ? (
           <Icon icon="chevron_down" />
         ) : (

--- a/packages/amplication-client/src/style/dark-css-variables.css
+++ b/packages/amplication-client/src/style/dark-css-variables.css
@@ -50,3 +50,15 @@
   --diffViewerTitleBorderColor: var(--gray-full);
   --screenResolutionMessageColor: var(--gray-base);
 }
+.spin {
+  animation: spin 1s infinite linear;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/amplication-client/src/style/dark-css-variables.css
+++ b/packages/amplication-client/src/style/dark-css-variables.css
@@ -50,15 +50,3 @@
   --diffViewerTitleBorderColor: var(--gray-full);
   --screenResolutionMessageColor: var(--gray-base);
 }
-.spin {
-  animation: spin 1s infinite linear;
-}
-
-@keyframes spin {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #7054 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->
This PR adds loading placeholders for folders in the CodeViewExplorerTree component, enhancing the user experience when expanding folders.
Enhances usability by providing visual feedback during folder expansion and fixes the currentFolder scope issue.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 229e3ae</samp>

### Summary
🎨🔄✨

<!--
1.  🎨 - This emoji is often used for changes related to CSS, styling, or design. The first change adds a new CSS class and rule for the animation effect, so this emoji is appropriate.
2.  🔄 - This emoji is often used for changes related to updating, refreshing, or reloading data or state. The second change improves the loading and error handling of the folder list, so this emoji is suitable.
3.  ✨ - This emoji is often used for changes that introduce new features, enhancements, or improvements. The third change adds a new loading animation to the folder icons, which could be considered a new feature or enhancement, so this emoji is fitting.
-->
This pull request adds a loading animation to the folder icons in the code view explorer tree component. It uses the `spin` class and the `@keyframes` rule defined in `dark-css-variables.css`. The animation indicates that the folder list is being fetched from the server.

> _In the code of darkness, we seek the light_
> _We spin the folders, loading our fight_
> _The tree of knowledge, our sacred quest_
> _We face the errors, we won't rest_

### Walkthrough
*  Handle errors and show loading state when fetching folder list from storage service ([link](https://github.com/amplication/amplication/pull/7330/files?diff=unified&w=0#diff-9654a4aa1ba3cd8290d695811587c56a36a5dfbe1a9dd718cb36e0c8eb689c4aL46-R73))
*  Pass `currentFolder` and `isLoading` props to `FileExplorerNode` component to indicate the current folder that is being loaded ([link](https://github.com/amplication/amplication/pull/7330/files?diff=unified&w=0#diff-9654a4aa1ba3cd8290d695811587c56a36a5dfbe1a9dd718cb36e0c8eb689c4aR135-R136), [link](https://github.com/amplication/amplication/pull/7330/files?diff=unified&w=0#diff-39da4c3330992afc00778a7a4bb42cea66a5b1abfabc3cfb16b2cf7642cb6d93L9-R18), [link](https://github.com/amplication/amplication/pull/7330/files?diff=unified&w=0#diff-39da4c3330992afc00778a7a4bb42cea66a5b1abfabc3cfb16b2cf7642cb6d93L45-R62))
*  Render a spinning animation for the folder icon of the current folder using a `spin` CSS class and a `@keyframes` rule ([link](https://github.com/amplication/amplication/pull/7330/files?diff=unified&w=0#diff-39da4c3330992afc00778a7a4bb42cea66a5b1abfabc3cfb16b2cf7642cb6d93L27-R43), [link](https://github.com/amplication/amplication/pull/7330/files?diff=unified&w=0#diff-315071f6f8c8836199b858e83de748353d3c0faee9f583954004160a9ef1f168R53-R64))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
