### PR TITLE
chore(server): add start signup email event

### DIFF
--- a/packages/amplication-server/src/core/auth/auth.module.ts
+++ b/packages/amplication-server/src/core/auth/auth.module.ts
@@ -23,6 +23,7 @@ import { GitHubStrategy } from "./github.strategy";
 import { GitHubStrategyConfigService } from "./githubStrategyConfig.service";
 import { GitHubAuthGuard } from "./github.guard";
 import { Auth0Middleware } from "./auth0.middleware";
+import { SegmentAnalyticsModule } from "../../services/segmentAnalytics/segmentAnalytics.module";
 
 @Module({
   imports: [
@@ -68,6 +69,7 @@ import { Auth0Middleware } from "./auth0.middleware";
     AuthResolver,
     GitHubStrategyConfigService,
     Auth0Middleware,
+    SegmentAnalyticsModule,
   ],
   controllers: [AuthController],
   exports: [GqlAuthGuard, AuthService, AuthResolver],

--- a/packages/amplication-server/src/core/auth/auth.module.ts
+++ b/packages/amplication-server/src/core/auth/auth.module.ts
@@ -72,7 +72,6 @@ import { Auth0Middleware } from "./auth0.middleware";
   controllers: [AuthController],
   exports: [GqlAuthGuard, AuthService, AuthResolver],
 })
-// export class AuthModule {}
 export class AuthModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer

--- a/packages/amplication-server/src/core/auth/auth.service.spec.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.spec.ts
@@ -9,7 +9,6 @@ import { MockedAmplicationLoggerProvider } from "@amplication/util/nestjs/loggin
 import { AuthService } from "./auth.service";
 import { WorkspaceService } from "../workspace/workspace.service";
 import { EnumTokenType } from "./dto";
-import { KafkaProducerService } from "@amplication/util/nestjs/kafka";
 import { ConfigService } from "@nestjs/config";
 import { KAFKA_TOPICS } from "@amplication/schema-registry";
 import { EnumPreviewAccountType } from "./dto/EnumPreviewAccountType";
@@ -283,12 +282,6 @@ describe("AuthService", () => {
           provide: JwtService,
           useClass: jest.fn(() => ({
             sign: signMock,
-          })),
-        },
-        {
-          provide: KafkaProducerService,
-          useClass: jest.fn(() => ({
-            emitMessage: jest.fn(() => Promise.resolve("error")),
           })),
         },
         {

--- a/packages/amplication-server/src/core/auth/auth.service.spec.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.spec.ts
@@ -19,6 +19,7 @@ import { JSONApiResponse, SignUpResponse, TextApiResponse } from "auth0";
 import { anyString } from "jest-mock-extended";
 import { AuthUser } from "./types";
 import { IdentityProvider } from "./auth.types";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 const EXAMPLE_TOKEN = "EXAMPLE TOKEN";
 const WORK_EMAIL_INVALID = `Email must be a work email address`;
 
@@ -220,6 +221,8 @@ const createPreviewEnvironmentMock = jest.fn(() => ({
 }));
 
 const prismaCreateProjectMock = jest.fn(() => EXAMPLE_PROJECT);
+const segmentAnalyticsIdentifyMock = jest.fn();
+const segmentAnalyticsTrackMock = jest.fn();
 
 describe("AuthService", () => {
   let service: AuthService;
@@ -297,6 +300,13 @@ describe("AuthService", () => {
             project: {
               create: prismaCreateProjectMock,
             },
+          })),
+        },
+        {
+          provide: SegmentAnalyticsService,
+          useClass: jest.fn(() => ({
+            identify: segmentAnalyticsIdentifyMock,
+            track: segmentAnalyticsTrackMock,
           })),
         },
         AuthService,

--- a/packages/amplication-server/src/core/auth/auth.service.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.ts
@@ -44,6 +44,10 @@ import {
 } from "./auth-utils";
 import { IdentityProvider, IdentityProviderPreview } from "./auth.types";
 import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
+import {
+  IdentifyData,
+  EnumEventType,
+} from "../../services/segmentAnalytics/segmentAnalytics.types";
 
 const TOKEN_PREVIEW_LENGTH = 8;
 const TOKEN_EXPIRY_DAYS = 30;
@@ -99,6 +103,32 @@ export class AuthService {
     });
   }
 
+  private async trackStartBusinessEmailSignup(
+    emailAddress: string,
+    existingUser: IdentityProvider | "No" = "No"
+  ) {
+    const userData: IdentifyData = {
+      userId: null,
+      createdAt: null,
+      email: emailAddress,
+      firstName: null,
+      lastName: null,
+    };
+
+    await this.analytics.identify(userData);
+    //we send the userData again to prevent race condition
+    await this.analytics.track({
+      userId: userData.userId,
+      event: EnumEventType.StartEmailSignup,
+      properties: {
+        identityProvider: IdentityProvider.IdentityPlatform,
+        existingUser: existingUser,
+      },
+      context: {
+        traits: userData,
+      },
+    });
+  }
   async signupWithBusinessEmail(
     args: SignupWithBusinessEmailArgs
   ): Promise<boolean> {
@@ -109,6 +139,11 @@ export class AuthService {
     }
 
     try {
+      const existedAccount = await this.accountService.findAccount({
+        where: {
+          email: emailAddress,
+        },
+      });
       let auth0User: JSONApiResponse<SignUpResponse>;
 
       const existedAuth0User = await this.getAuth0UserByEmail(emailAddress);
@@ -125,6 +160,15 @@ export class AuthService {
       );
       if (!resetPassword.data)
         throw Error("Failed to send reset message to new Auth0 user");
+
+      await this.trackStartBusinessEmailSignup(
+        emailAddress,
+        existedAccount
+          ? IdentityProvider.GitHub
+          : existedAuth0User
+          ? IdentityProvider.IdentityPlatform
+          : undefined
+      );
 
       return true;
     } catch (error) {

--- a/packages/amplication-server/src/core/auth/auth.service.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.ts
@@ -43,6 +43,7 @@ import {
   generateRandomString,
 } from "./auth-utils";
 import { IdentityProvider, IdentityProviderPreview } from "./auth.types";
+import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 
 const TOKEN_PREVIEW_LENGTH = 8;
 const TOKEN_EXPIRY_DAYS = 30;
@@ -76,7 +77,8 @@ export class AuthService {
     private readonly logger: AmplicationLogger,
     private readonly userService: UserService,
     @Inject(forwardRef(() => WorkspaceService))
-    private readonly workspaceService: WorkspaceService
+    private readonly workspaceService: WorkspaceService,
+    private readonly analytics: SegmentAnalyticsService
   ) {
     this.clientId = configService.get<string>(Env.AUTH_ISSUER_CLIENT_ID);
     const clientSecret = configService.get<string>(

--- a/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.types.ts
+++ b/packages/amplication-server/src/services/segmentAnalytics/segmentAnalytics.types.ts
@@ -1,5 +1,6 @@
 export enum EnumEventType {
   Signup = "Signup",
+  StartEmailSignup = "StartEmailSignup",
   WorkspacePlanUpgradeRequest = "WorkspacePlanUpgradeRequest",
   WorkspacePlanUpgradeCompleted = "WorkspacePlanUpgradeCompleted",
   WorkspacePlanDowngradeRequest = "WorkspacePlanDowngradeRequest",


### PR DESCRIPTION
Fixes: https://github.com/amplication/private-issues/issues/131

## PR Details

Added new tracking event for StartEmailSignup. (step 2 of https://github.com/amplication/private-issues/issues/131)

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
