### PR TITLE
test(dsg): refactor snapshot testing mock data for plugin installations

### DIFF
--- a/packages/data-service-generator/scripts/create-input-json.ts
+++ b/packages/data-service-generator/scripts/create-input-json.ts
@@ -14,7 +14,7 @@ async function createInputJsonFile() {
     roles,
     resourceInfo: appInfo,
     resourceType: EnumResourceType.Service,
-    pluginInstallations: [plugins.postgresPlugin],
+    pluginInstallations: [plugins.postgres],
   };
 
   const buildSpecPath = process.env.BUILD_SPEC_PATH;

--- a/packages/data-service-generator/src/create-data-service.ts
+++ b/packages/data-service-generator/src/create-data-service.ts
@@ -22,6 +22,7 @@ export async function createDataService(
 
   await dynamicPackagesInstallations(
     dSGResourceData.pluginInstallations,
+    pluginInstallationPath,
     internalLogger
   );
 

--- a/packages/data-service-generator/src/dynamic-package-installation.ts
+++ b/packages/data-service-generator/src/dynamic-package-installation.ts
@@ -1,6 +1,4 @@
 import { PluginInstallation } from "@amplication/code-gen-types";
-import { join } from "path";
-import { AMPLICATION_MODULES } from "./generate-code";
 import {
   DynamicPackageInstallationManager,
   PackageInstallation,
@@ -10,6 +8,7 @@ import DsgContext from "./dsg-context";
 
 export async function dynamicPackagesInstallations(
   packages: PluginInstallation[],
+  pluginInstallationPath: string,
   logger: ILogger
 ): Promise<void> {
   logger.info("Installing dynamic packages");
@@ -17,7 +16,7 @@ export async function dynamicPackagesInstallations(
   const context = DsgContext.getInstance;
 
   const manager = new DynamicPackageInstallationManager(
-    join(__dirname, "..", AMPLICATION_MODULES),
+    pluginInstallationPath,
     context.logger
   );
 

--- a/packages/data-service-generator/src/tests/create-data-service-custom-path.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-custom-path.spec.ts
@@ -3,7 +3,6 @@ import { createDataService } from "../create-data-service";
 import { EnumResourceType } from "../models";
 import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import entities from "./entities";
-import { installedPlugins } from "./pluginInstallation";
 import roles from "./roles";
 import { MockedLogger } from "@amplication/util/logging/test-utils";
 import { rm } from "fs/promises";
@@ -47,7 +46,7 @@ describe("createDataService", () => {
           roles,
           resourceInfo: newAppInfo,
           resourceType: EnumResourceType.Service,
-          pluginInstallations: installedPlugins,
+          pluginInstallations: [],
         },
         MockedLogger,
         temporaryPluginInstallationPath

--- a/packages/data-service-generator/src/tests/create-data-service-custom-path.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-custom-path.spec.ts
@@ -6,8 +6,8 @@ import entities from "./entities";
 import { installedPlugins } from "./pluginInstallation";
 import roles from "./roles";
 import { MockedLogger } from "@amplication/util/logging/test-utils";
-import { AMPLICATION_MODULES } from "../generate-code";
-import { join } from "path";
+import { rm } from "fs/promises";
+import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
 
 const newAppInfo: AppInfo = {
   ...appInfo,
@@ -27,9 +27,16 @@ const newAppInfo: AppInfo = {
 
 jest.setTimeout(100000);
 
+const temporaryPluginInstallationPath =
+  getTemporaryPluginInstallationPath(__filename);
+
 describe("createDataService", () => {
-  afterEach(() => {
+  afterEach(async () => {
     jest.clearAllMocks();
+    await rm(temporaryPluginInstallationPath, {
+      recursive: true,
+      force: true,
+    });
   });
   describe("when server and admin are configured with custom path", () => {
     test("creates app as expected", async () => {
@@ -43,7 +50,7 @@ describe("createDataService", () => {
           pluginInstallations: installedPlugins,
         },
         MockedLogger,
-        join(__dirname, "../../", AMPLICATION_MODULES)
+        temporaryPluginInstallationPath
       );
 
       const modulesToSnapshot = modules

--- a/packages/data-service-generator/src/tests/create-data-service-numeric-user-id.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-numeric-user-id.spec.ts
@@ -7,8 +7,8 @@ import entities from "./entities";
 import { installedPlugins } from "./pluginInstallation";
 import roles from "./roles";
 import { MockedLogger } from "@amplication/util/logging/test-utils";
-import { join } from "path";
-import { AMPLICATION_MODULES } from "../generate-code";
+import { rm } from "fs/promises";
+import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
 
 jest.setTimeout(100000);
 
@@ -25,10 +25,16 @@ beforeAll(() => {
   }
   (idField.properties as types.Id) = { idType: "AUTO_INCREMENT" };
 });
+const temporaryPluginInstallationPath =
+  getTemporaryPluginInstallationPath(__filename);
 
 describe("createDataService", () => {
-  afterEach(() => {
+  afterEach(async () => {
     jest.clearAllMocks();
+    await rm(temporaryPluginInstallationPath, {
+      recursive: true,
+      force: true,
+    });
   });
   describe("when using a numeric user id", () => {
     test("creates resource as expected", async () => {
@@ -42,7 +48,7 @@ describe("createDataService", () => {
           pluginInstallations: installedPlugins,
         },
         MockedLogger,
-        join(__dirname, "../../", AMPLICATION_MODULES)
+        temporaryPluginInstallationPath
       );
       const modulesToSnapshot = modules
         .modules()

--- a/packages/data-service-generator/src/tests/create-data-service-numeric-user-id.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-numeric-user-id.spec.ts
@@ -4,7 +4,6 @@ import { EnumDataType, EnumResourceType } from "../models";
 import { USER_ENTITY_NAME } from "../server/user-entity/user-entity";
 import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import entities from "./entities";
-import { installedPlugins } from "./pluginInstallation";
 import roles from "./roles";
 import { MockedLogger } from "@amplication/util/logging/test-utils";
 import { rm } from "fs/promises";
@@ -45,7 +44,7 @@ describe("createDataService", () => {
           roles,
           resourceInfo: appInfo,
           resourceType: EnumResourceType.Service,
-          pluginInstallations: installedPlugins,
+          pluginInstallations: [],
         },
         MockedLogger,
         temporaryPluginInstallationPath

--- a/packages/data-service-generator/src/tests/create-data-service-with-auth-jwt.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-with-auth-jwt.spec.ts
@@ -4,15 +4,22 @@ import { EnumResourceType } from "../models";
 import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import entities from "./entities";
 import roles from "./roles";
-import { join } from "path";
-import { AMPLICATION_MODULES } from "../generate-code";
 import { USER_ENTITY_NAME } from "../server/user-entity/user-entity";
+import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
+import { rm } from "fs/promises";
 
 jest.setTimeout(100000);
 
+const temporaryPluginInstallationPath =
+  getTemporaryPluginInstallationPath(__filename);
+
 describe("createDataService", () => {
-  afterEach(() => {
+  afterEach(async () => {
     jest.clearAllMocks();
+    await rm(temporaryPluginInstallationPath, {
+      recursive: true,
+      force: true,
+    });
   });
   describe("when auth-jwt plugin is installed", () => {
     test("creates resource as expected", async () => {
@@ -47,7 +54,7 @@ describe("createDataService", () => {
           ],
         },
         MockedLogger,
-        join(__dirname, "../../", AMPLICATION_MODULES)
+        temporaryPluginInstallationPath
       );
       const modulesToSnapshot = modules
         .modules()

--- a/packages/data-service-generator/src/tests/create-data-service-with-auth-jwt.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-with-auth-jwt.spec.ts
@@ -7,6 +7,7 @@ import roles from "./roles";
 import { USER_ENTITY_NAME } from "../server/user-entity/user-entity";
 import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
 import { rm } from "fs/promises";
+import { plugins } from "./mock-data-plugin-installations";
 
 jest.setTimeout(100000);
 
@@ -36,22 +37,7 @@ describe("createDataService", () => {
             },
           },
           resourceType: EnumResourceType.Service,
-          pluginInstallations: [
-            {
-              id: "auth-core",
-              npm: "@amplication/plugin-auth-core",
-              enabled: true,
-              version: "latest",
-              pluginId: "auth-core",
-            },
-            {
-              id: "auth-jwt",
-              npm: "@amplication/plugin-auth-jwt",
-              enabled: true,
-              version: "latest",
-              pluginId: "auth-jwt",
-            },
-          ],
+          pluginInstallations: [plugins.authCore, plugins.authJwt],
         },
         MockedLogger,
         temporaryPluginInstallationPath

--- a/packages/data-service-generator/src/tests/create-data-service-with-grpc.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-with-grpc.spec.ts
@@ -7,6 +7,7 @@ import { createDataService } from "../create-data-service";
 import { MockedLogger } from "@amplication/util/logging/test-utils";
 import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
 import { rm } from "fs/promises";
+import { plugins } from "./mock-data-plugin-installations";
 
 const newAppInfo: AppInfo = {
   ...appInfo,
@@ -43,18 +44,7 @@ describe("createDataService", () => {
           roles,
           resourceInfo: newAppInfo,
           resourceType: EnumResourceType.Service,
-          pluginInstallations: [
-            {
-              id: "transport-grpc",
-              npm: "@amplication/plugin-transport-grpc",
-              enabled: true,
-              version: "latest",
-              pluginId: "transport-grpc",
-              configurations: {
-                generateGRPC: "true",
-              },
-            },
-          ],
+          pluginInstallations: [plugins.grpc],
         },
         MockedLogger,
         temporaryPluginInstallationPath

--- a/packages/data-service-generator/src/tests/create-data-service-with-grpc.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-with-grpc.spec.ts
@@ -5,8 +5,8 @@ import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import { EnumResourceType } from "../models";
 import { createDataService } from "../create-data-service";
 import { MockedLogger } from "@amplication/util/logging/test-utils";
-import { join } from "path";
-import { AMPLICATION_MODULES } from "../generate-code";
+import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
+import { rm } from "fs/promises";
 
 const newAppInfo: AppInfo = {
   ...appInfo,
@@ -22,10 +22,18 @@ const newAppInfo: AppInfo = {
 
 jest.setTimeout(100000);
 
+const temporaryPluginInstallationPath =
+  getTemporaryPluginInstallationPath(__filename);
+
 describe("createDataService", () => {
-  afterEach(() => {
+  afterEach(async () => {
     jest.clearAllMocks();
+    await rm(temporaryPluginInstallationPath, {
+      recursive: true,
+      force: true,
+    });
   });
+
   describe("when grpc is enabled", () => {
     test("creates app as expected", async () => {
       const modules = await createDataService(
@@ -49,7 +57,7 @@ describe("createDataService", () => {
           ],
         },
         MockedLogger,
-        join(__dirname, "../../", AMPLICATION_MODULES)
+        temporaryPluginInstallationPath
       );
       const modulesToSnapshot = modules
         .modules()

--- a/packages/data-service-generator/src/tests/create-data-service-with-kafka.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-with-kafka.spec.ts
@@ -9,14 +9,21 @@ import { EnumResourceType } from "../models";
 import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import entities from "./entities";
 import roles from "./roles";
-import { join } from "path";
-import { AMPLICATION_MODULES } from "../generate-code";
+import { rm } from "fs/promises";
+import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
 
 jest.setTimeout(100000);
 
+const temporaryPluginInstallationPath =
+  getTemporaryPluginInstallationPath(__filename);
+
 describe("createDataService", () => {
-  afterEach(() => {
+  afterEach(async () => {
     jest.clearAllMocks();
+    await rm(temporaryPluginInstallationPath, {
+      recursive: true,
+      force: true,
+    });
   });
   describe("when kafka plugin is installed", () => {
     test("creates resource as expected", async () => {
@@ -73,7 +80,7 @@ describe("createDataService", () => {
       const modules = await createDataService(
         service,
         MockedLogger,
-        join(__dirname, "../../", AMPLICATION_MODULES)
+        temporaryPluginInstallationPath
       );
       const modulesToSnapshot = modules
         .modules()

--- a/packages/data-service-generator/src/tests/create-data-service-with-kafka.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-with-kafka.spec.ts
@@ -11,6 +11,7 @@ import entities from "./entities";
 import roles from "./roles";
 import { rm } from "fs/promises";
 import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
+import { plugins } from "./mock-data-plugin-installations";
 
 jest.setTimeout(100000);
 
@@ -67,15 +68,7 @@ describe("createDataService", () => {
           },
         ],
         otherResources: [messageBroker],
-        pluginInstallations: [
-          {
-            id: "broker-kafka",
-            npm: "@amplication/plugin-broker-kafka",
-            enabled: true,
-            pluginId: "broker-kafka",
-            version: "latest",
-          },
-        ],
+        pluginInstallations: [plugins.kafka],
       };
       const modules = await createDataService(
         service,

--- a/packages/data-service-generator/src/tests/create-data-service-without-admin-ui.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-without-admin-ui.spec.ts
@@ -3,7 +3,6 @@ import { createDataService } from "../create-data-service";
 import { EnumResourceType } from "../models";
 import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import entities from "./entities";
-import { installedPlugins } from "./pluginInstallation";
 import roles from "./roles";
 import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
 import { rm } from "fs/promises";
@@ -40,7 +39,7 @@ describe("createDataService", () => {
             },
           },
           resourceType: EnumResourceType.Service,
-          pluginInstallations: installedPlugins,
+          pluginInstallations: [],
         },
         MockedLogger,
         temporaryPluginInstallationPath

--- a/packages/data-service-generator/src/tests/create-data-service-without-admin-ui.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-without-admin-ui.spec.ts
@@ -5,14 +5,21 @@ import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import entities from "./entities";
 import { installedPlugins } from "./pluginInstallation";
 import roles from "./roles";
-import { join } from "path";
-import { AMPLICATION_MODULES } from "../generate-code";
+import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
+import { rm } from "fs/promises";
 
 jest.setTimeout(100000);
 
+const temporaryPluginInstallationPath =
+  getTemporaryPluginInstallationPath(__filename);
+
 describe("createDataService", () => {
-  afterEach(() => {
+  afterEach(async () => {
     jest.clearAllMocks();
+    await rm(temporaryPluginInstallationPath, {
+      recursive: true,
+      force: true,
+    });
   });
 
   describe("when admin-ui is disabled", () => {
@@ -36,7 +43,7 @@ describe("createDataService", () => {
           pluginInstallations: installedPlugins,
         },
         MockedLogger,
-        join(__dirname, "../../", AMPLICATION_MODULES)
+        temporaryPluginInstallationPath
       );
       const modulesToSnapshot = modules
         .modules()

--- a/packages/data-service-generator/src/tests/create-data-service-without-graphql.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-without-graphql.spec.ts
@@ -6,8 +6,8 @@ import { EnumResourceType } from "../models";
 import { installedPlugins } from "./pluginInstallation";
 import { createDataService } from "../create-data-service";
 import { MockedLogger } from "@amplication/util/logging/test-utils";
-import { join } from "path";
-import { AMPLICATION_MODULES } from "../generate-code";
+import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
+import { rm } from "fs/promises";
 
 const newAppInfo: AppInfo = {
   ...appInfo,
@@ -23,9 +23,16 @@ const newAppInfo: AppInfo = {
 
 jest.setTimeout(100000);
 
+const temporaryPluginInstallationPath =
+  getTemporaryPluginInstallationPath(__filename);
+
 describe("createDataService", () => {
-  afterEach(() => {
+  afterEach(async () => {
     jest.clearAllMocks();
+    await rm(temporaryPluginInstallationPath, {
+      recursive: true,
+      force: true,
+    });
   });
   describe("when graphql is disabled", () => {
     test("creates app as expected", async () => {
@@ -39,7 +46,7 @@ describe("createDataService", () => {
           pluginInstallations: installedPlugins,
         },
         MockedLogger,
-        join(__dirname, "../../", AMPLICATION_MODULES)
+        temporaryPluginInstallationPath
       );
       const modulesToSnapshot = modules
         .modules()

--- a/packages/data-service-generator/src/tests/create-data-service-without-graphql.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-without-graphql.spec.ts
@@ -3,7 +3,6 @@ import roles from "./roles";
 import { AppInfo } from "@amplication/code-gen-types";
 import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import { EnumResourceType } from "../models";
-import { installedPlugins } from "./pluginInstallation";
 import { createDataService } from "../create-data-service";
 import { MockedLogger } from "@amplication/util/logging/test-utils";
 import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
@@ -43,7 +42,7 @@ describe("createDataService", () => {
           roles,
           resourceInfo: newAppInfo,
           resourceType: EnumResourceType.Service,
-          pluginInstallations: installedPlugins,
+          pluginInstallations: [],
         },
         MockedLogger,
         temporaryPluginInstallationPath

--- a/packages/data-service-generator/src/tests/create-data-service-without-restApi.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-without-restApi.spec.ts
@@ -6,8 +6,8 @@ import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import entities from "./entities";
 import { installedPlugins } from "./pluginInstallation";
 import roles from "./roles";
-import { AMPLICATION_MODULES } from "../generate-code";
-import { join } from "path";
+import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
+import { rm } from "fs/promises";
 
 const newAppInfo: AppInfo = {
   ...appInfo,
@@ -23,11 +23,19 @@ const newAppInfo: AppInfo = {
 
 jest.setTimeout(100000);
 
+const temporaryPluginInstallationPath =
+  getTemporaryPluginInstallationPath(__filename);
+
 describe("createDataService", () => {
-  describe("when restapi is disabled", () => {
-    afterEach(() => {
-      jest.clearAllMocks();
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await rm(temporaryPluginInstallationPath, {
+      recursive: true,
+      force: true,
     });
+  });
+
+  describe("when restapi is disabled", () => {
     test("creates app as expected", async () => {
       const modules = await createDataService(
         {
@@ -39,7 +47,7 @@ describe("createDataService", () => {
           pluginInstallations: installedPlugins,
         },
         MockedLogger,
-        join(__dirname, "../../", AMPLICATION_MODULES)
+        temporaryPluginInstallationPath
       );
       const modulesToSnapshot = modules
         .modules()

--- a/packages/data-service-generator/src/tests/create-data-service-without-restApi.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-without-restApi.spec.ts
@@ -4,7 +4,6 @@ import { createDataService } from "../create-data-service";
 import { EnumResourceType } from "../models";
 import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import entities from "./entities";
-import { installedPlugins } from "./pluginInstallation";
 import roles from "./roles";
 import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
 import { rm } from "fs/promises";
@@ -44,7 +43,7 @@ describe("createDataService", () => {
           roles,
           resourceInfo: newAppInfo,
           resourceType: EnumResourceType.Service,
-          pluginInstallations: installedPlugins,
+          pluginInstallations: [],
         },
         MockedLogger,
         temporaryPluginInstallationPath

--- a/packages/data-service-generator/src/tests/create-data-service-without-server.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-without-server.spec.ts
@@ -5,14 +5,21 @@ import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import entities from "./entities";
 import { installedPlugins } from "./pluginInstallation";
 import roles from "./roles";
-import { join } from "path";
-import { AMPLICATION_MODULES } from "../generate-code";
+import { rm } from "fs/promises";
+import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
 
 jest.setTimeout(100000);
 
+const temporaryPluginInstallationPath =
+  getTemporaryPluginInstallationPath(__filename);
+
 describe("createDataService", () => {
-  afterEach(() => {
+  afterEach(async () => {
     jest.clearAllMocks();
+    await rm(temporaryPluginInstallationPath, {
+      recursive: true,
+      force: true,
+    });
   });
 
   describe("when server is disabled", () => {
@@ -36,7 +43,7 @@ describe("createDataService", () => {
           pluginInstallations: installedPlugins,
         },
         MockedLogger,
-        join(__dirname, "../../", AMPLICATION_MODULES)
+        temporaryPluginInstallationPath
       );
       const modulesToSnapshot = modules
         .modules()

--- a/packages/data-service-generator/src/tests/create-data-service-without-server.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service-without-server.spec.ts
@@ -3,7 +3,6 @@ import { createDataService } from "../create-data-service";
 import { EnumResourceType } from "../models";
 import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import entities from "./entities";
-import { installedPlugins } from "./pluginInstallation";
 import roles from "./roles";
 import { rm } from "fs/promises";
 import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
@@ -40,7 +39,7 @@ describe("createDataService", () => {
             },
           },
           resourceType: EnumResourceType.Service,
-          pluginInstallations: installedPlugins,
+          pluginInstallations: [],
         },
         MockedLogger,
         temporaryPluginInstallationPath

--- a/packages/data-service-generator/src/tests/create-data-service.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service.spec.ts
@@ -5,15 +5,23 @@ import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import entities from "./entities";
 import { installedPlugins } from "./pluginInstallation";
 import roles from "./roles";
-import { join } from "path";
-import { AMPLICATION_MODULES } from "../generate-code";
+import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
+import { rm } from "fs/promises";
 
 jest.setTimeout(100000);
 
+const temporaryPluginInstallationPath =
+  getTemporaryPluginInstallationPath(__filename);
+
 describe("createDataService", () => {
-  afterEach(() => {
+  afterEach(async () => {
     jest.clearAllMocks();
+    await rm(temporaryPluginInstallationPath, {
+      recursive: true,
+      force: true,
+    });
   });
+
   test("creates resource as expected", async () => {
     const modules = await createDataService(
       {
@@ -25,7 +33,7 @@ describe("createDataService", () => {
         pluginInstallations: installedPlugins,
       },
       MockedLogger,
-      join(__dirname, "../../", AMPLICATION_MODULES)
+      temporaryPluginInstallationPath
     );
     const modulesToSnapshot = modules
       .modules()

--- a/packages/data-service-generator/src/tests/create-data-service.spec.ts
+++ b/packages/data-service-generator/src/tests/create-data-service.spec.ts
@@ -3,7 +3,6 @@ import { createDataService } from "../create-data-service";
 import { EnumResourceType } from "../models";
 import { appInfo, MODULE_EXTENSIONS_TO_SNAPSHOT } from "./appInfo";
 import entities from "./entities";
-import { installedPlugins } from "./pluginInstallation";
 import roles from "./roles";
 import { getTemporaryPluginInstallationPath } from "./dynamic-plugin-installation-path";
 import { rm } from "fs/promises";
@@ -30,7 +29,7 @@ describe("createDataService", () => {
         buildId: "example_build_id",
         resourceInfo: appInfo,
         resourceType: EnumResourceType.Service,
-        pluginInstallations: installedPlugins,
+        pluginInstallations: [],
       },
       MockedLogger,
       temporaryPluginInstallationPath

--- a/packages/data-service-generator/src/tests/dynamic-plugin-installation-path.ts
+++ b/packages/data-service-generator/src/tests/dynamic-plugin-installation-path.ts
@@ -1,0 +1,14 @@
+import { join } from "path";
+import { AMPLICATION_MODULES } from "../generate-code";
+
+/**
+ *
+ * @param fileName __filename
+ * @returns
+ */
+export const getTemporaryPluginInstallationPath = (
+  fileName: string
+): string => {
+  const specFileName = fileName.split("/").pop().replaceAll(".", "_");
+  return join(__dirname, "../../", AMPLICATION_MODULES, specFileName);
+};

--- a/packages/data-service-generator/src/tests/mock-data-plugin-installations.ts
+++ b/packages/data-service-generator/src/tests/mock-data-plugin-installations.ts
@@ -9,7 +9,14 @@ export const plugins: Record<string, PluginInstallation> = Object.freeze({
     pluginId: "broker-kafka",
     settings: {},
   },
-  jwtAuth: {
+  authCore: {
+    id: "auth-core",
+    npm: "@amplication/plugin-auth-core",
+    enabled: true,
+    version: "latest",
+    pluginId: "auth-core",
+  },
+  authJwt: {
     id: "clb3p3uxx009bjn01zfbim7p1",
     npm: "@amplication/plugin-auth-jwt",
     enabled: true,
@@ -17,7 +24,17 @@ export const plugins: Record<string, PluginInstallation> = Object.freeze({
     pluginId: "auth-jwt",
     settings: {},
   },
-  postgresPlugin: {
+  grpc: {
+    id: "transport-grpc",
+    npm: "@amplication/plugin-transport-grpc",
+    enabled: true,
+    version: "latest",
+    pluginId: "transport-grpc",
+    configurations: {
+      generateGRPC: "true",
+    },
+  },
+  postgres: {
     id: "clb3p3ov800cplc01a8f6uwje",
     npm: "@amplication/plugin-db-postgres",
     enabled: true,

--- a/packages/data-service-generator/src/tests/pluginInstallation.ts
+++ b/packages/data-service-generator/src/tests/pluginInstallation.ts
@@ -1,2 +1,0 @@
-import { PluginInstallation } from "@amplication/code-gen-types";
-export const installedPlugins: PluginInstallation[] = [];


### PR DESCRIPTION
Co-authoring: Mor


Close: #7519

## PR Details

Due snapshot tests running parallel and the fact that dsg is download and extracting the plugins on each run, the flacky issue was due to the collision between one test downloading a plugin that was already in use by another test.
This PR fix the issue introducing dynamic plugin installation path directory per test to avoid collisions.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
