### PR TITLE
Fix(dsg): linting errors

### DIFF
--- a/packages/data-service-generator/src/server/create-main/main.template.ts
+++ b/packages/data-service-generator/src/server/create-main/main.template.ts
@@ -26,8 +26,8 @@ async function main() {
   const document = SwaggerModule.createDocument(app, swaggerDocumentOptions);
 
   /** check if there is Public decorator for each path (action) and its method (findMany / findOne) on each controller */
-  Object.values((document as OpenAPIObject).paths).forEach((path: any) => {
-    Object.values(path).forEach((method: any) => {
+  Object.values((document as OpenAPIObject).paths).forEach((path) => {
+    Object.values(path).forEach((method) => {
       if (
         Array.isArray(method.security) &&
         method.security.includes("isPublic")

--- a/packages/data-service-generator/src/server/static/src/decorators/api-nested-query.decorator.ts
+++ b/packages/data-service-generator/src/server/static/src/decorators/api-nested-query.decorator.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { applyDecorators } from "@nestjs/common";
 import {
   ApiExtraModels,

--- a/packages/data-service-generator/src/server/static/src/prisma.util.ts
+++ b/packages/data-service-generator/src/server/static/src/prisma.util.ts
@@ -1,6 +1,7 @@
 export const PRISMA_QUERY_INTERPRETATION_ERROR = "P2016";
 export const PRISMA_RECORD_NOT_FOUND = "RecordNotFound";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isRecordNotFoundError(error: any): boolean {
   return (
     error instanceof Error &&

--- a/packages/data-service-generator/src/server/static/src/prisma/prisma.service.ts
+++ b/packages/data-service-generator/src/server/static/src/prisma/prisma.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnModuleInit, INestApplication } from "@nestjs/common";
+import { Injectable, OnModuleInit } from "@nestjs/common";
 import { PrismaClient } from "@prisma/client";
 
 @Injectable()

--- a/packages/data-service-generator/src/server/static/src/validators/is-json-value-validator.ts
+++ b/packages/data-service-generator/src/server/static/src/validators/is-json-value-validator.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any */
 import {
   ValidationArguments,
   registerDecorator,

--- a/packages/gpt-gateway/src/interceptors/aclFilterResponse.interceptor.ts
+++ b/packages/gpt-gateway/src/interceptors/aclFilterResponse.interceptor.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   CallHandler,
   ExecutionContext,

--- a/packages/gpt-gateway/src/interceptors/aclValidateRequest.interceptor.ts
+++ b/packages/gpt-gateway/src/interceptors/aclValidateRequest.interceptor.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   CallHandler,
   ExecutionContext,

--- a/packages/gpt-gateway/src/providers/secrets/base/secretsManager.service.base.ts
+++ b/packages/gpt-gateway/src/providers/secrets/base/secretsManager.service.base.ts
@@ -1,7 +1,9 @@
 import { ConfigService } from "@nestjs/config";
 
 export interface ISecretsManager {
-  getSecret: (key: string) => Promise<any | null>;
+  getSecret: (
+    key: string
+  ) => Promise<unknown | null | string | Record<string, unknown>>;
 }
 
 export class SecretsManagerServiceBase implements ISecretsManager {


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Part of: #6783 

## PR Details

A reference to the fixes on the generated app.
We had to add in some places ts-ignores (when we must use the type `any` and sometimes for unused params)

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d5e294f</samp>

### Summary
🚨🎨🔧

<!--
1.  🚨 - This emoji represents the linting errors that were fixed by removing redundant or unused imports and type annotations, and adding eslint comments to disable some rules.
2.  🎨 - This emoji represents the improvement of the code style and readability by using more descriptive and accurate return types, and removing unnecessary parameters.
3.  🔧 - This emoji represents the configuration of the eslint rules to allow the use of the `any` type in some cases where it is needed for the decorators, validators, and interceptors.
-->
This pull request fixes several linting errors related to the use of the `any` type in TypeScript files, by either adding eslint comments to disable the relevant rules, or by replacing `any` with more specific types. It also removes some unused imports and type annotations.

> _`any` type gone_
> _eslint rules disabled now_
> _winter of silence_

### Walkthrough
*  Remove redundant type annotations for `path` and `method` in `main.template.ts` ([link](https://github.com/amplication/amplication/pull/7475/files?diff=unified&w=0#diff-2e334aa22ac1df0b44759a0ff707d0b7bb4361d992d5c64d9dadefb9213f8ac5L29-R30))
*  Disable `@typescript-eslint/no-explicit-any` rule for files that use `any` type for decorators, interceptors, or utility functions (`api-nested-query.decorator.ts`, `prisma.util.ts`, `aclFilterResponse.interceptor.ts`, `aclValidateRequest.interceptor.ts`, `is-json-value-validator.ts`) ([link](https://github.com/amplication/amplication/pull/7475/files?diff=unified&w=0#diff-d1931e613da47d399dbac7096ae2c109948d5d17becbb4823a9749ad478004d3R1), [link](https://github.com/amplication/amplication/pull/7475/files?diff=unified&w=0#diff-f8c6691e7443d19d02dccd1eb92e998b4c563cc609967d07add4bd88ebfeef41R4), [link](https://github.com/amplication/amplication/pull/7475/files?diff=unified&w=0#diff-f18b8158a4df8e9cc4867a534e993e02f7630e5c06c9babeb8cea0b2b4ce25daR1), [link](https://github.com/amplication/amplication/pull/7475/files?diff=unified&w=0#diff-8e6455d1ce99a9628422f99ef6db1cf832502a0e1c2761d16d337b65e312f8f2R1), [link](https://github.com/amplication/amplication/pull/7475/files?diff=unified&w=0#diff-e1f140f3b372b73bf0c0ca1f64171b20a260760d9dfaf2d0cbc9f7a6b492b364R1))
*  Remove unused import of `INestApplication` in `prisma.service.ts` ([link](https://github.com/amplication/amplication/pull/7475/files?diff=unified&w=0#diff-9827f2e84af7c5296a56f2a761c3e200ff39a11276fa396c9c4ecad8ff0c2f99L1-R1))
*  Change return type of `getSecret` method in `secretsManager.service.base.ts` from `any | null` to `unknown | null | string | Record<string, unknown>` for better type safety and readability ([link](https://github.com/amplication/amplication/pull/7475/files?diff=unified&w=0#diff-a994cf311719e754c7038b35d30497e6fd94c10619d7a2832f60e1dcd516b6dbL4-R6))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
