### PR TITLE
fix(server): update unique flag for default User Entity

### DIFF
--- a/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
@@ -324,7 +324,7 @@ const CreateServiceWizard: React.FC<Props> = ({
   const createResourcePlugins = useCallback(
     (
       databaseType: "postgres" | "mysql" | "mongo" | "sqlserver",
-      authType: string
+      authType: "no" | "core"
     ): models.PluginInstallationsCreateInput => {
       const dbPlugin = pluginsVersionData?.plugins.find(
         (x) => x.pluginId === `db-${databaseType}`

--- a/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
@@ -323,7 +323,7 @@ const CreateServiceWizard: React.FC<Props> = ({
 
   const createResourcePlugins = useCallback(
     (
-      databaseType: "postgres" | "mysql" | "mongo",
+      databaseType: "postgres" | "mysql" | "mongo" | "sqlserver",
       authType: string
     ): models.PluginInstallationsCreateInput => {
       const dbPlugin = pluginsVersionData?.plugins.find(

--- a/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceAuth.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceAuth.tsx
@@ -9,12 +9,12 @@ import ImgSvg from "./ImgSvg";
 const CreateServiceAuth: React.FC<WizardStepProps> = ({ formik }) => {
   const AuthCoreSvg = ImgSvg({ image: authModuleImage });
 
-  const handleDatabaseSelect = useCallback(
-    (database: string) => {
+  const handleAuthSelect = useCallback(
+    (authType: string) => {
       formik.setValues(
         {
           ...formik.values,
-          authType: database,
+          authType,
         },
         true
       );
@@ -37,7 +37,7 @@ const CreateServiceAuth: React.FC<WizardStepProps> = ({ formik }) => {
             image={AuthCoreSvg}
             label="Include Auth Module"
             description="Generate the code needed for authentication and authorization"
-            onClick={handleDatabaseSelect}
+            onClick={handleAuthSelect}
             currentValue={formik.values.authType}
           />
           <LabelDescriptionSelector
@@ -45,7 +45,7 @@ const CreateServiceAuth: React.FC<WizardStepProps> = ({ formik }) => {
             icon="unlock"
             label="Skip Authentication"
             description="Do not include code for authentication"
-            onClick={handleDatabaseSelect}
+            onClick={handleAuthSelect}
             currentValue={formik.values.authType}
           />
         </Layout.SelectorWrapper>

--- a/packages/amplication-client/src/Resource/create-resource/wizard-pages/interfaces.ts
+++ b/packages/amplication-client/src/Resource/create-resource/wizard-pages/interfaces.ts
@@ -14,7 +14,7 @@ export interface ResourceSettings {
   generateRestApi: boolean;
   baseDir: string;
   structureType: "Mono" | " Poly";
-  databaseType: "postgres" | "mysql" | "mongo";
+  databaseType: "postgres" | "mysql" | "mongo" | "sqlserver";
   templateType: "empty" | "orderManagement";
   authType: string;
   isGenerateCompleted: string;

--- a/packages/amplication-client/src/Resource/create-resource/wizard-pages/interfaces.ts
+++ b/packages/amplication-client/src/Resource/create-resource/wizard-pages/interfaces.ts
@@ -16,7 +16,7 @@ export interface ResourceSettings {
   structureType: "Mono" | " Poly";
   databaseType: "postgres" | "mysql" | "mongo" | "sqlserver";
   templateType: "empty" | "orderManagement";
-  authType: string;
+  authType: "no" | "core";
   isGenerateCompleted: string;
   connectToDemoRepo: boolean;
 }

--- a/packages/amplication-prisma-db/prisma/manual-data-migrations/20240131_fix_entity_field_type_username_unique.sql
+++ b/packages/amplication-prisma-db/prisma/manual-data-migrations/20240131_fix_entity_field_type_username_unique.sql
@@ -1,0 +1,34 @@
+DO $$
+DECLARE batch_size INT := 500; -- Adjust the batch size as needed
+total_rows INT;
+BEGIN
+SELECT COUNT(*) INTO total_rows
+FROM "public"."EntityField"
+WHERE "dataType" = 'Username';
+FOR i IN 0..ceil(total_rows / batch_size) - 1 LOOP
+UPDATE "public"."EntityField"
+SET "unique" = TRUE,
+	"updatedAt" = NOW()
+WHERE ctid IN(
+		SELECT ctid
+		FROM "EntityField"
+		WHERE id IN(
+				SELECT ef.id
+				FROM "EntityField" AS ef
+					JOIN "EntityVersion" AS ev ON ef."entityVersionId" = ev.id
+					AND ev."versionNumber" = 0
+					AND ef."dataType" = 'Username'
+					JOIN "Entity" AS e ON ev."entityId" = e.id
+					AND e."deletedAt" IS NULL
+					JOIN "Resource" AS r ON e."resourceId" = r.id
+					AND r."deletedAt" IS NULL
+					AND r.archived = FALSE
+					JOIN "Project" AS p ON r."projectId" = p.id
+					AND p."deletedAt" IS NULL
+			)
+		LIMIT batch_size OFFSET i * batch_size
+	);
+COMMIT;
+-- Commit after each batch to release locks
+END LOOP;
+END $$;

--- a/packages/amplication-server/src/core/entity/constants.ts
+++ b/packages/amplication-server/src/core/entity/constants.ts
@@ -142,7 +142,7 @@ export const DEFAULT_ENTITIES: EntityData[] = [
         displayName: "Username",
         description:
           "An automatically created field of the username of the user",
-        unique: false,
+        unique: true,
         required: true,
         searchable: true,
         properties: {

--- a/packages/data-service-generator/src/server/prisma/create-prisma-schema-fields.ts
+++ b/packages/data-service-generator/src/server/prisma/create-prisma-schema-fields.ts
@@ -473,7 +473,7 @@ export const createPrismaSchemaFieldsHandlers: {
       PrismaSchemaDSLTypes.ScalarType.String,
       false,
       field.required,
-      true,
+      field.unique,
       undefined,
       undefined,
       undefined,

--- a/packages/data-service-generator/src/server/prisma/create-prisma-schema.spec.ts
+++ b/packages/data-service-generator/src/server/prisma/create-prisma-schema.spec.ts
@@ -428,7 +428,7 @@ describe("createPrismaFields", () => {
         PrismaSchemaDSLTypes.ScalarType.String,
         false,
         true,
-        true
+        false
       ),
     ],
     [

--- a/packages/data-service-generator/src/tests/entities.ts
+++ b/packages/data-service-generator/src/tests/entities.ts
@@ -57,7 +57,7 @@ const USER: Entity = {
       displayName: "Username",
       dataType: EnumDataType.Username,
       required: true,
-      unique: false,
+      unique: true,
       searchable: true,
     },
     {


### PR DESCRIPTION
Close: #7492, #7899 

## PR Details

This PR changes the generated entity fields of type Username to NOT be defaulted to unique but to leverage the amplication user choise when selecting the Unique flag.

As part of the change, it will also going to retro fit the old behaviour to exising entities fields ( that are currently in use, so no deleted or archived ) thanks to a manual migration.


## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
