### PR TITLE
fix(client): issue upgrade button on a free account

### DIFF
--- a/packages/amplication-client/src/Workspaces/hooks/useUpgradeButtonData.ts
+++ b/packages/amplication-client/src/Workspaces/hooks/useUpgradeButtonData.ts
@@ -50,7 +50,7 @@ export const useUpgradeButtonData = (
           trialDaysLeft: 0,
           trialLeftProgress: 0,
           showUpgradeTrialButton,
-          showUpgradeDefaultButton: false,
+          showUpgradeDefaultButton: !showUpgradeTrialButton,
           isCompleted: true,
         });
       } else if (


### PR DESCRIPTION
Close: #7633 

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 87f0ee6</samp>

### Summary
🐛🔄🚫

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request.
2.  🔄 - This emoji represents a change or update, which is what the `showUpgradeDefaultButton` property was.
3.  🚫 - This emoji represents a removal or exclusion, which is what the logic of the `showUpgradeDefaultButton` property does to the `showUpgradeTrialButton` property.
-->
Fixed a bug where both upgrade buttons were shown on the workspace page. Changed the logic of `showUpgradeDefaultButton` in `useUpgradeButtonData.ts` to avoid conflicts with `showUpgradeTrialButton`.

> _`showUpgrade` changed_
> _Only one button appears_
> _Trial expired - fall_

### Walkthrough
*  Invert the logic of `showUpgradeDefaultButton` to avoid showing both upgrade buttons ([link](https://github.com/amplication/amplication/pull/7632/files?diff=unified&w=0#diff-97660417b6d1257e4d2e739f831e3b132ba73693ab2478bb20a9df4c41e1e0acL53-R53))



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
