### PR TITLE
Add:KafkaProducer validate message against schema before emitting .

### DIFF
--- a/libs/util/nestjs/kafka/src/producer/KafkaProducer.service.ts
+++ b/libs/util/nestjs/kafka/src/producer/KafkaProducer.service.ts
@@ -24,6 +24,13 @@ export class KafkaProducerService {
     message: DecodedKafkaMessage,
     schemaIds?: SchemaIds
   ): Promise<void> {
+   if (!schemaIds) {
+    throw new Error('Missing schema IDs');
+  }
+    const validationResult = await this.kafkaClient.validate(topic, message, schemaIds);
+   if (validationResult.errors) {
+    throw new Error('Message does not conform to the specified schema');
+  }
     const kafkaMessage = await this.serializer.serialize(message, schemaIds);
     return await new Promise((resolve, reject) => {
       this.kafkaClient.emit(topic, kafkaMessage).subscribe({


### PR DESCRIPTION

Close: #7742

## PR Details
This  method first validates the message against the provided schema IDs. If the message does not conform to the specified schema, it throws an error. Then, it proceeds to serialize the message using the provided schema IDs and emits the message to the Kafka client. This way, the KafkaProducerService ensures that only valid messages are published to the Kafka topic, preventing potential issues for the consumers.

## PR Checklist

- [x ] `npm test` doesn't throw any error
