### PR TITLE
chore: update docker compose dev to use redpanda instead of kafka ui to allow consuming/producing json format messages

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,18 +25,19 @@ services:
       - redis_data:/data
   kafka-ui:
     container_name: kafka-ui
-    image: provectuslabs/kafka-ui:latest
+    image: docker.redpanda.com/redpandadata/console:latest
+    entrypoint: /bin/sh
+    command: -c "echo \"$$CONSOLE_CONFIG_FILE\" > /tmp/config.yml; /app/console"
     ports:
       - "8080:8080"
     depends_on:
       - zookeeper
       - kafka
     environment:
-      KAFKA_CLUSTERS_0_NAME: local
-      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
-      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
-      KAFKA_CLUSTERS_0_JMXPORT: 9997
-
+      CONFIG_FILEPATH: /tmp/config.yml
+      CONSOLE_CONFIG_FILE: |
+        kafka:
+          brokers: ["kafka:29092"]
   zookeeper:
     image: confluentinc/cp-zookeeper:7.3.1
     environment:


### PR DESCRIPTION

Close: #7749

## PR Details

Replace the dev compose service kafka-ui with redpanda kafka GUI to allow devs to consume/produce JSON formatted messages.

<img width="865" alt="image" src="https://github.com/amplication/amplication/assets/2861984/81d5a0b9-33fd-4fb8-b3aa-9b8efefdeaf1">


## PR Checklist

- [] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
