### PR TITLE
fix(build-manager): handle and report build errors more accurately and reliably

### DIFF
--- a/packages/amplication-build-manager/src/build-runner/build-runner.service.spec.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.service.spec.ts
@@ -560,15 +560,6 @@ describe("BuildRunnerService", () => {
     const buildId = "buildId";
     const codeGeneratorVersion = "v1.0.0";
 
-    const kafkaFailureEventMock: CodeGenerationFailure.KafkaEvent = {
-      key: null,
-      value: <CodeGenerationFailure.Value>{
-        buildId,
-        codeGeneratorVersion,
-        error: errorMock,
-      },
-    } as unknown as CodeGenerationFailure.KafkaEvent;
-
     const spyOnSetJobStatus = jest.spyOn(
       buildJobsHandlerService,
       "setJobStatus"

--- a/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
@@ -224,15 +224,15 @@ export class BuildRunnerService {
         buildId
       );
 
-      if (buildStatus === EnumJobStatus.Failure) {
-        // do nothing - already emitted
-        return;
-      }
-
       await this.buildJobsHandlerService.setJobStatus(
         jobBuildId,
         EnumJobStatus.Failure
       );
+
+      if (buildStatus === EnumJobStatus.Failure) {
+        // do nothing - already emitted
+        return;
+      }
 
       const failureEvent: CodeGenerationFailure.KafkaEvent = {
         key: null,


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #7480

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 28edf46</samp>

### Summary
🧪🐛📊

<!--
1.  🧪 for adding a new test case.
2.  🐛 for fixing a bug in the error handling logic.
3.  📊 for improving the status reporting of the build service.
-->
This pull request enhances the `BuildRunnerService` class to handle and report build errors more accurately and reliably. It also adds a new unit test to verify the correct behavior of the `emitCodeGenerationFailureWhenJobStatusFailed` method.

> _Oh we are the `BuildRunnerService` crew_
> _We handle errors and status too_
> _We set the job to fail or pass_
> _And emit events with a class_

### Walkthrough
*  Update the `runBuild` method of the `BuildRunnerService` class to handle errors during code generation ([link](https://github.com/amplication/amplication/pull/7481/files?diff=unified&w=0#diff-a2d46b2df4132a6474b67758980206d93609e2deb576bab82bd20c13553f470bR227-R231), [link](https://github.com/amplication/amplication/pull/7481/files?diff=unified&w=0#diff-a2d46b2df4132a6474b67758980206d93609e2deb576bab82bd20c13553f470bL232-L236))
  - Call `setJobStatus` with failure status in the `catch` block ([link](https://github.com/amplication/amplication/pull/7481/files?diff=unified&w=0#diff-a2d46b2df4132a6474b67758980206d93609e2deb576bab82bd20c13553f470bR227-R231))
  - Remove redundant call to `setJobStatus` in the `finally` block ([link](https://github.com/amplication/amplication/pull/7481/files?diff=unified&w=0#diff-a2d46b2df4132a6474b67758980206d93609e2deb576bab82bd20c13553f470bL232-L236))
* Add a new test case for the `emitCodeGenerationFailureWhenJobStatusFailed` method of the `BuildRunnerService` class ([link](https://github.com/amplication/amplication/pull/7481/files?diff=unified&w=0#diff-ff434d5cde86de6213054cbce0cceb6c292f90d4d749a386d45988aa18197557R557-R601))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
