### PR TITLE
fix(util-logging): issue related to double error logs recorded

### DIFF
--- a/libs/util/logging/src/lib/logging.spec.ts
+++ b/libs/util/logging/src/lib/logging.spec.ts
@@ -28,6 +28,8 @@ describe("Logger", () => {
       logLevel: LogLevel.Debug,
       isProduction: false,
     };
+
+    jest.clearAllMocks();
   });
 
   afterAll(() => {
@@ -88,6 +90,7 @@ describe("Logger", () => {
 
       logger.debug("debug message");
 
+      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
       expect(mockLogger.debug).toHaveBeenCalledWith("debug message", undefined);
     });
 
@@ -96,6 +99,7 @@ describe("Logger", () => {
 
       logger.info("info message");
 
+      expect(mockLogger.info).toHaveBeenCalledTimes(1);
       expect(mockLogger.info).toHaveBeenCalledWith("info message", undefined);
     });
 
@@ -104,6 +108,7 @@ describe("Logger", () => {
 
       logger.warn("warn message");
 
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
       expect(mockLogger.warn).toHaveBeenCalledWith("warn message", undefined);
     });
 
@@ -112,6 +117,7 @@ describe("Logger", () => {
 
       logger.error("error message");
 
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).toHaveBeenCalledWith("error message", undefined);
     });
 
@@ -126,6 +132,7 @@ describe("Logger", () => {
         message: "My error message",
       });
 
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).toHaveBeenCalledWith(expectedError);
     });
 
@@ -141,6 +148,7 @@ describe("Logger", () => {
         foo: { what: "yeah" },
       });
 
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).toHaveBeenCalledWith(expectedError);
     });
 
@@ -152,6 +160,7 @@ describe("Logger", () => {
       const expectedError = error;
       Object.assign(expectedError, { foo: { what: "yeah" } });
 
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).toHaveBeenCalledWith(expectedError);
     });
   });

--- a/libs/util/logging/src/lib/logging.ts
+++ b/libs/util/logging/src/lib/logging.ts
@@ -83,8 +83,9 @@ export class Logger implements ILogger {
         ...params,
       });
       this.logger.error(error);
+    } else {
+      this.logger.error(message, params);
     }
-    this.logger.error(message, params);
   }
 
   child(metadata?: Pick<LoggerOptions, "metadata">): Logger {


### PR DESCRIPTION
Close: #7768

## PR Details

Fix issue related to duplicated error logs being fired on error.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
