### PR TITLE
fix(client): add showTooltip={false} to components that are using the render function

### DIFF
--- a/packages/amplication-client/src/ModuleActions/ModuleActions.tsx
+++ b/packages/amplication-client/src/ModuleActions/ModuleActions.tsx
@@ -104,6 +104,7 @@ const ModuleActions = React.memo(({ match }: Props) => {
     <FeatureIndicatorContainer
       featureId={BillingFeature.CustomActions}
       entitlementType={EntitlementType.Boolean}
+      showTooltip={false}
       render={({ disabled, icon }) => (
         <>
           {disabled ? (

--- a/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/RepositoryForm.tsx
+++ b/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/RepositoryForm.tsx
@@ -56,6 +56,7 @@ const RepositoryForm = ({ onSubmit, defaultValues }: Props) => {
     <FeatureIndicatorContainer
       featureId={BillingFeature.ChangeGitBaseBranch}
       entitlementType={EntitlementType.Boolean}
+      showTooltip={false}
       render={({ disabled, icon }) => (
         <>
           <FlexItem


### PR DESCRIPTION

Close: #7949 

## PR Details

 Add showTooltip={false} to components that are using the render function. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

