### PR TITLE
chore(build-manager): add logging and additional post param to the argo-events DSG sensor

### DIFF
--- a/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
@@ -41,6 +41,10 @@ export class BuildRunnerService {
   ) {
     let codeGeneratorVersion: string;
     try {
+      this.logger.debug(
+        `Calculating Code Generator Version with dsgResourceData:  ${dsgResourceData.resourceInfo.codeGeneratorVersionOptions}`
+      );
+
       codeGeneratorVersion =
         await this.codeGeneratorService.getCodeGeneratorVersion({
           codeGeneratorVersion:
@@ -50,6 +54,9 @@ export class BuildRunnerService {
             dsgResourceData.resourceInfo.codeGeneratorVersionOptions
               .codeGeneratorStrategy,
         });
+      this.logger.debug("Code Generator Version Calculated as: ", {
+        codeGeneratorVersion,
+      });
 
       const shouldSplitBuild =
         this.codeGeneratorService.compareVersions(
@@ -94,15 +101,21 @@ export class BuildRunnerService {
     data: DSGResourceData,
     codeGeneratorVersion: string
   ) {
+    this.logger.debug("Inside runJob with codeGeneratorVersion: ", {
+      codeGeneratorVersion,
+    });
     await this.saveDsgResourceData(jobBuildId, data, codeGeneratorVersion);
 
     const url = this.configService.get(Env.DSG_RUNNER_URL);
     try {
-      await axios.post(url, {
+      const postBody = {
         resourceId: resourceId,
         buildId: jobBuildId,
         codeGeneratorVersion,
-      });
+        containerImageTag: codeGeneratorVersion,
+      };
+      this.logger.debug("Calling argo event with post paylod: ", { postBody });
+      await axios.post(url, postBody);
     } catch (error) {
       throw new Error(error.message, {
         cause: {

--- a/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
@@ -41,10 +41,6 @@ export class BuildRunnerService {
   ) {
     let codeGeneratorVersion: string;
     try {
-      this.logger.debug(
-        `Calculating Code Generator Version with dsgResourceData:  ${dsgResourceData.resourceInfo.codeGeneratorVersionOptions}`
-      );
-
       codeGeneratorVersion =
         await this.codeGeneratorService.getCodeGeneratorVersion({
           codeGeneratorVersion:
@@ -54,6 +50,7 @@ export class BuildRunnerService {
             dsgResourceData.resourceInfo.codeGeneratorVersionOptions
               .codeGeneratorStrategy,
         });
+
       this.logger.debug("Code Generator Version Calculated as: ", {
         codeGeneratorVersion,
       });
@@ -101,20 +98,16 @@ export class BuildRunnerService {
     data: DSGResourceData,
     codeGeneratorVersion: string
   ) {
-    this.logger.debug("Inside runJob with codeGeneratorVersion: ", {
-      codeGeneratorVersion,
-    });
     await this.saveDsgResourceData(jobBuildId, data, codeGeneratorVersion);
 
     const url = this.configService.get(Env.DSG_RUNNER_URL);
     try {
       const postBody = {
-        resourceId: resourceId,
+        resourceId,
         buildId: jobBuildId,
         codeGeneratorVersion,
-        containerImageTag: codeGeneratorVersion,
       };
-      this.logger.debug("Calling argo event with post paylod: ", { postBody });
+      this.logger.debug("Calling argo event with post payload: ", { postBody });
       await axios.post(url, postBody);
     } catch (error) {
       throw new Error(error.message, {


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #7459

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c5205a4</samp>

### Summary
📝🚀🛠️

<!--
1.  📝 - This emoji represents logging or documentation, and can be used to indicate the addition of debug log statements to the `BuildRunnerService` class.
2.  🚀 - This emoji represents deployment or delivery, and can be used to indicate the passing of the `containerImageTag` property to the argo event service, which is responsible for triggering the code generation workflow.
3.  🛠️ - This emoji represents maintenance or improvement, and can be used to indicate the overall enhancement of the code generator version communication for the data service generator job.
-->
Improve logging and versioning of data service generator. Add `containerImageTag` to argo event service and debug logs to `BuildRunnerService`.

> _Oh we are the code generator crew_
> _We log and communicate what we do_
> _We pass the `containerImageTag` on the count of three_
> _And send it to the argo event service, yo ho ho and a bottle of tea_

### Walkthrough
*  Add debug log statements to print the code generator version options and the selected code generator version in the `calculateCodeGeneratorVersion` method of the `BuildRunnerService` class (`packages/amplication-build-manager/src/build-runner/build-runner.service.ts`, [link](https://github.com/amplication/amplication/pull/7462/files?diff=unified&w=0#diff-a2d46b2df4132a6474b67758980206d93609e2deb576bab82bd20c13553f470bR44-R47), [link](https://github.com/amplication/amplication/pull/7462/files?diff=unified&w=0#diff-a2d46b2df4132a6474b67758980206d93609e2deb576bab82bd20c13553f470bR57-R59))
*  Pass the selected code generator version and the container image tag as parameters to the `runJob` method of the `BuildRunnerService` class and to the axios request to the argo event service (`packages/amplication-build-manager/src/build-runner/build-runner.service.ts`, [link](https://github.com/amplication/amplication/pull/7462/files?diff=unified&w=0#diff-a2d46b2df4132a6474b67758980206d93609e2deb576bab82bd20c13553f470bL97-R118))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
