### PR TITLE
chore: use bun version 1.0.15 in ci nx template to avoid dependencies install issues

### DIFF
--- a/.github/workflows/nx.template.yml
+++ b/.github/workflows/nx.template.yml
@@ -73,6 +73,8 @@ jobs:
       - name: Setup Bun Runtime
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.0.15
 
       - name: Cache
         id: cache


### PR DESCRIPTION
Close: #7876

## PR Details

Configured bun version on nx ci workspace to v1.0.15 as suggested in here: https://github.com/oven-sh/bun/issues/8010
https://github.com/oven-sh/setup-bun

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
