### PR TITLE
refactor(server): business email signup flow to allow tracking at the end of the process

### DIFF
--- a/ee/packages/git-sync-manager/src/models.ts
+++ b/ee/packages/git-sync-manager/src/models.ts
@@ -824,7 +824,6 @@ export enum EnumPendingChangeOriginType {
 }
 
 export enum EnumPreviewAccountType {
-  Auth0Signup = 'Auth0Signup',
   BreakingTheMonolith = 'BreakingTheMonolith',
   None = 'None'
 }

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -824,7 +824,6 @@ export enum EnumPendingChangeOriginType {
 }
 
 export enum EnumPreviewAccountType {
-  Auth0Signup = 'Auth0Signup',
   BreakingTheMonolith = 'BreakingTheMonolith',
   None = 'None'
 }

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -827,7 +827,6 @@ export enum EnumPendingChangeOriginType {
 }
 
 export enum EnumPreviewAccountType {
-  Auth0Signup = 'Auth0Signup',
   BreakingTheMonolith = 'BreakingTheMonolith',
   None = 'None'
 }

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -824,7 +824,6 @@ export enum EnumPendingChangeOriginType {
 }
 
 export enum EnumPreviewAccountType {
-  Auth0Signup = 'Auth0Signup',
   BreakingTheMonolith = 'BreakingTheMonolith',
   None = 'None'
 }

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -824,7 +824,6 @@ export enum EnumPendingChangeOriginType {
 }
 
 export enum EnumPreviewAccountType {
-  Auth0Signup = 'Auth0Signup',
   BreakingTheMonolith = 'BreakingTheMonolith',
   None = 'None'
 }

--- a/packages/amplication-prisma-db/prisma/manual-data-migrations/20240202_remove_authosignup_option.sql
+++ b/packages/amplication-prisma-db/prisma/manual-data-migrations/20240202_remove_authosignup_option.sql
@@ -1,3 +1,0 @@
-UPDATE "Account"
-SET "previewAccountType" = 'None'
-WHERE "previewAccountType" = 'Auth0Signup'

--- a/packages/amplication-prisma-db/prisma/manual-data-migrations/20240202_remove_authosignup_option.sql
+++ b/packages/amplication-prisma-db/prisma/manual-data-migrations/20240202_remove_authosignup_option.sql
@@ -1,0 +1,3 @@
+UPDATE "Account"
+SET "previewAccountType" = 'None'
+WHERE "previewAccountType" = 'Auth0Signup'

--- a/packages/amplication-prisma-db/prisma/migrations/20240202103529_remove_auth0_preview_account_type_from_enum/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20240202103529_remove_auth0_preview_account_type_from_enum/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - The values [Auth0Signup] on the enum `PreviewAccountType` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "PreviewAccountType_new" AS ENUM ('None', 'BreakingTheMonolith');
+ALTER TABLE "Account" ALTER COLUMN "previewAccountType" DROP DEFAULT;
+ALTER TABLE "Account" ALTER COLUMN "previewAccountType" TYPE "PreviewAccountType_new" USING ("previewAccountType"::text::"PreviewAccountType_new");
+ALTER TYPE "PreviewAccountType" RENAME TO "PreviewAccountType_old";
+ALTER TYPE "PreviewAccountType_new" RENAME TO "PreviewAccountType";
+DROP TYPE "PreviewAccountType_old";
+ALTER TABLE "Account" ALTER COLUMN "previewAccountType" SET DEFAULT 'None';
+COMMIT;

--- a/packages/amplication-prisma-db/prisma/migrations/20240202103529_remove_auth0_preview_account_type_from_enum/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20240202103529_remove_auth0_preview_account_type_from_enum/migration.sql
@@ -6,6 +6,9 @@
 */
 -- AlterEnum
 BEGIN;
+UPDATE "Account"
+SET "previewAccountType" = 'None'
+WHERE "previewAccountType" = 'Auth0Signup';
 CREATE TYPE "PreviewAccountType_new" AS ENUM ('None', 'BreakingTheMonolith');
 ALTER TABLE "Account" ALTER COLUMN "previewAccountType" DROP DEFAULT;
 ALTER TABLE "Account" ALTER COLUMN "previewAccountType" TYPE "PreviewAccountType_new" USING ("previewAccountType"::text::"PreviewAccountType_new");

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -616,5 +616,4 @@ enum CodeGeneratorVersionStrategy {
 enum PreviewAccountType {
   None
   BreakingTheMonolith
-  Auth0Signup
 }

--- a/packages/amplication-server/src/core/account/account.service.spec.ts
+++ b/packages/amplication-server/src/core/account/account.service.spec.ts
@@ -2,8 +2,8 @@ import { PrismaService, Account } from "../../prisma";
 import { Test, TestingModule } from "@nestjs/testing";
 import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { AccountService } from "./account.service";
-import { IDENTITY_PROVIDER_MANUAL } from "../auth/auth.service";
 import { EnumPreviewAccountType } from "../auth/dto/EnumPreviewAccountType";
+import { IdentityProvider } from "../auth/auth.types";
 
 const EXAMPLE_ACCOUNT_ID = "ExampleAccountId",
   EXAMPLE_EMAIL = "example@email.com",
@@ -89,7 +89,7 @@ describe("AccountService", () => {
         password: EXAMPLE_PASSWORD,
       },
     };
-    expect(await service.createAccount(args, IDENTITY_PROVIDER_MANUAL)).toEqual(
+    expect(await service.createAccount(args, IdentityProvider.Local)).toEqual(
       EXAMPLE_ACCOUNT
     );
     expect(prismaAccountCreateMock).toBeCalledTimes(1);

--- a/packages/amplication-server/src/core/account/account.service.ts
+++ b/packages/amplication-server/src/core/account/account.service.ts
@@ -5,6 +5,7 @@ import { Workspace } from "../../models";
 import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
 import { IdentifyData } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { IdentityProvider, IdentityProviderPreview } from "../auth/auth.types";
 
 @Injectable()
 export class AccountService {
@@ -15,7 +16,7 @@ export class AccountService {
 
   async createAccount(
     args: Prisma.AccountCreateArgs,
-    identityProvider: string
+    identityProvider: IdentityProvider | IdentityProviderPreview
   ): Promise<Account> {
     const account = await this.prisma.account.create(args);
 
@@ -33,7 +34,7 @@ export class AccountService {
       userId: account.id,
       event: EnumEventType.Signup,
       properties: {
-        identityProvider,
+        identityProvider: identityProvider,
       },
       context: {
         traits: userData,

--- a/packages/amplication-server/src/core/account/account.service.ts
+++ b/packages/amplication-server/src/core/account/account.service.ts
@@ -2,11 +2,9 @@ import { Injectable } from "@nestjs/common";
 import { Account, Prisma } from "../../prisma";
 import { PrismaService } from "../../prisma/prisma.service";
 import { Workspace } from "../../models";
-import {
-  SegmentAnalyticsService,
-  EnumEventType,
-  IdentifyData,
-} from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { IdentifyData } from "../../services/segmentAnalytics/segmentAnalytics.types";
 
 @Injectable()
 export class AccountService {

--- a/packages/amplication-server/src/core/auth/auth.controller.ts
+++ b/packages/amplication-server/src/core/auth/auth.controller.ts
@@ -183,15 +183,6 @@ export class AuthController {
       isNew = false;
     }
 
-    if (
-      user.account.previewAccountType === EnumPreviewAccountType.Auth0Signup
-    ) {
-      user = await this.authService.updateUser(user, {
-        previewAccountType: EnumPreviewAccountType.None,
-      });
-      isNew = true;
-    }
-
     // @todo update the token to include the auth0 expiry / issued at / etc
     const token = await this.authService.prepareToken(user);
     const url = stringifyUrl({

--- a/packages/amplication-server/src/core/auth/auth.controller.ts
+++ b/packages/amplication-server/src/core/auth/auth.controller.ts
@@ -22,7 +22,6 @@ import { Env } from "../../env";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
 import { AuthExceptionFilter } from "../../filters/auth-exception.filter";
 import { requiresAuth } from "express-openid-connect";
-import { EnumPreviewAccountType } from "./dto/EnumPreviewAccountType";
 export const AUTH_LOGIN_PATH = "/auth/login";
 export const AUTH_LOGOUT_PATH = "/auth/logout";
 export const AUTH_CALLBACK_PATH = "/auth/callback";

--- a/packages/amplication-server/src/core/auth/auth.service.spec.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.spec.ts
@@ -6,7 +6,7 @@ import { AccountService } from "../account/account.service";
 import { PasswordService } from "../account/password.service";
 import { UserService } from "../user/user.service";
 import { MockedAmplicationLoggerProvider } from "@amplication/util/nestjs/logging/test-utils";
-import { AuthService, IDENTITY_PROVIDER_MANUAL } from "./auth.service";
+import { AuthService } from "./auth.service";
 import { WorkspaceService } from "../workspace/workspace.service";
 import { EnumTokenType } from "./dto";
 import { KafkaProducerService } from "@amplication/util/nestjs/kafka";
@@ -18,6 +18,7 @@ import { Workspace, Project, Resource, Account, User } from "../../models";
 import { JSONApiResponse, SignUpResponse, TextApiResponse } from "auth0";
 import { anyString } from "jest-mock-extended";
 import { AuthUser } from "./types";
+import { IdentityProvider } from "./auth.types";
 const EXAMPLE_TOKEN = "EXAMPLE TOKEN";
 const WORK_EMAIL_INVALID = `Email must be a work email address`;
 
@@ -331,7 +332,7 @@ describe("AuthService", () => {
           lastName: EXAMPLE_ACCOUNT.lastName,
         },
       },
-      IDENTITY_PROVIDER_MANUAL
+      IdentityProvider.Local
     );
     expect(setCurrentUserMock).toHaveBeenCalledTimes(1);
     expect(setCurrentUserMock).toHaveBeenCalledWith(

--- a/packages/amplication-server/src/core/auth/auth.service.spec.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.spec.ts
@@ -672,44 +672,8 @@ describe("AuthService", () => {
       ).rejects.toThrow(WORK_EMAIL_INVALID);
     });
 
-    it("should signs up for correct data with preview account", async () => {
+    it("should create only an Auth0 user (not an amplication user) and reset password if the user does not exist on Auth0", async () => {
       const email = "invalid@invalid.com";
-      findAccountMock.mockResolvedValueOnce(EXAMPLE_ACCOUNT);
-
-      mockManagementClientGetByEmail.mockResolvedValueOnce({
-        data: [
-          {
-            email,
-          },
-        ],
-      });
-
-      mockAuthenticationClientDatabaseChangePassword.mockResolvedValueOnce({
-        data: "ok",
-      });
-
-      const result = await service.signupWithBusinessEmail({
-        data: {
-          email,
-        },
-      });
-
-      expect(result).toBeTruthy();
-      expect(findAccountMock).toHaveBeenCalledTimes(1);
-      expect(
-        mockAuthenticationClientDatabaseChangePassword
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        mockAuthenticationClientDatabaseChangePassword
-      ).toHaveBeenCalledWith({
-        email,
-        connection: expect.any(String),
-      });
-    });
-
-    it("should create an Auth0 user and reset password if the user does not exist on Auth0", async () => {
-      const email = "invalid@invalid.com";
-      findAccountMock.mockResolvedValueOnce(EXAMPLE_ACCOUNT);
 
       mockManagementClientGetByEmail.mockResolvedValueOnce({
         data: [],
@@ -732,13 +696,10 @@ describe("AuthService", () => {
       });
 
       expect(result).toBeTruthy();
-      expect(findAccountMock).toHaveBeenCalledTimes(1);
 
       expect(mockAuthenticationClientDatabaseSignUp).toHaveBeenCalledTimes(1);
       expect(mockAuthenticationClientDatabaseSignUp).toHaveBeenCalledWith({
         email,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        email_verified: true,
         password: expect.any(String),
         connection: expect.any(String),
       });
@@ -749,7 +710,6 @@ describe("AuthService", () => {
 
     it("should not create an Auth0 user, but only reset password if the user already exists on Auth0", async () => {
       const email = "invalid@invalid.com";
-      findAccountMock.mockResolvedValueOnce(EXAMPLE_ACCOUNT);
 
       mockManagementClientGetByEmail.mockResolvedValueOnce({
         data: [{ email }],
@@ -772,7 +732,6 @@ describe("AuthService", () => {
       });
 
       expect(result).toBeTruthy();
-      expect(findAccountMock).toHaveBeenCalledTimes(1);
 
       expect(mockAuthenticationClientDatabaseSignUp).toHaveBeenCalledTimes(0);
       expect(

--- a/packages/amplication-server/src/core/auth/auth.service.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.ts
@@ -42,14 +42,10 @@ import {
   generateRandomEmail,
   generateRandomString,
 } from "./auth-utils";
+import { IdentityProvider, IdentityProviderPreview } from "./auth.types";
 
 const TOKEN_PREVIEW_LENGTH = 8;
 const TOKEN_EXPIRY_DAYS = 30;
-export const IDENTITY_PROVIDER_GITHUB = "GitHub";
-export const IDENTITY_PROVIDER_SSO = "SSO";
-export const IDENTITY_PROVIDER_MANUAL = "Manual";
-export const IDENTITY_PROVIDER_PREVIEW_ACCOUNT = "PreviewAccount";
-export const IDENTITY_PROVIDER_AUTH0 = "Auth0";
 const WORK_EMAIL_INVALID = `Email must be a work email address`;
 
 const AUTH_USER_INCLUDE = {
@@ -185,7 +181,7 @@ export class AuthService {
           githubId: payload.id,
         },
       },
-      IDENTITY_PROVIDER_GITHUB
+      IdentityProvider.GitHub
     );
 
     const user = await this.bootstrapUser(account, payload.id);
@@ -218,12 +214,13 @@ export class AuthService {
           lastName: profile.family_name || "",
           password: "",
           githubId: profile.sub,
+          previewAccountType: EnumPreviewAccountType.None,
         },
       },
-      IDENTITY_PROVIDER_SSO
+      IdentityProvider.IdentityPlatform
     );
 
-    const user = await this.bootstrapUser(account, profile.sub);
+    const user = await this.bootstrapUser(account, profile.email);
 
     return user;
   }
@@ -256,7 +253,7 @@ export class AuthService {
           password: hashedPassword,
         },
       },
-      IDENTITY_PROVIDER_MANUAL
+      IdentityProvider.Local
     );
 
     const user = await this.bootstrapUser(account, payload.workspaceName);
@@ -356,6 +353,7 @@ export class AuthService {
     previewAccountEmail: string,
     previewAccountType: EnumPreviewAccountType
   ) {
+    const identityProvider: IdentityProviderPreview = `${IdentityProvider.PreviewAccount}_${previewAccountType}`;
     return {
       signupData: {
         email: generateRandomEmail(),
@@ -365,7 +363,7 @@ export class AuthService {
         previewAccountType,
         previewAccountEmail,
       },
-      identityProvider: `${IDENTITY_PROVIDER_PREVIEW_ACCOUNT}_${previewAccountType}`,
+      identityProvider,
     };
   }
 

--- a/packages/amplication-server/src/core/auth/auth.service.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.ts
@@ -28,6 +28,7 @@ import {
   ChangePasswordRequest,
   JSONApiResponse,
   ManagementClient,
+  SignUpRequest,
   SignUpResponse,
   TextApiResponse,
 } from "auth0";
@@ -156,11 +157,9 @@ export class AuthService {
   async createAuth0User(
     email: string
   ): Promise<JSONApiResponse<SignUpResponse>> {
-    const data = {
+    const data: SignUpRequest = {
       email,
       password: generatePassword(),
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      email_verified: true,
       connection: this.configService.get<string>(
         Env.AUTH_ISSUER_CLIENT_DB_CONNECTION
       ),

--- a/packages/amplication-server/src/core/auth/auth.service.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.ts
@@ -25,6 +25,7 @@ import { AuthProfile, AuthUser, BootstrapPreviewUser } from "./types";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
 import {
   AuthenticationClient,
+  ChangePasswordRequest,
   JSONApiResponse,
   ManagementClient,
   SignUpResponse,
@@ -171,8 +172,10 @@ export class AuthService {
   }
 
   async resetAuth0UserPassword(email: string): Promise<TextApiResponse> {
-    const data = {
+    const data: ChangePasswordRequest = {
       email,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      client_id: this.clientId,
       connection: this.configService.get<string>(
         Env.AUTH_ISSUER_CLIENT_DB_CONNECTION
       ),

--- a/packages/amplication-server/src/core/auth/auth.service.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.ts
@@ -112,11 +112,6 @@ export class AuthService {
 
     try {
       let auth0User: JSONApiResponse<SignUpResponse>;
-      const existedAccount = await this.accountService.findAccount({
-        where: {
-          email: emailAddress,
-        },
-      });
 
       const existedAuth0User = await this.getAuth0UserByEmail(emailAddress);
 
@@ -132,23 +127,6 @@ export class AuthService {
       );
       if (!resetPassword.data)
         throw Error("Failed to send reset message to new Auth0 user");
-
-      if (!existedAccount) {
-        const account = await this.accountService.createAccount(
-          {
-            data: {
-              email: emailAddress,
-              firstName: emailAddress,
-              lastName: "",
-              password: "",
-              previewAccountType: EnumPreviewAccountType.Auth0Signup,
-            },
-          },
-          IDENTITY_PROVIDER_AUTH0
-        );
-        const workspaceName = generateRandomString();
-        await this.bootstrapUser(account, workspaceName);
-      }
 
       return true;
     } catch (error) {

--- a/packages/amplication-server/src/core/auth/auth.types.ts
+++ b/packages/amplication-server/src/core/auth/auth.types.ts
@@ -1,0 +1,11 @@
+import { EnumPreviewAccountType } from "./dto/EnumPreviewAccountType";
+
+export enum IdentityProvider {
+  GitHub = "GitHub",
+  IdentityPlatform = "Auth0",
+  Local = "Local",
+  PreviewAccount = "PreviewAccount",
+}
+
+export type IdentityProviderPreview =
+  `${IdentityProvider.PreviewAccount}_${EnumPreviewAccountType}`;

--- a/packages/amplication-server/src/core/auth/dto/EnumPreviewAccountType.ts
+++ b/packages/amplication-server/src/core/auth/dto/EnumPreviewAccountType.ts
@@ -3,7 +3,6 @@ import { registerEnumType } from "@nestjs/graphql";
 export enum EnumPreviewAccountType {
   None = "None",
   BreakingTheMonolith = "BreakingTheMonolith",
-  Auth0Signup = "Auth0Signup",
 }
 
 registerEnumType(EnumPreviewAccountType, {

--- a/packages/amplication-server/src/core/billing/billing.service.ts
+++ b/packages/amplication-server/src/core/billing/billing.service.ts
@@ -13,10 +13,8 @@ import { Env } from "../../env";
 import { EnumSubscriptionPlan } from "../subscription/dto";
 import { EnumSubscriptionStatus } from "../subscription/dto/EnumSubscriptionStatus";
 import { Subscription } from "../subscription/dto/Subscription";
-import {
-  EnumEventType,
-  SegmentAnalyticsService,
-} from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { ProvisionSubscriptionResult } from "../workspace/dto/ProvisionSubscriptionResult";
 import { BillingLimitationError } from "../../errors/BillingLimitationError";
 import { FeatureUsageReport } from "../project/FeatureUsageReport";

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -51,10 +51,8 @@ import {
 } from "@amplication/schema-registry";
 import { KafkaProducerService } from "@amplication/util/nestjs/kafka";
 import { GitProviderService } from "../git/git.provider.service";
-import {
-  EnumEventType,
-  SegmentAnalyticsService,
-} from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { kebabCase } from "lodash";
 import { CodeGeneratorVersionStrategy } from "../resource/dto";
 

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -80,10 +80,8 @@ import {
 } from "./dto";
 import { ReservedNameError } from "../resource/ReservedNameError";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
-import {
-  EnumEventType,
-  SegmentAnalyticsService,
-} from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { PrismaSchemaParserService } from "../prismaSchemaParser/prismaSchemaParser.service";
 import { EnumActionLogLevel, EnumActionStepStatus } from "../action/dto";
 import { BillingService } from "../billing/billing.service";

--- a/packages/amplication-server/src/core/git/git.provider.service.ts
+++ b/packages/amplication-server/src/core/git/git.provider.service.ts
@@ -44,10 +44,8 @@ import { ValidationError } from "../../errors/ValidationError";
 const GIT_REPOSITORY_EXIST =
   "Git Repository already connected to an other Resource";
 const INVALID_GIT_REPOSITORY_ID = "Git Repository does not exist";
-import {
-  EnumEventType,
-  SegmentAnalyticsService,
-} from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { GitRepository, User } from "../../models";
 import { BillingService } from "../billing/billing.service";
 import { BillingFeature } from "@amplication/util-billing-types";

--- a/packages/amplication-server/src/core/pluginInstallation/pluginInstallation.service.ts
+++ b/packages/amplication-server/src/core/pluginInstallation/pluginInstallation.service.ts
@@ -12,10 +12,8 @@ import { PluginOrder } from "./dto/PluginOrder";
 import { SetPluginOrderArgs } from "./dto/SetPluginOrderArgs";
 import { PluginOrderItem } from "./dto/PluginOrderItem";
 import { DeletePluginOrderArgs } from "./dto/DeletePluginOrderArgs";
-import {
-  EnumEventType,
-  SegmentAnalyticsService,
-} from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { ResourceService } from "../resource/resource.service";
 
 const reOrderPlugins = (

--- a/packages/amplication-server/src/core/project/project.service.ts
+++ b/packages/amplication-server/src/core/project/project.service.ts
@@ -23,10 +23,8 @@ import { BillingFeature } from "@amplication/util-billing-types";
 import { GitProviderService } from "../git/git.provider.service";
 
 export const INVALID_PROJECT_ID = "Invalid projectId";
-import {
-  EnumEventType,
-  SegmentAnalyticsService,
-} from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import dockerNames from "docker-names";
 import { EntityPendingChange } from "../entity/entity.service";
 import { BillingLimitationError } from "../../errors/BillingLimitationError";

--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -23,10 +23,8 @@ import {
   Prisma,
   PrismaService,
 } from "../../prisma";
-import {
-  EnumEventType,
-  SegmentAnalyticsService,
-} from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { prepareDeletedItemName } from "../../util/softDelete";
 import { BillingService } from "../billing/billing.service";
 import {

--- a/packages/amplication-server/src/core/resource/resourceBtm.service.spec.ts
+++ b/packages/amplication-server/src/core/resource/resourceBtm.service.spec.ts
@@ -12,12 +12,10 @@ import { ConversationTypeKey } from "../gpt/gpt.types";
 import { BreakServiceToMicroservicesData } from "./dto/BreakServiceToMicroservicesResult";
 import { MockedAmplicationLoggerProvider } from "@amplication/util/nestjs/logging/test-utils";
 import { Resource, User } from "../../models";
-import {
-  EnumEventType,
-  SegmentAnalyticsService,
-} from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { BillingService } from "../billing/billing.service";
 import { EnumSubscriptionPlan } from "../subscription/dto";
+import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
 
 const resourceIdMock = "resourceId";
 const userIdMock = "userId";

--- a/packages/amplication-server/src/core/resource/resourceBtm.service.ts
+++ b/packages/amplication-server/src/core/resource/resourceBtm.service.ts
@@ -18,13 +18,11 @@ import {
 } from "./dto/BreakServiceToMicroservicesResult";
 import { UserActionService } from "../userAction/userAction.service";
 import { GptBadFormatResponseError } from "./errors/GptBadFormatResponseError";
-import {
-  EnumEventType,
-  SegmentAnalyticsService,
-} from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { Resource, User } from "../../models";
 import { BillingService } from "../billing/billing.service";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
+import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
 
 @Injectable()
 export class ResourceBtmService {

--- a/packages/amplication-server/src/core/subscription/subscription.service.ts
+++ b/packages/amplication-server/src/core/subscription/subscription.service.ts
@@ -9,10 +9,8 @@ import {
 import { UpsertSubscriptionInput } from "./dto/UpsertSubscriptionInput";
 import { BillingService } from "../billing/billing.service";
 import { UpdateStatusDto } from "./dto/UpdateStatusDto";
-import {
-  EnumEventType,
-  SegmentAnalyticsService,
-} from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
 import { BillingFeature } from "@amplication/util-billing-types";
 import { EnumResourceType } from "../resource/dto/EnumResourceType";

--- a/packages/amplication-server/src/core/workspace/workspace.resolver.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.resolver.ts
@@ -34,10 +34,8 @@ import { ProvisionSubscriptionArgs } from "./dto/ProvisionSubscriptionArgs";
 import { ProvisionSubscriptionResult } from "./dto/ProvisionSubscriptionResult";
 import { SubscriptionService } from "../subscription/subscription.service";
 import { UserService } from "../user/user.service";
-import {
-  EnumEventType,
-  SegmentAnalyticsService,
-} from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { RedeemCouponArgs } from "./dto/RedeemCouponArgs";
 import { Coupon } from "./dto/Coupon";
 import { ConfigService } from "@nestjs/config";

--- a/packages/amplication-server/src/core/workspace/workspace.service.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.service.ts
@@ -27,10 +27,8 @@ import { isEmpty } from "lodash";
 import { FindOneArgs } from "../../dto";
 import { Role } from "../../enums/Role";
 import { GitOrganization } from "../../models/GitOrganization";
-import {
-  EnumEventType,
-  SegmentAnalyticsService,
-} from "../../services/segmentAnalytics/segmentAnalytics.service";
+import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { BillingService } from "../billing/billing.service";
 import { MailService } from "../mail/mail.service";
 import { ProjectService } from "../project/project.service";

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -788,7 +788,6 @@ enum EnumPendingChangeOriginType {
 }
 
 enum EnumPreviewAccountType {
-  Auth0Signup
   BreakingTheMonolith
   None
 }

--- a/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
+++ b/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.service.ts
@@ -2,69 +2,7 @@ import { Injectable, Inject } from "@nestjs/common";
 import Analytics from "analytics-node";
 import { SegmentAnalyticsOptions } from "./segmentAnalytics.interfaces";
 import { RequestContext } from "nestjs-request-context";
-
-export enum EnumEventType {
-  Signup = "Signup",
-  WorkspacePlanUpgradeRequest = "WorkspacePlanUpgradeRequest",
-  WorkspacePlanUpgradeCompleted = "WorkspacePlanUpgradeCompleted",
-  WorkspacePlanDowngradeRequest = "WorkspacePlanDowngradeRequest",
-  CommitCreate = "commit",
-  WorkspaceSelected = "selectWorkspace",
-  GitHubAuthResourceComplete = "completeAuthResourceWithGitHub",
-  ServiceWizardServiceGenerated = "ServiceWizard_ServiceGenerated",
-  SubscriptionLimitPassed = "SubscriptionLimitPassed",
-  EntityCreate = "createEntity",
-  EntityUpdate = "updateEntity",
-  EntityFieldCreate = "createEntityField",
-  EntityFieldUpdate = "updateEntityField",
-  EntityFieldFromImportPrismaSchemaCreate = "EntityFieldFromImportPrismaSchemaCreate",
-  PluginInstall = "installPlugin",
-  PluginUpdate = "updatePlugin",
-  DemoRepoCreate = "CreateDemoRepo",
-  InvitationAcceptance = "invitationAcceptance",
-
-  //Import Prisma Schema
-  ImportPrismaSchemaStart = "importPrismaSchemaStart",
-  ImportPrismaSchemaError = "importPrismaSchemaError",
-  ImportPrismaSchemaCompleted = "importPrismaSchemaCompleted",
-
-  GitSyncError = "gitSyncError",
-  CodeGenerationError = "codeGenerationError",
-
-  CodeGeneratorVersionUpdate = "codeGeneratorVersionUpdate",
-
-  RedeemCoupon = "RedeemCoupon",
-
-  // break the monolith
-  ArchitectureRedesignStartRedesign = " architectureRedesign_StartRedesign",
-  ArchitectureRedesignApply = "architectureRedesign__Apply",
-  ArchitectureRedesignStartBreakTheMonolith = "architectureRedesign__StartBreakTheMonolith",
-}
-
-export type IdentifyData = {
-  userId: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  createdAt: Date;
-};
-
-export type TrackData = {
-  userId: string;
-  event: EnumEventType;
-  properties?:
-    | {
-        [key: string]: unknown;
-      }
-    | undefined;
-  context?: {
-    traits?: IdentifyData;
-    amplication?: {
-      analyticsSessionId?: string;
-    };
-  };
-};
-
+import { IdentifyData, TrackData } from "./segmentAnalytics.types";
 @Injectable()
 export class SegmentAnalyticsService {
   private analytics: Analytics;

--- a/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.types.ts
+++ b/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.types.ts
@@ -1,0 +1,61 @@
+export enum EnumEventType {
+  Signup = "Signup",
+  WorkspacePlanUpgradeRequest = "WorkspacePlanUpgradeRequest",
+  WorkspacePlanUpgradeCompleted = "WorkspacePlanUpgradeCompleted",
+  WorkspacePlanDowngradeRequest = "WorkspacePlanDowngradeRequest",
+  CommitCreate = "commit",
+  WorkspaceSelected = "selectWorkspace",
+  GitHubAuthResourceComplete = "completeAuthResourceWithGitHub",
+  ServiceWizardServiceGenerated = "ServiceWizard_ServiceGenerated",
+  SubscriptionLimitPassed = "SubscriptionLimitPassed",
+  EntityCreate = "createEntity",
+  EntityUpdate = "updateEntity",
+  EntityFieldCreate = "createEntityField",
+  EntityFieldUpdate = "updateEntityField",
+  EntityFieldFromImportPrismaSchemaCreate = "EntityFieldFromImportPrismaSchemaCreate",
+  PluginInstall = "installPlugin",
+  PluginUpdate = "updatePlugin",
+  DemoRepoCreate = "CreateDemoRepo",
+  InvitationAcceptance = "invitationAcceptance",
+
+  //Import Prisma Schema
+  ImportPrismaSchemaStart = "importPrismaSchemaStart",
+  ImportPrismaSchemaError = "importPrismaSchemaError",
+  ImportPrismaSchemaCompleted = "importPrismaSchemaCompleted",
+
+  GitSyncError = "gitSyncError",
+  CodeGenerationError = "codeGenerationError",
+
+  CodeGeneratorVersionUpdate = "codeGeneratorVersionUpdate",
+
+  RedeemCoupon = "RedeemCoupon",
+
+  // break the monolith
+  ArchitectureRedesignStartRedesign = " architectureRedesign_StartRedesign",
+  ArchitectureRedesignApply = "architectureRedesign__Apply",
+  ArchitectureRedesignStartBreakTheMonolith = "architectureRedesign__StartBreakTheMonolith",
+}
+
+export type IdentifyData = {
+  userId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  createdAt: Date;
+};
+
+export type TrackData = {
+  userId: string;
+  event: EnumEventType;
+  properties?:
+    | {
+        [key: string]: unknown;
+      }
+    | undefined;
+  context?: {
+    traits?: IdentifyData;
+    amplication?: {
+      analyticsSessionId?: string;
+    };
+  };
+};

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -824,7 +824,6 @@ export enum EnumPendingChangeOriginType {
 }
 
 export enum EnumPreviewAccountType {
-  Auth0Signup = 'Auth0Signup',
   BreakingTheMonolith = 'BreakingTheMonolith',
   None = 'None'
 }


### PR DESCRIPTION
Fixes: https://github.com/amplication/private-issues/issues/131

## PR Details

This pull request includes changes to the `amplication-server` package. The changes involve business email signup flow, refactoring the identity provider types in the `account.service.ts` file and removing the `Auth0Signup` preview account type in the `auth.controller.ts` and `auth.service.spec.ts` files.

The drive of this refactoring/rework was due to the requirement to track a signup event ONLY at the registration completed, aka password reset and successful login. 

### Changes
- Remove amplication account creation on business email signup request and leverage OIDC login account autocreation functionality (same as any other OIDC authorisation grant flow.  
- Refactored the identity provider types in `account.service.ts`. The `identityProvider` parameter in the `createAccount` method now accepts `IdentityProvider | IdentityProviderPreview` instead of `string`.
- Removed the `Auth0Signup` preview account type as it will to reflect the nature of the preview account. 
  👀 have a look to the [modified migration script](https://github.com/amplication/amplication/pull/7916/files#diff-58915755139c9f202b7831c96d761f154129172ac89866afbe54b74d6b896991R9-R11
) that will allow us to avoid manual migrations 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
