### PR TITLE
fix(client): pro plan upgrade button logic

### DIFF
--- a/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
@@ -164,46 +164,46 @@ const WorkspaceHeader: React.FC = () => {
   );
 
   return (
-    upgradeButtonData.isCompleted && (
-      <>
-        <Dialog
-          className="new-entity-dialog"
-          isOpen={showProfileFormDialog}
-          onDismiss={handleShowProfileForm}
-          title="User Profile"
-        >
-          <ProfileForm />
-        </Dialog>
-        <GitHubBanner />
-        <div className={CLASS_NAME}>
-          <div className={`${CLASS_NAME}__left`}>
-            <div className={`${CLASS_NAME}__logo`}>
-              <Link to={`/${currentWorkspace?.id}`}>
-                <Icon icon="logo" size="medium" />
-              </Link>
-            </div>
-            <span>
-              <a
-                href="https://github.com/amplication/amplication/releases"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`${CLASS_NAME}__version`}
-              >
-                v{version}
-              </a>
-            </span>
-            <Breadcrumbs>
-              {breadcrumbsContext.breadcrumbsItems.map((item, index) => (
-                <Breadcrumbs.Item key={item.url} to={item.url}>
-                  {item.name}
-                </Breadcrumbs.Item>
-              ))}
-            </Breadcrumbs>
+    <>
+      <Dialog
+        className="new-entity-dialog"
+        isOpen={showProfileFormDialog}
+        onDismiss={handleShowProfileForm}
+        title="User Profile"
+      >
+        <ProfileForm />
+      </Dialog>
+      <GitHubBanner />
+      <div className={CLASS_NAME}>
+        <div className={`${CLASS_NAME}__left`}>
+          <div className={`${CLASS_NAME}__logo`}>
+            <Link to={`/${currentWorkspace?.id}`}>
+              <Icon icon="logo" size="medium" />
+            </Link>
           </div>
-          <div className={`${CLASS_NAME}__center`}></div>
-          <div className={`${CLASS_NAME}__right`}>
-            <div className={`${CLASS_NAME}__links`}>
-              {upgradeButtonData.showUpgradeTrialButton && (
+          <span>
+            <a
+              href="https://github.com/amplication/amplication/releases"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${CLASS_NAME}__version`}
+            >
+              v{version}
+            </a>
+          </span>
+          <Breadcrumbs>
+            {breadcrumbsContext.breadcrumbsItems.map((item, index) => (
+              <Breadcrumbs.Item key={item.url} to={item.url}>
+                {item.name}
+              </Breadcrumbs.Item>
+            ))}
+          </Breadcrumbs>
+        </div>
+        <div className={`${CLASS_NAME}__center`}></div>
+        <div className={`${CLASS_NAME}__right`}>
+          <div className={`${CLASS_NAME}__links`}>
+            {upgradeButtonData.isCompleted &&
+              upgradeButtonData.showUpgradeTrialButton && (
                 <ButtonProgress
                   className={`${CLASS_NAME}__upgrade__btn`}
                   onClick={handleUpgradeClick}
@@ -215,7 +215,8 @@ const WorkspaceHeader: React.FC = () => {
                   Upgrade
                 </ButtonProgress>
               )}
-              {upgradeButtonData.showUpgradeDefaultButton && (
+            {upgradeButtonData.isCompleted &&
+              upgradeButtonData.showUpgradeDefaultButton && (
                 <Button
                   className={`${CLASS_NAME}__upgrade__btn`}
                   buttonStyle={EnumButtonStyle.Outline}
@@ -224,129 +225,128 @@ const WorkspaceHeader: React.FC = () => {
                   Upgrade
                 </Button>
               )}
-            </div>
-            <hr className={`${CLASS_NAME}__vertical_border`} />
+          </div>
+          <hr className={`${CLASS_NAME}__vertical_border`} />
 
-            <CommandPalette
-              trigger={
-                <Tooltip
-                  className="amp-menu-item__tooltip"
-                  aria-label={`Search (${isMacOs ? "⌘" : "Ctrl"}+Shift+K)`}
-                  direction="sw"
-                  noDelay
-                >
-                  <Button
-                    buttonStyle={EnumButtonStyle.Text}
-                    icon="search"
-                    iconSize="small"
-                  />
-                </Tooltip>
-              }
-            />
-            <hr className={`${CLASS_NAME}__vertical_border`} />
-            <div className={`${CLASS_NAME}__help_popover`}>
-              <SelectMenu
-                title="Help"
-                buttonStyle={EnumButtonStyle.Text}
-                icon="chevron_down"
-                openIcon="chevron_up"
-                className={`${CLASS_NAME}__help_popover__menu`}
+          <CommandPalette
+            trigger={
+              <Tooltip
+                className="amp-menu-item__tooltip"
+                aria-label={`Search (${isMacOs ? "⌘" : "Ctrl"}+Shift+K)`}
+                direction="sw"
+                noDelay
               >
-                <SelectMenuModal align="right">
-                  <SelectMenuList>
-                    {HELP_MENU_LIST.map((route: HelpMenuItem, index) => (
-                      <SelectMenuItem
-                        closeAfterSelectionChange
-                        onSelectionChange={() => {
-                          !route.url && handleItemDataClicked(route.itemData);
-                        }}
-                        key={index}
-                        {...(route.url
-                          ? {
-                              rel: "noopener noreferrer",
-                              href: route.url,
-                              target: "_blank",
-                            }
-                          : {})}
-                      >
-                        <div className={`${CLASS_NAME}__help_popover__name`}>
-                          {route.name}
-                        </div>
-                      </SelectMenuItem>
-                    ))}
-                  </SelectMenuList>
-                </SelectMenuModal>
-              </SelectMenu>
-            </div>
-            {canShowNotification && (
-              <>
-                <hr className={`${CLASS_NAME}__vertical_border`} />
-                <div className={`${CLASS_NAME}__notification_bell`}>
-                  <NovuProvider
-                    subscriberId={currentWorkspace.externalId}
-                    applicationIdentifier={NX_REACT_APP_NOVU_IDENTIFIER}
-                    styles={styles}
-                  >
-                    <PopoverNotificationCenter
-                      colorScheme={"dark"}
-                      position="left-start"
-                      offset={0}
-                      onNotificationClick={onNotificationClick}
-                      onActionClick={onBuildNotificationClick}
-                      footer={() => <Footer />}
-                      emptyState={<EmptyState />}
+                <Button
+                  buttonStyle={EnumButtonStyle.Text}
+                  icon="search"
+                  iconSize="small"
+                />
+              </Tooltip>
+            }
+          />
+          <hr className={`${CLASS_NAME}__vertical_border`} />
+          <div className={`${CLASS_NAME}__help_popover`}>
+            <SelectMenu
+              title="Help"
+              buttonStyle={EnumButtonStyle.Text}
+              icon="chevron_down"
+              openIcon="chevron_up"
+              className={`${CLASS_NAME}__help_popover__menu`}
+            >
+              <SelectMenuModal align="right">
+                <SelectMenuList>
+                  {HELP_MENU_LIST.map((route: HelpMenuItem, index) => (
+                    <SelectMenuItem
+                      closeAfterSelectionChange
+                      onSelectionChange={() => {
+                        !route.url && handleItemDataClicked(route.itemData);
+                      }}
+                      key={index}
+                      {...(route.url
+                        ? {
+                            rel: "noopener noreferrer",
+                            href: route.url,
+                            target: "_blank",
+                          }
+                        : {})}
                     >
-                      {({ unseenCount }) => (
-                        <NotificationBell unseenCount={unseenCount} />
-                      )}
-                    </PopoverNotificationCenter>
-                  </NovuProvider>
-                </div>
-              </>
-            )}
-            <hr className={`${CLASS_NAME}__vertical_border`} />
-            <div
-              className={`${CLASS_NAME}__user_badge_wrapper`}
-              onClick={handleShowProfileForm}
-            >
-              <UserBadge />
-            </div>
-
-            <hr className={`${CLASS_NAME}__vertical_border`} />
-
-            <CommandPalette
-              trigger={
-                <Tooltip
-                  className="amp-menu-item__tooltip"
-                  aria-label={`Logout`}
-                  direction="sw"
-                  noDelay
+                      <div className={`${CLASS_NAME}__help_popover__name`}>
+                        {route.name}
+                      </div>
+                    </SelectMenuItem>
+                  ))}
+                </SelectMenuList>
+              </SelectMenuModal>
+            </SelectMenu>
+          </div>
+          {canShowNotification && (
+            <>
+              <hr className={`${CLASS_NAME}__vertical_border`} />
+              <div className={`${CLASS_NAME}__notification_bell`}>
+                <NovuProvider
+                  subscriberId={currentWorkspace.externalId}
+                  applicationIdentifier={NX_REACT_APP_NOVU_IDENTIFIER}
+                  styles={styles}
                 >
-                  <Button
-                    buttonStyle={EnumButtonStyle.Text}
-                    icon="log_out"
-                    onClick={handleSignOut}
-                  />
-                </Tooltip>
-              }
-            />
+                  <PopoverNotificationCenter
+                    colorScheme={"dark"}
+                    position="left-start"
+                    offset={0}
+                    onNotificationClick={onNotificationClick}
+                    onActionClick={onBuildNotificationClick}
+                    footer={() => <Footer />}
+                    emptyState={<EmptyState />}
+                  >
+                    {({ unseenCount }) => (
+                      <NotificationBell unseenCount={unseenCount} />
+                    )}
+                  </PopoverNotificationCenter>
+                </NovuProvider>
+              </div>
+            </>
+          )}
+          <hr className={`${CLASS_NAME}__vertical_border`} />
+          <div
+            className={`${CLASS_NAME}__user_badge_wrapper`}
+            onClick={handleShowProfileForm}
+          >
+            <UserBadge />
           </div>
-        </div>
 
-        {currentProject?.useDemoRepo && (
-          <div className={`${CLASS_NAME}__highlight`}>
-            Notice: You're currently using a preview repository for your
-            generated code. For a full personalized experience, please&nbsp;
-            <Link
-              title={"Go to project settings"}
-              to={`/${currentWorkspace?.id}/${currentProject?.id}/git-sync`}
-            >
-              connect to your own repository
-            </Link>
-          </div>
-        )}
-      </>
-    )
+          <hr className={`${CLASS_NAME}__vertical_border`} />
+
+          <CommandPalette
+            trigger={
+              <Tooltip
+                className="amp-menu-item__tooltip"
+                aria-label={`Logout`}
+                direction="sw"
+                noDelay
+              >
+                <Button
+                  buttonStyle={EnumButtonStyle.Text}
+                  icon="log_out"
+                  onClick={handleSignOut}
+                />
+              </Tooltip>
+            }
+          />
+        </div>
+      </div>
+
+      {currentProject?.useDemoRepo && (
+        <div className={`${CLASS_NAME}__highlight`}>
+          Notice: You're currently using a preview repository for your generated
+          code. For a full personalized experience, please&nbsp;
+          <Link
+            title={"Go to project settings"}
+            to={`/${currentWorkspace?.id}/${currentProject?.id}/git-sync`}
+          >
+            connect to your own repository
+          </Link>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/packages/amplication-client/src/Workspaces/hooks/useUpgradeButtonData.ts
+++ b/packages/amplication-client/src/Workspaces/hooks/useUpgradeButtonData.ts
@@ -35,16 +35,7 @@ export const useUpgradeButtonData = (
       await stigg.setCustomerId(currentWorkspace.id);
       const [subscription] = await stigg.getActiveSubscriptions();
 
-      if (
-        subscription.status === SubscriptionStatus.Active &&
-        subscription.plan.pricingType !== PricingType.Free
-      ) {
-        setUpgradeButtonData({
-          showUpgradeTrialButton: false,
-          showUpgradeDefaultButton: false,
-          isCompleted: true,
-        });
-      } else if (subscription.plan.id === BillingPlan.Free) {
+      if (subscription.plan.id === BillingPlan.Free) {
         const daysSinceStartOfPlan = Math.abs(
           (Date.now() - new Date(subscription.startDate).getTime()) / ONE_DAY
         );
@@ -62,7 +53,10 @@ export const useUpgradeButtonData = (
           showUpgradeDefaultButton: false,
           isCompleted: true,
         });
-      } else {
+      } else if (
+        subscription.plan.id === BillingPlan.Enterprise &&
+        subscription.trialEndDate
+      ) {
         const trialDaysLeft = Math.round(
           Math.abs((subscription.trialEndDate.getTime() - Date.now()) / ONE_DAY)
         );
@@ -78,6 +72,21 @@ export const useUpgradeButtonData = (
           trialLeftProgress,
           showUpgradeTrialButton: true,
           showUpgradeDefaultButton: false,
+          isCompleted: true,
+        });
+      } else if (
+        subscription.plan.id === BillingPlan.Enterprise &&
+        !subscription.trialEndDate
+      ) {
+        setUpgradeButtonData({
+          showUpgradeTrialButton: false,
+          showUpgradeDefaultButton: false,
+          isCompleted: true,
+        });
+      } else {
+        setUpgradeButtonData({
+          showUpgradeTrialButton: false,
+          showUpgradeDefaultButton: true,
           isCompleted: true,
         });
       }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: https://github.com/amplication/private-issues/issues/71

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5f4b86f</samp>

### Summary
🗑️🔄🐛

<!--
1.  🗑️ for removing the metered entitlement check for the services above entities per service limit feature.
2.  🔄 for refactoring the `useUpgradeButtonData` hook to use the subscription plan id.
3.  🐛 for fixing the bug with the profile form dialog and improving the rendering of the upgrade buttons.
-->
This pull request refactors and fixes some components and services related to the subscription and billing features. It uses the subscription plan id to determine the upgrade button data, fixes the profile form dialog visibility, and removes the metered entitlement check for the services above entities per service limit feature. These changes support the new trial period feature for the enterprise plan and simplify the billing logic.

> _Sing, O Muse, of the code that the skilled developers wrought_
> _To enhance and refine the subscription plans they sought_
> _They removed the metered check from the `BillingService` class_
> _And freed the users from the errors that would harass_

### Walkthrough
*  Simplify the logic of the `useUpgradeButtonData` hook to use the subscription plan id instead of the status and pricing type ([link](https://github.com/amplication/amplication/pull/7601/files?diff=unified&w=0#diff-97660417b6d1257e4d2e739f831e3b132ba73693ab2478bb20a9df4c41e1e0acL38-R38))
*  Add a case to the `useUpgradeButtonData` hook to handle the enterprise plan with a trial period and show the upgrade trial button ([link](https://github.com/amplication/amplication/pull/7601/files?diff=unified&w=0#diff-97660417b6d1257e4d2e739f831e3b132ba73693ab2478bb20a9df4c41e1e0acL65-R59))
*  Add a case to the `useUpgradeButtonData` hook to handle the enterprise plan without a trial period and hide the upgrade buttons ([link](https://github.com/amplication/amplication/pull/7601/files?diff=unified&w=0#diff-97660417b6d1257e4d2e739f831e3b132ba73693ab2478bb20a9df4c41e1e0acR77-R91))
*  Fix a bug that prevented the profile form dialog from showing up in the `WorkspaceHeader` component by removing the condition on the upgrade button data state ([link](https://github.com/amplication/amplication/pull/7601/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L167-R206))
*  Avoid flickering and errors in the `WorkspaceHeader` component by adding the condition on the upgrade button data state to the rendering of the upgrade trial button and the upgrade default button ([link](https://github.com/amplication/amplication/pull/7601/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L218-R219), [link](https://github.com/amplication/amplication/pull/7601/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L227-R349))
*  Disable the billing limitation for the services above entities per service limit feature in the `BillingService` class by removing the code that checks the metered entitlement ([link](https://github.com/amplication/amplication/pull/7601/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L367-L378))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
