### PR TITLE
test(dsg): fix flacky e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 100
+          fetch-depth: 1
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,3 +81,5 @@ jobs:
       - name: e2e
         if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.head_ref != 'next' )
         run: npx nx e2e ${{ matrix.project }} --prod
+        env:
+          VERBOSE: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,5 +81,3 @@ jobs:
       - name: e2e
         if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.head_ref != 'next' )
         run: npx nx e2e ${{ matrix.project }} --prod
-        env:
-          VERBOSE: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
       nx-force-all: ${{ inputs.nx-force-all || false }}
 
   e2e:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: nx
     if: ${{ needs.nx.outputs.affected-e2e != '[]' && needs.nx.outputs.affected-e2e != ''}}
     strategy:
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 100
 
       - uses: actions/setup-node@v3
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -255,7 +255,7 @@
         "base-64": "^1.0.0",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.8.1",
-        "docker-compose": "^0.23.19",
+        "docker-compose": "^0.24.2",
         "dockerode": "^3.3.5",
         "eslint": "8.46.0",
         "eslint-config-prettier": "^8.8.0",
@@ -29514,24 +29514,15 @@
       }
     },
     "node_modules/docker-compose": {
-      "version": "0.23.19",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.19.tgz",
-      "integrity": "sha512-v5vNLIdUqwj4my80wxFDkNH+4S85zsRuH29SO7dCWVWPCMt/ohZBsGN6g6KXWifT0pzQ7uOxqEKCYCDPJ8Vz4g==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.2.tgz",
+      "integrity": "sha512-2/WLvA7UZ6A2LDLQrYW0idKipmNBWhtfvrn2yzjC5PnHDzuFVj1zAZN6MJxVMKP0zZH8uzAK6OwVZYHGuyCmTw==",
       "dev": true,
       "dependencies": {
-        "yaml": "^1.10.2"
+        "yaml": "^2.2.2"
       },
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/docker-compose/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/docker-modem": {

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
     "base-64": "^1.0.0",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.8.1",
-    "docker-compose": "^0.23.19",
+    "docker-compose": "^0.24.2",
     "dockerode": "^3.3.5",
     "eslint": "8.46.0",
     "eslint-config-prettier": "^8.8.0",

--- a/packages/data-service-generator/package.json
+++ b/packages/data-service-generator/package.json
@@ -28,7 +28,7 @@
     "class-validator": "^0.14.0",
     "cross-fetch": "3.1.8",
     "decimal.js": "10.4.3",
-    "docker-compose": "^0.23.19",
+    "docker-compose": "^0.24.2",
     "dotenv": "^16.3.1",
     "download": "^8.0.0",
     "events": "1.1.1",

--- a/packages/data-service-generator/src/server/docker-compose/docker-compose.template.yml
+++ b/packages/data-service-generator/src/server/docker-compose/docker-compose.template.yml
@@ -13,6 +13,7 @@ services:
       JWT_EXPIRATION: "${JWT_EXPIRATION}"
     depends_on:
       - migrate
+    restart: on-failure
   migrate:
     build:
       context: .

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -2998,6 +2998,7 @@ services:
       JWT_EXPIRATION: \${JWT_EXPIRATION}
     depends_on:
       - migrate
+    restart: on-failure
   migrate:
     build:
       context: .

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -2998,6 +2998,7 @@ services:
       JWT_EXPIRATION: \${JWT_EXPIRATION}
     depends_on:
       - migrate
+    restart: on-failure
   migrate:
     build:
       context: .

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -2998,6 +2998,7 @@ services:
       JWT_EXPIRATION: \${JWT_EXPIRATION}
     depends_on:
       - migrate
+    restart: on-failure
   migrate:
     build:
       context: .

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -2998,6 +2998,7 @@ services:
       JWT_EXPIRATION: \${JWT_EXPIRATION}
     depends_on:
       - migrate
+    restart: on-failure
   migrate:
     build:
       context: .

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -2998,6 +2998,7 @@ services:
       JWT_EXPIRATION: \${JWT_EXPIRATION}
     depends_on:
       - migrate
+    restart: on-failure
   migrate:
     build:
       context: .

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -2998,6 +2998,7 @@ services:
       JWT_EXPIRATION: \${JWT_EXPIRATION}
     depends_on:
       - migrate
+    restart: on-failure
   migrate:
     build:
       context: .

--- a/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
+++ b/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
@@ -194,6 +194,8 @@ describe("Data Service Generator", () => {
             logger.error(err.message, err);
           });
 
+        // Wait for the server to be ready and for database migration before running tests.
+        // TODO replace with a better docker-compose solution that waits for the migraton to be completd before starting the server
         logger.info("Waiting for server to be ready...");
         let migrationCompleted = false;
         let startTime = Date.now();

--- a/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
+++ b/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
@@ -196,11 +196,12 @@ describe("Data Service Generator", () => {
 
         // Wait for the server to be ready and for database migration before running tests.
         // TODO replace with a better docker-compose solution that waits for the migraton to be completd before starting the server
-        logger.info("Waiting for server to be ready...");
+        logger.info("Waiting for db migration to be ...");
         let migrationCompleted = false;
         let startTime = Date.now();
 
         do {
+          logger.info("...");
           const containers = await compose.ps(dockerComposeOptions);
           if (
             !containers.data.services.find((s) => s.name.endsWith("migrate-1"))
@@ -215,10 +216,12 @@ describe("Data Service Generator", () => {
           startTime + SERVER_START_TIMEOUT < Date.now()
         );
 
+        logger.info("Waiting for server to be ready...");
         let servicesNotReady = true;
         startTime = Date.now();
         do {
           try {
+            logger.info("...");
             const res = await fetch(`${host}/api/_health/live`, {
               method: "GET",
             });

--- a/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
+++ b/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
@@ -210,7 +210,7 @@ describe("Data Service Generator", () => {
           const migrateContainer = containers.data.services.find((s) =>
             s.name.endsWith("migrate-1")
           );
-          if (migrateContainer.state.indexOf("Exited (0)")) {
+          if (migrateContainer.state.indexOf("Exited (0)") !== -1) {
             migrationCompleted = true;
             logger.info("migration completed!");
             break;

--- a/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
+++ b/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
@@ -204,9 +204,6 @@ describe("Data Service Generator", () => {
             ...dockerComposeOptions,
             commandOptions: ["--all"],
           });
-          logger.debug("containers", {
-            "docker-services": containers.data.services,
-          });
           const migrateContainer = containers.data.services.find((s) =>
             s.name.endsWith("migrate-1")
           );
@@ -397,7 +394,6 @@ describe("Data Service Generator", () => {
           // TODO uncomment once issue is fixed https://github.com/amplication/amplication/issues/5437
           xit("creates GET /api/customers/:id endpoint", async () => {
             const customerId = 1;
-            logger.debug(`${host}/api/customers/${customerId}`);
             const res = await fetch(`${host}/api/customers/${customerId}`, {
               headers: {
                 Authorization: APP_BASIC_AUTHORIZATION,

--- a/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
+++ b/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
@@ -194,7 +194,7 @@ describe("Data Service Generator", () => {
 
         // Wait for the server to be ready and for database migration before running tests.
         // TODO replace with a better docker-compose solution that waits for the migraton to be completd before starting the server
-        logger.info("Waiting for db migration to be ...");
+        logger.info("Waiting for db migration to be completed...");
         let migrationCompleted = false;
         let startTime = Date.now();
 

--- a/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
+++ b/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
@@ -220,26 +220,26 @@ describe("Data Service Generator", () => {
         let servicesNotReady = true;
         startTime = Date.now();
         do {
-          try {
-            logger.info("...");
-            const res = await fetch(`${host}/api/_health/live`, {
-              method: "GET",
-            });
-            if (res.status === STATUS_NO_CONTENT) {
-              const containers = await compose.ps(dockerComposeOptions);
-
-              if (
-                containers.data.services.find((s) =>
-                  s.name.endsWith("server-1")
-                )
-              ) {
+          logger.info("...");
+          const containers = await compose.ps(dockerComposeOptions);
+          logger.debug("containers", {
+            "docker-services": containers.data.services,
+          });
+          if (
+            containers.data.services.find((s) => s.name.endsWith("server-1"))
+          ) {
+            try {
+              const res = await fetch(`${host}/api/_health/live`, {
+                method: "GET",
+              });
+              if (res.status === STATUS_NO_CONTENT) {
                 servicesNotReady = false;
                 logger.info("server ready!");
                 break;
               }
+            } catch (error) {
+              /**/
             }
-          } catch (error) {
-            /**/
           }
           await sleep(1000);
         } while (


### PR DESCRIPTION
Close: #7334

## PR Details

This PR consists of 3 changes:

1. This PR introduce a dynamic wait time before starting e2e tests  based on the actual state of the docker-compose stack instead of a static timeout. 
  With this change, the test run time will also be reduce as it won't need to always wait for 30 seconds before running the actual tests. 🚀
2. Update docker-compose to v2

3. ⚠️ During the investigation, I've noticed that another reason for these e2e tests to fail was the following:

 ![image](https://github.com/amplication/amplication/assets/2861984/6d48434f-fc2d-45de-a1b6-be892429fff6)
 In order to fix this, in the most simple way, this PR adds a restart policy to the docker-compose stack `server` service to avoid the situation were server failed to start, due to race condition with the migration service, and stayed dead.
With the new policy, if `server` starts and fails due to migrations not being completed, it will automatically be restarted by the docker engine.
 
