### PR TITLE
fix(amplication): update models

### DIFF
--- a/ee/packages/git-sync-manager/src/models.ts
+++ b/ee/packages/git-sync-manager/src/models.ts
@@ -190,14 +190,14 @@ export type BooleanFilter = {
 export type Build = {
   action?: Maybe<Action>;
   actionId: Scalars['String']['output'];
-  archiveURI: Scalars['String']['output'];
+  archiveURI?: Maybe<Scalars['String']['output']>;
   codeGeneratorVersion?: Maybe<Scalars['String']['output']>;
-  commit: Commit;
+  commit?: Maybe<Commit>;
   commitId: Scalars['String']['output'];
   createdAt: Scalars['DateTime']['output'];
-  createdBy: User;
+  createdBy?: Maybe<User>;
   id: Scalars['String']['output'];
-  message: Scalars['String']['output'];
+  message?: Maybe<Scalars['String']['output']>;
   resource?: Maybe<Resource>;
   resourceId: Scalars['String']['output'];
   status?: Maybe<EnumBuildStatus>;

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -190,14 +190,14 @@ export type BooleanFilter = {
 export type Build = {
   action?: Maybe<Action>;
   actionId: Scalars['String']['output'];
-  archiveURI: Scalars['String']['output'];
+  archiveURI?: Maybe<Scalars['String']['output']>;
   codeGeneratorVersion?: Maybe<Scalars['String']['output']>;
-  commit: Commit;
+  commit?: Maybe<Commit>;
   commitId: Scalars['String']['output'];
   createdAt: Scalars['DateTime']['output'];
-  createdBy: User;
+  createdBy?: Maybe<User>;
   id: Scalars['String']['output'];
-  message: Scalars['String']['output'];
+  message?: Maybe<Scalars['String']['output']>;
   resource?: Maybe<Resource>;
   resourceId: Scalars['String']['output'];
   status?: Maybe<EnumBuildStatus>;

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -193,14 +193,14 @@ export type BooleanFilter = {
 export type Build = {
   action?: Maybe<Action>;
   actionId: Scalars['String']['output'];
-  archiveURI: Scalars['String']['output'];
+  archiveURI?: Maybe<Scalars['String']['output']>;
   codeGeneratorVersion?: Maybe<Scalars['String']['output']>;
-  commit: Commit;
+  commit?: Maybe<Commit>;
   commitId: Scalars['String']['output'];
   createdAt: Scalars['DateTime']['output'];
-  createdBy: User;
+  createdBy?: Maybe<User>;
   id: Scalars['String']['output'];
-  message: Scalars['String']['output'];
+  message?: Maybe<Scalars['String']['output']>;
   resource?: Maybe<Resource>;
   resourceId: Scalars['String']['output'];
   status?: Maybe<EnumBuildStatus>;

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -190,14 +190,14 @@ export type BooleanFilter = {
 export type Build = {
   action?: Maybe<Action>;
   actionId: Scalars['String']['output'];
-  archiveURI: Scalars['String']['output'];
+  archiveURI?: Maybe<Scalars['String']['output']>;
   codeGeneratorVersion?: Maybe<Scalars['String']['output']>;
-  commit: Commit;
+  commit?: Maybe<Commit>;
   commitId: Scalars['String']['output'];
   createdAt: Scalars['DateTime']['output'];
-  createdBy: User;
+  createdBy?: Maybe<User>;
   id: Scalars['String']['output'];
-  message: Scalars['String']['output'];
+  message?: Maybe<Scalars['String']['output']>;
   resource?: Maybe<Resource>;
   resourceId: Scalars['String']['output'];
   status?: Maybe<EnumBuildStatus>;

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -190,14 +190,14 @@ export type BooleanFilter = {
 export type Build = {
   action?: Maybe<Action>;
   actionId: Scalars['String']['output'];
-  archiveURI: Scalars['String']['output'];
+  archiveURI?: Maybe<Scalars['String']['output']>;
   codeGeneratorVersion?: Maybe<Scalars['String']['output']>;
-  commit: Commit;
+  commit?: Maybe<Commit>;
   commitId: Scalars['String']['output'];
   createdAt: Scalars['DateTime']['output'];
-  createdBy: User;
+  createdBy?: Maybe<User>;
   id: Scalars['String']['output'];
-  message: Scalars['String']['output'];
+  message?: Maybe<Scalars['String']['output']>;
   resource?: Maybe<Resource>;
   resourceId: Scalars['String']['output'];
   status?: Maybe<EnumBuildStatus>;

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -165,14 +165,14 @@ input BooleanFilter {
 type Build {
   action: Action
   actionId: String!
-  archiveURI: String!
+  archiveURI: String
   codeGeneratorVersion: String
-  commit: Commit!
+  commit: Commit
   commitId: String!
   createdAt: DateTime!
-  createdBy: User!
+  createdBy: User
   id: String!
-  message: String!
+  message: String
   resource: Resource
   resourceId: String!
   status: EnumBuildStatus

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -190,14 +190,14 @@ export type BooleanFilter = {
 export type Build = {
   action?: Maybe<Action>;
   actionId: Scalars['String']['output'];
-  archiveURI: Scalars['String']['output'];
+  archiveURI?: Maybe<Scalars['String']['output']>;
   codeGeneratorVersion?: Maybe<Scalars['String']['output']>;
-  commit: Commit;
+  commit?: Maybe<Commit>;
   commitId: Scalars['String']['output'];
   createdAt: Scalars['DateTime']['output'];
-  createdBy: User;
+  createdBy?: Maybe<User>;
   id: Scalars['String']['output'];
-  message: Scalars['String']['output'];
+  message?: Maybe<Scalars['String']['output']>;
   resource?: Maybe<Resource>;
   resourceId: Scalars['String']['output'];
   status?: Maybe<EnumBuildStatus>;


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Leftover from: #6922

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 851e2a3</samp>

### Summary
:sparkles::wrench::recycle:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or enhancement, which is the case for the `git-sync-manager` package and the related changes in the other packages.
2.  :wrench: - This emoji represents a fix or improvement of something that was not working properly or optimally, which is the case for the alignment of the `Build` type with the GraphQL schema and the other packages that use it.
3.  :recycle: - This emoji represents a refactor or cleanup of code or files, which is the case for the removal of the unnecessary `!` operators from the optional fields of the `Build` type.
-->
This pull request makes some fields of the `Build` type optional in several packages and the GraphQL schema. This is to support the new `git-sync-manager` feature that allows users to sync their applications with a Git repository and create pull requests for their changes.

> _`Build` type changes_
> _Aligning with schema, sync_
> _Winter of refactor_

### Walkthrough
*  Make some fields of the `Build` type optional to align it with the GraphQL schema and the other packages that use it ([link](https://github.com/amplication/amplication/pull/7376/files?diff=unified&w=0#diff-aebcd788f7feb9ebc4bbfd2b35aeee1153419a772551daa1cedb30b6735d5442L193-R200), [link](https://github.com/amplication/amplication/pull/7376/files?diff=unified&w=0#diff-8e34f7703a0b39fa5e612bb39ad750167d90a6b75df578f54f35a9348dd0a509L193-R200), [link](https://github.com/amplication/amplication/pull/7376/files?diff=unified&w=0#diff-b9ccc53c48e521fb7c98b07ad7f4761ba0ea91eb649e157d159b065ac2487c1dL196-R203), [link](https://github.com/amplication/amplication/pull/7376/files?diff=unified&w=0#diff-3860f234d2c5629bf7aeb4e7439fe3b357be4e00c08a9f008b56d3610bb017c0L193-R200), [link](https://github.com/amplication/amplication/pull/7376/files?diff=unified&w=0#diff-6137baa91c68c17d5e3716428198a16a3cb5cdd263e22998503daa29c86a296eL193-R200), [link](https://github.com/amplication/amplication/pull/7376/files?diff=unified&w=0#diff-73bf536b699acb92b02c96a64a98814559a3cc31673818128fb74e1aac8c9b75L168-R175), [link](https://github.com/amplication/amplication/pull/7376/files?diff=unified&w=0#diff-a54fca1e77b31822272d37bef66289ad466ba9d835ac76a5474a6808d4bcaaabL193-R200))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
