### PR TITLE
fix(server): team member usage reporting

### DIFF
--- a/packages/amplication-server/src/core/project/project.service.ts
+++ b/packages/amplication-server/src/core/project/project.service.ts
@@ -382,11 +382,6 @@ export class ProjectService {
       BillingFeature.CodeGenerationBuilds
     );
 
-    await this.billingService.reportUsage(
-      project.workspaceId,
-      BillingFeature.TeamMembers
-    );
-
     await Promise.all(
       changedEntities.flatMap((change) => {
         const versionPromise = this.entityService.createVersion({

--- a/packages/amplication-server/src/core/workspace/workspace.service.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.service.ts
@@ -304,6 +304,11 @@ export class WorkspaceService {
       },
     });
 
+    await this.billingService.reportUsage(
+      workspace.id,
+      BillingFeature.TeamMembers
+    );
+
     await this.analytics.track({
       userId: account.id,
       event: EnumEventType.InvitationAcceptance,


### PR DESCRIPTION
Close: https://github.com/amplication/private-issues/issues/96

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 47adf8c</samp>

### Summary
:recycle::moneybag::busts_in_silhouette:

<!--
1.  :recycle: This emoji represents the refactor or code improvement aspect of the changes, as they aim to simplify and align the billing logic with the workspace concept.
2.  :moneybag: This emoji represents the billing or monetization aspect of the changes, as they affect how the usage of the team members feature is reported and charged.
3.  :busts_in_silhouette: This emoji represents the team or collaboration aspect of the changes, as they relate to the workspace feature, which allows users to share and manage projects with other team members.
-->
Refactor the billing logic to report usage based on workspaces instead of projects. Remove the `reportUsage` call from `ProjectService` and add it to `WorkspaceService`.

> _`reportUsage` moves_
> _from project to workspace class_
> _billing refactored_

### Walkthrough
*  Move the usage reporting logic from the project level to the workspace level ([link](https://github.com/amplication/amplication/pull/7629/files?diff=unified&w=0#diff-cd946c1c9f9271b6dd02f554735fae66c53c2516f9b097daf8f798c2154118ffL385-L389), [link](https://github.com/amplication/amplication/pull/7629/files?diff=unified&w=0#diff-459b39603b99f959572cd0bf1bde2c4acdb355140d351c2ef545663706a01b0dR307-R311))
  - Remove the call to `this.billingService.reportUsage` from the `ProjectService` class in `project.service.ts` ([link](https://github.com/amplication/amplication/pull/7629/files?diff=unified&w=0#diff-cd946c1c9f9271b6dd02f554735fae66c53c2516f9b097daf8f798c2154118ffL385-L389))
  - Add the call to `this.billingService.reportUsage` to the `WorkspaceService` class in `workspace.service.ts` ([link](https://github.com/amplication/amplication/pull/7629/files?diff=unified&w=0#diff-459b39603b99f959572cd0bf1bde2c4acdb355140d351c2ef545663706a01b0dR307-R311))



## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
