### PR TITLE
fix(server): team members workspace usage report

### DIFF
--- a/packages/amplication-server/src/core/billing/billing.service.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.ts
@@ -119,8 +119,7 @@ export class BillingService {
   ): Promise<ReportUsageAck> {
     try {
       if (this.isBillingEnabled) {
-        const stiggClient = await this.getStiggClient();
-        return await stiggClient.reportUsage({
+        return await this.stiggClient.reportUsage({
           customerId: workspaceId,
           featureId: feature,
           value: value,
@@ -147,9 +146,7 @@ export class BillingService {
   ): Promise<ReportUsageAck> {
     try {
       if (this.isBillingEnabled) {
-        const stiggClient = await this.getStiggClient();
-
-        return await stiggClient.reportUsage({
+        return await this.stiggClient.reportUsage({
           customerId: workspaceId,
           featureId: feature,
           value,
@@ -399,23 +396,28 @@ export class BillingService {
 
   async resetUsage(workspaceId: string, currentUsage: FeatureUsageReport) {
     if (this.isBillingEnabled) {
-      await this.setUsage(
-        workspaceId,
-        BillingFeature.Projects,
-        currentUsage.projects
-      );
-
-      await this.setUsage(
-        workspaceId,
-        BillingFeature.Services,
-        currentUsage.services
-      );
-
-      await this.setUsage(
-        workspaceId,
-        BillingFeature.ServicesAboveEntitiesPerServiceLimit,
-        currentUsage.servicesAboveEntityPerServiceLimit
-      );
+      await Promise.all([
+        this.setUsage(
+          workspaceId,
+          BillingFeature.Projects,
+          currentUsage.projects
+        ),
+        this.setUsage(
+          workspaceId,
+          BillingFeature.Services,
+          currentUsage.services
+        ),
+        this.setUsage(
+          workspaceId,
+          BillingFeature.ServicesAboveEntitiesPerServiceLimit,
+          currentUsage.servicesAboveEntityPerServiceLimit
+        ),
+        this.setUsage(
+          workspaceId,
+          BillingFeature.TeamMembers,
+          currentUsage.teamMembers
+        ),
+      ]);
     }
   }
 

--- a/packages/amplication-server/src/core/project/FeatureUsageReport.ts
+++ b/packages/amplication-server/src/core/project/FeatureUsageReport.ts
@@ -2,4 +2,5 @@ export type FeatureUsageReport = {
   projects: number;
   services: number;
   servicesAboveEntityPerServiceLimit: number;
+  teamMembers: number;
 };

--- a/packages/amplication-server/src/core/project/project.service.ts
+++ b/packages/amplication-server/src/core/project/project.service.ts
@@ -237,6 +237,11 @@ export class ProjectService {
       },
       include: {
         subscriptions: true,
+        users: {
+          where: {
+            deletedAt: null,
+          },
+        },
         projects: {
           include: {
             resources: {
@@ -279,6 +284,7 @@ export class ProjectService {
       services: workspaceServices.length,
       servicesAboveEntityPerServiceLimit:
         servicesAboveEntityPerServiceLimitCount,
+      teamMembers: workspace.users.length,
     };
   }
 


### PR DESCRIPTION


Close: #7634

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6d24d7e</samp>

### Summary
🧪📊♻️

<!--
1.  🧪 - This emoji represents the addition of a new test suite for the `resetUsage` method, which is related to testing and quality assurance.
2.  📊 - This emoji represents the addition of a new property to the `FeatureUsageReport` type, which is related to data and analytics.
3.  ♻️ - This emoji represents the refactoring and improvement of the `BillingService` and `ProjectService` classes, which is related to code quality and performance.
-->
This pull request improves the billing and feature usage reporting functionality of the `amplication-server` package. It refactors the `BillingService` class to optimize the communication with the `Stigg` client and to track the number of users in a workspace. It also updates the `ProjectService` class and the `FeatureUsageReport` type to reflect the actual user count in a workspace. It adds a new test suite for the `resetUsage` method of the `BillingService` class.

> _Oh, we're the coders of the `BillingService` class_
> _And we work with the `Stigg` client to report usage fast_
> _We mock and test our methods with care and skill_
> _And we refactor and add features as we sail along_

### Walkthrough
*  Remove redundant calls to `getStiggClient` and use `stiggClient` property instead in `reportUsage` and `setUsage` methods of `BillingService` class ([link](https://github.com/amplication/amplication/pull/7640/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L122-R122), [link](https://github.com/amplication/amplication/pull/7640/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L150-R149))
* Add `teamMembers` property to `FeatureUsageReport` type to store the number of users in a workspace ([link](https://github.com/amplication/amplication/pull/7640/files?diff=unified&w=0#diff-3045b61429f2488e836512bb802813d83c7e4bec930f53233947d29e0df26858R5))
* Filter out deleted users from workspace query in `findWorkspace` method of `ProjectService` class ([link](https://github.com/amplication/amplication/pull/7640/files?diff=unified&w=0#diff-cd946c1c9f9271b6dd02f554735fae66c53c2516f9b097daf8f798c2154118ffR240-R244))
* Assign `teamMembers` property to the length of the `users` array of the workspace in `getWorkspaceUsage` method of `ProjectService` class ([link](https://github.com/amplication/amplication/pull/7640/files?diff=unified&w=0#diff-cd946c1c9f9271b6dd02f554735fae66c53c2516f9b097daf8f798c2154118ffR287))
* Use `Promise.all` to execute `setUsage` calls for each feature in parallel in `resetUsage` method of `BillingService` class, and add `teamMembers` feature to the method ([link](https://github.com/amplication/amplication/pull/7640/files?diff=unified&w=0#diff-f9aed5323cc2e69600bb73c5a362dbae00a82615452516017582cb2825fbe7d1L402-R420))
* Add test suite for `resetUsage` method of `BillingService` class in `billing.service.spec.ts` file, with two test cases for billing enabled and disabled scenarios ([link](https://github.com/amplication/amplication/pull/7640/files?diff=unified&w=0#diff-dc456c8512ec4b3cce5f935aa029a8e6b048ffe59a363332015cc186cfffc647R652-R719))



## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
