### PR TITLE
chore(server): increase test coverage threshold

### DIFF
--- a/packages/amplication-server/jest.config.ts
+++ b/packages/amplication-server/jest.config.ts
@@ -19,8 +19,8 @@ export default {
   coverageDirectory: "../../coverage/packages/amplication-server",
   coverageThreshold: {
     global: {
-      branches: 80,
-      lines: 50,
+      branches: 83,
+      lines: 51,
     },
   },
 };

--- a/packages/amplication-server/src/core/billing/billing.service.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.ts
@@ -232,10 +232,8 @@ export class BillingService {
     try {
       if (this.billingEnabled) {
         const stiggClient = await this.getStiggClient();
-        const workspace = await stiggClient.getCustomer(workspaceId);
-
-        const activeSub = await workspace.subscriptions.find((subscription) => {
-          return subscription.status === SubscriptionStatus.Active;
+        const [activeSub] = await stiggClient.getActiveSubscriptions({
+          customerId: workspaceId,
         });
 
         const amplicationSub = {


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #7533

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cf8e85d</samp>

### Summary
🎯🔄🧪

<!--
1.  🎯 - This emoji can be used to represent the increase in the coverage threshold, as it implies aiming for a higher standard and hitting the target.
2.  🔄 - This emoji can be used to represent the simplification and refactoring of the logic, as it implies replacing a complex or redundant process with a more efficient or elegant one.
3.  🧪 - This emoji can be used to represent the addition of new tests, as it implies experimenting and verifying the functionality and quality of the code.
-->
This pull request improves the test coverage and quality of the `billing.service` and its integration with the Stigg API. It adds new tests for the `getSubscription` method, increases the coverage threshold in the jest configuration file, and simplifies the logic of finding the active subscription for a workspace.

> _Sing, O Muse, of the valiant code warriors who strove_
> _To enhance the test coverage and quality of their code_
> _With skillful jest they raised the threshold of their lines and branches_
> _And mocked and spied the Stigg API with cunning and finesse_

### Walkthrough
* Increase the coverage threshold for branches and lines in the jest configuration file to improve the test quality ([link](https://github.com/amplication/amplication/pull/7534/files?diff=unified&w=0#diff-22fa1fc595c3d1922ef7cce106d3763ef2e5bbbfda1361fb54f112d2b39276c1L22-R23))
* Refactor the billing service to use the getActiveSubscriptions method of the Stigg client instead of looping through the subscriptions array, simplifying the logic of finding the active subscription for a workspace ([link](https://github.com/amplication/amplication/pull/7534/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L235-R236))
* Add new tests for the billing service and its integration with the Stigg API in the `billing.service.spec.ts` file, using jest mock and spy functions to simulate the Stigg API responses and check the expected subscription status and plan for different scenarios ([link](https://github.com/amplication/amplication/pull/7534/files?diff=unified&w=0#diff-dc456c8512ec4b3cce5f935aa029a8e6b048ffe59a363332015cc186cfffc647L10-R17), [link](https://github.com/amplication/amplication/pull/7534/files?diff=unified&w=0#diff-dc456c8512ec4b3cce5f935aa029a8e6b048ffe59a363332015cc186cfffc647R65-R150))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
