### PR TITLE
feat(client): disable unique flag for auth entity specific field types

### DIFF
--- a/packages/amplication-client/src/Entity/EntityField.tsx
+++ b/packages/amplication-client/src/Entity/EntityField.tsx
@@ -19,7 +19,10 @@ import {
   RelatedFieldDialog,
   Values as RelatedFieldValues,
 } from "./RelatedFieldDialog";
-import { SYSTEM_DATA_TYPES } from "./constants";
+import {
+  AUTHENTICATION_ENTITY_DATA_TYPES,
+  SYSTEM_DATA_TYPES,
+} from "./constants";
 
 type TData = {
   entity: models.Entity;
@@ -110,7 +113,7 @@ const EntityField = () => {
         }
       }
 
-      const { id, permanentId, ...rest } = data; // eslint-disable-line @typescript-eslint/no-unused-vars
+      const { id, permanentId, ...rest } = data;
       updateEntityField({
         variables: {
           where: {
@@ -128,7 +131,7 @@ const EntityField = () => {
       if (!lookupPendingData) {
         throw new Error("lookupPendingData must be defined");
       }
-      const { id, permanentId, ...rest } = lookupPendingData; // eslint-disable-line @typescript-eslint/no-unused-vars
+      const { id, permanentId, ...rest } = lookupPendingData;
       updateEntityField({
         variables: {
           where: {
@@ -191,6 +194,10 @@ const EntityField = () => {
           <EntityFieldForm
             isSystemDataType={
               defaultValues && SYSTEM_DATA_TYPES.has(defaultValues.dataType)
+            }
+            isAuthEntitySpecificDataType={
+              defaultValues &&
+              AUTHENTICATION_ENTITY_DATA_TYPES.has(defaultValues.dataType)
             }
             onSubmit={handleSubmit}
             defaultValues={defaultValues}

--- a/packages/amplication-client/src/Entity/EntityFieldForm.tsx
+++ b/packages/amplication-client/src/Entity/EntityFieldForm.tsx
@@ -96,18 +96,18 @@ const EntityFieldForm = ({
         );
         //validate the field dynamic properties
         const schema = getSchemaForDataType(values.dataType);
-        // eslint-disable-next-line @typescript-eslint/ban-types
-        const propertiesError = validate<Object>(values.properties, schema);
+        const propertiesError = validate<{
+          relatedEntityId?: string;
+          allowMultipleSelection?: string;
+        }>(values.properties, schema);
 
         // Ignore related field ID error
         if ("relatedFieldId" in propertiesError) {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
           delete propertiesError.relatedFieldId;
         }
 
         if (!isEmpty(propertiesError)) {
-          errors.properties = propertiesError as any; // TODO: remove eslint rules and fix this
+          errors.properties = propertiesError;
         }
 
         return errors;

--- a/packages/amplication-client/src/Entity/EntityFieldForm.tsx
+++ b/packages/amplication-client/src/Entity/EntityFieldForm.tsx
@@ -37,6 +37,7 @@ type Props = {
   resourceId: string;
   entity: models.Entity;
   isSystemDataType?: boolean;
+  isAuthEntitySpecificDataType?: boolean;
 };
 
 const FORM_SCHEMA = {
@@ -74,6 +75,7 @@ const EntityFieldForm = ({
   resourceId,
   entity,
   isSystemDataType,
+  isAuthEntitySpecificDataType,
 }: Props) => {
   const initialValues = useMemo(() => {
     const sanitizedDefaultValues = omit(
@@ -134,14 +136,15 @@ const EntityFieldForm = ({
               label="Description"
               disabled={isSystemDataType}
             />
-
-            <div>
-              <ToggleField
-                name="unique"
-                label="Unique Field"
-                disabled={isSystemDataType}
-              />
-            </div>
+            {!isAuthEntitySpecificDataType && (
+              <div>
+                <ToggleField
+                  name="unique"
+                  label="Unique Field"
+                  disabled={isSystemDataType}
+                />
+              </div>
+            )}
             <div>
               <ToggleField
                 name="required"

--- a/packages/amplication-client/src/Entity/EntityFieldForm.tsx
+++ b/packages/amplication-client/src/Entity/EntityFieldForm.tsx
@@ -136,15 +136,13 @@ const EntityFieldForm = ({
               label="Description"
               disabled={isSystemDataType}
             />
-            {!isAuthEntitySpecificDataType && (
-              <div>
-                <ToggleField
-                  name="unique"
-                  label="Unique Field"
-                  disabled={isSystemDataType}
-                />
-              </div>
-            )}
+            <div>
+              <ToggleField
+                name="unique"
+                label="Unique Field"
+                disabled={isSystemDataType || isAuthEntitySpecificDataType}
+              />
+            </div>
             <div>
               <ToggleField
                 name="required"

--- a/packages/amplication-client/src/Entity/constants.ts
+++ b/packages/amplication-client/src/Entity/constants.ts
@@ -35,6 +35,9 @@ export const SYSTEM_DATA_TYPES: Set<models.EnumDataType> = new Set([
   models.EnumDataType.Id,
 ]);
 
+export const AUTHENTICATION_ENTITY_DATA_TYPES: Set<models.EnumDataType> =
+  new Set([models.EnumDataType.Username, models.EnumDataType.Password]);
+
 export const DATA_TYPE_TO_LABEL_AND_ICON: {
   [key in models.EnumDataType]: {
     label: string;

--- a/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
@@ -324,7 +324,7 @@ const CreateServiceWizard: React.FC<Props> = ({
   const createResourcePlugins = useCallback(
     (
       databaseType: "postgres" | "mysql" | "mongo" | "sqlserver",
-      authType: string
+      authType: "no" | "core"
     ): models.PluginInstallationsCreateInput => {
       const dbPlugin = pluginsVersionData?.plugins.find(
         (x) => x.pluginId === `db-${databaseType}`

--- a/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
@@ -323,7 +323,7 @@ const CreateServiceWizard: React.FC<Props> = ({
 
   const createResourcePlugins = useCallback(
     (
-      databaseType: "postgres" | "mysql" | "mongo",
+      databaseType: "postgres" | "mysql" | "mongo" | "sqlserver",
       authType: string
     ): models.PluginInstallationsCreateInput => {
       const dbPlugin = pluginsVersionData?.plugins.find(

--- a/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceAuth.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceAuth.tsx
@@ -9,12 +9,12 @@ import ImgSvg from "./ImgSvg";
 const CreateServiceAuth: React.FC<WizardStepProps> = ({ formik }) => {
   const AuthCoreSvg = ImgSvg({ image: authModuleImage });
 
-  const handleDatabaseSelect = useCallback(
-    (database: string) => {
+  const handleAuthSelect = useCallback(
+    (authType: string) => {
       formik.setValues(
         {
           ...formik.values,
-          authType: database,
+          authType,
         },
         true
       );
@@ -37,7 +37,7 @@ const CreateServiceAuth: React.FC<WizardStepProps> = ({ formik }) => {
             image={AuthCoreSvg}
             label="Include Auth Module"
             description="Generate the code needed for authentication and authorization"
-            onClick={handleDatabaseSelect}
+            onClick={handleAuthSelect}
             currentValue={formik.values.authType}
           />
           <LabelDescriptionSelector
@@ -45,7 +45,7 @@ const CreateServiceAuth: React.FC<WizardStepProps> = ({ formik }) => {
             icon="unlock"
             label="Skip Authentication"
             description="Do not include code for authentication"
-            onClick={handleDatabaseSelect}
+            onClick={handleAuthSelect}
             currentValue={formik.values.authType}
           />
         </Layout.SelectorWrapper>

--- a/packages/amplication-client/src/Resource/create-resource/wizard-pages/interfaces.ts
+++ b/packages/amplication-client/src/Resource/create-resource/wizard-pages/interfaces.ts
@@ -14,7 +14,7 @@ export interface ResourceSettings {
   generateRestApi: boolean;
   baseDir: string;
   structureType: "Mono" | " Poly";
-  databaseType: "postgres" | "mysql" | "mongo";
+  databaseType: "postgres" | "mysql" | "mongo" | "sqlserver";
   templateType: "empty" | "orderManagement";
   authType: string;
   isGenerateCompleted: string;

--- a/packages/amplication-client/src/Resource/create-resource/wizard-pages/interfaces.ts
+++ b/packages/amplication-client/src/Resource/create-resource/wizard-pages/interfaces.ts
@@ -16,7 +16,7 @@ export interface ResourceSettings {
   structureType: "Mono" | " Poly";
   databaseType: "postgres" | "mysql" | "mongo" | "sqlserver";
   templateType: "empty" | "orderManagement";
-  authType: string;
+  authType: "no" | "core";
   isGenerateCompleted: string;
   connectToDemoRepo: boolean;
 }

--- a/packages/amplication-server/src/core/entity/constants.ts
+++ b/packages/amplication-server/src/core/entity/constants.ts
@@ -142,7 +142,7 @@ export const DEFAULT_ENTITIES: EntityData[] = [
         displayName: "Username",
         description:
           "An automatically created field of the username of the user",
-        unique: false,
+        unique: true,
         required: true,
         searchable: true,
         properties: {

--- a/packages/data-service-generator/src/tests/entities.ts
+++ b/packages/data-service-generator/src/tests/entities.ts
@@ -57,7 +57,7 @@ const USER: Entity = {
       displayName: "Username",
       dataType: EnumDataType.Username,
       required: true,
-      unique: false,
+      unique: true,
       searchable: true,
     },
     {


### PR DESCRIPTION

Close: #7492

## PR Details

Restrict users options on authentication entities specific field types like `Username` and `Password`.

In the specific, users won't be able to modify the unique flag as it will default to:
- Username: `unique=true`
- Password: `unique=false`

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
