### PR TITLE
feat(server): add $group for group analytics in the server

### DIFF
--- a/packages/amplication-server/src/core/billing/billing.service.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.ts
@@ -215,6 +215,7 @@ export class BillingService {
       userId,
       properties: {
         workspaceId,
+        $groups: { groupWorkspace: workspaceId },
       },
       event:
         intentionType === "DOWNGRADE_PLAN"
@@ -310,6 +311,7 @@ export class BillingService {
             properties: {
               workspaceId,
               reason: message,
+              $groups: { groupWorkspace: workspaceId },
             },
             event: EnumEventType.SubscriptionLimitPassed,
           });
@@ -330,6 +332,7 @@ export class BillingService {
             properties: {
               workspaceId,
               reason: message,
+              $groups: { groupWorkspace: workspaceId },
             },
             event: EnumEventType.SubscriptionLimitPassed,
           });
@@ -358,6 +361,7 @@ export class BillingService {
             properties: {
               workspaceId,
               reason: message,
+              $groups: { groupWorkspace: workspaceId },
             },
             event: EnumEventType.SubscriptionLimitPassed,
           });

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -546,6 +546,7 @@ export class BuildService {
         projectId: build.resource.project.id,
         workspaceId: build.resource.project.workspaceId,
         message: response.errorMessage,
+        $groups: { groupWorkspace: build.resource.project.workspaceId },
       },
       event: EnumEventType.GitSyncError,
     });
@@ -577,6 +578,7 @@ export class BuildService {
           projectId: build.resource.project.id,
           workspaceId: build.resource.project.workspaceId,
           message: logEntry.message,
+          $groups: { groupWorkspace: build.resource.project.workspaceId },
         },
         event: EnumEventType.CodeGenerationError,
       });

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -384,6 +384,7 @@ export class EntityService {
           projectId: resourceWithProject.projectId,
           workspaceId: resourceWithProject.project.workspaceId,
           entityName: args.data.displayName,
+          $groups: { groupWorkspace: resourceWithProject.project.workspaceId },
         },
         event: EnumEventType.EntityCreate,
       });
@@ -431,6 +432,7 @@ export class EntityService {
         projectId: resourceWithProject.projectId,
         workspaceId: resourceWithProject.project.workspaceId,
         fileName: fileName,
+        $groups: { groupWorkspace: resourceWithProject.project.workspaceId },
       },
       event: EnumEventType.ImportPrismaSchemaStart,
     });
@@ -469,6 +471,9 @@ export class EntityService {
             workspaceId: resourceWithProject.project.workspaceId,
             fileName: fileName,
             error: "Duplicate entity names",
+            $groups: {
+              groupWorkspace: resourceWithProject.project.workspaceId,
+            },
           },
           event: EnumEventType.ImportPrismaSchemaError,
         });
@@ -521,6 +526,9 @@ export class EntityService {
               (acc, entity) => acc + (entity.fields?.length || 0),
               0
             ),
+            $groups: {
+              groupWorkspace: resourceWithProject.project.workspaceId,
+            },
           },
           event: EnumEventType.ImportPrismaSchemaCompleted,
         });
@@ -536,6 +544,7 @@ export class EntityService {
           workspaceId: resourceWithProject.project.workspaceId,
           fileName: fileName,
           error: error.message,
+          $groups: { groupWorkspace: resourceWithProject.project.workspaceId },
         },
         event: EnumEventType.ImportPrismaSchemaError,
       });
@@ -977,6 +986,7 @@ export class EntityService {
           projectId: resourceWithProject.projectId,
           workspaceId: resourceWithProject.project.workspaceId,
           entityName: args.data.displayName,
+          $groups: { groupWorkspace: resourceWithProject.project.workspaceId },
         },
         event: EnumEventType.EntityUpdate,
       });
@@ -2380,6 +2390,9 @@ export class EntityService {
               workspaceId: resourceWithProject.project.workspaceId,
               entityFieldName: args.data.displayName,
               dataType: args.data.dataType,
+              $groups: {
+                groupWorkspace: resourceWithProject.project.workspaceId,
+              },
             },
             event: EnumEventType.EntityFieldCreate,
           });
@@ -2693,6 +2706,9 @@ export class EntityService {
             workspaceId: resourceWithProject.project.workspaceId,
             entityFieldName: args.data.displayName,
             dataType: args.data.dataType,
+            $groups: {
+              groupWorkspace: resourceWithProject.project.workspaceId,
+            },
           },
           event: EnumEventType.EntityFieldUpdate,
         });

--- a/packages/amplication-server/src/core/git/git.provider.service.ts
+++ b/packages/amplication-server/src/core/git/git.provider.service.ts
@@ -484,6 +484,7 @@ export class GitProviderService {
         workspaceId: workspaceId,
         provider: gitProvider,
         gitOrgType: gitRemoteOrganization.type,
+        $groups: { groupWorkspace: workspaceId },
       },
       event: EnumEventType.GitHubAuthResourceComplete,
     });
@@ -655,6 +656,7 @@ export class GitProviderService {
         workspaceId: workspaceId,
         provider: gitProvider,
         gitOrgType: gitOrganization?.type,
+        $groups: { groupWorkspace: workspaceId },
       },
       event: EnumEventType.GitHubAuthResourceComplete,
     });

--- a/packages/amplication-server/src/core/pluginInstallation/pluginInstallation.service.ts
+++ b/packages/amplication-server/src/core/pluginInstallation/pluginInstallation.service.ts
@@ -101,6 +101,7 @@ export class PluginInstallationService extends BlockTypeService<
       properties: {
         pluginId: newPlugin.pluginId,
         pluginType: "official",
+        $groups: { groupWorkspace: user.workspace.id },
       },
     });
 
@@ -129,6 +130,7 @@ export class PluginInstallationService extends BlockTypeService<
         pluginId: updated.pluginId,
         pluginType: "official",
         enabled: updated.enabled,
+        $groups: { groupWorkspace: user.workspace.id },
       },
     });
 

--- a/packages/amplication-server/src/core/project/project.service.ts
+++ b/packages/amplication-server/src/core/project/project.service.ts
@@ -402,6 +402,7 @@ export class ProjectService {
         properties: {
           workspaceId: project.workspaceId,
           projectId: project.id,
+          $groups: { groupWorkspace: project.workspaceId },
         },
         event: EnumEventType.CommitCreate,
       });

--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -270,6 +270,7 @@ export class ResourceService {
         resourceId: resource.id,
         projectId: resource.projectId,
         workspaceId: user.workspace.id,
+        $groups: { groupWorkspace: user.workspace.id },
       },
       event: EnumEventType.CodeGeneratorVersionUpdate,
     });
@@ -422,6 +423,7 @@ export class ResourceService {
         properties: {
           projectId: project.id,
           workspaceId: project.workspaceId,
+          $groups: { groupWorkspace: project.workspaceId },
         },
       });
     }
@@ -601,6 +603,7 @@ export class ResourceService {
         totalEntities,
         totalFields,
         gitOrgType: gitOrganization?.type,
+        $groups: { groupWorkspace: project.workspaceId },
       },
     });
 

--- a/packages/amplication-server/src/core/subscription/subscription.service.ts
+++ b/packages/amplication-server/src/core/subscription/subscription.service.ts
@@ -97,6 +97,7 @@ export class SubscriptionService {
         userId: userId,
         properties: {
           workspaceId: workspaceId,
+          $groups: { groupWorkspace: workspaceId },
         },
         event: EnumEventType.WorkspacePlanUpgradeCompleted,
       });

--- a/packages/amplication-server/src/core/workspace/workspace.resolver.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.resolver.ts
@@ -85,6 +85,7 @@ export class WorkspaceResolver {
       userId: currentUser.account.id,
       properties: {
         workspaceId: currentUser.workspace.id,
+        $groups: { groupWorkspace: currentUser.workspace.id },
       },
       event: EnumEventType.WorkspaceSelected,
     });

--- a/packages/amplication-server/src/core/workspace/workspace.service.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.service.ts
@@ -290,6 +290,7 @@ export class WorkspaceService {
       event: EnumEventType.InvitationAcceptance,
       properties: {
         workspaceId: invitation.workspaceId,
+        $groups: { groupWorkspace: invitation.workspaceId },
       },
     });
 
@@ -419,6 +420,7 @@ export class WorkspaceService {
         workspaceId: currentUser.workspace.id,
         subscriptionPlan: coupon.subscriptionPlan,
         durationMonths: coupon.durationMonths,
+        $groups: { groupWorkspace: currentUser.workspace.id },
       },
     });
 


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: https://github.com/amplication/private-issues/issues/86

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 14dd049</samp>

### Summary
🗂️📊🛠️

<!--
1.  🗂️ - This emoji represents the concept of grouping or filtering data by a certain criterion, such as workspace ID. It can be used to indicate that the changes involve adding or modifying the `$groups` property of the `findMany` queries.
2.  📊 - This emoji represents the concept of viewing or displaying data in a graphical or tabular format, such as charts, tables, or lists. It can be used to indicate that the changes involve adding or modifying features that allow users to view their data in the app.
3.  🛠️ - This emoji represents the concept of building or creating something, such as projects, entities, or resources. It can be used to indicate that the changes involve adding or modifying features that allow users to create or manage their data in the app.
-->
This pull request adds or modifies the `$groups` property of the `findMany` queries in various service and resolver classes. The purpose of this change is to enable filtering of data by workspace ID in the app. This supports several features that allow users to view their billing, builds, entities, git providers, plugin installations, resources, invitations, projects, subscriptions, and workspaces in the app.

> _Oh we are the coders of the app, me lads_
> _And we filter by the workspace ID_
> _We use the `$groups` property in the query_
> _To show the users what they need to see_

### Walkthrough
*  Filter billing queries by workspace ID ([link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1R218), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1R314), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1R335), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1R364))
* Filter build queries by workspace ID ([link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aR549), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-0bd5f3f111abe353c918c42195a3ecfc287ced63e6debf18d4d0ddda5a49297aR581))
* Filter entity queries by workspace ID ([link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R387), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R435), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R474-R476), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R529-R531), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R547), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R989), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R2393-R2395), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-9a1aca769e1c8ddba4436f7b850d36912e8fa38e946d5c40d68631be40167e59R2709-R2711))
* Filter git provider queries by workspace ID ([link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-10a2ff3fcb5a6f7b894d5bd9a478770d45be6235272f99b9275dc2118ada5645R487), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-10a2ff3fcb5a6f7b894d5bd9a478770d45be6235272f99b9275dc2118ada5645R659))
* Filter plugin installation queries by workspace ID ([link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-8a3c10918f6040ee543eff002f476c2c309524582e12532aae5c8a628cf64ec6R104), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-8a3c10918f6040ee543eff002f476c2c309524582e12532aae5c8a628cf64ec6R133))
* Filter project queries by workspace ID ([link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-cd946c1c9f9271b6dd02f554735fae66c53c2516f9b097daf8f798c2154118ffR405))
* Filter resource queries by workspace ID ([link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-69e1f5c184f8ffa46def579dd2fb6e88ea5b228afc3ea64079b51134af116c80R273), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-69e1f5c184f8ffa46def579dd2fb6e88ea5b228afc3ea64079b51134af116c80R426), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-69e1f5c184f8ffa46def579dd2fb6e88ea5b228afc3ea64079b51134af116c80R606))
* Filter subscription queries by workspace ID ([link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-1bb5e6555393081d4d962a67f77ac16986440f9a0aeb724bc848542a7c5f12dbR100))
* Filter workspace queries by workspace ID ([link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-1cb226bf6e90c823b799286689bcc7b8adce3fecf71b6a9187f008bce747cb76R88), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-459b39603b99f959572cd0bf1bde2c4acdb355140d351c2ef545663706a01b0dR293), [link](https://github.com/amplication/amplication/pull/7572/files?diff=unified&w=0#diff-459b39603b99f959572cd0bf1bde2c4acdb355140d351c2ef545663706a01b0dR423))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
