### PR TITLE
fix(dsg): avoid adding postgres plugin when ms-sql plugin is installed

### DIFF
--- a/packages/data-service-generator/src/utils/dynamic-installation/defaultPlugins.spec.ts
+++ b/packages/data-service-generator/src/utils/dynamic-installation/defaultPlugins.spec.ts
@@ -1,0 +1,66 @@
+import { PluginInstallation } from "@amplication/code-gen-types";
+import {
+  MSSQL_PLUGIN_ID,
+  POSTGRESQL_NPM,
+  POSTGRESQL_PLUGIN_ID,
+  prepareDefaultPlugins,
+} from "./defaultPlugins";
+
+describe("prepareDefaultPlugins", () => {
+  it("should return default plugins if no plugins are installed", () => {
+    const result = prepareDefaultPlugins([]);
+
+    expect(result).toEqual([
+      expect.objectContaining(<PluginInstallation>{
+        pluginId: POSTGRESQL_PLUGIN_ID,
+        npm: POSTGRESQL_NPM,
+        version: "latest",
+      }),
+    ]);
+  });
+
+  it("should return installed plugins if they are part of the default plugin category", () => {
+    const expectedPlugins = [
+      {
+        id: "placeholder-id",
+        pluginId: "plugin-id",
+        npm: "plugin-npm",
+        enabled: true,
+        version: "latest",
+      },
+      {
+        id: "postgres-id-123",
+        pluginId: POSTGRESQL_PLUGIN_ID,
+        npm: POSTGRESQL_NPM,
+        enabled: true,
+        version: "latest",
+      },
+    ];
+
+    const result = prepareDefaultPlugins(expectedPlugins);
+
+    expect(result).toEqual(expectedPlugins);
+  });
+
+  it("should return installed plugins if installed plugins contain a db plugin", () => {
+    const expectedPlugins = [
+      {
+        id: "placeholder-id",
+        pluginId: "plugin-id",
+        npm: "plugin-npm",
+        enabled: true,
+        version: "latest",
+      },
+      {
+        id: "postgres-id-123",
+        pluginId: MSSQL_PLUGIN_ID,
+        npm: "@amplication/plugin-db-sqlserver",
+        enabled: true,
+        version: "latest",
+      },
+    ];
+    const result = prepareDefaultPlugins(expectedPlugins);
+
+    expect(result).toStrictEqual(expectedPlugins);
+  });
+});

--- a/packages/data-service-generator/src/utils/dynamic-installation/defaultPlugins.ts
+++ b/packages/data-service-generator/src/utils/dynamic-installation/defaultPlugins.ts
@@ -3,6 +3,8 @@ export const POSTGRESQL_PLUGIN_ID = "db-postgres";
 export const MYSQL_PLUGIN_ID = "db-mysql";
 export const POSTGRESQL_NPM = "@amplication/plugin-db-postgres";
 export const MONGO_PLUGIN_ID = "db-mongo";
+export const MSSQL_PLUGIN_ID = "db-mssql";
+
 type DefaultPlugin = {
   categoryPluginIds: string[];
   defaultCategoryPlugin: PluginInstallation;
@@ -10,7 +12,12 @@ type DefaultPlugin = {
 
 const defaultPlugins: DefaultPlugin[] = [
   {
-    categoryPluginIds: [POSTGRESQL_PLUGIN_ID, MYSQL_PLUGIN_ID, MONGO_PLUGIN_ID],
+    categoryPluginIds: [
+      POSTGRESQL_PLUGIN_ID,
+      MYSQL_PLUGIN_ID,
+      MONGO_PLUGIN_ID,
+      MSSQL_PLUGIN_ID,
+    ],
     defaultCategoryPlugin: {
       id: "placeholder-id",
       pluginId: POSTGRESQL_PLUGIN_ID,


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #7515

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f31c0f9</samp>

### Summary
🧪🗄️🆕

<!--
1.  🧪 - This emoji represents testing or experimentation, and can be used to indicate the addition of a new test file or a new test case.
2.  🗄️ - This emoji represents databases or data storage, and can be used to indicate the addition of a new database plugin option or a change in the data service configuration.
3.  🆕 - This emoji represents something new or updated, and can be used to indicate the introduction of a new feature or functionality.
-->
This pull request adds support for Microsoft SQL Server databases as a plugin option for the data service generator. It also adds a new test file for the `prepareDefaultPlugins` function, which handles the plugin installation logic.

> _`prepareDefaultPlugins`_
> _Tests and SQL Server support_
> _Autumn of data_

### Walkthrough
*  Add a new constant for the MSSQL plugin ID and update the default plugin category definition to include it ([link](https://github.com/amplication/amplication/pull/7514/files?diff=unified&w=0#diff-f343d95b6809c6d299a6e60c25cc166f99d9e08e005984240e61bc0f78d9b939R6-R7), [link](https://github.com/amplication/amplication/pull/7514/files?diff=unified&w=0#diff-f343d95b6809c6d299a6e60c25cc166f99d9e08e005984240e61bc0f78d9b939L13-R20))
*  Add a new test file for the `prepareDefaultPlugins` function, which tests the scenarios of no plugins installed, default plugins installed, and database plugins installed ([link](https://github.com/amplication/amplication/pull/7514/files?diff=unified&w=0#diff-48f8fa904f27be3672840976c9f235694eedf716bf50c1594abe428d19c185caR1-R66))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
