### PR TITLE
chore(client): update events across commit and workspace pages

### DIFF
--- a/packages/amplication-client/src/Components/FeatureIndicator.tsx
+++ b/packages/amplication-client/src/Components/FeatureIndicator.tsx
@@ -62,8 +62,9 @@ export const FeatureIndicator = ({
       from: { pathname: window.location.pathname },
     });
     trackEvent({
-      eventName: AnalyticsEventNames.ProFeatureLockClick,
-      featureName,
+      eventName: AnalyticsEventNames.UpgradeClick,
+      eventOriginLocation: FeatureIndicator.name,
+      billingFeature: featureName,
     });
   }, [currentWorkspace, window.location.pathname]);
 

--- a/packages/amplication-client/src/Entity/EntityList.tsx
+++ b/packages/amplication-client/src/Entity/EntityList.tsx
@@ -125,7 +125,8 @@ const EntityList: React.FC<Props> = ({ match, innerRoutes }) => {
 
   const handleEntityClick = () => {
     trackEvent({
-      eventName: AnalyticsEventNames.UpgradeOnEntityListClick,
+      eventName: AnalyticsEventNames.UpgradeClick,
+      eventOriginLocation: "entity-list",
     });
   };
 

--- a/packages/amplication-client/src/Purchase/PurchasePage.tsx
+++ b/packages/amplication-client/src/Purchase/PurchasePage.tsx
@@ -92,8 +92,8 @@ const PurchasePage = (props) => {
     window.open(data?.contactUsLink, "_blank");
     trackEvent({
       eventName: AnalyticsEventNames.ContactUsButtonClick,
-      Action: "Contact Us",
-      workspaceId: currentWorkspace.id,
+      action: "Contact Us",
+      eventOriginLocation: "pricing-page",
     });
   }, [currentWorkspace.id, data?.contactUsLink]);
 

--- a/packages/amplication-client/src/Resource/PurchaseMenuItem.tsx
+++ b/packages/amplication-client/src/Resource/PurchaseMenuItem.tsx
@@ -16,7 +16,8 @@ function PurchaseButton() {
 
   const handleClick = useCallback(() => {
     trackEvent({
-      eventName: AnalyticsEventNames.UpgradeOnSideBarClick,
+      eventName: AnalyticsEventNames.UpgradeClick,
+      eventOriginLocation: "purchase-page",
     });
   }, []);
 

--- a/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnectionList.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/GitProviderConnectionList.tsx
@@ -64,7 +64,8 @@ export const GitProviderConnectionList: React.FC<Props> = ({
   const handleAddProvider = useCallback(
     (provider: EnumGitProvider) => {
       trackEvent({
-        eventName: AnalyticsEventNames.AddGitProviderClick,
+        eventName: AnalyticsEventNames.GitProviderConnectClick,
+        eventOriginLocation: "git-provider-connection-list",
         provider: provider,
       });
       authWithGit({

--- a/packages/amplication-client/src/Resource/git/useAuthWithGit.ts
+++ b/packages/amplication-client/src/Resource/git/useAuthWithGit.ts
@@ -120,6 +120,13 @@ const useGitHook: UseGitHook = ({
 
   const updateGitRepository = useCallback(
     (gitRepositoryId: string, data: models.GitRepositoryUpdateInput) => {
+      if (data.baseBranchName) {
+        trackEvent({
+          eventName: AnalyticsEventNames.GitProviderCustomBaseBranch,
+          eventOriginLocation: "git-provider-settings",
+        });
+      }
+
       updateGitRepositoryMutation({
         variables: {
           where: { id: gitRepositoryId },
@@ -137,6 +144,7 @@ const useGitHook: UseGitHook = ({
       gitRepositorySelected && setGitRepositorySelectedData(data);
       trackEvent({
         eventName: AnalyticsEventNames.GitHubRepositorySync,
+        eventOriginLocation: "git-provider-settings",
       });
     },
     [setSelectRepoOpen, setGitRepositorySelectedData]
@@ -168,6 +176,7 @@ const useGitHook: UseGitHook = ({
       }).catch((error) => {});
       trackEvent({
         eventName: AnalyticsEventNames.GitHubRepositoryCreate,
+        eventOriginLocation: "git-provider-settings",
       });
     },
     [

--- a/packages/amplication-client/src/VersionControl/Commit.tsx
+++ b/packages/amplication-client/src/VersionControl/Commit.tsx
@@ -1,7 +1,4 @@
 import {
-  EnumContentAlign,
-  EnumItemsAlign,
-  FlexItem,
   LimitationDialog,
   Snackbar,
   TextField,
@@ -119,6 +116,12 @@ const Commit = ({ projectId, noChanges }: Props) => {
 
   const limitationErrorMessage =
     isLimitationError && formatLimitationError(errorMessage);
+  const limitationBillingFeature =
+    isLimitationError &&
+    error?.graphQLErrors?.find(
+      (gqlError) =>
+        gqlError.extensions.code === GraphQLErrorCode.BILLING_LIMITATION_ERROR
+    ).extensions.billingFeature;
 
   const handleSubmit = useCallback(
     (data, { resetForm }) => {
@@ -212,8 +215,10 @@ const Commit = ({ projectId, noChanges }: Props) => {
           onConfirm={() => {
             redirectToPurchase();
             trackEvent({
-              eventName: AnalyticsEventNames.UpgradeOnPassedLimitsClick,
+              eventName: AnalyticsEventNames.UpgradeClick,
               reason: limitationErrorMessage,
+              eventOriginLocation: "commit-limitation-dialog",
+              billingFeature: limitationBillingFeature,
             });
             setOpenLimitationDialog(false);
           }}
@@ -222,19 +227,22 @@ const Commit = ({ projectId, noChanges }: Props) => {
             trackEvent({
               eventName: AnalyticsEventNames.PassedLimitsNotificationClose,
               reason: limitationErrorMessage,
+              eventOriginLocation: "commit-limitation-dialog",
+              billingFeature: limitationBillingFeature,
             });
             setOpenLimitationDialog(false);
           }}
           onBypass={() => {
             formikRef.current.values.bypassLimitations = true;
-
             formikRef.current.handleSubmit(formikRef.current.values, {
               resetForm: formikRef.current.resetForm,
             });
 
             trackEvent({
-              eventName: AnalyticsEventNames.PassedLimitsNotificationBypass,
+              eventName: AnalyticsEventNames.UpgradeLaterClick,
               reason: limitationErrorMessage,
+              eventOriginLocation: "commit-limitation-dialog",
+              billingFeature: limitationBillingFeature,
             });
             setOpenLimitationDialog(false);
           }}

--- a/packages/amplication-client/src/VersionControl/Commit.tsx
+++ b/packages/amplication-client/src/VersionControl/Commit.tsx
@@ -228,7 +228,6 @@ const Commit = ({ projectId, noChanges }: Props) => {
               eventName: AnalyticsEventNames.PassedLimitsNotificationClose,
               reason: limitationErrorMessage,
               eventOriginLocation: "commit-limitation-dialog",
-              billingFeature: limitationBillingFeature,
             });
             setOpenLimitationDialog(false);
           }}

--- a/packages/amplication-client/src/Workspaces/InviteMember.tsx
+++ b/packages/amplication-client/src/Workspaces/InviteMember.tsx
@@ -55,6 +55,7 @@ const InviteMember = ({ members }: { members: number }) => {
       trackEvent({
         eventName: AnalyticsEventNames.WorkspaceMemberInvite,
         email: data.inviteUser.email,
+        eventOriginLocation: "workspace-members-page",
       });
     },
     refetchQueries: [{ query: GET_WORKSPACE_MEMBERS }],

--- a/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
@@ -135,8 +135,8 @@ const WorkspaceHeader: React.FC = () => {
     openHubSpotChat();
     trackEvent({
       eventName: AnalyticsEventNames.HelpMenuItemClick,
-      Action: "Contact Us",
-      workspaceId: currentWorkspace.id,
+      action: "Contact Us",
+      eventOriginLocation: "workspace-header-help-menu",
     });
   }, [openHubSpotChat]);
 

--- a/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
@@ -123,7 +123,8 @@ const WorkspaceHeader: React.FC = () => {
       from: { pathname: window.location.pathname },
     });
     trackEvent({
-      eventName: AnalyticsEventNames.UpgradeOnTopBarClick,
+      eventName: AnalyticsEventNames.UpgradeClick,
+      eventOriginLocation: "workspace-header",
       workspace: currentWorkspace.id,
     });
   }, [currentWorkspace, window.location.pathname]);

--- a/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
@@ -25,6 +25,7 @@ import useCommits from "../VersionControl/hooks/useCommits";
 import RedeemCoupon from "../User/RedeemCoupon";
 import PendingChanges from "../VersionControl/PendingChanges";
 import LastCommit from "../VersionControl/LastCommit";
+import { EnumSubscriptionStatus } from "../models";
 
 const MobileMessage = lazy(() => import("../Layout/MobileMessage"));
 
@@ -109,6 +110,11 @@ const WorkspaceLayout: React.FC<Props> = ({
 
   const { trackEvent, Track } = useTracking<{ [key: string]: any }>({
     workspaceId: currentWorkspace?.id,
+    subscriptionPlan: `${currentWorkspace?.subscription?.subscriptionPlan}${
+      currentWorkspace?.subscription?.status === EnumSubscriptionStatus.Trailing
+        ? "-trial"
+        : ""
+    }`,
     projectId: currentProject?.id,
     resourceId: currentResource?.id,
     $groups: {

--- a/packages/amplication-client/src/util/analytics-events.types.ts
+++ b/packages/amplication-client/src/util/analytics-events.types.ts
@@ -86,7 +86,6 @@ export enum AnalyticsEventNames {
   LastCommitIdClick = "lastCommitIdClick",
   PendingChangesDiscard = "discardPendingChanges",
   LastBuildIdClick = "lastBuildIdClick",
-  PassedLimitsNotificationBypass = "passedLimitsNotificationBypass",
 
   // code view
   CodeViewTileClick = "viewCodeViewTileClick",
@@ -122,6 +121,10 @@ export enum AnalyticsEventNames {
   ContactUsButtonClick = "ContactUsButtonClick",
   UpgradeOnSideBarClick = "UpgradeOnSideBarClick",
   ProFeatureLockClick = "ProFeatureLockClick",
+
+  // upgrade
+  UpgradeClick = "UpgradeClick", // With event props: { buttonLocation: string }
+  UpgradeLaterClick = "UpgradeLaterClick", // With event props: { buttonLocation: string, featureLimitation: string }
 
   // Chat widget
   HelpMenuItemClick = "HelpMenuItemClick",

--- a/packages/amplication-client/src/util/analytics-events.types.ts
+++ b/packages/amplication-client/src/util/analytics-events.types.ts
@@ -112,15 +112,9 @@ export enum AnalyticsEventNames {
   PricingPageCTAClick = "PricingPageCTAClick",
   PassedLimitsNotificationClose = "PassedLimitsNotificationClose",
   PricingPageChangeBillingCycle = "PricingPageChangeBillingCycle",
-  UpgradeOnResourceListClick = "UpgradeOnResourceListClick",
-  UpgradeOnEntityListClick = "UpgradeOnEntityListClick",
-  UpgradeOnPassedLimitsClick = "UpgradeOnPassedLimitsClick",
   PricingPageChangeWorkspace = "PricingPageChangeWorkspace",
-  UpgradeOnTopBarClick = "UpgradeOnTopBarClick",
-  UpgradeFromCodeGeneratorVersionClick = "UpgradeFromCodeGeneratorVersionClick",
-  ContactUsButtonClick = "ContactUsButtonClick",
-  UpgradeOnSideBarClick = "UpgradeOnSideBarClick",
   ProFeatureLockClick = "ProFeatureLockClick",
+  ContactUsButtonClick = "ContactUsButtonClick", // With event props: { buttonLocation: string }
 
   // upgrade
   UpgradeClick = "UpgradeClick", // With event props: { buttonLocation: string }

--- a/packages/amplication-client/src/util/analytics-events.types.ts
+++ b/packages/amplication-client/src/util/analytics-events.types.ts
@@ -114,11 +114,11 @@ export enum AnalyticsEventNames {
   PricingPageChangeBillingCycle = "PricingPageChangeBillingCycle",
   PricingPageChangeWorkspace = "PricingPageChangeWorkspace",
   ProFeatureLockClick = "ProFeatureLockClick",
-  ContactUsButtonClick = "ContactUsButtonClick", // With event props: { buttonLocation: string }
+  ContactUsButtonClick = "ContactUsButtonClick",
 
   // upgrade
-  UpgradeClick = "UpgradeClick", // With event props: { buttonLocation: string }
-  UpgradeLaterClick = "UpgradeLaterClick", // With event props: { buttonLocation: string, featureLimitation: string }
+  UpgradeClick = "UpgradeClick",
+  UpgradeLaterClick = "UpgradeLaterClick",
 
   // Chat widget
   HelpMenuItemClick = "HelpMenuItemClick",

--- a/packages/amplication-client/src/util/analytics-events.types.ts
+++ b/packages/amplication-client/src/util/analytics-events.types.ts
@@ -91,6 +91,9 @@ export enum AnalyticsEventNames {
   CodeViewTileClick = "viewCodeViewTileClick",
   GithubCodeViewClick = "openGithubCodeView",
 
+  // git provider
+  GitProviderConnectClick = "addGitProviderClick",
+
   // GitHub
   GitHubAuthResourceStart = "startAuthResourceWithGitHub",
   GitHubRepositoryCreate = "createGitRepository",
@@ -103,9 +106,6 @@ export enum AnalyticsEventNames {
   CreateProjectConfiguration = "CreateProjectConfiguration",
   StarUsBannerCTAClick = "StarUsBannerCTAClick",
   StarUsBannerClose = "StarUsBannerClose",
-
-  // new event for startAuthResourceWithGitHub
-  AddGitProviderClick = "addGitProviderClick",
 
   // Purchase Page
   PricingPageClose = "PricingPageClose",

--- a/packages/amplication-client/src/util/analytics-events.types.ts
+++ b/packages/amplication-client/src/util/analytics-events.types.ts
@@ -93,6 +93,7 @@ export enum AnalyticsEventNames {
 
   // git provider
   GitProviderConnectClick = "addGitProviderClick",
+  GitProviderCustomBaseBranch = "GitProviderCustomBaseBranch",
 
   // GitHub
   GitHubAuthResourceStart = "startAuthResourceWithGitHub",

--- a/packages/amplication-client/src/util/analytics.ts
+++ b/packages/amplication-client/src/util/analytics.ts
@@ -5,6 +5,8 @@ import { version } from "../util/version";
 
 export interface Event {
   eventName: AnalyticsEventNames;
+  /** The location of a button / HTML element. i.e. WorkspaceHeader */
+  eventOriginLocation?: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
Close: https://github.com/amplication/private-issues/issues/75

## PR Details

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 83fcacc</samp>

### Summary
📊🔧🗑️

<!--
1.  📊 - This emoji represents the analytics tracking changes, which are the main focus of this commit. It conveys the idea of collecting and analyzing data from user interactions and events.
2.  🔧 - This emoji represents the modifications and improvements to the existing code, such as renaming variables, moving functions, and adding properties. It conveys the idea of fixing and adjusting something to make it work better or more consistently.
3.  🗑️ - This emoji represents the removal of unused and replaced code, such as enum values and imports. It conveys the idea of cleaning up and deleting unnecessary or outdated things.
-->
This pull request improves the analytics tracking of various user actions related to git provider settings, entity list, workspace members, and billing features. It adds a new property `eventOriginLocation` to the analytics events to capture the location of the event source. It also simplifies and standardizes the analytics event names and types. It affects the files `useAuthWithGit.ts`, `analytics-events.types.ts`, `Commit.tsx`, `EntityList.tsx`, `GitProviderConnectionList.tsx`, `PurchaseMenuItem.tsx`, `analytics.ts`, `InviteMember.tsx`, and `WorkspaceHeader.tsx`.

> _We're tracking events with a new property_
> _To know where they come from and what they do_
> _So heave away and make the code more tidy_
> _And use the `eventOriginLocation` too_

### Walkthrough
*  Add `eventOriginLocation` property to analytics events to track the source of user actions ([link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-07750f951d970ece6646dc7b22c8344ca2ee26f8e5a7dc6c00e1f010b617f828R8-R9), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-46cc6f90a9c4c5614b6c68c13f5eebf1d57a5b3df9c08fe35621958da38659c0L128-R129), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-5af106441ba9187b6775a40d93abe24a8d709f56acd1bb7a60d58a1167fe4ef8L67-R68), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-3c78d6946ba48732e8803a3eaf9ec8260a51bd29899490451ab87eb1dd980660R123-R129), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-3c78d6946ba48732e8803a3eaf9ec8260a51bd29899490451ab87eb1dd980660R147), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-3c78d6946ba48732e8803a3eaf9ec8260a51bd29899490451ab87eb1dd980660R179), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-6d3ad95a9761963847af064dcfc4c410db091775a917cf476e70b672740ebee6L215-R221), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-6d3ad95a9761963847af064dcfc4c410db091775a917cf476e70b672740ebee6R230), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-6d3ad95a9761963847af064dcfc4c410db091775a917cf476e70b672740ebee6L236-R244), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-43642b2e3591bc6b71330b167678de3164096848c943cc951ae73b471f4aa3f6R58), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L126-R127))
*  Use more generic event name `UpgradeClick` for tracking upgrade button clicks and pass the billing feature as a property ([link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-46cc6f90a9c4c5614b6c68c13f5eebf1d57a5b3df9c08fe35621958da38659c0L128-R129), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-7695c3d06d281c4d592cc99332141409533b68d37a8952c2726752e80ab7286cL19-R20), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-6d3ad95a9761963847af064dcfc4c410db091775a917cf476e70b672740ebee6L215-R221), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L126-R127), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-917333793bfc12bbce1fed70cf28308c74cf550fb42d3653f076a65ad209e697L89), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-917333793bfc12bbce1fed70cf28308c74cf550fb42d3653f076a65ad209e697L116-R123))
*  Use new event name `UpgradeLaterClick` for tracking upgrade later button clicks in the limitation dialog ([link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-6d3ad95a9761963847af064dcfc4c410db091775a917cf476e70b672740ebee6L236-R244), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-917333793bfc12bbce1fed70cf28308c74cf550fb42d3653f076a65ad209e697R94-R97))
*  Use more specific event name `GitProviderConnectClick` for tracking git provider connection clicks and remove unused `AddGitProviderClick` event ([link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-5af106441ba9187b6775a40d93abe24a8d709f56acd1bb7a60d58a1167fe4ef8L67-R68), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-917333793bfc12bbce1fed70cf28308c74cf550fb42d3653f076a65ad209e697R94-R97), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-917333793bfc12bbce1fed70cf28308c74cf550fb42d3653f076a65ad209e697L108-L110))
*  Add new event name `GitProviderCustomBaseBranch` for tracking custom base branch settings for git providers ([link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-3c78d6946ba48732e8803a3eaf9ec8260a51bd29899490451ab87eb1dd980660R123-R129), [link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-917333793bfc12bbce1fed70cf28308c74cf550fb42d3653f076a65ad209e697R94-R97))
*  Store the billing feature that caused the limitation error from the GraphQL response in `limitationBillingFeature` variable in `Commit.tsx` ([link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-6d3ad95a9761963847af064dcfc4c410db091775a917cf476e70b672740ebee6R119-R124))
*  Remove unused imports from `Commit.tsx` ([link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-6d3ad95a9761963847af064dcfc4c410db091775a917cf476e70b672740ebee6L2-L4))
*  Remove empty line from `Commit.tsx` ([link](https://github.com/amplication/amplication/pull/7605/files?diff=unified&w=0#diff-6d3ad95a9761963847af064dcfc4c410db091775a917cf476e70b672740ebee6L230))



## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
