### PR TITLE
Fix/npm downloads

### DIFF
--- a/packages/amplication-plugin-api/src/plugin/plugin.service.ts
+++ b/packages/amplication-plugin-api/src/plugin/plugin.service.ts
@@ -42,6 +42,7 @@ export class PluginService extends PluginServiceBase {
           createdAt: plugin.createdAt,
           updatedAt: plugin.updatedAt,
           categories: plugin.categories,
+          downloads: plugin.downloads,
         })),
         skipDuplicates: true,
       });
@@ -62,6 +63,7 @@ export class PluginService extends PluginServiceBase {
             npm: plugin.npm,
             website: plugin.website,
             categories: plugin.categories,
+            downloads: plugin.downloads,
           },
         })
       );


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #7429 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8c21b1c</samp>

### Summary
:sparkles::mag::chart_with_upwards_trend:

<!--
1.  :sparkles: - This emoji is often used to indicate a new feature or enhancement, and adding a `downloads` property to the `PluginDTO` object can be considered as such.
2.  :mag: - This emoji is commonly used to signify a search or query operation, and the `find` and `findOne` methods of the `PluginService` are responsible for fetching the plugins from the database and populating the `downloads` property.
3.  :chart_with_upwards_trend: - This emoji is typically used to represent growth, progress, or statistics, and the `downloads` property shows the download count of plugins, which can be a useful metric for measuring the popularity or performance of plugins in the marketplace.
-->
Added download count to plugins in the marketplace. The `PluginDTO` object and the `PluginService` methods were updated to include the `downloads` property.

> _`PluginDTO` shows_
> _downloads of plugins in spring_
> _cut by `find` methods_

### Walkthrough
*  Add `downloads` property to `PluginDTO` object to indicate how many times the plugin has been downloaded from the marketplace ([link](https://github.com/amplication/amplication/pull/7628/files?diff=unified&w=0#diff-4b163c2a2459eef7c204d7675ce14f654d83652480cfe7e5af0859c1aa7a4dd6R45), [link](https://github.com/amplication/amplication/pull/7628/files?diff=unified&w=0#diff-4b163c2a2459eef7c204d7675ce14f654d83652480cfe7e5af0859c1aa7a4dd6R66))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
