### PR TITLE
ci: update aws-credentials & setup-bun actions to use Node 20

### DIFF
--- a/.github/workflows/deployment.container.template.yml
+++ b/.github/workflows/deployment.container.template.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deployment.production.yml
+++ b/.github/workflows/deployment.production.yml
@@ -98,7 +98,7 @@ jobs:
         run: npm ci
 
       - name: Configure AWS Credentials (operations account)
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deployment.static.template.yml
+++ b/.github/workflows/deployment.static.template.yml
@@ -56,7 +56,7 @@ jobs:
         if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
         run: npm ci
 
-      - uses: aws-actions/configure-aws-credentials@v1-node16
+      - uses: aws-actions/configure-aws-credentials@v4-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/nx.template.yml
+++ b/.github/workflows/nx.template.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Setup Bun Runtime
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v1.1.1
         with:
           bun-version: 1.0.15
 

--- a/.github/workflows/release.template.yml
+++ b/.github/workflows/release.template.yml
@@ -77,7 +77,7 @@ jobs:
         run: npm ci
 
       - name: Configure AWS Credentials (operations account)
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Close: #7893

## PR Details

Update the following github actions to use the supported node version (v20) instead of the deprecated v16

- oven-sh/setup-bun
- https://github.com/aws-actions/configure-aws-credentials

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
