### PR TITLE
refactor(server): move oidc logic to service instead of leaving it in controller

### DIFF
--- a/packages/amplication-server/jest.config.ts
+++ b/packages/amplication-server/jest.config.ts
@@ -20,7 +20,7 @@ export default {
   coverageThreshold: {
     global: {
       branches: 84,
-      lines: 54,
+      lines: 54.5,
     },
   },
 };

--- a/packages/amplication-server/src/core/account/account.service.spec.ts
+++ b/packages/amplication-server/src/core/account/account.service.spec.ts
@@ -89,9 +89,11 @@ describe("AccountService", () => {
         password: EXAMPLE_PASSWORD,
       },
     };
-    expect(await service.createAccount(args, IdentityProvider.Local)).toEqual(
-      EXAMPLE_ACCOUNT
-    );
+    expect(
+      await service.createAccount(args, {
+        identityProvider: IdentityProvider.Local,
+      })
+    ).toEqual(EXAMPLE_ACCOUNT);
     expect(prismaAccountCreateMock).toBeCalledTimes(1);
     expect(prismaAccountCreateMock).toBeCalledWith(args);
     expect(segmentAnalyticsIdentifyMock).toBeCalledTimes(1);

--- a/packages/amplication-server/src/core/account/account.service.ts
+++ b/packages/amplication-server/src/core/account/account.service.ts
@@ -5,7 +5,6 @@ import { Workspace } from "../../models";
 import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
 import { IdentifyData } from "../../services/segmentAnalytics/segmentAnalytics.types";
-import { IdentityProvider, IdentityProviderPreview } from "../auth/auth.types";
 
 @Injectable()
 export class AccountService {
@@ -16,7 +15,7 @@ export class AccountService {
 
   async createAccount(
     args: Prisma.AccountCreateArgs,
-    identityProvider: IdentityProvider | IdentityProviderPreview
+    trackingMetadata: Record<string, any>
   ): Promise<Account> {
     const account = await this.prisma.account.create(args);
 
@@ -34,7 +33,7 @@ export class AccountService {
       userId: account.id,
       event: EnumEventType.Signup,
       properties: {
-        identityProvider: identityProvider,
+        ...trackingMetadata,
       },
       context: {
         traits: userData,

--- a/packages/amplication-server/src/core/auth/auth.controller.ts
+++ b/packages/amplication-server/src/core/auth/auth.controller.ts
@@ -17,7 +17,6 @@ import { AuthService } from "./auth.service";
 import { GithubAuthExceptionFilter } from "../../filters/github-auth-exception.filter";
 import { GitHubAuthGuard } from "./github.guard";
 import { AuthProfile, AuthUser, GitHubRequest } from "./types";
-import { stringifyUrl } from "query-string";
 import { Env } from "../../env";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
 import { AuthExceptionFilter } from "../../filters/auth-exception.filter";
@@ -64,24 +63,7 @@ export class AuthController {
       `receive login callback from github account_id=${user.account.id}`
     );
 
-    const token = await this.authService.prepareToken(user);
-    const url = stringifyUrl({
-      url: this.clientHost,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      query: { "complete-signup": isNew ? "1" : "0" },
-    });
-    const clientDomain = new URL(url).hostname;
-
-    const cookieDomainParts = clientDomain.split(".");
-    const cookieDomain = cookieDomainParts
-      .slice(Math.max(cookieDomainParts.length - 2, 0))
-      .join(".");
-
-    response.cookie("AJWT", token, {
-      domain: cookieDomain,
-      secure: true,
-    });
-    response.redirect(301, url);
+    await this.authService.configureJtw(response, user, isNew);
   }
 
   @UseInterceptors(MorganInterceptor("combined"))
@@ -156,57 +138,15 @@ export class AuthController {
   @UseInterceptors(MorganInterceptor("combined"))
   @UseFilters(AuthExceptionFilter)
   @Get(AUTH_AFTER_CALLBACK_PATH)
-  async authorisationCode(
+  async authorizationCode(
     @Req() request: GitHubRequest,
     @Res() response: Response
   ): Promise<void> {
     // Populate the request.oidc.user object
     requiresAuth();
 
-    let isNew: boolean;
     const profile = <AuthProfile>request.oidc.user;
 
-    let user = await this.authService.getAuthUser({
-      account: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        OR: [{ githubId: profile.sub }, { email: profile.email }],
-      },
-    });
-
-    const existingUser = !!user;
-    if (!user) {
-      user = await this.authService.createUser(profile);
-      isNew = true;
-    }
-    if (!user.account.githubId || user.account.githubId !== profile.sub) {
-      user = await this.authService.updateUser(user, { githubId: profile.sub });
-      isNew = false;
-    }
-
-    this.authService.trackCompleteEmailSignup(
-      user.account,
-      profile,
-      existingUser
-    );
-
-    // @todo update the token to include the auth0 expiry / issued at / etc
-    const token = await this.authService.prepareToken(user);
-    const url = stringifyUrl({
-      url: this.clientHost,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      query: { "complete-signup": isNew ? "1" : "0" },
-    });
-    const clientDomain = new URL(url).hostname;
-
-    const cookieDomainParts = clientDomain.split(".");
-    const cookieDomain = cookieDomainParts
-      .slice(Math.max(cookieDomainParts.length - 2, 0))
-      .join(".");
-
-    response.cookie("AJWT", token, {
-      domain: cookieDomain,
-      secure: true,
-    });
-    response.redirect(301, url);
+    await this.authService.loginOrSignUp(profile, response);
   }
 }

--- a/packages/amplication-server/src/core/auth/auth.module.ts
+++ b/packages/amplication-server/src/core/auth/auth.module.ts
@@ -22,7 +22,7 @@ import { JwtStrategy } from "./jwt.strategy";
 import { GitHubStrategy } from "./github.strategy";
 import { GitHubStrategyConfigService } from "./githubStrategyConfig.service";
 import { GitHubAuthGuard } from "./github.guard";
-import { Auth0Middleware } from "./auth0.middleware";
+import { OpenIDConnectAuthMiddleware } from "./oidc.middleware";
 import { SegmentAnalyticsModule } from "../../services/segmentAnalytics/segmentAnalytics.module";
 
 @Module({
@@ -68,7 +68,7 @@ import { SegmentAnalyticsModule } from "../../services/segmentAnalytics/segmentA
     GqlAuthGuard,
     AuthResolver,
     GitHubStrategyConfigService,
-    Auth0Middleware,
+    OpenIDConnectAuthMiddleware,
     SegmentAnalyticsModule,
   ],
   controllers: [AuthController],
@@ -77,7 +77,7 @@ import { SegmentAnalyticsModule } from "../../services/segmentAnalytics/segmentA
 export class AuthModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
-      .apply(Auth0Middleware)
+      .apply(OpenIDConnectAuthMiddleware)
       .forRoutes(
         AUTH_LOGIN_PATH,
         AUTH_LOGOUT_PATH,

--- a/packages/amplication-server/src/core/auth/auth.service.spec.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.spec.ts
@@ -343,7 +343,7 @@ describe("AuthService", () => {
           lastName: EXAMPLE_ACCOUNT.lastName,
         },
       },
-      IdentityProvider.Local
+      { identityProvider: IdentityProvider.Local }
     );
     expect(setCurrentUserMock).toHaveBeenCalledTimes(1);
     expect(setCurrentUserMock).toHaveBeenCalledWith(

--- a/packages/amplication-server/src/core/auth/auth.service.spec.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.spec.ts
@@ -19,6 +19,7 @@ import { AuthUser } from "./types";
 import { IdentityProvider } from "./auth.types";
 import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { Response } from "express";
 import { Env } from "../../env";
 const EXAMPLE_TOKEN = "EXAMPLE TOKEN";
 const WORK_EMAIL_INVALID = `Email must be a work email address`;
@@ -153,6 +154,7 @@ const EXAMPLE_ACCOUNT_WITH_CURRENT_USER_WITH_ROLES_AND_WORKSPACE: Account & {
 };
 
 const EXAMPLE_BUSINESS_EMAIL_IDP_CONNECTION_NAME = "business-users-local";
+const expectedDomain = "amplication.com";
 
 jest.mock("auth0", () => {
   return {
@@ -242,6 +244,8 @@ describe("AuthService", () => {
               switch (variable) {
                 case Env.AUTH_ISSUER_CLIENT_DB_CONNECTION:
                   return EXAMPLE_BUSINESS_EMAIL_IDP_CONNECTION_NAME;
+                case Env.CLIENT_HOST:
+                  return `https://server.${expectedDomain}`;
                 default:
                   return "";
               }
@@ -904,6 +908,54 @@ describe("AuthService", () => {
 
       expect(segmentAnalyticsIdentifyMock).toHaveBeenCalledTimes(0);
       expect(segmentAnalyticsTrackMock).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe("configureJtw", () => {
+    it("should generate a jwt, setup a temporary cookie that client will use to store the jwt and return a redirect 301", async () => {
+      const responseMock = {
+        status: jest.fn((x) => responseMock),
+        cookie: jest.fn(),
+        redirect: jest.fn(),
+      } as unknown as Response;
+
+      await service.configureJtw(
+        responseMock,
+        {
+          account: {
+            id: "test",
+            createdAt: undefined,
+            updatedAt: undefined,
+            email: "",
+            firstName: "",
+            lastName: "",
+            password: "",
+            previewAccountType: "None",
+            previewAccountEmail: "",
+          },
+          id: "",
+          createdAt: undefined,
+          updatedAt: undefined,
+          workspace: new Workspace(),
+          userRoles: [],
+          isOwner: false,
+        },
+        false
+      );
+
+      expect(responseMock.cookie).toHaveBeenCalledWith(
+        "AJWT",
+        expect.any(String),
+        {
+          domain: expectedDomain,
+          secure: true,
+        }
+      );
+
+      expect(responseMock.redirect).toHaveBeenCalledWith(
+        301,
+        "https://server.amplication.com?complete-signup=0"
+      );
     });
   });
 });

--- a/packages/amplication-server/src/core/auth/auth.service.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, forwardRef, Inject } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
 import { subDays } from "date-fns";
+import { Response } from "express";
 import { ConfigService } from "@nestjs/config";
 import cuid from "cuid";
 import { Env } from "../../env";
@@ -48,6 +49,7 @@ import {
   IdentifyData,
   EnumEventType,
 } from "../../services/segmentAnalytics/segmentAnalytics.types";
+import { stringifyUrl } from "query-string";
 
 const TOKEN_PREVIEW_LENGTH = 8;
 const TOKEN_EXPIRY_DAYS = 30;
@@ -71,6 +73,7 @@ export class AuthService {
   private readonly auth0Management: ManagementClient;
   private readonly clientId: string;
   private readonly businessEmailDbConnectionName: string;
+  private clientHost: string;
 
   constructor(
     configService: ConfigService,
@@ -84,6 +87,8 @@ export class AuthService {
     private readonly workspaceService: WorkspaceService,
     private readonly analytics: SegmentAnalyticsService
   ) {
+    this.clientHost = configService.get(Env.CLIENT_HOST);
+
     this.clientId = configService.get<string>(Env.AUTH_ISSUER_CLIENT_ID);
     const clientSecret = configService.get<string>(
       Env.AUTH_ISSUER_CLIENT_SECRET
@@ -761,6 +766,54 @@ export class AuthService {
     });
 
     return workspace as unknown as Workspace & { users: AuthUser[] };
+  }
+
+  async loginOrSignUp(profile: AuthProfile, response: Response): Promise<void> {
+    let user = await this.getAuthUser({
+      account: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        OR: [{ githubId: profile.sub }, { email: profile.email }],
+      },
+    });
+    let isNew: boolean;
+    const existingUser = !!user;
+    if (!user) {
+      user = await this.createUser(profile);
+      isNew = true;
+    }
+    if (!user.account.githubId || user.account.githubId !== profile.sub) {
+      user = await this.updateUser(user, { githubId: profile.sub });
+      isNew = false;
+    }
+
+    this.trackCompleteEmailSignup(user.account, profile, existingUser);
+
+    await this.configureJtw(response, user, isNew);
+  }
+
+  async configureJtw(
+    response: Response,
+    user: AuthUser,
+    isNew: boolean
+  ): Promise<void> {
+    const token = await this.prepareToken(user);
+    const url = stringifyUrl({
+      url: this.clientHost,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      query: { "complete-signup": isNew ? "1" : "0" },
+    });
+    const clientDomain = new URL(url).hostname;
+
+    const cookieDomainParts = clientDomain.split(".");
+    const cookieDomain = cookieDomainParts
+      .slice(Math.max(cookieDomainParts.length - 2, 0))
+      .join(".");
+
+    response.cookie("AJWT", token, {
+      domain: cookieDomain,
+      secure: true,
+    });
+    response.redirect(301, url);
   }
 
   async completeInvitation(

--- a/packages/amplication-server/src/core/auth/auth.service.ts
+++ b/packages/amplication-server/src/core/auth/auth.service.ts
@@ -283,7 +283,9 @@ export class AuthService {
           githubId: payload.id,
         },
       },
-      IdentityProvider.GitHub
+      {
+        identityProvider: IdentityProvider.GitHub,
+      }
     );
 
     const user = await this.bootstrapUser(account, payload.id);
@@ -319,7 +321,11 @@ export class AuthService {
           previewAccountType: EnumPreviewAccountType.None,
         },
       },
-      IdentityProvider.IdentityPlatform
+      {
+        identityProvider: IdentityProvider.IdentityPlatform,
+        identityOrigin: profile.identityOrigin,
+        identityLoginsCount: profile.loginsCount,
+      }
     );
 
     const user = await this.bootstrapUser(account, profile.email);
@@ -355,7 +361,7 @@ export class AuthService {
           password: hashedPassword,
         },
       },
-      IdentityProvider.Local
+      { identityProvider: IdentityProvider.Local }
     );
 
     const user = await this.bootstrapUser(account, payload.workspaceName);
@@ -435,7 +441,7 @@ export class AuthService {
       {
         data: signupData,
       },
-      identityProvider
+      { identityProvider }
     );
 
     const { user, workspaceId, projectId, resourceId } =

--- a/packages/amplication-server/src/core/auth/oidc.middleware.ts
+++ b/packages/amplication-server/src/core/auth/oidc.middleware.ts
@@ -1,22 +1,15 @@
-import { Inject, Injectable, NestMiddleware } from "@nestjs/common";
+import { Injectable, NestMiddleware } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Request, Response, NextFunction, RequestHandler } from "express";
 import { auth } from "express-openid-connect";
 import { Env } from "../../env";
-import { AmplicationLogger } from "@amplication/util/nestjs/logging";
-import { AuthService } from "./auth.service";
 
 @Injectable()
-export class Auth0Middleware implements NestMiddleware {
+export class OpenIDConnectAuthMiddleware implements NestMiddleware {
   private middleware: RequestHandler;
   private clientHost: string;
 
-  constructor(
-    configService: ConfigService,
-    @Inject(AmplicationLogger)
-    private readonly logger: AmplicationLogger,
-    private readonly authService: AuthService
-  ) {
+  constructor(configService: ConfigService) {
     this.clientHost = configService.get(Env.CLIENT_HOST);
     const baseURL = `${configService.get(Env.HOST)}`;
 


### PR DESCRIPTION
Fixes: amplication/private-issues#131

## PR Details

consolidate auth throgh OIDC and JWT generation in auth service.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
