### PR TITLE
fix(server): allow all field names on the Auth entity

### DIFF
--- a/packages/amplication-server/src/core/entity/constants.ts
+++ b/packages/amplication-server/src/core/entity/constants.ts
@@ -27,7 +27,6 @@ type EntityFieldData = Omit<
 > & { properties: JsonObject };
 
 export const USER_ENTITY_NAME = "User";
-export const USER_ENTITY_FIELDS = ["password", "username"];
 
 export const DEFAULT_PERMISSIONS: Prisma.EntityPermissionCreateWithoutEntityVersionInput[] =
   [

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -35,7 +35,6 @@ import {
   CURRENT_VERSION_NUMBER,
   INITIAL_ENTITY_FIELDS,
   USER_ENTITY_NAME,
-  USER_ENTITY_FIELDS,
   DEFAULT_ENTITIES,
   DEFAULT_PERMISSIONS,
   SYSTEM_DATA_TYPES,
@@ -2217,12 +2216,6 @@ export class EntityService {
     }
 
     if (isUserEntity(entity)) {
-      // Make sure the field's name is not reserved
-      if (isReservedUserEntityFieldName(data.name)) {
-        throw new DataConflictError(
-          `The field name '${data.name}' is a reserved field name and it cannot be used on the 'user' entity`
-        );
-      }
       // In case the field data type is Lookup make sure it is not required
       if (data.dataType === EnumDataType.Lookup && data.required) {
         throw new DataConflictError(
@@ -2739,10 +2732,6 @@ function validateFieldName(name: string): void {
 
 function isSystemDataType(dataType: EnumDataType): boolean {
   return SYSTEM_DATA_TYPES.has(dataType);
-}
-
-function isReservedUserEntityFieldName(name: string): boolean {
-  return USER_ENTITY_FIELDS.includes(name.toLowerCase());
 }
 
 function isUserEntity(entity: Entity): boolean {


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #7438
## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 920e6d3</samp>

### Summary
🔥🆓🛠️

<!--
1.  🔥 - This emoji represents the removal of code or functionality that is no longer needed or relevant. It can also signify simplifying or refactoring code.
2.  🆓 - This emoji represents the freedom or flexibility that the user entity now has to define any fields that they want, without any limitations or constraints. It can also signify removing restrictions or barriers.
3.  🛠️ - This emoji represents the improvement or enhancement of the user entity feature, as well as the maintenance or fixing of any potential issues or bugs. It can also signify updating or upgrading code.
-->
Removed reserved field names on the user entity. This allows more flexibility and customization for the user entity and simplifies the code in `entity.service.ts` and `constants.ts`.

> _Sing, O Muse, of the code that was changed by the skillful developer_
> _Who removed the `USER_ENTITY_FIELDS` from the constants of the server_
> _And freed the user entity from the bonds of the reserved names_
> _Like Zeus who broke the chains of Cronus and his Titan flames_

### Walkthrough
*  Remove `USER_ENTITY_FIELDS` constant and its imports ([link](https://github.com/amplication/amplication/pull/7439/files?diff=unified&w=0#diff-29776bf4332e3c374efcd7679d2f4bbe2fb626a0f31b799b4c8c06f3ca1d1273L30), [link](https://github.com/amplication/amplication/pull/7439/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L38))
*  Delete validation logic for reserved field names on user entity in `createField` method of `EntityService` class ([link](https://github.com/amplication/amplication/pull/7439/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L2220-L2225))
*  Erase unused `isReservedUserEntityFieldName` function from `entity.service.ts` ([link](https://github.com/amplication/amplication/pull/7439/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59L2744-L2747))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
