### PR TITLE
feat(server+client): Update RedesignProject flow 

### DIFF
--- a/ee/packages/git-sync-manager/src/models.ts
+++ b/ee/packages/git-sync-manager/src/models.ts
@@ -1194,7 +1194,7 @@ export type Mutation = {
   login: Auth;
   provisionSubscription?: Maybe<ProvisionSubscriptionResult>;
   redeemCoupon: Coupon;
-  redesignProject: Array<Resource>;
+  redesignProject: UserAction;
   resendInvitation?: Maybe<Invitation>;
   revokeInvitation?: Maybe<Invitation>;
   setCurrentWorkspace: Auth;
@@ -2231,7 +2231,6 @@ export type Resource = {
   project?: Maybe<Project>;
   projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
-  tempId?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
 };
 
@@ -2258,7 +2257,6 @@ export type ResourceCreateInput = {
   project: WhereParentIdInput;
   resourceType: EnumResourceType;
   serviceSettings?: InputMaybe<ServiceSettingsUpdateInput>;
-  tempId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceCreateWithEntitiesEntityInput = {

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -1194,7 +1194,7 @@ export type Mutation = {
   login: Auth;
   provisionSubscription?: Maybe<ProvisionSubscriptionResult>;
   redeemCoupon: Coupon;
-  redesignProject: Array<Resource>;
+  redesignProject: UserAction;
   resendInvitation?: Maybe<Invitation>;
   revokeInvitation?: Maybe<Invitation>;
   setCurrentWorkspace: Auth;
@@ -2231,7 +2231,6 @@ export type Resource = {
   project?: Maybe<Project>;
   projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
-  tempId?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
 };
 
@@ -2258,7 +2257,6 @@ export type ResourceCreateInput = {
   project: WhereParentIdInput;
   resourceType: EnumResourceType;
   serviceSettings?: InputMaybe<ServiceSettingsUpdateInput>;
-  tempId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceCreateWithEntitiesEntityInput = {

--- a/packages/amplication-client/src/Entity/ImportPrismaSchema/EntitiesImport.tsx
+++ b/packages/amplication-client/src/Entity/ImportPrismaSchema/EntitiesImport.tsx
@@ -14,7 +14,7 @@ import { AnalyticsEventNames } from "../../util/analytics-events.types";
 import { formatError } from "../../util/error";
 import "./EntitiesImport.scss";
 import { CREATE_ENTITIES_FROM_SCHEMA } from "./queries";
-import useUserActionWatchStatus from "./useUserActionWatchStatus";
+import useUserActionWatchStatus from "../../UserAction/useUserActionWatchStatus";
 import { BillingFeature } from "@amplication/util-billing-types";
 import { useStiggContext } from "@stigg/react-sdk";
 import { Button } from "../../Components/Button";

--- a/packages/amplication-client/src/Entity/ImportPrismaSchema/queries.ts
+++ b/packages/amplication-client/src/Entity/ImportPrismaSchema/queries.ts
@@ -64,33 +64,3 @@ export const CREATE_ENTITIES_FROM_PREDEFINED_SCHEMA = gql`
     }
   }
 `;
-
-export const GET_USER_ACTION = gql`
-  query userAction($userActionId: String!) {
-    userAction(where: { id: $userActionId }) {
-      id
-      createdAt
-      actionId
-      status
-      action {
-        id
-        createdAt
-        steps {
-          id
-          name
-          createdAt
-          message
-          status
-          completedAt
-          logs {
-            id
-            createdAt
-            message
-            meta
-            level
-          }
-        }
-      }
-    }
-  }
-`;

--- a/packages/amplication-client/src/Project/ArchitectureConsole/CreateResource.tsx
+++ b/packages/amplication-client/src/Project/ArchitectureConsole/CreateResource.tsx
@@ -40,7 +40,6 @@ const CreateResource = ({ onSuccess, title, actionDescription }: Props) => {
     (data) => {
       const tempId = generatedKey();
       onSuccess({
-        tempId: tempId,
         builds: [],
         createdAt: new Date(),
         description: `create service: ${data.name} from architecture model`,

--- a/packages/amplication-client/src/Project/ArchitectureConsole/ModelOrganizer.tsx
+++ b/packages/amplication-client/src/Project/ArchitectureConsole/ModelOrganizer.tsx
@@ -78,6 +78,7 @@ export default function ModelOrganizer() {
     applyChanges,
     applyChangesLoading,
     applyChangesError,
+    applyChangesData,
     moveNodeToParent,
     createNewTempService,
     modelGroupFilterChanged,
@@ -273,6 +274,7 @@ export default function ModelOrganizer() {
               onCancelChanges={onCancelChangesClick}
               mergeNewResourcesChanges={mergeNewResourcesChanges}
               applyChangesError={applyChangesError}
+              applyChangesData={applyChangesData}
             />
             <Dialog
               isOpen={!isValidResourceName}

--- a/packages/amplication-client/src/Project/ArchitectureConsole/ModelOrganizerConfirmation.tsx
+++ b/packages/amplication-client/src/Project/ArchitectureConsole/ModelOrganizerConfirmation.tsx
@@ -78,18 +78,32 @@ export default function ModelOrganizerConfirmation({
     setApplyChangesSteps(true);
   }, [setKeepLoadingChanges, setApplyChangesSteps]);
 
+  const ActionStep = applyChangesData?.action?.steps?.length
+    ? applyChangesData?.action?.steps[0]
+    : null;
+
   return (
     <div className={CLASS_NAME}>
-      {applyChangesData ? (
+      {ActionStep?.status === models.EnumActionStepStatus.Failed ? (
         <>
+          <Panel
+            panelStyle={EnumPanelStyle.Bordered}
+            className={`${CLASS_NAME}__error`}
+          >
+            <Text textStyle={EnumTextStyle.Tag} textColor={EnumTextColor.White}>
+              Something went wrong. See the log below for more details.
+            </Text>
+          </Panel>
           <ActionLog
-            height={"150px"}
+            height={"250px"}
             action={applyChangesData?.action}
             title={"Apply Changes to Architecture"}
             versionNumber={""}
           />
         </>
-      ) : keepLoadingChanges || applyChangesLoading ? (
+      ) : keepLoadingChanges ||
+        applyChangesLoading ||
+        ActionStep?.status === models.EnumActionStepStatus.Running ? (
         <CreateApplyChangesLoader
           onTimeout={handleTimeout}
           minimumLoadTimeMS={MIN_TIME_OUT_LOADER}

--- a/packages/amplication-client/src/Project/ArchitectureConsole/ModelOrganizerConfirmation.tsx
+++ b/packages/amplication-client/src/Project/ArchitectureConsole/ModelOrganizerConfirmation.tsx
@@ -20,6 +20,8 @@ import { ApplyChangesNextSteps } from "./ApplyChangesNextSteps";
 import CreateApplyChangesLoader from "./CreateApplyChangesLoader";
 import "./ModelOrganizerConfirmation.scss";
 import { EntityNode, ModelChanges, NODE_TYPE_MODEL, Node } from "./types";
+import ActionLog from "../../VersionControl/ActionLog";
+import * as models from "../../models";
 
 type movedEntitiesData = {
   id: string;
@@ -35,6 +37,7 @@ type Props = {
   nodes: Node[];
   applyChangesLoading: boolean;
   applyChangesErrorMessage: string;
+  applyChangesData: models.UserAction;
 };
 
 export default function ModelOrganizerConfirmation({
@@ -44,6 +47,7 @@ export default function ModelOrganizerConfirmation({
   changes,
   applyChangesLoading,
   applyChangesErrorMessage,
+  applyChangesData,
 }: Props) {
   const [applyChangesSteps, setApplyChangesSteps] = useState<boolean>(false);
   const [keepLoadingChanges, setKeepLoadingChanges] = useState<boolean>(false);
@@ -76,7 +80,16 @@ export default function ModelOrganizerConfirmation({
 
   return (
     <div className={CLASS_NAME}>
-      {keepLoadingChanges || applyChangesLoading ? (
+      {applyChangesData ? (
+        <>
+          <ActionLog
+            height={"150px"}
+            action={applyChangesData?.action}
+            title={"Apply Changes to Architecture"}
+            versionNumber={""}
+          />
+        </>
+      ) : keepLoadingChanges || applyChangesLoading ? (
         <CreateApplyChangesLoader
           onTimeout={handleTimeout}
           minimumLoadTimeMS={MIN_TIME_OUT_LOADER}
@@ -141,6 +154,7 @@ export default function ModelOrganizerConfirmation({
                   <ListItem>
                     {changes.newServices.map((service) => (
                       <Text
+                        key={service.id}
                         textStyle={EnumTextStyle.Tag}
                         textColor={EnumTextColor.White}
                       >
@@ -188,6 +202,7 @@ export default function ModelOrganizerConfirmation({
                 )}
                 {movedEntities.map((entity) => (
                   <Text
+                    key={entity.id}
                     textStyle={EnumTextStyle.Tag}
                     textColor={EnumTextColor.White}
                   >

--- a/packages/amplication-client/src/Project/ArchitectureConsole/ModelOrganizerToolbar.tsx
+++ b/packages/amplication-client/src/Project/ArchitectureConsole/ModelOrganizerToolbar.tsx
@@ -39,6 +39,7 @@ type Props = {
   mergeNewResourcesChanges: () => void;
   applyChangesLoading: boolean;
   applyChangesError: any;
+  applyChangesData: models.UserAction;
 };
 
 export default function ModelOrganizerToolbar({
@@ -49,6 +50,7 @@ export default function ModelOrganizerToolbar({
   resources,
   applyChangesLoading,
   applyChangesError,
+  applyChangesData,
   onApplyPlan,
   searchPhraseChanged,
   onRedesign,
@@ -95,6 +97,7 @@ export default function ModelOrganizerToolbar({
           changes={changes}
           applyChangesErrorMessage={applyChangesErrorMessage}
           applyChangesLoading={applyChangesLoading}
+          applyChangesData={applyChangesData}
         ></ModelOrganizerConfirmation>
       </Dialog>
 

--- a/packages/amplication-client/src/Project/ArchitectureConsole/helpers.ts
+++ b/packages/amplication-client/src/Project/ArchitectureConsole/helpers.ts
@@ -132,7 +132,6 @@ function entitiesToNodes(
     deletable: false,
     draggable: false,
     id: resource.id,
-    tempId: resource.tempId,
     type: NODE_TYPE_MODEL_GROUP,
     dragHandle: ".group-drag-handle",
     position: {

--- a/packages/amplication-client/src/Project/ArchitectureConsole/hooks/useModelOrganizer.tsx
+++ b/packages/amplication-client/src/Project/ArchitectureConsole/hooks/useModelOrganizer.tsx
@@ -192,30 +192,38 @@ const useModelOrganization = ({ projectId, onMessage }: Props) => {
     saveToPersistentData,
   ]);
 
-  const resetChanges = useCallback(() => {
-    setChanges({
-      movedEntities: [],
-      newServices: [],
-    });
-    if (currentEditableResourceNode) {
-      currentEditableResourceNode.data.isEditable = false;
-    }
-    setCurrentEditableResourceNode(null);
-    setRedesignMode(false);
+  const resetChanges = useCallback(
+    (showResetMessage = true) => {
+      setChanges({
+        movedEntities: [],
+        newServices: [],
+      });
+      if (currentEditableResourceNode) {
+        currentEditableResourceNode.data.isEditable = false;
+      }
+      setCurrentEditableResourceNode(null);
+      setRedesignMode(false);
 
-    clearPersistentData();
-    loadProjectResources(true, () => {
-      onMessage(
-        "Redesign changes were discarded successfully",
-        EnumMessageType.Success
+      clearPersistentData();
+      loadProjectResources(
+        true,
+        showResetMessage
+          ? () => {
+              onMessage(
+                "Redesign changes were discarded successfully",
+                EnumMessageType.Success
+              );
+            }
+          : undefined
       );
-    });
-  }, [
-    currentEditableResourceNode,
-    clearPersistentData,
-    loadProjectResources,
-    onMessage,
-  ]);
+    },
+    [
+      currentEditableResourceNode,
+      clearPersistentData,
+      loadProjectResources,
+      onMessage,
+    ]
+  );
 
   const createNewServiceObject = useCallback(
     (serviceName: string, serviceTempId: string) => {
@@ -555,7 +563,7 @@ const useModelOrganization = ({ projectId, onMessage }: Props) => {
       },
       onCompleted: async (data) => {
         setUserAction(data.redesignProject);
-        resetChanges();
+        resetChanges(false);
       },
       onError: (error) => {
         //@todo: show Errors

--- a/packages/amplication-client/src/Project/ArchitectureConsole/queries/modelsQueries.ts
+++ b/packages/amplication-client/src/Project/ArchitectureConsole/queries/modelsQueries.ts
@@ -41,20 +41,26 @@ export const REDESIGN_PROJECT = gql`
   mutation redesignProject($data: RedesignProjectInput!) {
     redesignProject(data: $data) {
       id
-      name
-      entities {
+      createdAt
+      actionId
+      status
+      action {
         id
-        displayName
-        resourceId
-        fields {
-          permanentId
-          displayName
-          description
-          properties
-          dataType
-          customAttributes
-          required
-          unique
+        createdAt
+        steps {
+          id
+          name
+          createdAt
+          message
+          status
+          completedAt
+          logs {
+            id
+            createdAt
+            message
+            meta
+            level
+          }
         }
       }
     }

--- a/packages/amplication-client/src/Resource/preview-pages/breaking-the-monolith/BreakingTheMonolithOptionsPage.tsx
+++ b/packages/amplication-client/src/Resource/preview-pages/breaking-the-monolith/BreakingTheMonolithOptionsPage.tsx
@@ -16,7 +16,7 @@ import {
 } from "@amplication/ui/design-system";
 import * as models from "../../../models";
 import { MonolithOption, monolithOptions } from "./monolith-options";
-import useUserActionWatchStatus from "../../../Entity/ImportPrismaSchema/useUserActionWatchStatus";
+import useUserActionWatchStatus from "../../../UserAction/useUserActionWatchStatus";
 import { AppRouteProps } from "../../../routes/routesUtil";
 import { CREATE_ENTITIES_FROM_PREDEFINED_SCHEMA } from "../../../Entity/ImportPrismaSchema/queries";
 

--- a/packages/amplication-client/src/UserAction/queries.ts
+++ b/packages/amplication-client/src/UserAction/queries.ts
@@ -1,0 +1,31 @@
+import { gql } from "@apollo/client";
+
+export const GET_USER_ACTION = gql`
+  query userAction($userActionId: String!) {
+    userAction(where: { id: $userActionId }) {
+      id
+      createdAt
+      actionId
+      status
+      action {
+        id
+        createdAt
+        steps {
+          id
+          name
+          createdAt
+          message
+          status
+          completedAt
+          logs {
+            id
+            createdAt
+            message
+            meta
+            level
+          }
+        }
+      }
+    }
+  }
+`;

--- a/packages/amplication-client/src/UserAction/useUserActionWatchStatus.ts
+++ b/packages/amplication-client/src/UserAction/useUserActionWatchStatus.ts
@@ -1,9 +1,9 @@
 import { useContext, useEffect } from "react";
 import { useQuery } from "@apollo/client";
 
-import * as models from "../../models";
-import { GET_USER_ACTION } from "./queries";
-import { AppContext } from "../../context/appContext";
+import * as models from "../models";
+import { GET_USER_ACTION } from "../Entity/ImportPrismaSchema/queries";
+import { AppContext } from "../context/appContext";
 
 const POLL_INTERVAL = 2000;
 
@@ -36,11 +36,12 @@ const useUserActionWatchStatus = (
     } else {
       startPolling(POLL_INTERVAL);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, stopPolling, startPolling]);
 
   useEffect(() => {
     if (userAction) refetch();
-  }, [userAction]);
+  }, [refetch, userAction]);
 
   //cleanup polling
   useEffect(() => {

--- a/packages/amplication-client/src/UserAction/useUserActionWatchStatus.ts
+++ b/packages/amplication-client/src/UserAction/useUserActionWatchStatus.ts
@@ -2,7 +2,7 @@ import { useContext, useEffect } from "react";
 import { useQuery } from "@apollo/client";
 
 import * as models from "../models";
-import { GET_USER_ACTION } from "../Entity/ImportPrismaSchema/queries";
+import { GET_USER_ACTION } from "./queries";
 import { AppContext } from "../context/appContext";
 
 const POLL_INTERVAL = 2000;

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -1197,7 +1197,7 @@ export type Mutation = {
   login: Auth;
   provisionSubscription?: Maybe<ProvisionSubscriptionResult>;
   redeemCoupon: Coupon;
-  redesignProject: Array<Resource>;
+  redesignProject: UserAction;
   resendInvitation?: Maybe<Invitation>;
   revokeInvitation?: Maybe<Invitation>;
   setCurrentWorkspace: Auth;
@@ -2234,7 +2234,6 @@ export type Resource = {
   project?: Maybe<Project>;
   projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
-  tempId?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
 };
 
@@ -2261,7 +2260,6 @@ export type ResourceCreateInput = {
   project: WhereParentIdInput;
   resourceType: EnumResourceType;
   serviceSettings?: InputMaybe<ServiceSettingsUpdateInput>;
-  tempId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceCreateWithEntitiesEntityInput = {

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -1194,7 +1194,7 @@ export type Mutation = {
   login: Auth;
   provisionSubscription?: Maybe<ProvisionSubscriptionResult>;
   redeemCoupon: Coupon;
-  redesignProject: Array<Resource>;
+  redesignProject: UserAction;
   resendInvitation?: Maybe<Invitation>;
   revokeInvitation?: Maybe<Invitation>;
   setCurrentWorkspace: Auth;
@@ -2231,7 +2231,6 @@ export type Resource = {
   project?: Maybe<Project>;
   projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
-  tempId?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
 };
 
@@ -2258,7 +2257,6 @@ export type ResourceCreateInput = {
   project: WhereParentIdInput;
   resourceType: EnumResourceType;
   serviceSettings?: InputMaybe<ServiceSettingsUpdateInput>;
-  tempId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceCreateWithEntitiesEntityInput = {

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -1194,7 +1194,7 @@ export type Mutation = {
   login: Auth;
   provisionSubscription?: Maybe<ProvisionSubscriptionResult>;
   redeemCoupon: Coupon;
-  redesignProject: Array<Resource>;
+  redesignProject: UserAction;
   resendInvitation?: Maybe<Invitation>;
   revokeInvitation?: Maybe<Invitation>;
   setCurrentWorkspace: Auth;
@@ -2231,7 +2231,6 @@ export type Resource = {
   project?: Maybe<Project>;
   projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
-  tempId?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
 };
 
@@ -2258,7 +2257,6 @@ export type ResourceCreateInput = {
   project: WhereParentIdInput;
   resourceType: EnumResourceType;
   serviceSettings?: InputMaybe<ServiceSettingsUpdateInput>;
-  tempId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceCreateWithEntitiesEntityInput = {

--- a/packages/amplication-prisma-db/prisma/migrations/20240204114540_add_enum_user_action_type_project_redesign/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20240204114540_add_enum_user_action_type_project_redesign/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "EnumUserActionType" ADD VALUE 'ProjectRedesign';

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -605,6 +605,7 @@ enum EnumGitOrganizationType {
 enum EnumUserActionType {
   DBSchemaImport
   GptConversation
+  ProjectRedesign
 }
 
 enum CodeGeneratorVersionStrategy {

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -3034,9 +3034,7 @@ export class EntityService {
    * @throws {NotFoundException} thrown if the field is not found or it relates
    * to a past entity version
    */
-  private async getField(
-    args: Prisma.EntityFieldFindFirstArgs
-  ): Promise<EntityField> {
+  async getField(args: Prisma.EntityFieldFindFirstArgs): Promise<EntityField> {
     const field = await this.prisma.entityField.findFirst({
       ...args,
       where: {

--- a/packages/amplication-server/src/core/resource/constants.ts
+++ b/packages/amplication-server/src/core/resource/constants.ts
@@ -1,4 +1,27 @@
+import { Prisma } from "../../prisma";
+import { EnumActionLogLevel, EnumActionStepStatus } from "../action/dto";
+
 export const DEFAULT_RESOURCE_COLORS = {
   projectConfiguration: "#FFBD70",
   service: "#20A4F3",
 };
+
+export const APPLYING_PROJECT_REDESIGN_CHANGES =
+  "APPLYING_PROJECT_REDESIGN_CHANGES";
+
+export const REDESIGN_PROJECT_INITIAL_STEP_DATA: Prisma.ActionStepCreateWithoutActionInput =
+  {
+    name: APPLYING_PROJECT_REDESIGN_CHANGES,
+    message: "Applying project redesign changes",
+    status: EnumActionStepStatus.Running,
+    completedAt: undefined,
+    logs: {
+      create: [
+        {
+          message: "Starting to apply project redesign changes",
+          level: EnumActionLogLevel.Info,
+          meta: {},
+        },
+      ],
+    },
+  };

--- a/packages/amplication-server/src/core/resource/dto/ResourceCreateInput.ts
+++ b/packages/amplication-server/src/core/resource/dto/ResourceCreateInput.ts
@@ -14,11 +14,6 @@ export class ResourceCreateInput {
   name!: string;
 
   @Field(() => String, {
-    nullable: true,
-  })
-  tempId?: string;
-
-  @Field(() => String, {
     nullable: false,
   })
   description!: string;

--- a/packages/amplication-server/src/core/resource/resource.module.ts
+++ b/packages/amplication-server/src/core/resource/resource.module.ts
@@ -22,6 +22,7 @@ import { ResourceBtmResolver } from "./resourceBtm.resolver";
 import { ResourceBtmService } from "./resourceBtm.service";
 import { GptModule } from "../gpt/gpt.module";
 import { UserActionModule } from "../userAction/userAction.module";
+import { ActionModule } from "../action/action.module";
 
 @Module({
   imports: [
@@ -44,6 +45,7 @@ import { UserActionModule } from "../userAction/userAction.module";
     KafkaModule,
     forwardRef(() => GptModule),
     UserActionModule,
+    ActionModule,
   ],
   providers: [
     ResourceService,

--- a/packages/amplication-server/src/core/resource/resource.resolver.ts
+++ b/packages/amplication-server/src/core/resource/resource.resolver.ts
@@ -32,6 +32,7 @@ import {
   UpdateCodeGeneratorVersionArgs,
 } from "./dto";
 import { RedesignProjectArgs } from "./dto/RedesignProjectArgs";
+import { UserAction } from "../userAction/dto";
 
 @Resolver(() => Resource)
 @UseFilters(GqlResolverExceptionsFilter)
@@ -160,13 +161,13 @@ export class ResourceResolver {
     return this.resourceService.updateResource(args);
   }
 
-  @Mutation(() => [Resource], { nullable: false })
+  @Mutation(() => UserAction, { nullable: false })
   @Roles("ORGANIZATION_ADMIN")
   @AuthorizeContext(AuthorizableOriginParameter.ProjectId, "data.projectId")
   async redesignProject(
     @Args() args: RedesignProjectArgs,
     @UserEntity() user: User
-  ): Promise<Resource[]> {
+  ): Promise<UserAction> {
     return this.resourceService.redesignProject(args, user);
   }
 

--- a/packages/amplication-server/src/core/resource/resource.service.spec.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.spec.ts
@@ -65,6 +65,8 @@ import { BillingLimitationError } from "../../errors/BillingLimitationError";
 import { BillingFeature } from "@amplication/util-billing-types";
 import { SubscriptionService } from "../subscription/subscription.service";
 import { EnumPreviewAccountType } from "../auth/dto/EnumPreviewAccountType";
+import { ActionService } from "../action/action.service";
+import { UserActionService } from "../userAction/userAction.service";
 
 const EXAMPLE_MESSAGE = "exampleMessage";
 const EXAMPLE_RESOURCE_ID = "exampleResourceId";
@@ -652,6 +654,15 @@ describe("ResourceService", () => {
             commit: projectServiceFindUniqueMock,
           })),
         },
+        {
+          provide: ActionService,
+          useClass: jest.fn(() => ({})),
+        },
+        {
+          provide: UserActionService,
+          useClass: jest.fn(() => ({})),
+        },
+
         MockedAmplicationLoggerProvider,
       ],
     }).compile();

--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -548,7 +548,7 @@ export class ResourceService {
 
     const userAction =
       await this.userActionService.createUserActionByTypeWithInitialStep(
-        EnumUserActionType.DBSchemaImport, //@todo: create new user action type
+        EnumUserActionType.ProjectRedesign,
         undefined,
         REDESIGN_PROJECT_INITIAL_STEP_DATA,
         user.id,

--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -1,4 +1,9 @@
-import { LookupResolvedProperties } from "@amplication/code-gen-types";
+import {
+  EnumActionStepStatus,
+  RedesignProjectMovedEntity,
+} from "@amplication/code-gen-types/models";
+import { Lookup, SingleLineText } from "@amplication/code-gen-types/types";
+import { KAFKA_TOPICS } from "@amplication/schema-registry";
 import { BillingFeature } from "@amplication/util-billing-types";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
 import {
@@ -7,16 +12,17 @@ import {
   Injectable,
   forwardRef,
 } from "@nestjs/common";
+import cuid from "cuid";
 import { isEmpty } from "lodash";
 import { pascalCase } from "pascal-case";
 import pluralize from "pluralize";
-import { JsonValue } from "type-fest";
+import { JsonObject, JsonValue } from "type-fest";
 import { FindOneArgs } from "../../dto";
 import { EnumDataType } from "../../enums/EnumDataType";
 import { QueryMode } from "../../enums/QueryMode";
 import { AmplicationError } from "../../errors/AmplicationError";
 import { BillingLimitationError } from "../../errors/BillingLimitationError";
-import { Entity, GitOrganization, Project, Resource, User } from "../../models";
+import { GitOrganization, Project, Resource, User } from "../../models";
 import {
   EnumResourceType,
   GitRepository,
@@ -28,13 +34,16 @@ import {
   SegmentAnalyticsService,
 } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { prepareDeletedItemName } from "../../util/softDelete";
+import { ActionService } from "../action/action.service";
+import { EnumActionLogLevel } from "../action/dto/EnumActionLogLevel";
 import { BillingService } from "../billing/billing.service";
+import { USER_ENTITY_NAME } from "../entity/constants";
 import {
-  CURRENT_VERSION_NUMBER,
-  INITIAL_ENTITY_FIELDS,
-  USER_ENTITY_NAME,
-} from "../entity/constants";
-import { EntityService } from "../entity/entity.service";
+  CreateBulkEntitiesAndFieldsArgs,
+  CreateBulkEntitiesInput,
+  CreateBulkFieldsInput,
+  EntityService,
+} from "../entity/entity.service";
 import { EnvironmentService } from "../environment/environment.service";
 import { ConnectGitRepositoryInput } from "../git/dto/inputs/ConnectGitRepositoryInput";
 import { PluginInstallationCreateInput } from "../pluginInstallation/dto/PluginInstallationCreateInput";
@@ -47,7 +56,11 @@ import { ServiceSettingsService } from "../serviceSettings/serviceSettings.servi
 import { ServiceTopicsService } from "../serviceTopics/serviceTopics.service";
 import { SubscriptionService } from "../subscription/subscription.service";
 import { TopicService } from "../topic/topic.service";
+import { UserAction } from "../userAction/dto";
+import { EnumUserActionType } from "../userAction/types";
+import { UserActionService } from "../userAction/userAction.service";
 import { ReservedEntityNameError } from "./ReservedEntityNameError";
+import { REDESIGN_PROJECT_INITIAL_STEP_DATA } from "./constants";
 import {
   CreateOneResourceArgs,
   FindManyResourceArgs,
@@ -125,7 +138,9 @@ export class ResourceService {
     private readonly billingService: BillingService,
     private readonly pluginInstallationService: PluginInstallationService,
     private readonly analytics: SegmentAnalyticsService,
-    private readonly subscriptionService: SubscriptionService
+    private readonly subscriptionService: SubscriptionService,
+    private readonly actionService: ActionService,
+    private readonly userActionService: UserActionService
   ) {}
 
   async findOne(args: FindOneArgs): Promise<Resource | null> {
@@ -495,19 +510,21 @@ export class ResourceService {
   async redesignProject(
     args: RedesignProjectArgs,
     user: User
-  ): Promise<Resource[]> {
+  ): Promise<UserAction> {
     const { movedEntities, newServices, projectId } = args.data;
 
     const subscription = await this.billingService.getSubscription(
       user.workspace?.id
     );
 
+    const resourceId = movedEntities[0]?.originalResourceId;
+
     await this.analytics.track({
       userId: user.id,
       properties: {
         workspaceId: user.workspace?.id,
         projectId,
-        resourceId: movedEntities[0].originalResourceId,
+        resourceId: resourceId,
         plan: subscription.subscriptionPlan,
         movedEntities: movedEntities.length,
         newServices: newServices.length,
@@ -529,266 +546,282 @@ export class ResourceService {
       authProvider: EnumAuthProviderType.Jwt,
     };
 
-    // 1. create new resources
-    const newResources: Resource[] = [];
-    const projectGitRepository = await this.prisma.gitRepository.findFirst({
-      where: {
-        resources: {
-          some: {
-            id: projectId,
-          },
-        },
-      },
-    });
+    const userAction =
+      await this.userActionService.createUserActionByTypeWithInitialStep(
+        EnumUserActionType.DBSchemaImport, //@todo: create new user action type
+        undefined,
+        REDESIGN_PROJECT_INITIAL_STEP_DATA,
+        user.id,
+        resourceId
+      );
 
-    for (const newService of newServices) {
-      const args: CreateOneResourceArgs = {
-        data: {
-          name: newService.name,
-          description: "",
-          project: {
-            connect: {
+    const actionContext = this.actionService.createActionContext(
+      userAction.id,
+      userAction.action.steps[0],
+      KAFKA_TOPICS.USER_ACTION_LOG_TOPIC
+    );
+
+    try {
+      // 1. create new resources
+      const projectGitRepository = await this.prisma.gitRepository.findFirst({
+        where: {
+          resources: {
+            some: {
               id: projectId,
             },
           },
-          resourceType: EnumResourceType.Service,
-          serviceSettings: defaultServiceSettings,
-          gitRepository: projectGitRepository
-            ? {
-                isOverrideGitRepository: false,
-                name: projectGitRepository?.name,
-                resourceId: "",
-                gitOrganizationId: projectGitRepository?.gitOrganizationId,
-              }
-            : null,
         },
-      };
-
-      const resource = await this.createService(args, user);
-      resource.tempId = newService.id; //@todo: remove tempId from resource type
-
-      await this.installPlugins(resource.id, [DEFAULT_DB_PLUGIN], user);
-
-      newResources.push(resource);
-    }
-
-    // 2. update resourceId in copied entities list
-    if (newResources?.length > 0) {
-      const moduleGroupResourcesMap = newResources.reduce(
-        (resourcesObj, resource) => {
-          resourcesObj[resource.tempId] = resource;
-          return resourcesObj;
+        include: {
+          resources: true,
         },
-        {}
-      );
+      });
 
+      const newResourcesMap = new Map<string, Resource>();
+
+      for (const newService of newServices) {
+        const args: CreateOneResourceArgs = {
+          data: {
+            name: newService.name,
+            description: "",
+            project: {
+              connect: {
+                id: projectId,
+              },
+            },
+            resourceType: EnumResourceType.Service,
+            serviceSettings: defaultServiceSettings,
+            gitRepository: projectGitRepository
+              ? {
+                  isOverrideGitRepository: false,
+                  name: projectGitRepository?.name,
+                  resourceId: "",
+                  gitOrganizationId: projectGitRepository?.gitOrganizationId,
+                }
+              : null,
+          },
+        };
+
+        const resource = await this.createService(args, user);
+        await actionContext.onEmitUserActionLog(
+          `Successfully created service ${resource.name} with id ${resource.id}`,
+          EnumActionLogLevel.Info
+        );
+
+        newResourcesMap.set(newService.id, resource);
+
+        await this.installPlugins(resource.id, [DEFAULT_DB_PLUGIN], user);
+      }
+
+      // 2. update resourceId in copied entities list
       for (const entityToCopy of movedEntities) {
-        const newResource: Resource =
-          moduleGroupResourcesMap[entityToCopy.targetResourceId];
+        const newResource: Resource = newResourcesMap.get(
+          entityToCopy.targetResourceId
+        );
 
         if (newResource) {
           entityToCopy.targetResourceId = newResource.id;
         }
       }
-    }
 
-    // 3.create resource entities
-
-    const copiedEntities: Entity[] = [];
-    const entitiesWithFields: Entity[] = [];
-    const resources: Resource[] = [];
-
-    for (const entityToCopy of movedEntities) {
-      const currentEntityToCopy = await this.prisma.entity.findUnique({
-        where: {
-          id: entityToCopy.entityId,
+      // 3.group moved entities by target resource
+      const movedEntitiesByResource = movedEntities.reduce(
+        (entitiesByResource, entity) => {
+          if (!entitiesByResource[entity.targetResourceId]) {
+            entitiesByResource[entity.targetResourceId] = [];
+          }
+          entitiesByResource[entity.targetResourceId].push(entity);
+          return entitiesByResource;
         },
-        include: {
-          versions: {
-            include: {
-              fields: true,
-            },
-          },
-        },
-      });
-
-      entitiesWithFields.push(currentEntityToCopy);
-
-      const entity = await this.createResourceCopiedEntity(
-        currentEntityToCopy,
-        entityToCopy.targetResourceId,
-        user
+        {} as { [resourceId: string]: RedesignProjectMovedEntity[] }
       );
 
-      copiedEntities.push(entity);
+      const sourceEntityIdToNewEntityMap = new Map<
+        string,
+        CreateBulkEntitiesInput
+      >();
 
-      const currentResource = await this.prisma.resource.findUnique({
-        where: {
-          id: entityToCopy.targetResourceId,
-        },
-        include: {
-          entities: {
-            include: {
-              versions: {
-                include: {
-                  fields: true,
-                },
-              },
+      // 4. create entities per resource
+      for (const [resourceId, entities] of Object.entries(
+        movedEntitiesByResource
+      )) {
+        await actionContext.onEmitUserActionLog(
+          `starting to move entities to resource ${resourceId}`,
+          EnumActionLogLevel.Info
+        );
+
+        const createBulkData: CreateBulkEntitiesAndFieldsArgs = {
+          resourceId: resourceId,
+          preparedEntitiesWithFields: [],
+          user: user,
+        };
+
+        //First create all entities, so we have the IDs for the relations
+        for (const movedEntity of entities) {
+          const entity = await this.entityService.entity({
+            where: {
+              id: movedEntity.entityId,
             },
-          },
-        },
-      });
+          });
 
-      const resourceExist =
-        resources?.find((resource) => resource.id === currentResource.id) !==
-        null;
-
-      !resourceExist && resources.push(currentResource);
-    }
-
-    const entitiesWithFieldsMap = entitiesWithFields.reduce(
-      (entitiesObj, entity) => {
-        entitiesObj[entity.name] = entity;
-        return entitiesObj;
-      },
-      {}
-    );
-
-    // 2.create entities fields
-
-    for (const copiedEntity of copiedEntities) {
-      const currentEntity: Entity = entitiesWithFieldsMap[copiedEntity.name];
-
-      for (const field of currentEntity.versions[0].fields) {
-        const { dataType, properties } = field;
-        const { allowMultipleSelection, relatedEntityId } =
-          properties as unknown as LookupResolvedProperties;
-
-        if (dataType === EnumDataType.Id) {
-          await this.createCopiedEntityIdField(copiedEntity.id);
-          continue;
+          const createEntityInput: CreateBulkEntitiesInput = {
+            id: cuid(), // creating here the entity id because we need it for the relation
+            name: entity.name,
+            displayName: entity.displayName,
+            pluralDisplayName: entity.pluralDisplayName,
+            description: entity.description,
+            customAttributes: entity.customAttributes,
+            fields: [],
+          };
+          sourceEntityIdToNewEntityMap.set(entity.id, createEntityInput);
+          createBulkData.preparedEntitiesWithFields.push(createEntityInput);
         }
-        if (dataType === EnumDataType.Lookup) {
-          const isFieldExist = await this.isEntityFieldExist(
-            pascalCase(field.name),
-            copiedEntity.id
+
+        const lookupFieldsToSkip = new Set<string>();
+
+        //run again on all entities to create the fields
+        for (const movedEntity of entities) {
+          const currentEntityCreateInput = sourceEntityIdToNewEntityMap.get(
+            movedEntity.entityId
           );
 
-          if (isFieldExist) continue;
-
-          const currentRelatedEntity = movedEntities.find(
-            (entity) => entity.entityId === relatedEntityId
+          //get the list of fields of the source entity
+          const fields = await this.entityService.getFields(
+            movedEntity.entityId,
+            {}
           );
 
-          if (!currentRelatedEntity) {
-            if (allowMultipleSelection) continue;
-
-            //one to one relation or one to many relation
-            //create id field by the idType and field name
-
-            await this.entityService.updateFieldDataTypeIdByRelatedEntity(
-              field,
-              relatedEntityId
+          for (const field of fields) {
+            await actionContext.onEmitUserActionLog(
+              `Preparing data to move field ${field.name} to entity ${currentEntityCreateInput.name} `,
+              EnumActionLogLevel.Info
             );
+
+            const createFieldInput: CreateBulkFieldsInput = {
+              permanentId: cuid(),
+              name: field.name,
+              displayName: field.displayName,
+              dataType: field.dataType,
+              required: field.required,
+              unique: field.unique,
+              searchable: field.searchable,
+              description: field.description,
+              properties: field.properties as JsonObject,
+              customAttributes: field.customAttributes,
+            };
+
+            if (field.dataType === EnumDataType.Lookup) {
+              const relatedEntityId = (field.properties as unknown as Lookup)
+                .relatedEntityId;
+
+              const fieldProperties = field.properties as unknown as Lookup;
+
+              //If the related entity is moved to the SAME RESOURCE - we should keep the relation
+              if (
+                entities.find((entity) => entity.entityId === relatedEntityId)
+              ) {
+                if (lookupFieldsToSkip.has(field.permanentId)) {
+                  //The other side of this relation field was already moved
+                  continue;
+                }
+
+                const relatedField = await this.entityService.getField({
+                  where: {
+                    permanentId: fieldProperties.relatedFieldId,
+                  },
+                });
+
+                await actionContext.onEmitUserActionLog(
+                  `moving relation field ${field.name} to entity ${currentEntityCreateInput.name} - related field ${relatedField.name} is in the same resource`,
+                  EnumActionLogLevel.Info
+                );
+
+                //@todo: what about the rest of the properties of the related field (like searchable, unique, required, description, customAttributes etc.)
+                createFieldInput.relatedFieldName = relatedField.name;
+                createFieldInput.relatedFieldDisplayName =
+                  relatedField.displayName;
+                createFieldInput.relatedFieldAllowMultipleSelection = (
+                  relatedField.properties as unknown as Lookup
+                ).allowMultipleSelection;
+
+                (
+                  createFieldInput.properties as unknown as Lookup
+                ).relatedFieldId = undefined; //clear the related field id, because it will be set later
+
+                (
+                  createFieldInput.properties as unknown as Lookup
+                ).relatedEntityId = sourceEntityIdToNewEntityMap.get(
+                  fieldProperties.relatedEntityId
+                ).id; //the new entity Id of the related entity
+
+                lookupFieldsToSkip.add(relatedField.permanentId);
+              } else {
+                await actionContext.onEmitUserActionLog(
+                  `moving relation field ${field.name} to resource ${resourceId} - related entity ${relatedEntityId} is in a different resource`,
+                  EnumActionLogLevel.Info
+                );
+
+                //if the related entity is moved to a different resource - we should remove the relation
+                if (!fieldProperties.allowMultipleSelection) {
+                  createFieldInput.name = `${createFieldInput.name}Id`;
+                  createFieldInput.displayName = `${createFieldInput.displayName} ID`;
+                  createFieldInput.dataType = EnumDataType.SingleLineText; //@todo: set the new type based on the ID type of the related entity (WholeNumber or SingleLineText)
+                  const fieldProperties: SingleLineText = {
+                    maxLength: 255,
+                  };
+                  createFieldInput.properties =
+                    fieldProperties as unknown as JsonObject;
+                } else {
+                  createFieldInput.dataType = EnumDataType.Json;
+                  createFieldInput.properties = {}; //type Json does not have properties
+                }
+              }
+            }
+            currentEntityCreateInput.fields.push(createFieldInput);
           }
         }
 
-        await this.entityService.createCopiedEntityFieldByDisplayName(
-          copiedEntity.id,
-          field,
+        await this.entityService.createBulkEntitiesAndFields(
+          createBulkData,
+          actionContext
+        );
+      }
+
+      // 3.delete entities from source services
+      //@todo: we should keep the relation fields on the related entities that were not moved
+      for (const entity of movedEntities) {
+        await actionContext.onEmitUserActionLog(
+          `deleting entity ${entity.entityId} from source service`,
+          EnumActionLogLevel.Info
+        );
+        await this.entityService.deleteEntityFromSource(
+          { where: { id: entity.entityId } },
           user
         );
       }
-    }
-
-    // 3.delete entities from source services
-    for (const entity of entitiesWithFields) {
-      await this.entityService.deleteEntityFromSource(
-        { where: { id: entity.id } },
-        user
-      );
-    }
-
-    return resources;
-  }
-
-  async createResourceCopiedEntity(
-    entityToCopy: Entity,
-    targetResourceId: string,
-    user: User
-  ): Promise<Entity> {
-    const {
-      name,
-      displayName,
-      pluralDisplayName,
-      description,
-      customAttributes,
-    } = entityToCopy;
-
-    let copiedEntity: Entity;
-
-    try {
-      copiedEntity = await this.entityService.createOneEntity(
-        {
-          data: {
-            resource: {
-              connect: {
-                id: targetResourceId,
-              },
-            },
-            name,
-            displayName,
-            pluralDisplayName,
-            description,
-            customAttributes,
-          },
-        },
-        user,
-        false,
-        false,
-        false
-      );
     } catch (error) {
-      this.logger.error(error.message, error, { entity: entityToCopy.name });
-      throw new Error(
-        `Failed to create entity "${entityToCopy.name}" due to ${error.message}`
+      await actionContext.onEmitUserActionLog(
+        error.message,
+        EnumActionLogLevel.Error
       );
+
+      await actionContext.onEmitUserActionLog(
+        `Failed to move entities to new resources. See previous logs for more details`,
+        EnumActionLogLevel.Error,
+        EnumActionStepStatus.Failed,
+        true
+      );
+
+      return userAction;
     }
 
-    return copiedEntity;
-  }
+    await actionContext.onEmitUserActionLog(
+      `Successfully moved all entities to new resources`,
+      EnumActionLogLevel.Info,
+      EnumActionStepStatus.Success,
+      true
+    );
 
-  async createCopiedEntityIdField(copiedEntityId: string): Promise<void> {
-    await this.prisma.entityField.create({
-      data: {
-        ...INITIAL_ENTITY_FIELDS[0],
-        entityVersion: {
-          connect: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            entityId_versionNumber: {
-              entityId: copiedEntityId,
-              versionNumber: CURRENT_VERSION_NUMBER,
-            },
-          },
-        },
-      },
-    });
-  }
-
-  async isEntityFieldExist(
-    fieldDisplayName: string,
-    entityId: string
-  ): Promise<boolean> {
-    const field = await this.prisma.entityField.findFirst({
-      where: {
-        displayName: fieldDisplayName,
-        entityVersion: {
-          entityId: entityId,
-        },
-      },
-    });
-
-    return field ? true : false;
+    return userAction;
   }
 
   async userEntityValidation(

--- a/packages/amplication-server/src/core/userAction/types.ts
+++ b/packages/amplication-server/src/core/userAction/types.ts
@@ -5,6 +5,7 @@ import { registerEnumType } from "@nestjs/graphql";
 export enum EnumUserActionType {
   DBSchemaImport = "DBSchemaImport",
   GptConversation = "GptConversation",
+  ProjectRedesign = "ProjectRedesign",
 }
 
 registerEnumType(EnumUserActionType, {

--- a/packages/amplication-server/src/core/userAction/userAction.service.ts
+++ b/packages/amplication-server/src/core/userAction/userAction.service.ts
@@ -51,6 +51,13 @@ export class UserActionService {
 
     return await this.prisma.userAction.create({
       data,
+      include: {
+        action: {
+          include: {
+            steps: true,
+          },
+        },
+      },
     });
   }
 

--- a/packages/amplication-server/src/models/Resource.ts
+++ b/packages/amplication-server/src/models/Resource.ts
@@ -16,11 +16,6 @@ export class Resource {
   })
   id!: string;
 
-  @Field(() => String, {
-    nullable: true,
-  })
-  tempId?: string;
-
   @Field(() => Date, {
     nullable: false,
   })

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -1168,7 +1168,7 @@ type Mutation {
   login(data: LoginInput!): Auth!
   provisionSubscription(data: ProvisionSubscriptionInput!): ProvisionSubscriptionResult
   redeemCoupon(data: RedeemCouponInput!): Coupon!
-  redesignProject(data: RedesignProjectInput!): [Resource!]!
+  redesignProject(data: RedesignProjectInput!): UserAction!
   resendInvitation(where: WhereUniqueInput!): Invitation
   revokeInvitation(where: WhereUniqueInput!): Invitation
   setCurrentWorkspace(data: WhereUniqueInput!): Auth!
@@ -1546,7 +1546,6 @@ type Resource {
   project: Project
   projectId: String
   resourceType: EnumResourceType!
-  tempId: String
   updatedAt: DateTime!
 }
 
@@ -1557,7 +1556,6 @@ input ResourceCreateInput {
   project: WhereParentIdInput!
   resourceType: EnumResourceType!
   serviceSettings: ServiceSettingsUpdateInput
-  tempId: String
 }
 
 input ResourceCreateWithEntitiesEntityInput {

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -1194,7 +1194,7 @@ export type Mutation = {
   login: Auth;
   provisionSubscription?: Maybe<ProvisionSubscriptionResult>;
   redeemCoupon: Coupon;
-  redesignProject: Array<Resource>;
+  redesignProject: UserAction;
   resendInvitation?: Maybe<Invitation>;
   revokeInvitation?: Maybe<Invitation>;
   setCurrentWorkspace: Auth;
@@ -2231,7 +2231,6 @@ export type Resource = {
   project?: Maybe<Project>;
   projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
-  tempId?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
 };
 
@@ -2258,7 +2257,6 @@ export type ResourceCreateInput = {
   project: WhereParentIdInput;
   resourceType: EnumResourceType;
   serviceSettings?: InputMaybe<ServiceSettingsUpdateInput>;
-  tempId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResourceCreateWithEntitiesEntityInput = {


### PR DESCRIPTION
Close: #7931

## PR Details

Update ResourceService.redesignProject to use the existing EntityService.createBulkEntitiesAndFields 


There are several use cases that still need to be handled and are not included in this PR:
1. Create new UserAction type for the RedesignProject flow
2. when moving relation fields, the other side is missing some properties like custom attributes, required, serachable, etc
3. When converting a relation field to a scalar field in a target service, set the type of the scalar based on the related ID field.
4. Convert related fields to scalar fields on relation fields of entities that are left in the source service
5. Complete tests for the updated code



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
