### PR TITLE
Refactor(build-manager): copy files and emit logic

### DIFF
--- a/packages/amplication-build-manager/jest.config.ts
+++ b/packages/amplication-build-manager/jest.config.ts
@@ -16,8 +16,8 @@ export default {
   coverageDirectory: "../../coverage/packages/amplication-build-manager",
   coverageThreshold: {
     global: {
-      branches: 70,
-      lines: 78,
+      branches: 87,
+      lines: 89,
     },
   },
 };

--- a/packages/amplication-build-manager/src/build-runner/build-runner.service.spec.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.service.spec.ts
@@ -171,7 +171,7 @@ describe("BuildRunnerService", () => {
   });
 
   describe("copyFromJobToArtifact", () => {
-    it("should copy file and/or directories from `jobPath` to `artifactPath` and return true", async () => {
+    it("should copy file and/or directories from `jobPath` to `artifactPath`", async () => {
       const resourceId = "resourceId";
       const buildId = "buildId";
 
@@ -190,31 +190,28 @@ describe("BuildRunnerService", () => {
         buildId
       );
 
-      const result = await service.copyFromJobToArtifact(resourceId, buildId);
+      await service.copyFromJobToArtifact(resourceId, buildId);
 
       expect(spyOnBuildJobsHandlerServiceExtractBuildId).toBeCalledTimes(1);
       expect(spyOnFsExtraCopy).toBeCalledWith(jobPath, artifactPath);
-      expect(result).toBe(true);
       await expect(fsExtra.copy(jobPath, artifactPath)).resolves.not.toThrow();
     });
 
-    it("should return false something went wrong", async () => {
-      const resourceId = "resourceId";
+    it("should throw an error when copy files failed", async () => {
       const buildId = "buildId";
+      const mockedError = new Error("Copy files failed");
 
-      const spyOnBuildJobsHandlerServiceExtractBuildId = jest
+      jest
         .spyOn(buildJobsHandlerService, "extractBuildId")
         .mockReturnValue(buildId);
 
       spyOnFsExtraCopy.mockImplementationOnce(() => {
-        throw new Error("Error");
+        throw mockedError;
       });
 
-      const result = await service.copyFromJobToArtifact(resourceId, buildId);
-
-      expect(spyOnBuildJobsHandlerServiceExtractBuildId).toBeCalledTimes(1);
-      expect(spyOnFsExtraCopy).toBeCalledTimes(1);
-      expect(result).toBe(false);
+      await expect(
+        service.copyFromJobToArtifact("resource-id", "job-build-id")
+      ).rejects.toThrow(mockedError.message);
     });
   });
 
@@ -568,7 +565,7 @@ describe("BuildRunnerService", () => {
       .spyOn(service, "getCodeGeneratorVersion")
       .mockResolvedValue(codeGeneratorVersion);
 
-    jest.spyOn(service, "copyFromJobToArtifact").mockResolvedValue(true);
+    jest.spyOn(service, "copyFromJobToArtifact");
 
     spyOnSetJobStatus.mockResolvedValue(undefined);
     jest
@@ -672,7 +669,7 @@ describe("BuildRunnerService", () => {
           .spyOn(service, "getCodeGeneratorVersion")
           .mockResolvedValue(codeGeneratorVersion);
 
-        jest.spyOn(service, "copyFromJobToArtifact").mockResolvedValue(true);
+        jest.spyOn(service, "copyFromJobToArtifact");
         jest
           .spyOn(buildJobsHandlerService, "setJobStatus")
           .mockResolvedValue(undefined);

--- a/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
@@ -299,7 +299,7 @@ export class BuildRunnerService {
       await copy(jobPath, artifactPath);
     } catch (error) {
       this.logger.error(error.message, error);
-      throw new Error(error.message);
+      throw error;
     }
   }
 }

--- a/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
@@ -150,53 +150,25 @@ export class BuildRunnerService {
   async emitKafkaEventBasedOnJobStatus(resourceId: string, jobBuildId: string) {
     let codeGeneratorVersion: string;
     const buildId = this.buildJobsHandlerService.extractBuildId(jobBuildId);
-
-    const currentBuildStatus =
-      await this.buildJobsHandlerService.getBuildStatus(buildId);
-    const otherJobsHaveAlreadyFailed =
-      currentBuildStatus === EnumJobStatus.Failure;
-
-    if (otherJobsHaveAlreadyFailed) {
-      // do nothing
-      return;
-    }
+    let otherJobsHaveNotFailed = true;
 
     try {
       codeGeneratorVersion = await this.getCodeGeneratorVersion(jobBuildId);
-      const isCopySucceeded = await this.copyFromJobToArtifact(
-        resourceId,
-        jobBuildId
-      );
 
-      isCopySucceeded
-        ? await this.buildJobsHandlerService.setJobStatus(
-            jobBuildId,
-            EnumJobStatus.Success
-          )
-        : await this.buildJobsHandlerService.setJobStatus(
-            jobBuildId,
-            EnumJobStatus.Failure
-          );
+      const currentBuildStatus =
+        await this.buildJobsHandlerService.getBuildStatus(buildId);
+      otherJobsHaveNotFailed = currentBuildStatus !== EnumJobStatus.Failure;
+
+      await this.copyFromJobToArtifact(resourceId, jobBuildId);
+
+      await this.buildJobsHandlerService.setJobStatus(
+        jobBuildId,
+        EnumJobStatus.Success
+      );
 
       const buildStatus = await this.buildJobsHandlerService.getBuildStatus(
         buildId
       );
-
-      if (buildStatus === EnumJobStatus.Failure) {
-        const failureEvent: CodeGenerationFailure.KafkaEvent = {
-          key: null,
-          value: {
-            buildId,
-            codeGeneratorVersion,
-            error: new Error("Failed to copy from job to artifact"),
-          },
-        };
-
-        await this.producerService.emitMessage(
-          KAFKA_TOPICS.CODE_GENERATION_FAILURE_TOPIC,
-          failureEvent
-        );
-      }
 
       if (buildStatus === EnumJobStatus.InProgress) {
         // do nothing
@@ -215,20 +187,21 @@ export class BuildRunnerService {
         );
       }
     } catch (error) {
-      this.logger.error(error.message, error);
-      const failureEvent: CodeGenerationFailure.KafkaEvent = {
-        key: null,
-        value: {
-          buildId,
-          codeGeneratorVersion,
-          error,
-        },
-      };
+      if (otherJobsHaveNotFailed) {
+        const failureEvent: CodeGenerationFailure.KafkaEvent = {
+          key: null,
+          value: {
+            buildId,
+            codeGeneratorVersion,
+            error,
+          },
+        };
 
-      await this.producerService.emitMessage(
-        KAFKA_TOPICS.CODE_GENERATION_FAILURE_TOPIC,
-        failureEvent
-      );
+        await this.producerService.emitMessage(
+          KAFKA_TOPICS.CODE_GENERATION_FAILURE_TOPIC,
+          failureEvent
+        );
+      }
     }
   }
 
@@ -307,7 +280,7 @@ export class BuildRunnerService {
   async copyFromJobToArtifact(
     resourceId: string,
     jobBuildId: string
-  ): Promise<boolean> {
+  ): Promise<void> {
     const buildId = this.buildJobsHandlerService.extractBuildId(jobBuildId);
 
     try {
@@ -324,10 +297,9 @@ export class BuildRunnerService {
       );
 
       await copy(jobPath, artifactPath);
-      return true;
     } catch (error) {
       this.logger.error(error.message, error);
-      return false;
+      throw new Error(error.message);
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #7494

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 337f896</samp>

### Summary
🔧🚨📝

<!--
1.  🔧 - This emoji represents refactoring or fixing something, which is what the first bullet point describes.
2.  🚨 - This emoji represents testing or adding tests, which is what the first bullet point also involves.
3.  📝 - This emoji represents logging or documenting something, which is what the second bullet point describes.
-->
Improved the error handling and logging in the `BuildRunnerService` class and its tests. Refactored the `copyFromJobToArtifact` method to throw errors instead of returning false. Updated the tests in `build-runner.service.spec.ts` to match the new behavior.

> _`BuildRunnerService`_
> _Simplifies error handling_
> _Logs messages, too_

### Walkthrough
*  Refactor `run` method in `BuildRunnerService` to simplify logic and error handling ([link](https://github.com/amplication/amplication/pull/7495/files?diff=unified&w=0#diff-a2d46b2df4132a6474b67758980206d93609e2deb576bab82bd20c13553f470bL153-R172), [link](https://github.com/amplication/amplication/pull/7495/files?diff=unified&w=0#diff-a2d46b2df4132a6474b67758980206d93609e2deb576bab82bd20c13553f470bL218-R204))
* Change return type of `copyFromJobToArtifact` method in `BuildRunnerService` from `Promise<boolean>` to `Promise<void>` and rethrow error on failure ([link](https://github.com/amplication/amplication/pull/7495/files?diff=unified&w=0#diff-a2d46b2df4132a6474b67758980206d93609e2deb576bab82bd20c13553f470bL310-R283), [link](https://github.com/amplication/amplication/pull/7495/files?diff=unified&w=0#diff-a2d46b2df4132a6474b67758980206d93609e2deb576bab82bd20c13553f470bL327-R302))
* Modify test cases for `copyFromJobToArtifact` method in `build-runner.service.spec.ts` to expect error to be thrown on failure and remove mock implementation ([link](https://github.com/amplication/amplication/pull/7495/files?diff=unified&w=0#diff-ff434d5cde86de6213054cbce0cceb6c292f90d4d749a386d45988aa18197557L174-R174), [link](https://github.com/amplication/amplication/pull/7495/files?diff=unified&w=0#diff-ff434d5cde86de6213054cbce0cceb6c292f90d4d749a386d45988aa18197557L193-R214), [link](https://github.com/amplication/amplication/pull/7495/files?diff=unified&w=0#diff-ff434d5cde86de6213054cbce0cceb6c292f90d4d749a386d45988aa18197557L571-R568), [link](https://github.com/amplication/amplication/pull/7495/files?diff=unified&w=0#diff-ff434d5cde86de6213054cbce0cceb6c292f90d4d749a386d45988aa18197557L675-R672))



## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
