### PR TITLE
fix(server):do not pull the entities list for other resources

### DIFF
--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -878,7 +878,7 @@ export class BuildService {
       : undefined;
 
     return {
-      entities: await this.getOrderedEntities(buildId),
+      entities: rootGeneration ? await this.getOrderedEntities(buildId) : [],
       roles: await this.getResourceRoles(resourceId),
       pluginInstallations: plugins,
       moduleContainers: modules,


### PR DESCRIPTION
Close: #7801 

## PR Details

The DSG is not using the entities of "other" resources. 
We send an empty list, and if there will be need, we can fill the list with the relevant data in the future


## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
