### PR TITLE
fix(dsg): controller.spec => change the imported IsJSONValue to relative path

### DIFF
--- a/packages/data-service-generator/src/server/resource/dto/class-validator.util.ts
+++ b/packages/data-service-generator/src/server/resource/dto/class-validator.util.ts
@@ -1,8 +1,7 @@
 import { builders } from "ast-types";
 
 export const CLASS_VALIDATOR_MODULE = "class-validator";
-export const CLASS_VALIDATOR_CUSTOM_VALIDATORS_MODULE =
-  "../../validators/is-json-value-validator";
+export const CLASS_VALIDATOR_CUSTOM_VALIDATORS_MODULE = "../../validators";
 export const IS_BOOLEAN_ID = builders.identifier("IsBoolean");
 export const IS_DATE_ID = builders.identifier("IsDate");
 export const IS_NUMBER_ID = builders.identifier("IsNumber");

--- a/packages/data-service-generator/src/server/resource/dto/class-validator.util.ts
+++ b/packages/data-service-generator/src/server/resource/dto/class-validator.util.ts
@@ -2,7 +2,7 @@ import { builders } from "ast-types";
 
 export const CLASS_VALIDATOR_MODULE = "class-validator";
 export const CLASS_VALIDATOR_CUSTOM_VALIDATORS_MODULE =
-  "@app/custom-validators";
+  "../../validators/is-json-value-validator";
 export const IS_BOOLEAN_ID = builders.identifier("IsBoolean");
 export const IS_DATE_ID = builders.identifier("IsDate");
 export const IS_NUMBER_ID = builders.identifier("IsNumber");

--- a/packages/data-service-generator/src/server/static/tsconfig.json
+++ b/packages/data-service-generator/src/server/static/tsconfig.json
@@ -15,10 +15,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true,
-    "paths": {
-      "@app/custom-validators": ["src/validators"]
-    }
+    "strict": true
   },
   "include": ["src"]
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -12072,7 +12072,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -12294,7 +12294,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -12890,7 +12890,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -12072,7 +12072,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -12294,7 +12294,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -12890,7 +12890,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -15935,10 +15935,7 @@ export function IsJSONValue(validationOptions?: ValidationOptions) {
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true,
-    "paths": {
-      "@app/custom-validators": ["src/validators"]
-    }
+    "strict": true
   },
   "include": ["src"]
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -12072,7 +12072,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -12294,7 +12294,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -12890,7 +12890,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -12072,7 +12072,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -12294,7 +12294,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -12890,7 +12890,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -15939,10 +15939,7 @@ export function IsJSONValue(validationOptions?: ValidationOptions) {
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true,
-    "paths": {
-      "@app/custom-validators": ["src/validators"]
-    }
+    "strict": true
   },
   "include": ["src"]
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
@@ -14103,7 +14103,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -14325,7 +14325,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -14921,7 +14921,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -18174,10 +18174,7 @@ export function IsJSONValue(validationOptions?: ValidationOptions) {
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true,
-    "paths": {
-      "@app/custom-validators": ["src/validators"]
-    }
+    "strict": true
   },
   "include": ["src"]
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
@@ -14103,7 +14103,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -14325,7 +14325,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -14921,7 +14921,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
@@ -13158,7 +13158,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -13380,7 +13380,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -13976,7 +13976,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
@@ -13158,7 +13158,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -13380,7 +13380,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -13976,7 +13976,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -17421,10 +17421,7 @@ export function IsJSONValue(validationOptions?: ValidationOptions) {
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true,
-    "paths": {
-      "@app/custom-validators": ["src/validators"]
-    }
+    "strict": true
   },
   "include": ["src"]
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -12291,7 +12291,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -12513,7 +12513,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -13109,7 +13109,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -12291,7 +12291,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -12513,7 +12513,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -13109,7 +13109,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -16154,10 +16154,7 @@ export function IsJSONValue(validationOptions?: ValidationOptions) {
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true,
-    "paths": {
-      "@app/custom-validators": ["src/validators"]
-    }
+    "strict": true
   },
   "include": ["src"]
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
@@ -9066,7 +9066,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -9288,7 +9288,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -9884,7 +9884,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
@@ -9066,7 +9066,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -9288,7 +9288,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -9884,7 +9884,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -12929,10 +12929,7 @@ export function IsJSONValue(validationOptions?: ValidationOptions) {
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true,
-    "paths": {
-      "@app/custom-validators": ["src/validators"]
-    }
+    "strict": true
   },
   "include": ["src"]
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -11338,7 +11338,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -11560,7 +11560,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -12156,7 +12156,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -15009,10 +15009,7 @@ export function IsJSONValue(validationOptions?: ValidationOptions) {
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true,
-    "paths": {
-      "@app/custom-validators": ["src/validators"]
-    }
+    "strict": true
   },
   "include": ["src"]
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -11338,7 +11338,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -11560,7 +11560,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -12156,7 +12156,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -9663,7 +9663,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -9885,7 +9885,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -10481,7 +10481,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -9663,7 +9663,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -9885,7 +9885,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -10481,7 +10481,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -12837,10 +12837,7 @@ export function IsJSONValue(validationOptions?: ValidationOptions) {
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true,
-    "paths": {
-      "@app/custom-validators": ["src/validators"]
-    }
+    "strict": true
   },
   "include": ["src"]
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -12072,7 +12072,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -12294,7 +12294,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -12890,7 +12890,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "../../validators/is-json-value-validator";
+import { IsJSONValue } from "../../validators";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -12072,7 +12072,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { JsonValue } from "type-fest";
 import { Type } from "class-transformer";
@@ -12294,7 +12294,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -12890,7 +12890,7 @@ import {
   IsBoolean,
 } from "class-validator";
 
-import { IsJSONValue } from "@app/custom-validators";
+import { IsJSONValue } from "../../validators/is-json-value-validator";
 import { GraphQLJSON } from "graphql-type-json";
 import { InputJsonValue } from "../../types";
 import { Type } from "class-transformer";
@@ -15935,10 +15935,7 @@ export function IsJSONValue(validationOptions?: ValidationOptions) {
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true,
-    "paths": {
-      "@app/custom-validators": ["src/validators"]
-    }
+    "strict": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Close: #7521

## PR Details

change the imported IsJSONValue to relative path

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1a8c8c4</samp>

### Summary
🛠️🗑️📄

<!--
1.  🛠️ - This emoji represents a fix or improvement of something that was broken or not working well. In this case, the alias was causing errors and was replaced by a relative path.
2.  🗑️ - This emoji represents a removal or deletion of something that was unnecessary or redundant. In this case, the `paths` property was no longer needed after removing the alias.
3.  📄 - This emoji represents a change or update of a document or configuration file. In this case, the `tsconfig.json` file was modified to reflect the removal of the `paths` property.
-->
Fixed a bug with custom validators in the data service generator. Removed the alias from `tsconfig.json` and used a relative path in `class-validator.util.ts`.

> _No more alias path_
> _`CLASS_VALIDATOR` fixed_
> _Autumn code cleanup_

### Walkthrough
*  Update the constant for importing custom validators in class-validator.util.ts ([link](https://github.com/amplication/amplication/pull/7523/files?diff=unified&w=0#diff-ff87c0d2f1a27c01707ae4707ef720f31ab810072a23338571b5acca3d8947fcL5-R5))
*  Remove the alias paths from tsconfig.json to avoid errors with the generated code ([link](https://github.com/amplication/amplication/pull/7523/files?diff=unified&w=0#diff-9a594a9d8b6600737003b91a7f5b65a97fbe3303e243b4ed8324d16e3a565924L18-R18))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

