### PR TITLE
ci: fix release notes generator picking dsg changes 

### DIFF
--- a/.github/workflows/release.production.yml
+++ b/.github/workflows/release.production.yml
@@ -148,7 +148,7 @@ jobs:
                   "exhaustive_rules": "true",
                   "rules": [
                     {
-                      "pattern": "(app|lib):(?!data-service-generator)",
+                      "pattern": "(app|lib):(?!data-service-generator|local-data-service-generator-controller)",
                       "on_property": "labels",
                       "flags": "gu"
                     }


### PR DESCRIPTION
Close: #7552

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

Exclude `local-data-service-generator-controller` label from production release workflow. This label is for a new feature that allows users to create and run local data services from Amplication, which do not need to be deployed to production.

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
