### PR TITLE
fix(server): only auto-commit Module and ModuleAction blocks during migration

### DIFF
--- a/packages/amplication-server/src/core/block/block.service.ts
+++ b/packages/amplication-server/src/core/block/block.service.ts
@@ -786,6 +786,72 @@ export class BlockService {
     });
   }
 
+  /**
+   * @todo REMOVE this after we finish with the custom actions blocks migration
+   *
+   * Gets Blocks of types Module and ModuleAction (ONLY) changed since the last resource commit
+   * @param projectId the resource ID to find changes to
+   * @param userId the user ID the resource ID relates to
+   */
+  async getChangedBlocksForCustomActionsMigration(
+    projectId: string,
+    userId: string
+  ): Promise<BlockPendingChange[]> {
+    const changedBlocks = await this.prisma.block.findMany({
+      where: {
+        lockedByUserId: userId,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        OR: [
+          { blockType: EnumBlockType.Module },
+          { blockType: EnumBlockType.ModuleAction },
+        ],
+        resource: {
+          deletedAt: null,
+          project: {
+            id: projectId,
+          },
+        },
+      },
+      include: {
+        lockedByUser: true,
+        resource: true,
+        versions: {
+          orderBy: {
+            versionNumber: Prisma.SortOrder.desc,
+          },
+          /**find the first two versions to decide whether it is an update or a create */
+          take: 2,
+        },
+      },
+    });
+
+    return changedBlocks.map((block) => {
+      const [lastVersion] = block.versions;
+      const action = block.deletedAt
+        ? EnumPendingChangeAction.Delete
+        : block.versions.length > 1
+        ? EnumPendingChangeAction.Update
+        : EnumPendingChangeAction.Create;
+
+      block.versions =
+        undefined; /**remove the versions data - it will only be returned if explicitly asked by gql */
+
+      //prepare name fields for display
+      if (action === EnumPendingChangeAction.Delete) {
+        block.displayName = revertDeletedItemName(block.displayName, block.id);
+      }
+
+      return {
+        originId: block.id,
+        action: action,
+        originType: EnumPendingChangeOriginType.Block,
+        versionNumber: lastVersion.versionNumber + 1,
+        origin: block,
+        resource: block.resource,
+      };
+    });
+  }
+
   async getChangedBlocksByCommit(commitId: string): Promise<PendingChange[]> {
     const changedBlocks = await this.prisma.block.findMany({
       where: {


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #7408

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a914450</samp>

### Summary
🆕🛠️🗑️

<!--
1.  🆕 - This emoji represents the addition of a new method to the `BlockService` class, which is a significant feature for the migration process.
2.  🛠️ - This emoji represents the update of the `ProjectService` module, which is a fix or improvement for the existing functionality of handling custom actions blocks.
3.  🗑️ - This emoji represents the temporary nature of the migration process, which will be removed later and is not a permanent part of the codebase.
-->
This pull request implements a temporary migration process for custom actions blocks, which are a new feature that allows users to create custom logic without building the app. It modifies the `ProjectService` and `BlockService` modules to find and handle the blocks that need to be migrated.

> _The blocks of doom have been changed by the user_
> _They need to migrate or face the wrath of the builder_
> _`getChangedBlocksForCustomActionsMigration` is the key_
> _To unleash the power of Module and ModuleAction_

### Walkthrough
*  Add a new method to find changed custom actions blocks for migration ([link](https://github.com/amplication/amplication/pull/7538/files?diff=unified&w=0#diff-1524bf99e0e0edfbae8f4f9a3a0226ccf2f682acb2a133e1429abcf36bd276a6R789-R854))
*  Import `BlockPendingChange` and `EntityPendingChange` types from `BlockService` and `EntityService` modules ([link](https://github.com/amplication/amplication/pull/7538/files?diff=unified&w=0#diff-cd946c1c9f9271b6dd02f554735fae66c53c2516f9b097daf8f798c2154118ffL7-R7), [link](https://github.com/amplication/amplication/pull/7538/files?diff=unified&w=0#diff-cd946c1c9f9271b6dd02f554735fae66c53c2516f9b097daf8f798c2154118ffR31))
*  Update `createBuild` method in `project.service.ts` to use the new method instead of `getChangedBlocks` when `skipBuild` is true ([link](https://github.com/amplication/amplication/pull/7538/files?diff=unified&w=0#diff-cd946c1c9f9271b6dd02f554735fae66c53c2516f9b097daf8f798c2154118ffL291-R305))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
