### PR TITLE
Feat(client): model organizer fit view with delay

### DIFF
--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -517,7 +517,12 @@ export class ResourceService {
       user.workspace?.id
     );
 
-    const resourceId = movedEntities[0]?.originalResourceId;
+    const [firstResource] = await this.resources({
+      where: { projectId: projectId },
+    });
+
+    const resourceId =
+      movedEntities[0]?.originalResourceId ?? firstResource?.id;
 
     await this.analytics.track({
       userId: user.id,


### PR DESCRIPTION
Close: #7933

## PR Details

Adds a delay before using ReactFlowInstance.fitView to allow async operations to complete
add useRef and useEffect to clear the reference to the timeout instance to avoid memory leaks 

Bonus 😄 : adds animation duration for the fitView() function to allow a smooth transition  

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
