### PR TITLE
chore(server): ignore webpack sourcemap errors for prisma generated client

### DIFF
--- a/packages/amplication-server/webpack.config.js
+++ b/packages/amplication-server/webpack.config.js
@@ -9,5 +9,8 @@ module.exports = composePlugins(withNx(), (config) => {
     const rel = path.relative(process.cwd(), info.absoluteResourcePath);
     return `webpack:///./${rel}`;
   };
+  config.ignoreWarnings = [
+    /(Failed to parse source map from)\s.*\/generated-prisma-client\/runtime\/library.js.map\/.*/,
+  ];
   return config;
 });

--- a/packages/amplication-server/webpack.config.js
+++ b/packages/amplication-server/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = composePlugins(withNx(), (config) => {
     return `webpack:///./${rel}`;
   };
   config.ignoreWarnings = [
-    /(Failed to parse source map from)\s.*\/generated-prisma-client\/runtime\/library.js.map\/.*/,
+    /(Failed to parse source map from)\s.*\/generated-prisma-client\/.*/,
   ];
   return config;
 });


### PR DESCRIPTION
Close: #7563

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

Update Prisma version and ignore source map warnings. This pull request updates the Prisma version to the latest release and adds a webpack rule to ignore source map warnings from the generated-prisma-client library in the `amplication-server` package.


<img width="1023" alt="image" src="https://github.com/amplication/amplication/assets/2861984/3bc9be5e-1457-4a90-9ae5-4f447fad48b7">
