### PR TITLE
add two events to notification center

### DIFF
--- a/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
@@ -110,7 +110,7 @@ const WorkspaceHeader: React.FC = () => {
   const onNotificationClick = useCallback((message: IMessage) => {
     trackEvent({
       eventName: AnalyticsEventNames.ClickNotificationMessage,
-      messageType: "now-buildSucceeded",
+      messageType: message.templateIdentifier,
     });
 
     if (message?.cta?.data?.url) {

--- a/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceHeader/WorkspaceHeader.tsx
@@ -92,7 +92,6 @@ const WorkspaceHeader: React.FC = () => {
   const novuBellRef = useRef(null);
   const breadcrumbsContext = useContext(BreadcrumbsContext);
 
-  // const [versionAlert, setVersionAlert] = useState(false);
   const [novuCenterState, setNovuCenterState] = useState(false);
   const canShowNotification = stigg.getBooleanEntitlement({
     featureId: BillingFeature.Notification,
@@ -115,7 +114,7 @@ const WorkspaceHeader: React.FC = () => {
     });
 
     if (message?.cta?.data?.url) {
-      window.location.href = message.cta.data.url;
+      // window.location.href = message.cta.data.url;
     }
   }, []);
 

--- a/packages/amplication-client/src/util/analytics-events.types.ts
+++ b/packages/amplication-client/src/util/analytics-events.types.ts
@@ -151,4 +151,8 @@ export enum AnalyticsEventNames {
   ViewServiceWizardError = "ViewServiceWizardError",
   ServiceWizardError_TryAgain = "ServiceWizardError_TryAgain",
   ServiceWizardError_Continue = "ServiceWizardError_Continue",
+
+  // notification
+  OpenNotificationCenter = "OpenNotificationCenter",
+  ClickNotificationMessage = "ClickNotificationMessage",
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #7539 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4e5da13</samp>

### Summary
📊🗨️🎈

<!--
1.  📊 - This emoji represents the analytics aspect of the changes, as the new event names are related to tracking user behavior and engagement with the notification center and messages.
2.  🗨️ - This emoji represents the notification center and messages feature, as it is a common symbol for communication, chat, and feedback.
3.  🎈 - This emoji represents the popover component, as it is a visual metaphor for something that pops up or floats above the main content. It also conveys a sense of fun and celebration, which could be associated with receiving positive or exciting messages from Amplication.
-->
Added a notification center feature to the client app that displays messages from Amplication in the workspace header. The feature uses React hooks, references, and analytics to track user interactions with the notification center and the messages.

> _`AnalyticsEventNames`_
> _Popovers show messages_
> _Autumn of feedback_

### Walkthrough
*  Add analytics events for notification center interactions ([link](https://github.com/amplication/amplication/pull/7606/files?diff=unified&w=0#diff-917333793bfc12bbce1fed70cf28308c74cf550fb42d3653f076a65ad209e697R154-R157), [link](https://github.com/amplication/amplication/pull/7606/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L106-R116), [link](https://github.com/amplication/amplication/pull/7606/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24R165-R173))
  - Define new event names in `analytics-events.types.ts` ([link](https://github.com/amplication/amplication/pull/7606/files?diff=unified&w=0#diff-917333793bfc12bbce1fed70cf28308c74cf550fb42d3653f076a65ad209e697R154-R157))
  - Track when a notification message is clicked in `WorkspaceHeader.tsx` ([link](https://github.com/amplication/amplication/pull/7606/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L106-R116))
  - Track when the notification bell is clicked and toggle the popover state in `WorkspaceHeader.tsx` ([link](https://github.com/amplication/amplication/pull/7606/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24R165-R173))
*  Refactor notification bell component and state in `WorkspaceHeader.tsx` ([link](https://github.com/amplication/amplication/pull/7606/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L21-R27), [link](https://github.com/amplication/amplication/pull/7606/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L86-R96), [link](https://github.com/amplication/amplication/pull/7606/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L301-R322))
  - Import `useRef` hook and create a reference to the bell component ([link](https://github.com/amplication/amplication/pull/7606/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L21-R27))
  - Comment out unused `versionAlert` state and replace it with `novuCenterState` ([link](https://github.com/amplication/amplication/pull/7606/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L86-R96))
  - Wrap the bell component in a div with an onClick handler and pass the reference to the popover ([link](https://github.com/amplication/amplication/pull/7606/files?diff=unified&w=0#diff-7fdb758d72b986ee99ae091fcd9f9b1312ecd063170e9dcbd9d99d5f47812d24L301-R322))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
