### PR TITLE
feat(server): update customer provisioning with new default Enterprise plan

### DIFF
--- a/libs/util/billing-types/src/index.ts
+++ b/libs/util/billing-types/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./lib/billing-plan.types";
+export * from "./lib/billing-addons.types";
 export * from "./lib/billing-feature.types";

--- a/libs/util/billing-types/src/lib/billing-addons.types.ts
+++ b/libs/util/billing-types/src/lib/billing-addons.types.ts
@@ -1,0 +1,3 @@
+export enum BillingAddon {
+  CustomActions = "addon-amplication-custom-action",
+}

--- a/packages/amplication-client/src/Purchase/PurchasePage.tsx
+++ b/packages/amplication-client/src/Purchase/PurchasePage.tsx
@@ -1,4 +1,6 @@
 import { Paywall, BillingPeriod, Price } from "@stigg/react-sdk";
+import { BillingPlan } from "@amplication/util-billing-types";
+
 import { useTracking } from "../util/analytics";
 import { AnalyticsEventNames } from "../util/analytics-events.types";
 import { useHistory } from "react-router-dom";
@@ -109,7 +111,7 @@ const PurchasePage = (props) => {
         variables: {
           data: {
             workspaceId: currentWorkspace.id,
-            planId: "plan-amplication-pro",
+            planId: BillingPlan.Pro,
             billingPeriod: selectedBillingPeriod,
             intentionType,
             successUrl: props.location.state?.from?.pathname,
@@ -139,14 +141,14 @@ const PurchasePage = (props) => {
         currency,
       });
       switch (plan.id) {
-        case "plan-amplication-enterprise":
+        case BillingPlan.Enterprise:
           handleContactUsClick();
           break;
-        case "plan-amplication-pro":
+        case BillingPlan.Pro:
           setLoading(true);
           await upgradeToPro(selectedBillingPeriod, intentionType);
           break;
-        case "plan-amplication-free":
+        case BillingPlan.Free:
           handleDowngradeClick();
           break;
       }

--- a/packages/amplication-server/src/core/billing/billing.service.spec.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.spec.ts
@@ -148,20 +148,22 @@ describe("BillingService", () => {
     );
   });
 
-  it("should provision customer and not sync free plans to Stripe", async () => {
-    const spyOnStiggProvisionCustomer = jest.spyOn(
-      Stigg.prototype,
-      "provisionCustomer"
-    );
+  describe("provisionCustomer", () => {
+    it("should provision customer and not sync free plans to Stripe", async () => {
+      const spyOnStiggProvisionCustomer = jest.spyOn(
+        Stigg.prototype,
+        "provisionCustomer"
+      );
 
-    await service.provisionCustomer("id", BillingPlan.Free);
+      await service.provisionCustomer("id");
 
-    expect(spyOnStiggProvisionCustomer).toHaveBeenCalledTimes(1);
-    expect(spyOnStiggProvisionCustomer).toHaveBeenCalledWith(
-      expect.objectContaining({
-        shouldSyncFree: false,
-      })
-    );
+      expect(spyOnStiggProvisionCustomer).toHaveBeenCalledTimes(1);
+      expect(spyOnStiggProvisionCustomer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          shouldSyncFree: false,
+        })
+      );
+    });
   });
 
   describe("validateSubscriptionPlanLimitationsForWorkspace", () => {

--- a/packages/amplication-server/src/core/billing/billing.service.spec.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.spec.ts
@@ -4,7 +4,11 @@ import { BillingService } from "./billing.service";
 import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { ConfigService } from "@nestjs/config";
 import { Env } from "../../env";
-import { BillingPlan, BillingFeature } from "@amplication/util-billing-types";
+import {
+  BillingPlan,
+  BillingFeature,
+  BillingAddon,
+} from "@amplication/util-billing-types";
 import Stigg, {
   BooleanEntitlement,
   FullSubscription,
@@ -164,6 +168,31 @@ describe("BillingService", () => {
         })
       );
     });
+  });
+
+  it("should provision customer with default plan: enterprise with custom actions addon", async () => {
+    const expectedWorkspaceId = "id";
+    const spyOnStiggProvisionCustomer = jest.spyOn(
+      Stigg.prototype,
+      "provisionCustomer"
+    );
+
+    await service.provisionCustomer(expectedWorkspaceId);
+
+    expect(spyOnStiggProvisionCustomer).toHaveBeenCalledTimes(1);
+    expect(spyOnStiggProvisionCustomer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customerId: expectedWorkspaceId,
+        subscriptionParams: {
+          planId: BillingPlan.Enterprise,
+          addons: [
+            {
+              addonId: BillingAddon.CustomActions,
+            },
+          ],
+        },
+      })
+    );
   });
 
   describe("validateSubscriptionPlanLimitationsForWorkspace", () => {

--- a/packages/amplication-server/src/core/billing/billing.service.spec.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.spec.ts
@@ -164,267 +164,24 @@ describe("BillingService", () => {
     );
   });
 
-  it("should throw exceptions on number of services if the workspace has no entitlement to bypass code generation limitation", async () => {
-    const workspaceId = "id";
-    const projectId = "project-id-1";
-    const servicesPerWorkspaceLimit = 3;
-
-    const spyOnServiceGetBooleanEntitlement = jest
-      .spyOn(service, "getBooleanEntitlement")
-      .mockResolvedValue({
-        hasAccess: false,
-      } as BooleanEntitlement);
-
-    const spyOnServiceGetMeteredEntitlement = jest
-      .spyOn(service, "getMeteredEntitlement")
-      .mockResolvedValue({
-        hasAccess: false,
-        usageLimit: servicesPerWorkspaceLimit,
-      } as MeteredEntitlement);
-
-    const user: User = {
-      id: "user-id",
-      account: {
-        id: "account-id",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        email: "email",
-        firstName: "first-name",
-        lastName: "last-name",
-        password: "password",
-      },
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      isOwner: true,
-    };
-
-    const projects: Project[] = [
-      {
-        id: projectId,
-        name: "project-1",
-        workspaceId: workspaceId,
-        useDemoRepo: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    ];
-    const repositories: GitRepository[] = [
-      {
-        gitOrganizationId: "git-organization-id",
-        name: "git-repository-name",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        id: "git-repository-id",
-        gitOrganization: {
-          provider: EnumGitProvider.Github,
-          id: "git-organization-id",
-        } as unknown as GitOrganization,
-      },
-    ];
-
-    await expect(
-      service.validateSubscriptionPlanLimitationsForWorkspace({
-        workspaceId,
-        currentUser: user,
-        currentProjectId: projectId,
-        projects,
-        repositories,
-      })
-    ).rejects.toThrow(
-      new BillingLimitationError(
-        "Your workspace exceeds its resource limitation."
-      )
-    );
-
-    expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledTimes(1);
-    expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledWith(
-      workspaceId,
-      BillingFeature.IgnoreValidationCodeGeneration
-    );
-    await expect(
-      service.getBooleanEntitlement(
-        workspaceId,
-        BillingFeature.IgnoreValidationCodeGeneration
-      )
-    ).resolves.toEqual(
-      expect.objectContaining({
-        hasAccess: false,
-      })
-    );
-
-    expect(spyOnServiceGetMeteredEntitlement).toHaveBeenNthCalledWith(
-      1,
-      workspaceId,
-      BillingFeature.Services
-    );
-    await expect(
-      service.getMeteredEntitlement(workspaceId, BillingFeature.Services)
-    ).resolves.toEqual(
-      expect.objectContaining({
-        hasAccess: false,
-      })
-    );
-  });
-
-  it("should throw exceptions on number of team members if the workspace has no entitlement to bypass code generation limitation", async () => {
-    const workspaceId = "id";
-    const projectId = "project-id-1";
-    const projectsPerWorkspaceLimit = 1;
-    const entitiesPerServiceLimit = 5;
-    const servicesPerWorkspaceLimit = 3;
-    const teamMembersPerWorkspaceLimit = 2;
-
-    const spyOnServiceGetBooleanEntitlement = jest
-      .spyOn(service, "getBooleanEntitlement")
-      .mockResolvedValue({
-        hasAccess: false,
-      } as BooleanEntitlement);
-
-    const spyOnServiceGetMeteredEntitlement = jest
-      .spyOn(service, "getMeteredEntitlement")
-      .mockImplementation(async (workspaceId, feature) => {
-        switch (feature) {
-          case BillingFeature.Projects:
-            return {
-              hasAccess: true,
-              usageLimit: projectsPerWorkspaceLimit,
-            } as MeteredEntitlement;
-          case BillingFeature.Services:
-            return {
-              hasAccess: true,
-              usageLimit: servicesPerWorkspaceLimit,
-            } as MeteredEntitlement;
-          case BillingFeature.ServicesAboveEntitiesPerServiceLimit:
-            return {
-              hasAccess: false,
-              usageLimit: entitiesPerServiceLimit,
-            } as MeteredEntitlement;
-          case BillingFeature.TeamMembers:
-            return {
-              hasAccess: false,
-              usageLimit: teamMembersPerWorkspaceLimit,
-            } as MeteredEntitlement;
-        }
-      });
-
-    const user: User = {
-      id: "user-id",
-      account: {
-        id: "account-id",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        email: "email",
-        firstName: "first-name",
-        lastName: "last-name",
-        password: "password",
-      },
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      isOwner: true,
-    };
-
-    const projects: Project[] = [
-      {
-        id: projectId,
-        name: "project-1",
-        workspaceId: workspaceId,
-        useDemoRepo: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    ];
-
-    const repositories: GitRepository[] = [
-      {
-        gitOrganizationId: "git-organization-id",
-        name: "git-repository-name",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        id: "git-repository-id",
-        gitOrganization: {
-          provider: EnumGitProvider.Github,
-          id: "git-organization-id",
-        } as unknown as GitOrganization,
-      },
-    ];
-
-    await expect(
-      service.validateSubscriptionPlanLimitationsForWorkspace({
-        workspaceId,
-        currentUser: user,
-        currentProjectId: projectId,
-        projects,
-        repositories,
-      })
-    ).rejects.toThrow(
-      new BillingLimitationError(
-        "Your workspace exceeds its team member limitation."
-      )
-    );
-
-    expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledTimes(1);
-    expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledWith(
-      workspaceId,
-      BillingFeature.IgnoreValidationCodeGeneration
-    );
-    await expect(
-      service.getBooleanEntitlement(
-        workspaceId,
-        BillingFeature.IgnoreValidationCodeGeneration
-      )
-    ).resolves.toEqual(
-      expect.objectContaining({
-        hasAccess: false,
-      })
-    );
-
-    expect(spyOnServiceGetMeteredEntitlement).toHaveBeenCalledTimes(2);
-
-    expect(spyOnServiceGetMeteredEntitlement).toHaveBeenNthCalledWith(
-      1,
-      workspaceId,
-      BillingFeature.Services
-    );
-    expect(spyOnServiceGetMeteredEntitlement).toHaveBeenNthCalledWith(
-      2,
-      workspaceId,
-      BillingFeature.TeamMembers
-    );
-  });
-
-  it.each([
-    EnumGitProvider.AwsCodeCommit,
-    EnumGitProvider.Bitbucket,
-    EnumGitProvider.GitLab,
-  ])(
-    "should throw exception when using %s git provider if the workspace has no entitlement or bypass code generation limitation",
-    async (currentGitProvider) => {
+  describe("validateSubscriptionPlanLimitationsForWorkspace", () => {
+    it("should throw exceptions on number of services if the workspace has no entitlement to bypass code generation limitation", async () => {
       const workspaceId = "id";
       const projectId = "project-id-1";
+      const servicesPerWorkspaceLimit = 3;
 
       const spyOnServiceGetBooleanEntitlement = jest
         .spyOn(service, "getBooleanEntitlement")
-        .mockImplementation(async (workspaceId, feature) => {
-          switch (feature) {
-            case BillingFeature[
-              currentGitProvider as keyof typeof BillingFeature
-            ]:
-            case BillingFeature.IgnoreValidationCodeGeneration:
-              return {
-                hasAccess: false,
-              } as BooleanEntitlement;
+        .mockResolvedValue({
+          hasAccess: false,
+        } as BooleanEntitlement);
 
-            default:
-              return {
-                hasAccess: true,
-              } as BooleanEntitlement;
-          }
-        });
-
-      jest.spyOn(service, "getMeteredEntitlement").mockResolvedValue({
-        hasAccess: true,
-        usageLimit: 1000,
-      } as MeteredEntitlement);
+      const spyOnServiceGetMeteredEntitlement = jest
+        .spyOn(service, "getMeteredEntitlement")
+        .mockResolvedValue({
+          hasAccess: false,
+          usageLimit: servicesPerWorkspaceLimit,
+        } as MeteredEntitlement);
 
       const user: User = {
         id: "user-id",
@@ -452,7 +209,6 @@ describe("BillingService", () => {
           updatedAt: new Date(),
         },
       ];
-
       const repositories: GitRepository[] = [
         {
           gitOrganizationId: "git-organization-id",
@@ -461,7 +217,7 @@ describe("BillingService", () => {
           updatedAt: new Date(),
           id: "git-repository-id",
           gitOrganization: {
-            provider: EnumGitProvider[currentGitProvider],
+            provider: EnumGitProvider.Github,
             id: "git-organization-id",
           } as unknown as GitOrganization,
         },
@@ -477,51 +233,80 @@ describe("BillingService", () => {
         })
       ).rejects.toThrow(
         new BillingLimitationError(
-          `Your workspace uses ${currentGitProvider} integration, while it is not part of your current plan.`
+          "Your workspace exceeds its resource limitation."
         )
       );
 
+      expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledTimes(1);
       expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledWith(
         workspaceId,
         BillingFeature.IgnoreValidationCodeGeneration
       );
-
-      expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledWith(
-        workspaceId,
-        BillingFeature[currentGitProvider as keyof typeof BillingFeature]
+      await expect(
+        service.getBooleanEntitlement(
+          workspaceId,
+          BillingFeature.IgnoreValidationCodeGeneration
+        )
+      ).resolves.toEqual(
+        expect.objectContaining({
+          hasAccess: false,
+        })
       );
-    }
-  );
 
-  it.each([EnumGitProvider.Github])(
-    "should not throw exception when using %s git provider as it is the default provider and never checked for entitlements",
-    async (currentGitProvider) => {
+      expect(spyOnServiceGetMeteredEntitlement).toHaveBeenNthCalledWith(
+        1,
+        workspaceId,
+        BillingFeature.Services
+      );
+      await expect(
+        service.getMeteredEntitlement(workspaceId, BillingFeature.Services)
+      ).resolves.toEqual(
+        expect.objectContaining({
+          hasAccess: false,
+        })
+      );
+    });
+
+    it("should throw exceptions on number of team members if the workspace has no entitlement to bypass code generation limitation", async () => {
       const workspaceId = "id";
       const projectId = "project-id-1";
+      const projectsPerWorkspaceLimit = 1;
+      const entitiesPerServiceLimit = 5;
+      const servicesPerWorkspaceLimit = 3;
+      const teamMembersPerWorkspaceLimit = 2;
 
       const spyOnServiceGetBooleanEntitlement = jest
         .spyOn(service, "getBooleanEntitlement")
+        .mockResolvedValue({
+          hasAccess: false,
+        } as BooleanEntitlement);
+
+      const spyOnServiceGetMeteredEntitlement = jest
+        .spyOn(service, "getMeteredEntitlement")
         .mockImplementation(async (workspaceId, feature) => {
           switch (feature) {
-            case BillingFeature[
-              currentGitProvider as keyof typeof BillingFeature
-            ]:
-            case BillingFeature.IgnoreValidationCodeGeneration:
-              return {
-                hasAccess: false,
-              } as BooleanEntitlement;
-
-            default:
+            case BillingFeature.Projects:
               return {
                 hasAccess: true,
-              } as BooleanEntitlement;
+                usageLimit: projectsPerWorkspaceLimit,
+              } as MeteredEntitlement;
+            case BillingFeature.Services:
+              return {
+                hasAccess: true,
+                usageLimit: servicesPerWorkspaceLimit,
+              } as MeteredEntitlement;
+            case BillingFeature.ServicesAboveEntitiesPerServiceLimit:
+              return {
+                hasAccess: false,
+                usageLimit: entitiesPerServiceLimit,
+              } as MeteredEntitlement;
+            case BillingFeature.TeamMembers:
+              return {
+                hasAccess: false,
+                usageLimit: teamMembersPerWorkspaceLimit,
+              } as MeteredEntitlement;
           }
         });
-
-      jest.spyOn(service, "getMeteredEntitlement").mockResolvedValue({
-        hasAccess: true,
-        usageLimit: 1000,
-      } as MeteredEntitlement);
 
       const user: User = {
         id: "user-id",
@@ -558,29 +343,246 @@ describe("BillingService", () => {
           updatedAt: new Date(),
           id: "git-repository-id",
           gitOrganization: {
-            provider: EnumGitProvider[currentGitProvider],
+            provider: EnumGitProvider.Github,
             id: "git-organization-id",
           } as unknown as GitOrganization,
         },
       ];
 
-      await service.validateSubscriptionPlanLimitationsForWorkspace({
-        workspaceId,
-        currentUser: user,
-        currentProjectId: projectId,
-        projects,
-        repositories,
-      });
+      await expect(
+        service.validateSubscriptionPlanLimitationsForWorkspace({
+          workspaceId,
+          currentUser: user,
+          currentProjectId: projectId,
+          projects,
+          repositories,
+        })
+      ).rejects.toThrow(
+        new BillingLimitationError(
+          "Your workspace exceeds its team member limitation."
+        )
+      );
 
+      expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledTimes(1);
       expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledWith(
         workspaceId,
         BillingFeature.IgnoreValidationCodeGeneration
       );
-
-      expect(spyOnServiceGetBooleanEntitlement).not.toHaveBeenCalledWith(
-        workspaceId,
-        BillingFeature[currentGitProvider as keyof typeof BillingFeature]
+      await expect(
+        service.getBooleanEntitlement(
+          workspaceId,
+          BillingFeature.IgnoreValidationCodeGeneration
+        )
+      ).resolves.toEqual(
+        expect.objectContaining({
+          hasAccess: false,
+        })
       );
-    }
-  );
+
+      expect(spyOnServiceGetMeteredEntitlement).toHaveBeenCalledTimes(2);
+
+      expect(spyOnServiceGetMeteredEntitlement).toHaveBeenNthCalledWith(
+        1,
+        workspaceId,
+        BillingFeature.Services
+      );
+      expect(spyOnServiceGetMeteredEntitlement).toHaveBeenNthCalledWith(
+        2,
+        workspaceId,
+        BillingFeature.TeamMembers
+      );
+    });
+
+    it.each([
+      EnumGitProvider.AwsCodeCommit,
+      EnumGitProvider.Bitbucket,
+      EnumGitProvider.GitLab,
+    ])(
+      "should throw exception when using %s git provider if the workspace has no entitlement or bypass code generation limitation",
+      async (currentGitProvider) => {
+        const workspaceId = "id";
+        const projectId = "project-id-1";
+
+        const spyOnServiceGetBooleanEntitlement = jest
+          .spyOn(service, "getBooleanEntitlement")
+          .mockImplementation(async (workspaceId, feature) => {
+            switch (feature) {
+              case BillingFeature[
+                currentGitProvider as keyof typeof BillingFeature
+              ]:
+              case BillingFeature.IgnoreValidationCodeGeneration:
+                return {
+                  hasAccess: false,
+                } as BooleanEntitlement;
+
+              default:
+                return {
+                  hasAccess: true,
+                } as BooleanEntitlement;
+            }
+          });
+
+        jest.spyOn(service, "getMeteredEntitlement").mockResolvedValue({
+          hasAccess: true,
+          usageLimit: 1000,
+        } as MeteredEntitlement);
+
+        const user: User = {
+          id: "user-id",
+          account: {
+            id: "account-id",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            email: "email",
+            firstName: "first-name",
+            lastName: "last-name",
+            password: "password",
+          },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          isOwner: true,
+        };
+
+        const projects: Project[] = [
+          {
+            id: projectId,
+            name: "project-1",
+            workspaceId: workspaceId,
+            useDemoRepo: false,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ];
+
+        const repositories: GitRepository[] = [
+          {
+            gitOrganizationId: "git-organization-id",
+            name: "git-repository-name",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            id: "git-repository-id",
+            gitOrganization: {
+              provider: EnumGitProvider[currentGitProvider],
+              id: "git-organization-id",
+            } as unknown as GitOrganization,
+          },
+        ];
+
+        await expect(
+          service.validateSubscriptionPlanLimitationsForWorkspace({
+            workspaceId,
+            currentUser: user,
+            currentProjectId: projectId,
+            projects,
+            repositories,
+          })
+        ).rejects.toThrow(
+          new BillingLimitationError(
+            `Your workspace uses ${currentGitProvider} integration, while it is not part of your current plan.`
+          )
+        );
+
+        expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledWith(
+          workspaceId,
+          BillingFeature.IgnoreValidationCodeGeneration
+        );
+
+        expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledWith(
+          workspaceId,
+          BillingFeature[currentGitProvider as keyof typeof BillingFeature]
+        );
+      }
+    );
+
+    it.each([EnumGitProvider.Github])(
+      "should not throw exception when using %s git provider as it is the default provider and never checked for entitlements",
+      async (currentGitProvider) => {
+        const workspaceId = "id";
+        const projectId = "project-id-1";
+
+        const spyOnServiceGetBooleanEntitlement = jest
+          .spyOn(service, "getBooleanEntitlement")
+          .mockImplementation(async (workspaceId, feature) => {
+            switch (feature) {
+              case BillingFeature[
+                currentGitProvider as keyof typeof BillingFeature
+              ]:
+              case BillingFeature.IgnoreValidationCodeGeneration:
+                return {
+                  hasAccess: false,
+                } as BooleanEntitlement;
+
+              default:
+                return {
+                  hasAccess: true,
+                } as BooleanEntitlement;
+            }
+          });
+
+        jest.spyOn(service, "getMeteredEntitlement").mockResolvedValue({
+          hasAccess: true,
+          usageLimit: 1000,
+        } as MeteredEntitlement);
+
+        const user: User = {
+          id: "user-id",
+          account: {
+            id: "account-id",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            email: "email",
+            firstName: "first-name",
+            lastName: "last-name",
+            password: "password",
+          },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          isOwner: true,
+        };
+
+        const projects: Project[] = [
+          {
+            id: projectId,
+            name: "project-1",
+            workspaceId: workspaceId,
+            useDemoRepo: false,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ];
+
+        const repositories: GitRepository[] = [
+          {
+            gitOrganizationId: "git-organization-id",
+            name: "git-repository-name",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            id: "git-repository-id",
+            gitOrganization: {
+              provider: EnumGitProvider[currentGitProvider],
+              id: "git-organization-id",
+            } as unknown as GitOrganization,
+          },
+        ];
+
+        await service.validateSubscriptionPlanLimitationsForWorkspace({
+          workspaceId,
+          currentUser: user,
+          currentProjectId: projectId,
+          projects,
+          repositories,
+        });
+
+        expect(spyOnServiceGetBooleanEntitlement).toHaveBeenCalledWith(
+          workspaceId,
+          BillingFeature.IgnoreValidationCodeGeneration
+        );
+
+        expect(spyOnServiceGetBooleanEntitlement).not.toHaveBeenCalledWith(
+          workspaceId,
+          BillingFeature[currentGitProvider as keyof typeof BillingFeature]
+        );
+      }
+    );
+  });
 });

--- a/packages/amplication-server/src/core/billing/billing.service.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.ts
@@ -20,7 +20,11 @@ import { ProvisionSubscriptionResult } from "../workspace/dto/ProvisionSubscript
 import { BillingLimitationError } from "../../errors/BillingLimitationError";
 import { FeatureUsageReport } from "../project/FeatureUsageReport";
 import { ProvisionSubscriptionInput } from "../workspace/dto/ProvisionSubscriptionInput";
-import { BillingFeature, BillingPlan } from "@amplication/util-billing-types";
+import {
+  BillingAddon,
+  BillingFeature,
+  BillingPlan,
+} from "@amplication/util-billing-types";
 import { ValidateSubscriptionPlanLimitationsArgs } from "./billing.service.types";
 import { EnumGitProvider } from "../git/dto/enums/EnumGitProvider";
 
@@ -32,6 +36,17 @@ export class BillingService {
 
   get isBillingEnabled(): boolean {
     return this.billingEnabled;
+  }
+
+  private get defaultSubscriptionPlan() {
+    return {
+      planId: BillingPlan.Enterprise,
+      addons: [
+        {
+          addonId: BillingAddon.CustomActions,
+        },
+      ],
+    };
   }
 
   constructor(
@@ -258,18 +273,12 @@ export class BillingService {
     }
   }
 
-  async provisionCustomer(
-    workspaceId: string,
-    plan: BillingPlan
-  ): Promise<null> {
+  async provisionCustomer(workspaceId: string): Promise<null> {
     if (this.isBillingEnabled) {
-      const stiggClient = await this.getStiggClient();
-      await stiggClient.provisionCustomer({
+      await this.stiggClient.provisionCustomer({
         customerId: workspaceId,
         shouldSyncFree: false,
-        subscriptionParams: {
-          planId: plan,
-        },
+        subscriptionParams: this.defaultSubscriptionPlan,
       });
     }
     return;

--- a/packages/amplication-server/src/core/subscription/subscription.service.ts
+++ b/packages/amplication-server/src/core/subscription/subscription.service.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable } from "@nestjs/common";
-import { FindSubscriptionsArgs } from "./dto/FindSubscriptionsArgs";
 import { Subscription } from "./dto/Subscription";
 import { EnumSubscriptionPlan, EnumSubscriptionStatus } from "./dto";
 import {
@@ -25,14 +24,6 @@ export class SubscriptionService {
     private readonly billingService: BillingService,
     private readonly analyticsService: SegmentAnalyticsService
   ) {}
-
-  private async getSubscriptions(
-    args: FindSubscriptionsArgs
-  ): Promise<Subscription[] | null> {
-    const subs = await this.prisma.subscription.findMany(args);
-
-    return subs;
-  }
 
   async getSubscriptionById(id: string): Promise<Subscription | null> {
     const sub = await this.prisma.subscription.findUnique({

--- a/packages/amplication-server/src/core/workspace/workspace.service.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.service.ts
@@ -116,7 +116,7 @@ export class WorkspaceService {
       },
     });
 
-    await this.billingService.provisionCustomer(workspace.id, BillingPlan.Free);
+    await this.billingService.provisionCustomer(workspace.id);
 
     const [user] = workspace.users;
     await this.projectService.createProject(


### PR DESCRIPTION
Close: https://github.com/amplication/private-issues/issues/82

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 37a48dc</samp>

### Summary
🚀🧹🔧

<!--
1.  🚀 - This emoji can represent the change that exports the billing-addons.types module from the util-billing-types library, which defines a new enum for billing addons. This is because this change adds a new feature or functionality to the library that can be used by other modules or services.
2.  🧹 - This emoji can represent the change that updates the call to the provisionCustomer method in the WorkspaceService class by removing the BillingPlan.Free argument and using the default subscription plan instead. This is because this change cleans up or simplifies the code by removing unnecessary or redundant arguments or logic.
3.  🔧 - This emoji can represent the change that refactors the PurchasePage component to use the BillingPlan enum from the util-billing-types library instead of hardcoded plan IDs, to improve code readability and maintainability. This is because this change fixes or improves the code quality or structure by using a more consistent and reusable source of data.
-->
This pull request refactors the billing and subscription logic in the client and server packages to use a fixed default plan and a new enum for billing addons. It also exports the new enum from the util-billing-types library and removes some unused code.

> _No more free plans, no more user choice_
> _We force them all to pay with a single voice_
> _We import the `BillingAddon` from the util_
> _We are the masters of the billing cruel_

### Walkthrough
*  Export the billing-addons.types module from the util-billing-types library, which defines a new enum for billing addons ([link](https://github.com/amplication/amplication/pull/7585/files?diff=unified&w=0#diff-3485662f54df6c0b097529ccc9bf530d8a957ba044b5249857e2f003e5a5df41R2))
* Add the BillingAddon enum to the billing-addons.types module, which currently has only one value for custom actions ([link](https://github.com/amplication/amplication/pull/7585/files?diff=unified&w=0#diff-539d85a6dca0b89ac0326889d55dc5521704858a7e424a7ee32534267c1c84dfR1-R3))
* Use the BillingPlan enum from the util-billing-types library in the PurchasePage component, which is used to display and handle the purchase of different plans ([link](https://github.com/amplication/amplication/pull/7585/files?diff=unified&w=0#diff-5a2c55b6a53d9d5a540e05bfef0694bdac1851e3007fccb6d563a5df492e1c73R2-R3))
  * Replace the hardcoded plan ID with the BillingPlan enum value in the data object that is sent to the provisionSubscription mutation, which creates or updates a subscription for a workspace ([link](https://github.com/amplication/amplication/pull/7585/files?diff=unified&w=0#diff-5a2c55b6a53d9d5a540e05bfef0694bdac1851e3007fccb6d563a5df492e1c73L112-R114))
  * Replace the hardcoded plan IDs with the BillingPlan enum values in the switch statement that handles the different actions based on the selected plan, such as contacting the sales team, upgrading to pro, or downgrading to free ([link](https://github.com/amplication/amplication/pull/7585/files?diff=unified&w=0#diff-5a2c55b6a53d9d5a540e05bfef0694bdac1851e3007fccb6d563a5df492e1c73L142-R151))
* Import the BillingAddon enum from the util-billing-types library in the BillingService class, which is used to interact with the billing provider and validate the subscription plan limitations ([link](https://github.com/amplication/amplication/pull/7585/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L23-R27))
  * Add a private getter for the default subscription plan, which is the enterprise plan with the custom actions addon, to the BillingService class. This is used to provision a customer with the default plan when they create a workspace ([link](https://github.com/amplication/amplication/pull/7585/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1R41-R51))
  * Simplify the provisionCustomer method in the BillingService class by removing the plan parameter and using the default subscription plan instead. This is because the plan is no longer a user choice but a fixed value for all customers ([link](https://github.com/amplication/amplication/pull/7585/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L261-R281))
* Update the call to the provisionCustomer method in the WorkspaceService class by removing the BillingPlan.Free argument and using the default subscription plan instead. This is because the plan is no longer a user choice but a fixed value for all customers ([link](https://github.com/amplication/amplication/pull/7585/files?diff=unified&w=0#diff-459b39603b99f959572cd0bf1bde2c4acdb355140d351c2ef545663706a01b0dL119-R119))
* Remove the unused import of the FindSubscriptionsArgs type from the SubscriptionService class, which is used to query the subscriptions from the database ([link](https://github.com/amplication/amplication/pull/7585/files?diff=unified&w=0#diff-1bb5e6555393081d4d962a67f77ac16986440f9a0aeb724bc848542a7c5f12dbL2))
* Remove the unused private method getSubscriptions from the SubscriptionService class, which was previously used to query the subscriptions from the database but is now replaced by the billing provider API ([link](https://github.com/amplication/amplication/pull/7585/files?diff=unified&w=0#diff-1bb5e6555393081d4d962a67f77ac16986440f9a0aeb724bc848542a7c5f12dbL29-L36))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
