### PR TITLE
fix(client): issue related to changes to username and password fields in User entity were not persisted

### DIFF
--- a/packages/amplication-code-gen-types/src/schemas/password.json
+++ b/packages/amplication-code-gen-types/src/schemas/password.json
@@ -4,5 +4,12 @@
   "title": "password",
   "type": "object",
   "additionalProperties": false,
-  "properties": {}
+  "properties": {
+    "maxLength": {
+      "type": "integer",
+      "description": "The maximum length of the field",
+      "minimum": 1,
+      "default": 256
+    }
+  }
 }

--- a/packages/amplication-code-gen-types/src/schemas/username.json
+++ b/packages/amplication-code-gen-types/src/schemas/username.json
@@ -4,5 +4,12 @@
   "title": "username",
   "type": "object",
   "additionalProperties": false,
-  "properties": {}
+  "properties": {
+    "maxLength": {
+      "type": "integer",
+      "description": "The maximum length of the field",
+      "minimum": 1,
+      "default": 256
+    }
+  }
 }


### PR DESCRIPTION
Close: #7911

## PR Details

Update dataType username and password schemas to reflect the actual usage.
The default User entity is configured with a char length limitation on both of them:
 https://github.com/amplication/amplication/blob/master/packages/amplication-server/src/core/entity/constants.ts#L149

## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
