### PR TITLE
feat: add proper info while repository naming

### DIFF
--- a/libs/util/git/src/git.constants.ts
+++ b/libs/util/git/src/git.constants.ts
@@ -1,6 +1,6 @@
 import { join } from "path";
 
-export const REPO_NAME_TAKEN_ERROR_MESSAGE = "Repository is already exist";
+export const REPO_NAME_TAKEN_ERROR_MESSAGE = "Repository is already existing.";
 export const INVALID_SOURCE_CONTROL_ERROR_MESSAGE =
   "Invalid source control service";
 export const MISSING_TOKEN_ERROR = `App Missing a Github token. You should first complete the authorization process`;

--- a/libs/util/git/src/git.constants.ts
+++ b/libs/util/git/src/git.constants.ts
@@ -1,6 +1,6 @@
 import { join } from "path";
 
-export const REPO_NAME_TAKEN_ERROR_MESSAGE = "Repository is already existing.";
+export const REPO_NAME_TAKEN_ERROR_MESSAGE = "Repository already exists.";
 export const INVALID_SOURCE_CONTROL_ERROR_MESSAGE =
   "Invalid source control service";
 export const MISSING_TOKEN_ERROR = `App Missing a Github token. You should first complete the authorization process`;

--- a/libs/util/git/src/providers/github/github.service.ts
+++ b/libs/util/git/src/providers/github/github.service.ts
@@ -39,7 +39,10 @@ import {
 } from "../../types";
 import { ConverterUtil } from "../../utils/convert-to-number";
 import { NotImplementedError } from "../../utils/custom-error";
-import { UNSUPPORTED_GIT_ORGANIZATION_TYPE } from "../../git.constants";
+import {
+  REPO_NAME_TAKEN_ERROR_MESSAGE,
+  UNSUPPORTED_GIT_ORGANIZATION_TYPE,
+} from "../../git.constants";
 import { NoChangesOnPullRequest } from "../../errors/NoChangesOnPullRequest";
 
 const GITHUB_FILE_TYPE = "file";
@@ -256,7 +259,7 @@ export class GithubService implements GitProvider {
       repositoryName
     );
     if (exists) {
-      return null;
+      throw new Error(REPO_NAME_TAKEN_ERROR_MESSAGE);
     }
 
     const { data: repo } = await this.octokit.rest.repos.createInOrg({

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/GitCreateRepo.scss
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/GitCreateRepo.scss
@@ -42,4 +42,13 @@
     margin-bottom: var(--icon-spacing);
     font-size: 10px;
   }
+
+  &__info {
+    font-size: 10px;
+    color: var(--gray-20);
+  }
+
+  &__info__emphasis {
+    color: var(--theme-green);
+  }
 }

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/GitCreateRepo.scss
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/GitCreateRepo.scss
@@ -42,13 +42,4 @@
     margin-bottom: var(--icon-spacing);
     font-size: 10px;
   }
-
-  &__info {
-    font-size: 10px;
-    color: var(--gray-20);
-  }
-
-  &__info__emphasis {
-    color: var(--theme-green);
-  }
 }

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/GitCreateRepo.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/GitCreateRepo.tsx
@@ -54,11 +54,24 @@ export default function GitCreateRepo({
     }
   }, [gitGroups]);
 
+  const processGitRepositoryName = useCallback((name: string) => {
+    if (!name || name.length < 2) {
+      return null;
+    }
+    return name
+      .replace(/[^a-zA-Z0-9.\-_]/g, "-") // Replace characters other than ASCII letters, digits, ., -, and _ with -
+      .replace(/-{2,}/g, "-"); // Replace consecutive dashes with a single dash
+  }, []);
+
   const handleCreation = useCallback(
     (data: CreateGitRepositoryInput) => {
       const inputData = repositoryGroup
-        ? { ...data, groupName: repositoryGroup.name }
-        : data;
+        ? {
+            ...data,
+            groupName: repositoryGroup.name,
+            name: processGitRepositoryName(data.name),
+          }
+        : { ...data, name: processGitRepositoryName(data.name) };
       onCreateGitRepository(inputData);
     },
     [repositoryGroup]
@@ -107,6 +120,18 @@ export default function GitCreateRepo({
             autoComplete="off"
             showError={false}
           />
+
+          {!!values.name && values.name.length > 1 && (
+            <div className={`${CLASS_NAME}__info`}>
+              <p className={`${CLASS_NAME}__info__emphasis`}>
+                {"Your new repository will be created as "}{" "}
+                <b>{processGitRepositoryName(values.name)}.</b>
+              </p>
+              {
+                "The repository name can only contain ASCII letters, digits, and the characters ., -, and _."
+              }
+            </div>
+          )}
 
           <HorizontalRule />
 

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/GitCreateRepo.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/GitCreateRepo.tsx
@@ -22,6 +22,7 @@ import "./GitCreateRepo.scss";
 import { GitSelectMenu } from "../../select/GitSelectMenu";
 import { GitOrganizationFromGitRepository } from "../../SyncWithGithubPage";
 import { GET_GROUPS } from "../../queries/gitProvider";
+import { GIT_REPO_CREATION_MESSAGE, GIT_REPO_NAME_RULES } from "./constants";
 
 type Props = {
   gitOrganization: GitOrganizationFromGitRepository;
@@ -136,15 +137,11 @@ export default function GitCreateRepo({
                 textStyle={EnumTextStyle.Subtle}
                 textColor={EnumTextColor.ThemeGreen}
               >
-                {"Your new repository will be created as "}
-                <b>{processGitRepositoryName(values.name)}.</b>
+                {GIT_REPO_CREATION_MESSAGE}
+                {processGitRepositoryName(values.name)}.
               </Text>
 
-              <Text textStyle={EnumTextStyle.Label}>
-                {
-                  "The repository name can only contain ASCII letters, digits, and the characters ., -, and _."
-                }
-              </Text>
+              <Text textStyle={EnumTextStyle.Label}>{GIT_REPO_NAME_RULES}</Text>
             </FlexItem>
           )}
 

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/GitCreateRepo.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/GitCreateRepo.tsx
@@ -1,8 +1,14 @@
 import {
   Button,
   CircularProgress,
+  EnumFlexDirection,
+  EnumGapSize,
+  EnumTextColor,
+  EnumTextStyle,
+  FlexItem,
   HorizontalRule,
   Label,
+  Text,
   TextField,
   Toggle,
 } from "@amplication/ui/design-system";
@@ -122,15 +128,24 @@ export default function GitCreateRepo({
           />
 
           {!!values.name && values.name.length > 1 && (
-            <div className={`${CLASS_NAME}__info`}>
-              <p className={`${CLASS_NAME}__info__emphasis`}>
-                {"Your new repository will be created as "}{" "}
+            <FlexItem
+              direction={EnumFlexDirection.Column}
+              gap={EnumGapSize.Default}
+            >
+              <Text
+                textStyle={EnumTextStyle.Subtle}
+                textColor={EnumTextColor.ThemeGreen}
+              >
+                {"Your new repository will be created as "}
                 <b>{processGitRepositoryName(values.name)}.</b>
-              </p>
-              {
-                "The repository name can only contain ASCII letters, digits, and the characters ., -, and _."
-              }
-            </div>
+              </Text>
+
+              <Text textStyle={EnumTextStyle.Label}>
+                {
+                  "The repository name can only contain ASCII letters, digits, and the characters ., -, and _."
+                }
+              </Text>
+            </FlexItem>
           )}
 
           <HorizontalRule />

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/WizardGitCreateRepo.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/WizardGitCreateRepo.tsx
@@ -22,6 +22,7 @@ import { GET_GROUPS } from "../../queries/gitProvider";
 import { GitSelectMenu } from "../../select/GitSelectMenu";
 import { GitRepositoryCreatedData } from "../GitRepos/GithubRepos";
 import "./GitCreateRepo.scss";
+import { GIT_REPO_CREATION_MESSAGE, GIT_REPO_NAME_RULES } from "./constants";
 
 type createRepositoryInput = {
   name: string;
@@ -174,15 +175,11 @@ export default function WizardGitCreateRepo({
             textStyle={EnumTextStyle.Subtle}
             textColor={EnumTextColor.ThemeGreen}
           >
-            {"Your new repository will be created as "}
-            <b>{createRepositoryInput.name}.</b>
+            {GIT_REPO_CREATION_MESSAGE}
+            {createRepositoryInput.name}.
           </Text>
 
-          <Text textStyle={EnumTextStyle.Label}>
-            {
-              "The repository name can only contain ASCII letters, digits, and the characters ., -, and _."
-            }
-          </Text>
+          <Text textStyle={EnumTextStyle.Label}>{GIT_REPO_NAME_RULES}</Text>
         </FlexItem>
       )}
 

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/WizardGitCreateRepo.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/WizardGitCreateRepo.tsx
@@ -1,8 +1,14 @@
 import {
   Button,
   CircularProgress,
+  EnumFlexDirection,
+  EnumGapSize,
+  EnumTextColor,
+  EnumTextStyle,
+  FlexItem,
   HorizontalRule,
   Label,
+  Text,
   TextField,
   Toggle,
 } from "@amplication/ui/design-system";
@@ -160,15 +166,24 @@ export default function WizardGitCreateRepo({
       />
 
       {!!createRepositoryInput.name && (
-        <div className={`${CLASS_NAME}__info`}>
-          <p className={`${CLASS_NAME}__info__emphasis`}>
-            {"Your new repository will be created as "}{" "}
+        <FlexItem
+          direction={EnumFlexDirection.Column}
+          gap={EnumGapSize.Default}
+        >
+          <Text
+            textStyle={EnumTextStyle.Subtle}
+            textColor={EnumTextColor.ThemeGreen}
+          >
+            {"Your new repository will be created as "}
             <b>{createRepositoryInput.name}.</b>
-          </p>
-          {
-            "The repository name can only contain ASCII letters, digits, and the characters ., -, and _."
-          }
-        </div>
+          </Text>
+
+          <Text textStyle={EnumTextStyle.Label}>
+            {
+              "The repository name can only contain ASCII letters, digits, and the characters ., -, and _."
+            }
+          </Text>
+        </FlexItem>
       )}
 
       <HorizontalRule />

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/WizardGitCreateRepo.tsx
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/WizardGitCreateRepo.tsx
@@ -78,13 +78,16 @@ export default function WizardGitCreateRepo({
 
   const handleNameChange = useCallback(
     (event) => {
+      const processedName = event.target.value
+        .replace(/[^a-zA-Z0-9.\-_]/g, "-") // Replace characters other than ASCII letters, digits, ., -, and _ with -
+        .replace(/-{2,}/g, "-"); // Replace consecutive dashes with a single dash
       setCreateRepositoryInput({
         ...createRepositoryInput,
-        name: event.target.value,
+        name: processedName,
       });
       const gitRepositoryUrl = getGitRepositoryDetails({
         organization: gitOrganization,
-        repositoryName: event.target.value,
+        repositoryName: processedName,
         groupName: createRepositoryInput.groupName,
       }).repositoryUrl;
       setGitRepositoryUrl(gitRepositoryUrl);
@@ -155,6 +158,18 @@ export default function WizardGitCreateRepo({
         showError={false}
         onChange={handleNameChange}
       />
+
+      {!!createRepositoryInput.name && (
+        <div className={`${CLASS_NAME}__info`}>
+          <p className={`${CLASS_NAME}__info__emphasis`}>
+            {"Your new repository will be created as "}{" "}
+            <b>{createRepositoryInput.name}.</b>
+          </p>
+          {
+            "The repository name can only contain ASCII letters, digits, and the characters ., -, and _."
+          }
+        </div>
+      )}
 
       <HorizontalRule />
 

--- a/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/constants.ts
+++ b/packages/amplication-client/src/Resource/git/dialogs/GitCreateRepo/constants.ts
@@ -1,0 +1,4 @@
+export const GIT_REPO_CREATION_MESSAGE =
+  "Your new repository will be created as ";
+export const GIT_REPO_NAME_RULES =
+  "Repository name must be unique can only contain ASCII letters, digits, and the characters ., -, and _.";


### PR DESCRIPTION
Fixes: #6051 

## PR Details

This PR adds proper information while naming repositories.

![image](https://github.com/amplication/amplication/assets/100484401/4a8bcf3d-9203-4372-bd0d-9cf507000e99)

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
