### PR TITLE
Fix:The "Username" and "Password" fields in "User" entity cannot be changed to be a unique field 

### DIFF
--- a/packages/data-service-generator/src/server/user-entity/user-entity.ts
+++ b/packages/data-service-generator/src/server/user-entity/user-entity.ts
@@ -29,7 +29,7 @@ export const USER_PASSWORD_FIELD: EntityField = {
   displayName: "Password",
   dataType: EnumDataType.Password,
   required: true,
-  unique: false,
+  unique: true,
   searchable: false,
 };
 


### PR DESCRIPTION
Close: #7493

## PR Details

 Both USER_NAME_FIELD and USER_PASSWORD_FIELD have the unique property set to true. This change indicates that the values in these fields must be unique across all records in the "User" entity.

