### PR TITLE
refactor(server): billing report methods to use explicit instructions and remove custom logic

### DIFF
--- a/packages/amplication-server/src/core/billing/billing.service.spec.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.spec.ts
@@ -14,6 +14,7 @@ import Stigg, {
   FullSubscription,
   MeteredEntitlement,
   SubscriptionStatus,
+  UsageUpdateBehavior,
 } from "@stigg/node-server-sdk";
 import { GitOrganization, GitRepository, Project, User } from "../../models";
 import { EnumSubscriptionPlan, EnumSubscriptionStatus } from "../../prisma";
@@ -619,5 +620,33 @@ describe("BillingService", () => {
         );
       }
     );
+  });
+
+  it("should report usage as delta update by using the UsageUpdateBehavior.Delta", async () => {
+    const reportUsage = jest.spyOn(Stigg.prototype, "reportUsage");
+
+    await service.reportUsage("workspace-id", BillingFeature.Projects, 1);
+
+    expect(reportUsage).toHaveBeenCalledTimes(1);
+    expect(reportUsage).toHaveBeenCalledWith({
+      customerId: "workspace-id",
+      featureId: BillingFeature.Projects,
+      updateBehavior: UsageUpdateBehavior.Delta,
+      value: 1,
+    });
+  });
+
+  it("should set usage overriding current usage by using the UsageUpdateBehavior.Set", async () => {
+    const reportUsage = jest.spyOn(Stigg.prototype, "reportUsage");
+
+    await service.setUsage("workspace-id", BillingFeature.Projects, 100);
+
+    expect(reportUsage).toHaveBeenCalledTimes(1);
+    expect(reportUsage).toHaveBeenCalledWith({
+      customerId: "workspace-id",
+      featureId: BillingFeature.Projects,
+      updateBehavior: UsageUpdateBehavior.Set,
+      value: 100,
+    });
   });
 });


### PR DESCRIPTION
Related: https://github.com/amplication/private-issues/issues/97

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1f3eb0b</samp>

### Summary
📊🛠️🧹

<!--
1.  📊 This emoji can be used to represent the reporting and setting of usage for metered features, as it suggests data analysis and tracking of metrics.
2.  🛠️ This emoji can be used to represent the addition and modification of methods in the `BillingService` class, as it suggests building or improving functionality or tools.
3.  🧹 This emoji can be used to represent the simplification of the logic and error handling for non-metered or non-subscribed cases, as it suggests cleaning up or refactoring code.
-->
Improved billing service to support metered features with `stigg`. Refactored non-metered and non-subscribed scenarios.

> _`BillingService` changed_
> _Metered features use `stigg`_
> _Simpler logic now_

### Walkthrough
*  Add `reportUsage` method to `BillingService` class to report usage for a specific feature by adding or removing a value from the current usage ([link](https://github.com/amplication/amplication/pull/7631/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1R108-R114), [link](https://github.com/amplication/amplication/pull/7631/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L119-R130))
  * Import `UsageUpdateBehavior` enum from `stigg` package to specify how the usage value is updated ([link](https://github.com/amplication/amplication/pull/7631/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1R10))
  * Use `UsageUpdateBehavior.Delta` option when calling `stiggClient.reportUsage` method to indicate that the value parameter is a delta value ([link](https://github.com/amplication/amplication/pull/7631/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L119-R130))
  * Return a default object with a null measurement id if the feature is not metered or the workspace is not subscribed ([link](https://github.com/amplication/amplication/pull/7631/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L119-R130))
  * Add a missing semicolon after `this.logger.error` statement ([link](https://github.com/amplication/amplication/pull/7631/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L119-R130))
* Add `setUsage` method to `BillingService` class to set usage for a specific feature by overwriting the current usage ([link](https://github.com/amplication/amplication/pull/7631/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1R136-R142), [link](https://github.com/amplication/amplication/pull/7631/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L135-R159))
  * Use `UsageUpdateBehavior.Set` option when calling `stiggClient.reportUsage` method to indicate that the value parameter is the new usage value ([link](https://github.com/amplication/amplication/pull/7631/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L135-R159))
  * Return a default object with a null measurement id if the feature is not metered or the workspace is not subscribed ([link](https://github.com/amplication/amplication/pull/7631/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L135-R159))
  * Remove unnecessary code that fetched the metered entitlement and calculated the result ([link](https://github.com/amplication/amplication/pull/7631/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L135-R159))



## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
