### PR TITLE
test(build-manager): add tests for build log when build is split

### DIFF
--- a/packages/amplication-build-manager/src/build-job-handler/build-job-handler.service.spec.ts
+++ b/packages/amplication-build-manager/src/build-job-handler/build-job-handler.service.spec.ts
@@ -601,4 +601,23 @@ describe("BuildJobsHandlerService", () => {
     expect(mockRedisSet).toHaveBeenCalledTimes(1);
     expect(mockRedisSet).toHaveBeenCalledWith(buildId, value);
   });
+
+  describe("extractDomain", () => {
+    it("should extract the domain name from the jobBuildId", () => {
+      const jobBuildId: JobBuildId<BuildId> = `${buildId}-${EnumDomainName.AdminUI}`;
+      expect(service.extractDomain(jobBuildId)).toBe(EnumDomainName.AdminUI);
+    });
+
+    it("should return null when the jobBuildId doesn't contain a domain name", () => {
+      const jobBuildId: JobBuildId<BuildId> = `${buildId}`;
+      expect(service.extractDomain(jobBuildId)).toBe(null);
+    });
+
+    it.each([null, undefined])(
+      "should return null when the jobBuildId is %s",
+      (jobBuildId) => {
+        expect(service.extractDomain(jobBuildId)).toBe(null);
+      }
+    );
+  });
 });

--- a/packages/amplication-build-manager/src/build-job-handler/build-job-handler.service.ts
+++ b/packages/amplication-build-manager/src/build-job-handler/build-job-handler.service.ts
@@ -147,4 +147,15 @@ export class BuildJobsHandlerService {
 
     return jobBuildId.replace(regex, "");
   }
+
+  extractDomain(jobBuildId: string): string {
+    const regexPattern = `-(?:${EnumDomainName.Server}|${EnumDomainName.AdminUI})$`;
+    const regex = new RegExp(regexPattern);
+
+    if (!regex.test(jobBuildId)) {
+      return null;
+    }
+
+    return regex.exec(jobBuildId)[0].replace("-", "");
+  }
 }

--- a/packages/amplication-build-manager/src/build-logger/build-logger.controller.spec.ts
+++ b/packages/amplication-build-manager/src/build-logger/build-logger.controller.spec.ts
@@ -6,10 +6,13 @@ import { CodeGenerationLog, KAFKA_TOPICS } from "@amplication/schema-registry";
 import { BuildLoggerController } from "./build-logger.controller";
 import { CodeGenerationLogRequestDto } from "./dto/OnCodeGenerationLogRequest";
 import { BuildJobsHandlerService } from "../build-job-handler/build-job-handler.service";
+import { EnumDomainName } from "../types";
 
 describe("Build Logger Controller", () => {
   let controller: BuildLoggerController;
   let buildJobsHandlerService: BuildJobsHandlerService;
+  const mockBuildJobsHandlerServiceExtractBuildId = jest.fn();
+  const mockBuildJobsHandlerServiceExtractDomain = jest.fn();
 
   const mockServiceEmitMessage = jest
     .fn()
@@ -18,9 +21,11 @@ describe("Build Logger Controller", () => {
         Promise.resolve()
     );
 
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.clearAllMocks();
+  });
 
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [],
       controllers: [BuildLoggerController],
@@ -47,7 +52,8 @@ describe("Build Logger Controller", () => {
         {
           provide: BuildJobsHandlerService,
           useValue: {
-            extractBuildId: jest.fn(),
+            extractBuildId: mockBuildJobsHandlerServiceExtractBuildId,
+            extractDomain: mockBuildJobsHandlerServiceExtractDomain,
           },
         },
       ],
@@ -89,4 +95,42 @@ describe("Build Logger Controller", () => {
     expect(spyOnBuildJobsHandlerServiceExtractBuildId).toBeCalledTimes(1);
     await expect(mockServiceEmitMessage()).resolves.not.toThrow();
   });
+
+  it.each([EnumDomainName.Server, EnumDomainName.AdminUI])(
+    "should emit `CodeGenerationLog.KafkaEvent` message with log message prefixed with job domain when exists",
+    async (domain) => {
+      const buildId = `buildID`;
+      const jobBuildId = `${buildId}-${domain}`;
+      mockBuildJobsHandlerServiceExtractBuildId.mockReturnValue(buildId);
+      mockBuildJobsHandlerServiceExtractDomain.mockReturnValue(domain);
+
+      const mockRequestLogDOT: CodeGenerationLogRequestDto = {
+        buildId: jobBuildId,
+        level: "info",
+        message: "test message",
+      };
+
+      const logEvent: CodeGenerationLog.KafkaEvent = {
+        key: { buildId },
+        value: mockRequestLogDOT,
+      };
+
+      await controller.onCodeGenerationLog(mockRequestLogDOT);
+
+      expect(mockServiceEmitMessage).toBeCalledWith(
+        KAFKA_TOPICS.DSG_LOG_TOPIC,
+        {
+          ...logEvent,
+          value: {
+            buildId,
+            level: mockRequestLogDOT.level,
+            message: `[${domain}] test message`,
+          },
+        }
+      );
+
+      expect(mockBuildJobsHandlerServiceExtractBuildId).toBeCalledTimes(1);
+      expect(mockBuildJobsHandlerServiceExtractDomain).toBeCalledTimes(1);
+    }
+  );
 });

--- a/packages/amplication-build-manager/src/build-logger/build-logger.controller.ts
+++ b/packages/amplication-build-manager/src/build-logger/build-logger.controller.ts
@@ -18,6 +18,14 @@ export class BuildLoggerController {
     const buildId = this.buildJobsHandlerService.extractBuildId(
       logEntry.buildId
     );
+
+    if (buildId !== logEntry.buildId) {
+      const domain = this.buildJobsHandlerService.extractDomain(
+        logEntry.buildId
+      );
+      logEntry.message = `[${domain}] ${logEntry.message}`;
+    }
+
     const logEvent: CodeGenerationLog.KafkaEvent = {
       key: { buildId },
       value: { ...logEntry, buildId },


### PR DESCRIPTION
Close: #7554

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

This pull request adds a new feature to the build manager that allows logging messages from different domains (Server or AdminUI) in a single build. It implements a new method to extract the domain name from the jobBuildId, and modifies the controller and the tests to use this method and prefix the log messages with the domain name.

Result:
![image](https://github.com/amplication/amplication/assets/2861984/f455c7c2-822f-4cc3-bf0a-2e7dad8f2ed7)


## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
