### PR TITLE
fix(build-manager): support for old `data-servivce-generator` versions that don't support build split

### DIFF
--- a/packages/amplication-build-manager/src/build-job-handler/build-job-handler.module.ts
+++ b/packages/amplication-build-manager/src/build-job-handler/build-job-handler.module.ts
@@ -1,0 +1,13 @@
+import { KafkaModule } from "@amplication/util/nestjs/kafka";
+import { Module } from "@nestjs/common";
+import { BuildJobsHandlerService } from "../build-job-handler/build-job-handler.service";
+import { RedisService } from "../redis/redis.service";
+import { CodeGeneratorService } from "../code-generator/code-generator-catalog.service";
+
+@Module({
+  imports: [KafkaModule],
+  controllers: [],
+  providers: [BuildJobsHandlerService, RedisService, CodeGeneratorService],
+  exports: [BuildJobsHandlerService],
+})
+export class BuildJobsHandlerModule {}

--- a/packages/amplication-build-manager/src/build-job-handler/build-job-handler.service.spec.ts
+++ b/packages/amplication-build-manager/src/build-job-handler/build-job-handler.service.spec.ts
@@ -597,8 +597,7 @@ describe("BuildJobsHandlerService", () => {
     const mockRedisSet = jest.spyOn(redisService, "set");
 
     await service.setJobStatus(jobBuildId, status);
-    // eslint-disable-next-line no-console
-    console.error(`jobBuildId, status`, { jobBuildId, status, buildId, value });
+
     expect(mockRedisSet).toHaveBeenCalledTimes(1);
     expect(mockRedisSet).toHaveBeenCalledWith(buildId, value);
   });

--- a/packages/amplication-build-manager/src/build-job-handler/build-job-handler.service.spec.ts
+++ b/packages/amplication-build-manager/src/build-job-handler/build-job-handler.service.spec.ts
@@ -11,6 +11,9 @@ import { BuildJobsHandlerService } from "./build-job-handler.service";
 import { BuildId, EnumDomainName, EnumJobStatus, JobBuildId } from "../types";
 import { RedisService } from "../redis/redis.service";
 import { MockedAmplicationLoggerProvider } from "@amplication/util/nestjs/logging/test-utils";
+import { CodeGeneratorService } from "../code-generator/code-generator-catalog.service";
+import { Env } from "../env";
+import { ConfigService } from "@nestjs/config";
 
 const adminAndServerInputJson: DSGResourceData = {
   entities: [
@@ -384,24 +387,51 @@ const buildId = "cloo1bi5t0001p5888jj5wle9";
 describe("BuildJobsHandlerService", () => {
   let service: BuildJobsHandlerService;
   let redisService: RedisService;
+  const mockCodeGeneratorServiceCompareVersions = jest.fn();
+  const mockRedisSet = jest.fn();
+  const mockOnRedisGet = jest.fn();
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        BuildJobsHandlerService,
+        MockedAmplicationLoggerProvider,
         {
           provide: RedisService,
           useValue: {
-            get: jest.fn(),
-            set: jest.fn(),
+            get: mockOnRedisGet,
+            set: mockRedisSet,
           },
         },
-        MockedAmplicationLoggerProvider,
+        {
+          provide: ConfigService,
+          useValue: {
+            getOrThrow: (variable) => {
+              switch (variable) {
+                case Env.FEATURE_SPLIT_JOBS_MIN_DSG_VERSION:
+                  return "v2.0.0";
+                default:
+                  return "";
+              }
+            },
+          },
+        },
+        {
+          provide: CodeGeneratorService,
+          useValue: {
+            getCodeGeneratorVersion: jest.fn(),
+            compareVersions: mockCodeGeneratorServiceCompareVersions,
+          },
+        },
+        BuildJobsHandlerService,
       ],
     }).compile();
 
     service = module.get<BuildJobsHandlerService>(BuildJobsHandlerService);
     redisService = module.get<RedisService>(RedisService);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   describe("extractBuildId", () => {
@@ -417,79 +447,101 @@ describe("BuildJobsHandlerService", () => {
   });
 
   describe("splitBuildsIntoJobs", () => {
-    it("should create two requests to start two jobs, one for admin by passing onlyAdminInputJson and one for server by passing onlyServerInputJson", async () => {
-      const spyOnSetJobStatus = jest
-        .spyOn(service, "setJobStatus")
-        .mockResolvedValue(undefined);
-      const adminJobBuildId = `${buildId}-${EnumDomainName.AdminUI}`;
-      const serverJobBuildId = `${buildId}-${EnumDomainName.Server}`;
+    describe("when the code generator version is greater than the min version to split builds", () => {
+      beforeEach(() => {
+        mockCodeGeneratorServiceCompareVersions.mockReturnValueOnce(1);
+      });
 
-      const jobs = await service.splitBuildsIntoJobs(
-        adminAndServerInputJson,
-        buildId
-      );
-      expect(jobs.length).toBe(2);
-      expect(jobs).toEqual([
-        [serverJobBuildId, onlyServerInputJson],
-        [adminJobBuildId, onlyAdminInputJson],
-      ]);
+      it("should create two requests to start two jobs, one for admin by passing onlyAdminInputJson and one for server by passing onlyServerInputJson", async () => {
+        const spyOnSetJobStatus = jest.spyOn(service, "setJobStatus");
+        const adminJobBuildId = `${buildId}-${EnumDomainName.AdminUI}`;
+        const serverJobBuildId = `${buildId}-${EnumDomainName.Server}`;
 
-      expect(
-        jobs[0][1].resourceInfo.settings.adminUISettings.generateAdminUI
-      ).toBe(false);
+        const jobs = await service.splitBuildsIntoJobs(
+          adminAndServerInputJson,
+          buildId,
+          "0.1.3"
+        );
+        expect(jobs.length).toBe(2);
+        expect(jobs).toEqual([
+          [serverJobBuildId, onlyServerInputJson],
+          [adminJobBuildId, onlyAdminInputJson],
+        ]);
 
-      expect(
-        jobs[1][1].resourceInfo.settings.serverSettings.generateServer
-      ).toBe(false);
+        expect(
+          jobs[0][1].resourceInfo.settings.adminUISettings.generateAdminUI
+        ).toBe(false);
 
-      expect(spyOnSetJobStatus).toBeCalledTimes(2);
+        expect(
+          jobs[1][1].resourceInfo.settings.serverSettings.generateServer
+        ).toBe(false);
+
+        expect(spyOnSetJobStatus).toBeCalledTimes(2);
+      });
+
+      it("should build only server, it will create one request to start a jobs with onlyServerInputJson", async () => {
+        const spyOnSetJobStatus = jest.spyOn(service, "setJobStatus");
+        const serverJobBuildId = `${buildId}-${EnumDomainName.Server}`;
+
+        const jobs = await service.splitBuildsIntoJobs(
+          onlyServerInputJson,
+          buildId,
+          "0.1.3"
+        );
+        expect(jobs.length).toBe(1);
+        expect(jobs).toEqual([[serverJobBuildId, onlyServerInputJson]]);
+
+        expect(spyOnSetJobStatus).toHaveBeenCalledWith(
+          serverJobBuildId,
+          EnumJobStatus.InProgress
+        );
+        expect(spyOnSetJobStatus).toBeCalledTimes(1);
+      });
+
+      it("should build only admin, it will create one request to start a jobs with onlyAdminInputJson", async () => {
+        const spyOnSetJobStatus = jest.spyOn(service, "setJobStatus");
+        const adminJobBuildId = `${buildId}-${EnumDomainName.AdminUI}`;
+
+        const jobs = await service.splitBuildsIntoJobs(
+          onlyAdminInputJson,
+          buildId,
+          "0.1.3"
+        );
+        expect(jobs.length).toBe(1);
+        expect(jobs).toEqual([[adminJobBuildId, onlyAdminInputJson]]);
+
+        expect(spyOnSetJobStatus).toHaveBeenCalledWith(
+          adminJobBuildId,
+          EnumJobStatus.InProgress
+        );
+        expect(spyOnSetJobStatus).toBeCalledTimes(1);
+      });
     });
 
-    it("should build only server, it will create one request to start a jobs with onlyServerInputJson", async () => {
-      const spyOnSetJobStatus = jest
-        .spyOn(service, "setJobStatus")
-        .mockResolvedValue(undefined);
-      const serverJobBuildId = `${buildId}-${EnumDomainName.Server}`;
+    describe("when the code generator version is lower than the min version to split builds", () => {
+      beforeEach(() => {
+        mockCodeGeneratorServiceCompareVersions.mockReturnValueOnce(-1);
+      });
 
-      const jobs = await service.splitBuildsIntoJobs(
-        onlyServerInputJson,
-        buildId
-      );
-      expect(jobs.length).toBe(1);
-      expect(jobs).toEqual([[serverJobBuildId, onlyServerInputJson]]);
+      it("should create one request to start a job with the input json", async () => {
+        const spyOnSetJobStatus = jest.spyOn(service, "setJobStatus");
 
-      expect(spyOnSetJobStatus).toHaveBeenCalledWith(
-        serverJobBuildId,
-        EnumJobStatus.InProgress
-      );
-      expect(spyOnSetJobStatus).toBeCalledTimes(1);
-    });
-
-    it("should build only admin, it will create one request to start a jobs with onlyAdminInputJson", async () => {
-      const spyOnSetJobStatus = jest
-        .spyOn(service, "setJobStatus")
-        .mockResolvedValue(undefined);
-      const adminJobBuildId = `${buildId}-${EnumDomainName.AdminUI}`;
-
-      const jobs = await service.splitBuildsIntoJobs(
-        onlyAdminInputJson,
-        buildId
-      );
-      expect(jobs.length).toBe(1);
-      expect(jobs).toEqual([[adminJobBuildId, onlyAdminInputJson]]);
-
-      expect(spyOnSetJobStatus).toHaveBeenCalledWith(
-        adminJobBuildId,
-        EnumJobStatus.InProgress
-      );
-      expect(spyOnSetJobStatus).toBeCalledTimes(1);
+        const jobs = await service.splitBuildsIntoJobs(
+          adminAndServerInputJson,
+          buildId,
+          "1.0.0"
+        );
+        expect(jobs.length).toBe(1);
+        expect(jobs).toStrictEqual([[buildId, adminAndServerInputJson]]);
+        expect(spyOnSetJobStatus).toBeCalledTimes(1);
+      });
     });
   });
 
   describe("getBuildStatus", () => {
     it("should return Success when all jobs have succeeded", async () => {
       const buildId = "build-id";
-      jest.spyOn(redisService, "get").mockResolvedValue({
+      mockOnRedisGet.mockResolvedValue({
         job1: EnumJobStatus.Success,
         job2: EnumJobStatus.Success,
       });
@@ -500,7 +552,7 @@ describe("BuildJobsHandlerService", () => {
 
     it("should return Failure when at least one job has failed", async () => {
       const buildId = "build-id";
-      jest.spyOn(redisService, "get").mockResolvedValue({
+      mockOnRedisGet.mockResolvedValue({
         job1: EnumJobStatus.Success,
         job2: EnumJobStatus.Failure,
       });
@@ -511,7 +563,7 @@ describe("BuildJobsHandlerService", () => {
 
     it("should return InProgress when at least one job is in progress", async () => {
       const buildId = "build-id";
-      jest.spyOn(redisService, "get").mockResolvedValue({
+      mockOnRedisGet.mockResolvedValue({
         job1: EnumJobStatus.InProgress,
         job2: EnumJobStatus.Success,
       });
@@ -527,12 +579,10 @@ describe("BuildJobsHandlerService", () => {
     const value = {
       [jobBuildId]: status,
     };
-    const spyOnRedisGet = jest
-      .spyOn(redisService, "get")
-      .mockResolvedValue(value);
+    mockOnRedisGet.mockResolvedValue(value);
 
     const result = await service.getJobStatus(jobBuildId);
-    expect(spyOnRedisGet).toHaveBeenCalledWith(buildId);
+    expect(mockOnRedisGet).toHaveBeenCalledWith(buildId);
     expect(result).toBe(status);
   });
 
@@ -542,11 +592,14 @@ describe("BuildJobsHandlerService", () => {
     const value = {
       [jobBuildId]: status,
     };
-    const spyOnRedisSet = jest
-      .spyOn(redisService, "set")
-      .mockResolvedValue(undefined);
+    mockOnRedisGet.mockResolvedValue(null);
+
+    const mockRedisSet = jest.spyOn(redisService, "set");
 
     await service.setJobStatus(jobBuildId, status);
-    expect(spyOnRedisSet).toHaveBeenCalledWith(buildId, value);
+    // eslint-disable-next-line no-console
+    console.error(`jobBuildId, status`, { jobBuildId, status, buildId, value });
+    expect(mockRedisSet).toHaveBeenCalledTimes(1);
+    expect(mockRedisSet).toHaveBeenCalledWith(buildId, value);
   });
 });

--- a/packages/amplication-build-manager/src/build-job-handler/build-job-handler.service.ts
+++ b/packages/amplication-build-manager/src/build-job-handler/build-job-handler.service.ts
@@ -10,19 +10,37 @@ import {
 } from "../types";
 import { RedisService } from "../redis/redis.service";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
+import { ConfigService } from "@nestjs/config";
+import { Env } from "../env";
+import { CodeGeneratorService } from "../code-generator/code-generator-catalog.service";
 
 type ResourceTuple = [JobBuildId<BuildId>, DSGResourceData];
 @Injectable()
 export class BuildJobsHandlerService {
+  private readonly minDsgVersionToSplitBuild: string;
+
   constructor(
     private readonly redisService: RedisService,
-    private readonly logger: AmplicationLogger
-  ) {}
+    private readonly logger: AmplicationLogger,
+    private readonly configService: ConfigService<Env, true>,
+    private readonly codeGeneratorService: CodeGeneratorService
+  ) {
+    this.minDsgVersionToSplitBuild = this.configService.getOrThrow(
+      Env.FEATURE_SPLIT_JOBS_MIN_DSG_VERSION
+    );
+  }
 
   async splitBuildsIntoJobs(
     dsgResourceData: DSGResourceData,
-    buildId: BuildId
+    buildId: BuildId,
+    codeGeneratorVersion: string
   ): Promise<ResourceTuple[]> {
+    const shouldSplitBuild =
+      this.codeGeneratorService.compareVersions(
+        codeGeneratorVersion,
+        this.minDsgVersionToSplitBuild
+      ) >= 0;
+
     const {
       resourceInfo: {
         settings: {
@@ -33,23 +51,29 @@ export class BuildJobsHandlerService {
     } = dsgResourceData;
 
     const jobs: ResourceTuple[] = [];
-    if (generateServer) {
-      const serverDSGResourceData: DSGResourceData = cloneDeep(dsgResourceData);
-      serverDSGResourceData.resourceInfo.settings.adminUISettings.generateAdminUI =
-        false;
-      const jobBuildId: JobBuildId<BuildId> = `${buildId}-${EnumDomainName.Server}`;
-      await this.setJobStatus(jobBuildId, EnumJobStatus.InProgress);
-      jobs.push([jobBuildId, serverDSGResourceData]);
-    }
+    if (shouldSplitBuild) {
+      if (generateServer) {
+        const serverDSGResourceData: DSGResourceData =
+          cloneDeep(dsgResourceData);
+        serverDSGResourceData.resourceInfo.settings.adminUISettings.generateAdminUI =
+          false;
+        const jobBuildId: JobBuildId<BuildId> = `${buildId}-${EnumDomainName.Server}`;
+        await this.setJobStatus(jobBuildId, EnumJobStatus.InProgress);
+        jobs.push([jobBuildId, serverDSGResourceData]);
+      }
 
-    if (generateAdminUI) {
-      const adminUiDSGResourceData: DSGResourceData =
-        cloneDeep(dsgResourceData);
-      adminUiDSGResourceData.resourceInfo.settings.serverSettings.generateServer =
-        false;
-      const jobBuildId: JobBuildId<BuildId> = `${buildId}-${EnumDomainName.AdminUI}`;
-      await this.setJobStatus(jobBuildId, EnumJobStatus.InProgress);
-      jobs.push([jobBuildId, adminUiDSGResourceData]);
+      if (generateAdminUI) {
+        const adminUiDSGResourceData: DSGResourceData =
+          cloneDeep(dsgResourceData);
+        adminUiDSGResourceData.resourceInfo.settings.serverSettings.generateServer =
+          false;
+        const jobBuildId: JobBuildId<BuildId> = `${buildId}-${EnumDomainName.AdminUI}`;
+        await this.setJobStatus(jobBuildId, EnumJobStatus.InProgress);
+        jobs.push([jobBuildId, adminUiDSGResourceData]);
+      }
+    } else {
+      await this.setJobStatus(buildId, EnumJobStatus.InProgress);
+      jobs.push([buildId, dsgResourceData]);
     }
 
     return jobs;

--- a/packages/amplication-build-manager/src/build-logger/build-logger.module.ts
+++ b/packages/amplication-build-manager/src/build-logger/build-logger.module.ts
@@ -1,12 +1,12 @@
 import { KafkaModule } from "@amplication/util/nestjs/kafka";
 import { Module } from "@nestjs/common";
 import { BuildLoggerController } from "./build-logger.controller";
-import { BuildJobsHandlerService } from "../build-job-handler/build-job-handler.service";
 import { RedisService } from "../redis/redis.service";
+import { BuildJobsHandlerModule } from "../build-job-handler/build-job-handler.module";
 
 @Module({
-  imports: [KafkaModule],
+  imports: [KafkaModule, BuildJobsHandlerModule],
   controllers: [BuildLoggerController],
-  providers: [BuildJobsHandlerService, RedisService],
+  providers: [RedisService],
 })
 export class BuildLoggerModule {}

--- a/packages/amplication-build-manager/src/build-runner/build-runner.module.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.module.ts
@@ -3,17 +3,12 @@ import { Module } from "@nestjs/common";
 import { BuildRunnerController } from "./build-runner.controller";
 import { BuildRunnerService } from "./build-runner.service";
 import { CodeGeneratorService } from "../code-generator/code-generator-catalog.service";
-import { BuildJobsHandlerService } from "../build-job-handler/build-job-handler.service";
 import { RedisService } from "../redis/redis.service";
+import { BuildJobsHandlerModule } from "../build-job-handler/build-job-handler.module";
 
 @Module({
-  imports: [KafkaModule],
+  imports: [KafkaModule, BuildJobsHandlerModule],
   controllers: [BuildRunnerController],
-  providers: [
-    BuildRunnerService,
-    CodeGeneratorService,
-    BuildJobsHandlerService,
-    RedisService,
-  ],
+  providers: [BuildRunnerService, CodeGeneratorService, RedisService],
 })
 export class BuildRunnerModule {}

--- a/packages/amplication-build-manager/src/build-runner/build-runner.service.spec.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.service.spec.ts
@@ -313,55 +313,6 @@ describe("BuildRunnerService", () => {
       });
     });
 
-    it("should NOT split the build into jobs when code generator version doesn't have support for the new split job functionality", async () => {
-      // Arrange
-      const resourceId = "resourceId";
-      const buildId = "buildId";
-      const expectedCodeGeneratorVersion = "v2.1.1";
-      const dsgResourceDataMock: DSGResourceData = {
-        resourceType: "Service",
-        buildId: buildId,
-        pluginInstallations: [],
-        resourceInfo: {
-          settings: {
-            serverSettings: {
-              generateServer: true,
-            },
-            adminUISettings: {
-              generateAdminUI: true,
-            },
-          },
-          codeGeneratorVersionOptions: {
-            version: expectedCodeGeneratorVersion,
-            selectionStrategy: CodeGeneratorVersionStrategy.Specific,
-          },
-        } as unknown as AppInfo,
-      };
-
-      jest
-        .spyOn(codeGeneratorService, "getCodeGeneratorVersion")
-        .mockResolvedValue(expectedCodeGeneratorVersion);
-
-      jest.spyOn(codeGeneratorService, "compareVersions").mockReturnValue(-1);
-
-      const spyOnAxiosPost = jest.spyOn(axios, "post").mockResolvedValue({
-        data: {
-          message: "Success",
-        },
-      });
-
-      // Act
-      await service.runBuild(resourceId, buildId, dsgResourceDataMock);
-
-      // Assert
-      expect(spyOnAxiosPost).toBeCalledTimes(1);
-      expect(spyOnAxiosPost).toHaveBeenCalledWith("http://runner.url/", {
-        resourceId,
-        buildId,
-        codeGeneratorVersion: expectedCodeGeneratorVersion,
-      });
-    });
-
     it("On code generation request, it should split the build into jobs, save the DSG resource data and send it to the runner", async () => {
       // Arrange
       const resourceId = "resourceId";

--- a/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
@@ -55,28 +55,14 @@ export class BuildRunnerService {
         codeGeneratorVersion,
       });
 
-      const shouldSplitBuild =
-        this.codeGeneratorService.compareVersions(
-          codeGeneratorVersion,
-          this.minDsgVersionToSplitBuild
-        ) >= 0;
-
-      if (shouldSplitBuild) {
-        const jobs = await this.buildJobsHandlerService.splitBuildsIntoJobs(
-          dsgResourceData,
-          buildId
-        );
-        for (const [jobBuildId, data] of jobs) {
-          this.logger.debug("Running job for...", { jobBuildId });
-          await this.runJob(resourceId, jobBuildId, data, codeGeneratorVersion);
-        }
-      } else {
-        await this.runJob(
-          resourceId,
-          buildId,
-          dsgResourceData,
-          codeGeneratorVersion
-        );
+      const jobs = await this.buildJobsHandlerService.splitBuildsIntoJobs(
+        dsgResourceData,
+        buildId,
+        codeGeneratorVersion
+      );
+      for (const [jobBuildId, data] of jobs) {
+        this.logger.debug("Running job for...", { jobBuildId });
+        await this.runJob(resourceId, jobBuildId, data, codeGeneratorVersion);
       }
     } catch (error) {
       this.logger.error(error.message, error);

--- a/packages/amplication-build-manager/src/types.ts
+++ b/packages/amplication-build-manager/src/types.ts
@@ -9,6 +9,6 @@ export enum EnumJobStatus {
   Failure = "failure",
 }
 
-export type JobBuildId<T extends string> = `${T}-${EnumDomainName}`;
+export type JobBuildId<T extends BuildId> = `${T}-${EnumDomainName}` | T;
 export type BuildId = string;
 export type RedisValue = Record<JobBuildId<BuildId>, EnumJobStatus>;


### PR DESCRIPTION
Close: #7550

## PR Details

This pull request fix the issue reported in #7550. The cause being the logic that handle the status reporting only working for builds that were split in multiple jobs. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
