### PR TITLE
fix(client): start trial cta

### DIFF
--- a/packages/amplication-client/src/Purchase/PurchasePage.tsx
+++ b/packages/amplication-client/src/Purchase/PurchasePage.tsx
@@ -188,6 +188,7 @@ const PurchasePage = (props) => {
                 : `All core backend functionality:`;
             },
             planCTAButton: {
+              startTrial: "Contact us",
               startNew: provisionSubscriptionLoading
                 ? "...Loading"
                 : "Upgrade now",


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #7636

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 83e19cb</samp>

### Summary
🆙🎨📞

<!--
1.  🆙 - This emoji can be used to represent the update of the dependency `@stigg/react-sdk` from `^2.0.0` to `^4.11.0`. The emoji conveys the idea of upgrading, increasing, or improving something, which is the intention of updating the library to the latest version. Alternatively, the 📦 emoji could also be used to represent the update of a package or dependency.
2.  🎨 - This emoji can be used to represent the modification of the styles for the `PurchasePage.scss` file. The emoji conveys the idea of painting, designing, or beautifying something, which is the intention of changing the styles to improve the layout and appearance of the purchase page. Alternatively, the 🖌️ emoji could also be used to represent the modification of styles or graphics.
3.  📞 - This emoji can be used to represent the change of the text for the button that starts a trial for the Amplication Enterprise plan from "Start trial" to "Contact us". The emoji conveys the idea of calling, contacting, or communicating with someone, which is the intention of changing the text to encourage users to reach out to the Amplication team for more information. Alternatively, the 💬 emoji could also be used to represent the change of text or message.
-->
This pull request updates the `@stigg/react-sdk` dependency, improves the styles of the purchase page, and changes the text of the trial button for the Amplication Enterprise plan. These changes are intended to use the latest UI library, enhance the design and usability of the purchase page, and clarify the availability of the Enterprise plan.

> _`@stigg/react-sdk`_
> _Updated for new features, fixes_
> _Winter of web apps_

### Walkthrough
*  Update `@stigg/react-sdk` dependency to use latest features and bug fixes ([link](https://github.com/amplication/amplication/pull/7635/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L83-R83))
*  Improve layout and appearance of purchase page with style modifications ([link](https://github.com/amplication/amplication/pull/7635/files?diff=unified&w=0#diff-847ade2394d6ea2c7e82d05133c5d31bb423b86ac08c373bbda61eaa6bfac872L96-R315))
*  Change trial button text for Enterprise plan to "Contact us" to reflect custom setup process ([link](https://github.com/amplication/amplication/pull/7635/files?diff=unified&w=0#diff-5a2c55b6a53d9d5a540e05bfef0694bdac1851e3007fccb6d563a5df492e1c73R191))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
