### PR TITLE
feat(dsg): allow dynamic imports in service.base.ts

### DIFF
--- a/packages/data-service-generator/src/server/resource/service/create-service.ts
+++ b/packages/data-service-generator/src/server/resource/service/create-service.ts
@@ -27,6 +27,7 @@ import {
   extractImportDeclarations,
   getClassDeclarationById,
   getMethods,
+  importContainedIdentifiers,
   importNames,
   interpolate,
 } from "../../../utils/ast";
@@ -39,6 +40,8 @@ import pluginWrapper from "../../../plugin-wrapper";
 import DsgContext from "../../../dsg-context";
 import { getEntityIdType } from "../../../utils/get-entity-id-type";
 import { logger as applicationLogger } from "../../../logging";
+import { getDTONameToPath } from "../create-dtos";
+import { getImportableDTOs } from "../dto/create-dto-module";
 
 const MIXIN_ID = builders.identifier("Mixin");
 const ARGS_ID = builders.identifier("args");
@@ -147,7 +150,8 @@ async function createServiceBaseModule({
   moduleContainers,
   entityActions,
 }: CreateEntityServiceBaseParams): Promise<ModuleMap> {
-  const { serverDirectories } = DsgContext.getInstance;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { serverDirectories, DTOs } = DsgContext.getInstance;
 
   const moduleBasePath = `${serverDirectories.srcDirectory}/${entityName}/base/${entityName}.service.base.ts`;
 
@@ -272,6 +276,13 @@ async function createServiceBaseModule({
     template,
     toOneRelations.flatMap((relation) => relation.imports)
   );
+  const dtoNameToPath = getDTONameToPath(DTOs);
+
+  const dtoImports = importContainedIdentifiers(
+    template,
+    getImportableDTOs(moduleBasePath, dtoNameToPath)
+  );
+  addImports(template, [...dtoImports]);
 
   addAutoGenerationComment(template);
 

--- a/packages/data-service-generator/src/server/resource/service/create-service.ts
+++ b/packages/data-service-generator/src/server/resource/service/create-service.ts
@@ -334,6 +334,7 @@ async function createToOneRelationFile(
     DELEGATE: delegateId,
     PARENT_ID_TYPE: getParentIdType(entity.name),
     RELATED_ENTITY: builders.identifier(relatedEntity.name),
+    PRISMA_RELATED_ENTITY: builders.identifier(`Prisma${relatedEntity.name}`),
     PROPERTY: builders.identifier(field.name),
     FIND_ONE: createFieldFindOneFunctionId(field.name),
   });
@@ -356,6 +357,7 @@ async function createToManyRelationFile(
     DELEGATE: delegateId,
     PARENT_ID_TYPE: getParentIdType(entity.name),
     RELATED_ENTITY: builders.identifier(relatedEntity.name),
+    PRISMA_RELATED_ENTITY: builders.identifier(`Prisma${relatedEntity.name}`),
     PROPERTY: builders.identifier(field.name),
     FIND_MANY: createFieldFindManyFunctionId(field.name),
     ARGS: relatedEntityDTOs.findManyArgs.id,
@@ -390,6 +392,7 @@ function createTemplateMapping(
     SERVICE: serviceId,
     SERVICE_BASE: serviceBaseId,
     ENTITY: builders.identifier(entityType),
+    PRISMA_ENTITY: builders.identifier(`Prisma${entityType}`),
     COUNT_ARGS: builders.identifier(`${entityType}CountArgs`),
     FIND_MANY_ARGS: builders.identifier(`${entityType}FindManyArgs`),
     FIND_ONE_ARGS: builders.identifier(`${entityType}FindUniqueArgs`),

--- a/packages/data-service-generator/src/server/resource/service/service.base.template.ts
+++ b/packages/data-service-generator/src/server/resource/service/service.base.template.ts
@@ -1,5 +1,5 @@
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, ENTITY } from "@prisma/client";
+import { Prisma, ENTITY as PRISMA_ENTITY } from "@prisma/client";
 
 declare const CREATE_ARGS_MAPPING: Prisma.CREATE_ARGS;
 declare const UPDATE_ARGS_MAPPING: Prisma.UPDATE_ARGS;
@@ -15,27 +15,27 @@ export class SERVICE_BASE {
 
   async FIND_MANY_ENTITY_FUNCTION<T extends Prisma.FIND_MANY_ARGS>(
     args: Prisma.SelectSubset<T, Prisma.FIND_MANY_ARGS>
-  ): Promise<ENTITY[]> {
+  ): Promise<PRISMA_ENTITY[]> {
     return this.prisma.DELEGATE.findMany(args);
   }
   async FIND_ONE_ENTITY_FUNCTION<T extends Prisma.FIND_ONE_ARGS>(
     args: Prisma.SelectSubset<T, Prisma.FIND_ONE_ARGS>
-  ): Promise<ENTITY | null> {
+  ): Promise<PRISMA_ENTITY | null> {
     return this.prisma.DELEGATE.findUnique(args);
   }
   async CREATE_ENTITY_FUNCTION<T extends Prisma.CREATE_ARGS>(
     args: Prisma.SelectSubset<T, Prisma.CREATE_ARGS>
-  ): Promise<ENTITY> {
+  ): Promise<PRISMA_ENTITY> {
     return this.prisma.DELEGATE.create<T>(CREATE_ARGS_MAPPING);
   }
   async UPDATE_ENTITY_FUNCTION<T extends Prisma.UPDATE_ARGS>(
     args: Prisma.SelectSubset<T, Prisma.UPDATE_ARGS>
-  ): Promise<ENTITY> {
+  ): Promise<PRISMA_ENTITY> {
     return this.prisma.DELEGATE.update<T>(UPDATE_ARGS_MAPPING);
   }
   async DELETE_ENTITY_FUNCTION<T extends Prisma.DELETE_ARGS>(
     args: Prisma.SelectSubset<T, Prisma.DELETE_ARGS>
-  ): Promise<ENTITY> {
+  ): Promise<PRISMA_ENTITY> {
     return this.prisma.DELEGATE.delete(args);
   }
 }

--- a/packages/data-service-generator/src/server/resource/service/to-many.template.ts
+++ b/packages/data-service-generator/src/server/resource/service/to-many.template.ts
@@ -1,6 +1,9 @@
 import { PrismaService } from "../../prisma/prisma.service";
 
-import { Prisma, RELATED_ENTITY } from "@prisma/client";
+import {
+  Prisma,
+  RELATED_ENTITY as PRISMA_RELATED_ENTITY,
+} from "@prisma/client";
 
 declare class PARENT_ID_TYPE {}
 
@@ -10,7 +13,7 @@ export class Mixin {
   async FIND_MANY(
     parentId: PARENT_ID_TYPE,
     args: Prisma.ARGS
-  ): Promise<RELATED_ENTITY[]> {
+  ): Promise<PRISMA_RELATED_ENTITY[]> {
     return this.prisma.DELEGATE.findUniqueOrThrow({
       where: { id: parentId },
     }).PROPERTY(args);

--- a/packages/data-service-generator/src/server/resource/service/to-one.template.ts
+++ b/packages/data-service-generator/src/server/resource/service/to-one.template.ts
@@ -1,13 +1,15 @@
 import { PrismaService } from "../../prisma/prisma.service";
 
-import { RELATED_ENTITY } from "@prisma/client";
+import { RELATED_ENTITY as PRISMA_RELATED_ENTITY } from "@prisma/client";
 
 declare class PARENT_ID_TYPE {}
 
 export class Mixin {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async FIND_ONE(parentId: PARENT_ID_TYPE): Promise<RELATED_ENTITY | null> {
+  async FIND_ONE(
+    parentId: PARENT_ID_TYPE
+  ): Promise<PRISMA_RELATED_ENTITY | null> {
     return this.prisma.DELEGATE.findUnique({
       where: { id: parentId },
     }).PROPERTY();

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -5640,7 +5640,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Customer, Order, Organization } from "@prisma/client";
+
+import {
+  Prisma,
+  Customer as PrismaCustomer,
+  Order as PrismaOrder,
+  Organization as PrismaOrganization,
+} from "@prisma/client";
 
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -5653,34 +5659,34 @@ export class CustomerServiceBase {
 
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.customer.findMany(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
-  ): Promise<Customer | null> {
+  ): Promise<PrismaCustomer | null> {
     return this.prisma.customer.findUnique(args);
   }
   async createCustomer<T extends Prisma.CustomerCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerCreateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.create<T>(args);
   }
   async updateCustomer<T extends Prisma.CustomerUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerUpdateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.update<T>(args);
   }
   async deleteCustomer<T extends Prisma.CustomerDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerDeleteArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.delete(args);
   }
 
   async findOrders(
     parentId: number,
     args: Prisma.OrderFindManyArgs
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -5688,7 +5694,7 @@ export class CustomerServiceBase {
       .orders(args);
   }
 
-  async getOrganization(parentId: number): Promise<Organization | null> {
+  async getOrganization(parentId: number): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -5696,7 +5702,9 @@ export class CustomerServiceBase {
       .organization();
   }
 
-  async getVipOrganization(parentId: number): Promise<Organization | null> {
+  async getVipOrganization(
+    parentId: number
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -6691,7 +6699,7 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Empty } from "@prisma/client";
+import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -6704,27 +6712,27 @@ export class EmptyServiceBase {
 
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
-  ): Promise<Empty[]> {
+  ): Promise<PrismaEmpty[]> {
     return this.prisma.empty.findMany(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
-  ): Promise<Empty | null> {
+  ): Promise<PrismaEmpty | null> {
     return this.prisma.empty.findUnique(args);
   }
   async createEmpty<T extends Prisma.EmptyCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyCreateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.create<T>(args);
   }
   async updateEmpty<T extends Prisma.EmptyUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyUpdateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.update<T>(args);
   }
   async deleteEmpty<T extends Prisma.EmptyDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyDeleteArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.delete(args);
   }
 }
@@ -8289,7 +8297,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Order, Customer } from "@prisma/client";
+import {
+  Prisma,
+  Order as PrismaOrder,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -8302,31 +8314,31 @@ export class OrderServiceBase {
 
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.order.findMany(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
-  ): Promise<Order | null> {
+  ): Promise<PrismaOrder | null> {
     return this.prisma.order.findUnique(args);
   }
   async createOrder<T extends Prisma.OrderCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderCreateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.create<T>(args);
   }
   async updateOrder<T extends Prisma.OrderUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderUpdateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.update<T>(args);
   }
   async deleteOrder<T extends Prisma.OrderDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderDeleteArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.delete(args);
   }
 
-  async getCustomer(parentId: string): Promise<Customer | null> {
+  async getCustomer(parentId: string): Promise<PrismaCustomer | null> {
     return this.prisma.order
       .findUnique({
         where: { id: parentId },
@@ -10047,7 +10059,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Organization, User, Customer } from "@prisma/client";
+
+import {
+  Prisma,
+  Organization as PrismaOrganization,
+  User as PrismaUser,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -10060,34 +10078,34 @@ export class OrganizationServiceBase {
 
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.organization.findMany(args);
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
-  ): Promise<Organization | null> {
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.organization.findUnique(args);
   }
   async createOrganization<T extends Prisma.OrganizationCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationCreateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.create<T>(args);
   }
   async updateOrganization<T extends Prisma.OrganizationUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationUpdateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.update<T>(args);
   }
   async deleteOrganization<T extends Prisma.OrganizationDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationDeleteArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.delete(args);
   }
 
   async findUsers(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -10098,7 +10116,7 @@ export class OrganizationServiceBase {
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -10109,7 +10127,7 @@ export class OrganizationServiceBase {
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -11536,7 +11554,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Profile, User } from "@prisma/client";
+import {
+  Prisma,
+  Profile as PrismaProfile,
+  User as PrismaUser,
+} from "@prisma/client";
 
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -11549,31 +11571,31 @@ export class ProfileServiceBase {
 
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
-  ): Promise<Profile[]> {
+  ): Promise<PrismaProfile[]> {
     return this.prisma.profile.findMany(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
-  ): Promise<Profile | null> {
+  ): Promise<PrismaProfile | null> {
     return this.prisma.profile.findUnique(args);
   }
   async createProfile<T extends Prisma.ProfileCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileCreateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.create<T>(args);
   }
   async updateProfile<T extends Prisma.ProfileUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileUpdateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.update<T>(args);
   }
   async deleteProfile<T extends Prisma.ProfileDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileDeleteArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.delete(args);
   }
 
-  async getUser(parentId: number): Promise<User | null> {
+  async getUser(parentId: number): Promise<PrismaUser | null> {
     return this.prisma.profile
       .findUnique({
         where: { id: parentId },
@@ -14231,7 +14253,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, User, Organization, Profile } from "@prisma/client";
+
+import {
+  Prisma,
+  User as PrismaUser,
+  Organization as PrismaOrganization,
+  Profile as PrismaProfile,
+} from "@prisma/client";
 
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -14244,34 +14272,34 @@ export class UserServiceBase {
 
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user.findMany(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>
-  ): Promise<User | null> {
+  ): Promise<PrismaUser | null> {
     return this.prisma.user.findUnique(args);
   }
   async createUser<T extends Prisma.UserCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserCreateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.create<T>(args);
   }
   async updateUser<T extends Prisma.UserUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserUpdateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.update<T>(args);
   }
   async deleteUser<T extends Prisma.UserDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserDeleteArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.delete(args);
   }
 
   async findEmployees(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -14282,7 +14310,7 @@ export class UserServiceBase {
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -14290,7 +14318,7 @@ export class UserServiceBase {
       .organizations(args);
   }
 
-  async getManager(parentId: string): Promise<User | null> {
+  async getManager(parentId: string): Promise<PrismaUser | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },
@@ -14298,7 +14326,7 @@ export class UserServiceBase {
       .manager();
   }
 
-  async getProfile(parentId: string): Promise<Profile | null> {
+  async getProfile(parentId: string): Promise<PrismaProfile | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -5640,7 +5640,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Customer, Order, Organization } from "@prisma/client";
+
+import {
+  Prisma,
+  Customer as PrismaCustomer,
+  Order as PrismaOrder,
+  Organization as PrismaOrganization,
+} from "@prisma/client";
 
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -5653,34 +5659,34 @@ export class CustomerServiceBase {
 
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.customer.findMany(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
-  ): Promise<Customer | null> {
+  ): Promise<PrismaCustomer | null> {
     return this.prisma.customer.findUnique(args);
   }
   async createCustomer<T extends Prisma.CustomerCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerCreateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.create<T>(args);
   }
   async updateCustomer<T extends Prisma.CustomerUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerUpdateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.update<T>(args);
   }
   async deleteCustomer<T extends Prisma.CustomerDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerDeleteArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.delete(args);
   }
 
   async findOrders(
     parentId: number,
     args: Prisma.OrderFindManyArgs
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -5688,7 +5694,7 @@ export class CustomerServiceBase {
       .orders(args);
   }
 
-  async getOrganization(parentId: number): Promise<Organization | null> {
+  async getOrganization(parentId: number): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -5696,7 +5702,9 @@ export class CustomerServiceBase {
       .organization();
   }
 
-  async getVipOrganization(parentId: number): Promise<Organization | null> {
+  async getVipOrganization(
+    parentId: number
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -6691,7 +6699,7 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Empty } from "@prisma/client";
+import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -6704,27 +6712,27 @@ export class EmptyServiceBase {
 
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
-  ): Promise<Empty[]> {
+  ): Promise<PrismaEmpty[]> {
     return this.prisma.empty.findMany(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
-  ): Promise<Empty | null> {
+  ): Promise<PrismaEmpty | null> {
     return this.prisma.empty.findUnique(args);
   }
   async createEmpty<T extends Prisma.EmptyCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyCreateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.create<T>(args);
   }
   async updateEmpty<T extends Prisma.EmptyUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyUpdateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.update<T>(args);
   }
   async deleteEmpty<T extends Prisma.EmptyDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyDeleteArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.delete(args);
   }
 }
@@ -8289,7 +8297,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Order, Customer } from "@prisma/client";
+import {
+  Prisma,
+  Order as PrismaOrder,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -8302,31 +8314,31 @@ export class OrderServiceBase {
 
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.order.findMany(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
-  ): Promise<Order | null> {
+  ): Promise<PrismaOrder | null> {
     return this.prisma.order.findUnique(args);
   }
   async createOrder<T extends Prisma.OrderCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderCreateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.create<T>(args);
   }
   async updateOrder<T extends Prisma.OrderUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderUpdateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.update<T>(args);
   }
   async deleteOrder<T extends Prisma.OrderDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderDeleteArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.delete(args);
   }
 
-  async getCustomer(parentId: string): Promise<Customer | null> {
+  async getCustomer(parentId: string): Promise<PrismaCustomer | null> {
     return this.prisma.order
       .findUnique({
         where: { id: parentId },
@@ -10047,7 +10059,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Organization, User, Customer } from "@prisma/client";
+
+import {
+  Prisma,
+  Organization as PrismaOrganization,
+  User as PrismaUser,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -10060,34 +10078,34 @@ export class OrganizationServiceBase {
 
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.organization.findMany(args);
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
-  ): Promise<Organization | null> {
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.organization.findUnique(args);
   }
   async createOrganization<T extends Prisma.OrganizationCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationCreateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.create<T>(args);
   }
   async updateOrganization<T extends Prisma.OrganizationUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationUpdateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.update<T>(args);
   }
   async deleteOrganization<T extends Prisma.OrganizationDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationDeleteArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.delete(args);
   }
 
   async findUsers(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -10098,7 +10116,7 @@ export class OrganizationServiceBase {
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -10109,7 +10127,7 @@ export class OrganizationServiceBase {
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -11536,7 +11554,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Profile, User } from "@prisma/client";
+import {
+  Prisma,
+  Profile as PrismaProfile,
+  User as PrismaUser,
+} from "@prisma/client";
 
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -11549,31 +11571,31 @@ export class ProfileServiceBase {
 
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
-  ): Promise<Profile[]> {
+  ): Promise<PrismaProfile[]> {
     return this.prisma.profile.findMany(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
-  ): Promise<Profile | null> {
+  ): Promise<PrismaProfile | null> {
     return this.prisma.profile.findUnique(args);
   }
   async createProfile<T extends Prisma.ProfileCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileCreateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.create<T>(args);
   }
   async updateProfile<T extends Prisma.ProfileUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileUpdateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.update<T>(args);
   }
   async deleteProfile<T extends Prisma.ProfileDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileDeleteArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.delete(args);
   }
 
-  async getUser(parentId: number): Promise<User | null> {
+  async getUser(parentId: number): Promise<PrismaUser | null> {
     return this.prisma.profile
       .findUnique({
         where: { id: parentId },
@@ -14235,7 +14257,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, User, Organization, Profile } from "@prisma/client";
+
+import {
+  Prisma,
+  User as PrismaUser,
+  Organization as PrismaOrganization,
+  Profile as PrismaProfile,
+} from "@prisma/client";
 
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -14248,34 +14276,34 @@ export class UserServiceBase {
 
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user.findMany(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>
-  ): Promise<User | null> {
+  ): Promise<PrismaUser | null> {
     return this.prisma.user.findUnique(args);
   }
   async createUser<T extends Prisma.UserCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserCreateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.create<T>(args);
   }
   async updateUser<T extends Prisma.UserUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserUpdateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.update<T>(args);
   }
   async deleteUser<T extends Prisma.UserDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserDeleteArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.delete(args);
   }
 
   async findEmployees(
     parentId: number,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -14286,7 +14314,7 @@ export class UserServiceBase {
   async findOrganizations(
     parentId: number,
     args: Prisma.OrganizationFindManyArgs
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -14294,7 +14322,7 @@ export class UserServiceBase {
       .organizations(args);
   }
 
-  async getManager(parentId: number): Promise<User | null> {
+  async getManager(parentId: number): Promise<PrismaUser | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },
@@ -14302,7 +14330,7 @@ export class UserServiceBase {
       .manager();
   }
 
-  async getProfile(parentId: number): Promise<Profile | null> {
+  async getProfile(parentId: number): Promise<PrismaProfile | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
@@ -6538,7 +6538,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Customer, Order, Organization } from "@prisma/client";
+
+import {
+  Prisma,
+  Customer as PrismaCustomer,
+  Order as PrismaOrder,
+  Organization as PrismaOrganization,
+} from "@prisma/client";
 
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -6551,34 +6557,34 @@ export class CustomerServiceBase {
 
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.customer.findMany(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
-  ): Promise<Customer | null> {
+  ): Promise<PrismaCustomer | null> {
     return this.prisma.customer.findUnique(args);
   }
   async createCustomer<T extends Prisma.CustomerCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerCreateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.create<T>(args);
   }
   async updateCustomer<T extends Prisma.CustomerUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerUpdateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.update<T>(args);
   }
   async deleteCustomer<T extends Prisma.CustomerDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerDeleteArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.delete(args);
   }
 
   async findOrders(
     parentId: number,
     args: Prisma.OrderFindManyArgs
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -6586,7 +6592,7 @@ export class CustomerServiceBase {
       .orders(args);
   }
 
-  async getOrganization(parentId: number): Promise<Organization | null> {
+  async getOrganization(parentId: number): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -6594,7 +6600,9 @@ export class CustomerServiceBase {
       .organization();
   }
 
-  async getVipOrganization(parentId: number): Promise<Organization | null> {
+  async getVipOrganization(
+    parentId: number
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -7689,7 +7697,7 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Empty } from "@prisma/client";
+import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -7702,27 +7710,27 @@ export class EmptyServiceBase {
 
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
-  ): Promise<Empty[]> {
+  ): Promise<PrismaEmpty[]> {
     return this.prisma.empty.findMany(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
-  ): Promise<Empty | null> {
+  ): Promise<PrismaEmpty | null> {
     return this.prisma.empty.findUnique(args);
   }
   async createEmpty<T extends Prisma.EmptyCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyCreateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.create<T>(args);
   }
   async updateEmpty<T extends Prisma.EmptyUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyUpdateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.update<T>(args);
   }
   async deleteEmpty<T extends Prisma.EmptyDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyDeleteArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.delete(args);
   }
 }
@@ -9891,7 +9899,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Order, Customer } from "@prisma/client";
+import {
+  Prisma,
+  Order as PrismaOrder,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -9904,31 +9916,31 @@ export class OrderServiceBase {
 
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.order.findMany(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
-  ): Promise<Order | null> {
+  ): Promise<PrismaOrder | null> {
     return this.prisma.order.findUnique(args);
   }
   async createOrder<T extends Prisma.OrderCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderCreateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.create<T>(args);
   }
   async updateOrder<T extends Prisma.OrderUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderUpdateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.update<T>(args);
   }
   async deleteOrder<T extends Prisma.OrderDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderDeleteArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.delete(args);
   }
 
-  async getCustomer(parentId: string): Promise<Customer | null> {
+  async getCustomer(parentId: string): Promise<PrismaCustomer | null> {
     return this.prisma.order
       .findUnique({
         where: { id: parentId },
@@ -11843,7 +11855,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Organization, User, Customer } from "@prisma/client";
+
+import {
+  Prisma,
+  Organization as PrismaOrganization,
+  User as PrismaUser,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -11856,34 +11874,34 @@ export class OrganizationServiceBase {
 
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.organization.findMany(args);
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
-  ): Promise<Organization | null> {
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.organization.findUnique(args);
   }
   async createOrganization<T extends Prisma.OrganizationCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationCreateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.create<T>(args);
   }
   async updateOrganization<T extends Prisma.OrganizationUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationUpdateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.update<T>(args);
   }
   async deleteOrganization<T extends Prisma.OrganizationDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationDeleteArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.delete(args);
   }
 
   async findUsers(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -11894,7 +11912,7 @@ export class OrganizationServiceBase {
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -11905,7 +11923,7 @@ export class OrganizationServiceBase {
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -13451,7 +13469,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Profile, User } from "@prisma/client";
+import {
+  Prisma,
+  Profile as PrismaProfile,
+  User as PrismaUser,
+} from "@prisma/client";
 
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -13464,31 +13486,31 @@ export class ProfileServiceBase {
 
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
-  ): Promise<Profile[]> {
+  ): Promise<PrismaProfile[]> {
     return this.prisma.profile.findMany(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
-  ): Promise<Profile | null> {
+  ): Promise<PrismaProfile | null> {
     return this.prisma.profile.findUnique(args);
   }
   async createProfile<T extends Prisma.ProfileCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileCreateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.create<T>(args);
   }
   async updateProfile<T extends Prisma.ProfileUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileUpdateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.update<T>(args);
   }
   async deleteProfile<T extends Prisma.ProfileDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileDeleteArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.delete(args);
   }
 
-  async getUser(parentId: number): Promise<User | null> {
+  async getUser(parentId: number): Promise<PrismaUser | null> {
     return this.prisma.profile
       .findUnique({
         where: { id: parentId },
@@ -16424,7 +16446,14 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, User, Organization, Profile } from "@prisma/client";
+
+import {
+  Prisma,
+  User as PrismaUser,
+  Organization as PrismaOrganization,
+  Profile as PrismaProfile,
+} from "@prisma/client";
+
 import { PasswordService } from "../../auth/password.service";
 import { transformStringFieldUpdateInput } from "../../prisma.util";
 
@@ -16442,17 +16471,17 @@ export class UserServiceBase {
 
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user.findMany(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>
-  ): Promise<User | null> {
+  ): Promise<PrismaUser | null> {
     return this.prisma.user.findUnique(args);
   }
   async createUser<T extends Prisma.UserCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserCreateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.create<T>({
       ...args,
 
@@ -16464,7 +16493,7 @@ export class UserServiceBase {
   }
   async updateUser<T extends Prisma.UserUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserUpdateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.update<T>({
       ...args,
 
@@ -16482,14 +16511,14 @@ export class UserServiceBase {
   }
   async deleteUser<T extends Prisma.UserDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserDeleteArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.delete(args);
   }
 
   async findEmployees(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -16500,7 +16529,7 @@ export class UserServiceBase {
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -16508,7 +16537,7 @@ export class UserServiceBase {
       .organizations(args);
   }
 
-  async getManager(parentId: string): Promise<User | null> {
+  async getManager(parentId: string): Promise<PrismaUser | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },
@@ -16516,7 +16545,7 @@ export class UserServiceBase {
       .manager();
   }
 
-  async getProfile(parentId: string): Promise<Profile | null> {
+  async getProfile(parentId: string): Promise<PrismaProfile | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
@@ -5827,7 +5827,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Customer, Order, Organization } from "@prisma/client";
+
+import {
+  Prisma,
+  Customer as PrismaCustomer,
+  Order as PrismaOrder,
+  Organization as PrismaOrganization,
+} from "@prisma/client";
 
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -5840,34 +5846,34 @@ export class CustomerServiceBase {
 
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.customer.findMany(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
-  ): Promise<Customer | null> {
+  ): Promise<PrismaCustomer | null> {
     return this.prisma.customer.findUnique(args);
   }
   async createCustomer<T extends Prisma.CustomerCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerCreateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.create<T>(args);
   }
   async updateCustomer<T extends Prisma.CustomerUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerUpdateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.update<T>(args);
   }
   async deleteCustomer<T extends Prisma.CustomerDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerDeleteArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.delete(args);
   }
 
   async findOrders(
     parentId: number,
     args: Prisma.OrderFindManyArgs
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -5875,7 +5881,7 @@ export class CustomerServiceBase {
       .orders(args);
   }
 
-  async getOrganization(parentId: number): Promise<Organization | null> {
+  async getOrganization(parentId: number): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -5883,7 +5889,9 @@ export class CustomerServiceBase {
       .organization();
   }
 
-  async getVipOrganization(parentId: number): Promise<Organization | null> {
+  async getVipOrganization(
+    parentId: number
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -7052,7 +7060,7 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Empty } from "@prisma/client";
+import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -7065,27 +7073,27 @@ export class EmptyServiceBase {
 
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
-  ): Promise<Empty[]> {
+  ): Promise<PrismaEmpty[]> {
     return this.prisma.empty.findMany(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
-  ): Promise<Empty | null> {
+  ): Promise<PrismaEmpty | null> {
     return this.prisma.empty.findUnique(args);
   }
   async createEmpty<T extends Prisma.EmptyCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyCreateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.create<T>(args);
   }
   async updateEmpty<T extends Prisma.EmptyUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyUpdateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.update<T>(args);
   }
   async deleteEmpty<T extends Prisma.EmptyDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyDeleteArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.delete(args);
   }
 }
@@ -8777,7 +8785,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Order, Customer } from "@prisma/client";
+import {
+  Prisma,
+  Order as PrismaOrder,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -8790,31 +8802,31 @@ export class OrderServiceBase {
 
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.order.findMany(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
-  ): Promise<Order | null> {
+  ): Promise<PrismaOrder | null> {
     return this.prisma.order.findUnique(args);
   }
   async createOrder<T extends Prisma.OrderCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderCreateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.create<T>(args);
   }
   async updateOrder<T extends Prisma.OrderUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderUpdateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.update<T>(args);
   }
   async deleteOrder<T extends Prisma.OrderDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderDeleteArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.delete(args);
   }
 
-  async getCustomer(parentId: string): Promise<Customer | null> {
+  async getCustomer(parentId: string): Promise<PrismaCustomer | null> {
     return this.prisma.order
       .findUnique({
         where: { id: parentId },
@@ -10885,7 +10897,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Organization, User, Customer } from "@prisma/client";
+
+import {
+  Prisma,
+  Organization as PrismaOrganization,
+  User as PrismaUser,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -10898,34 +10916,34 @@ export class OrganizationServiceBase {
 
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.organization.findMany(args);
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
-  ): Promise<Organization | null> {
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.organization.findUnique(args);
   }
   async createOrganization<T extends Prisma.OrganizationCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationCreateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.create<T>(args);
   }
   async updateOrganization<T extends Prisma.OrganizationUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationUpdateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.update<T>(args);
   }
   async deleteOrganization<T extends Prisma.OrganizationDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationDeleteArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.delete(args);
   }
 
   async findUsers(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -10936,7 +10954,7 @@ export class OrganizationServiceBase {
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -10947,7 +10965,7 @@ export class OrganizationServiceBase {
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -12580,7 +12598,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Profile, User } from "@prisma/client";
+import {
+  Prisma,
+  Profile as PrismaProfile,
+  User as PrismaUser,
+} from "@prisma/client";
 
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -12593,31 +12615,31 @@ export class ProfileServiceBase {
 
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
-  ): Promise<Profile[]> {
+  ): Promise<PrismaProfile[]> {
     return this.prisma.profile.findMany(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
-  ): Promise<Profile | null> {
+  ): Promise<PrismaProfile | null> {
     return this.prisma.profile.findUnique(args);
   }
   async createProfile<T extends Prisma.ProfileCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileCreateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.create<T>(args);
   }
   async updateProfile<T extends Prisma.ProfileUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileUpdateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.update<T>(args);
   }
   async deleteProfile<T extends Prisma.ProfileDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileDeleteArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.delete(args);
   }
 
-  async getUser(parentId: number): Promise<User | null> {
+  async getUser(parentId: number): Promise<PrismaUser | null> {
     return this.prisma.profile
       .findUnique({
         where: { id: parentId },
@@ -15619,7 +15641,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, User, Organization, Profile } from "@prisma/client";
+
+import {
+  Prisma,
+  User as PrismaUser,
+  Organization as PrismaOrganization,
+  Profile as PrismaProfile,
+} from "@prisma/client";
 
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -15632,34 +15660,34 @@ export class UserServiceBase {
 
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user.findMany(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>
-  ): Promise<User | null> {
+  ): Promise<PrismaUser | null> {
     return this.prisma.user.findUnique(args);
   }
   async createUser<T extends Prisma.UserCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserCreateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.create<T>(args);
   }
   async updateUser<T extends Prisma.UserUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserUpdateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.update<T>(args);
   }
   async deleteUser<T extends Prisma.UserDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserDeleteArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.delete(args);
   }
 
   async findEmployees(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -15670,7 +15698,7 @@ export class UserServiceBase {
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -15678,7 +15706,7 @@ export class UserServiceBase {
       .organizations(args);
   }
 
-  async getManager(parentId: string): Promise<User | null> {
+  async getManager(parentId: string): Promise<PrismaUser | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },
@@ -15686,7 +15714,7 @@ export class UserServiceBase {
       .manager();
   }
 
-  async getProfile(parentId: string): Promise<Profile | null> {
+  async getProfile(parentId: string): Promise<PrismaProfile | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -5727,7 +5727,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Customer, Order, Organization } from "@prisma/client";
+
+import {
+  Prisma,
+  Customer as PrismaCustomer,
+  Order as PrismaOrder,
+  Organization as PrismaOrganization,
+} from "@prisma/client";
 
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -5740,34 +5746,34 @@ export class CustomerServiceBase {
 
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.customer.findMany(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
-  ): Promise<Customer | null> {
+  ): Promise<PrismaCustomer | null> {
     return this.prisma.customer.findUnique(args);
   }
   async createCustomer<T extends Prisma.CustomerCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerCreateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.create<T>(args);
   }
   async updateCustomer<T extends Prisma.CustomerUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerUpdateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.update<T>(args);
   }
   async deleteCustomer<T extends Prisma.CustomerDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerDeleteArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.delete(args);
   }
 
   async findOrders(
     parentId: number,
     args: Prisma.OrderFindManyArgs
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -5775,7 +5781,7 @@ export class CustomerServiceBase {
       .orders(args);
   }
 
-  async getOrganization(parentId: number): Promise<Organization | null> {
+  async getOrganization(parentId: number): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -5783,7 +5789,9 @@ export class CustomerServiceBase {
       .organization();
   }
 
-  async getVipOrganization(parentId: number): Promise<Organization | null> {
+  async getVipOrganization(
+    parentId: number
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -6778,7 +6786,7 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Empty } from "@prisma/client";
+import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -6791,27 +6799,27 @@ export class EmptyServiceBase {
 
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
-  ): Promise<Empty[]> {
+  ): Promise<PrismaEmpty[]> {
     return this.prisma.empty.findMany(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
-  ): Promise<Empty | null> {
+  ): Promise<PrismaEmpty | null> {
     return this.prisma.empty.findUnique(args);
   }
   async createEmpty<T extends Prisma.EmptyCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyCreateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.create<T>(args);
   }
   async updateEmpty<T extends Prisma.EmptyUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyUpdateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.update<T>(args);
   }
   async deleteEmpty<T extends Prisma.EmptyDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyDeleteArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.delete(args);
   }
 }
@@ -8512,7 +8520,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Order, Customer } from "@prisma/client";
+import {
+  Prisma,
+  Order as PrismaOrder,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -8525,31 +8537,31 @@ export class OrderServiceBase {
 
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.order.findMany(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
-  ): Promise<Order | null> {
+  ): Promise<PrismaOrder | null> {
     return this.prisma.order.findUnique(args);
   }
   async createOrder<T extends Prisma.OrderCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderCreateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.create<T>(args);
   }
   async updateOrder<T extends Prisma.OrderUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderUpdateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.update<T>(args);
   }
   async deleteOrder<T extends Prisma.OrderDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderDeleteArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.delete(args);
   }
 
-  async getCustomer(parentId: string): Promise<Customer | null> {
+  async getCustomer(parentId: string): Promise<PrismaCustomer | null> {
     return this.prisma.order
       .findUnique({
         where: { id: parentId },
@@ -10270,7 +10282,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Organization, User, Customer } from "@prisma/client";
+
+import {
+  Prisma,
+  Organization as PrismaOrganization,
+  User as PrismaUser,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -10283,34 +10301,34 @@ export class OrganizationServiceBase {
 
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.organization.findMany(args);
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
-  ): Promise<Organization | null> {
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.organization.findUnique(args);
   }
   async createOrganization<T extends Prisma.OrganizationCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationCreateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.create<T>(args);
   }
   async updateOrganization<T extends Prisma.OrganizationUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationUpdateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.update<T>(args);
   }
   async deleteOrganization<T extends Prisma.OrganizationDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationDeleteArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.delete(args);
   }
 
   async findUsers(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -10321,7 +10339,7 @@ export class OrganizationServiceBase {
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -10332,7 +10350,7 @@ export class OrganizationServiceBase {
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -11759,7 +11777,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Profile, User } from "@prisma/client";
+import {
+  Prisma,
+  Profile as PrismaProfile,
+  User as PrismaUser,
+} from "@prisma/client";
 
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -11772,31 +11794,31 @@ export class ProfileServiceBase {
 
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
-  ): Promise<Profile[]> {
+  ): Promise<PrismaProfile[]> {
     return this.prisma.profile.findMany(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
-  ): Promise<Profile | null> {
+  ): Promise<PrismaProfile | null> {
     return this.prisma.profile.findUnique(args);
   }
   async createProfile<T extends Prisma.ProfileCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileCreateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.create<T>(args);
   }
   async updateProfile<T extends Prisma.ProfileUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileUpdateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.update<T>(args);
   }
   async deleteProfile<T extends Prisma.ProfileDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileDeleteArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.delete(args);
   }
 
-  async getUser(parentId: number): Promise<User | null> {
+  async getUser(parentId: number): Promise<PrismaUser | null> {
     return this.prisma.profile
       .findUnique({
         where: { id: parentId },
@@ -14454,7 +14476,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, User, Organization, Profile } from "@prisma/client";
+
+import {
+  Prisma,
+  User as PrismaUser,
+  Organization as PrismaOrganization,
+  Profile as PrismaProfile,
+} from "@prisma/client";
 
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -14467,34 +14495,34 @@ export class UserServiceBase {
 
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user.findMany(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>
-  ): Promise<User | null> {
+  ): Promise<PrismaUser | null> {
     return this.prisma.user.findUnique(args);
   }
   async createUser<T extends Prisma.UserCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserCreateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.create<T>(args);
   }
   async updateUser<T extends Prisma.UserUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserUpdateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.update<T>(args);
   }
   async deleteUser<T extends Prisma.UserDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserDeleteArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.delete(args);
   }
 
   async findEmployees(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -14505,7 +14533,7 @@ export class UserServiceBase {
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -14513,7 +14541,7 @@ export class UserServiceBase {
       .organizations(args);
   }
 
-  async getManager(parentId: string): Promise<User | null> {
+  async getManager(parentId: string): Promise<PrismaUser | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },
@@ -14521,7 +14549,7 @@ export class UserServiceBase {
       .manager();
   }
 
-  async getProfile(parentId: string): Promise<Profile | null> {
+  async getProfile(parentId: string): Promise<PrismaProfile | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
@@ -2636,7 +2636,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Customer, Order, Organization } from "@prisma/client";
+
+import {
+  Prisma,
+  Customer as PrismaCustomer,
+  Order as PrismaOrder,
+  Organization as PrismaOrganization,
+} from "@prisma/client";
 
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -2649,34 +2655,34 @@ export class CustomerServiceBase {
 
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.customer.findMany(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
-  ): Promise<Customer | null> {
+  ): Promise<PrismaCustomer | null> {
     return this.prisma.customer.findUnique(args);
   }
   async createCustomer<T extends Prisma.CustomerCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerCreateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.create<T>(args);
   }
   async updateCustomer<T extends Prisma.CustomerUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerUpdateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.update<T>(args);
   }
   async deleteCustomer<T extends Prisma.CustomerDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerDeleteArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.delete(args);
   }
 
   async findOrders(
     parentId: number,
     args: Prisma.OrderFindManyArgs
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -2684,7 +2690,7 @@ export class CustomerServiceBase {
       .orders(args);
   }
 
-  async getOrganization(parentId: number): Promise<Organization | null> {
+  async getOrganization(parentId: number): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -2692,7 +2698,9 @@ export class CustomerServiceBase {
       .organization();
   }
 
-  async getVipOrganization(parentId: number): Promise<Organization | null> {
+  async getVipOrganization(
+    parentId: number
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -3687,7 +3695,7 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Empty } from "@prisma/client";
+import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -3700,27 +3708,27 @@ export class EmptyServiceBase {
 
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
-  ): Promise<Empty[]> {
+  ): Promise<PrismaEmpty[]> {
     return this.prisma.empty.findMany(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
-  ): Promise<Empty | null> {
+  ): Promise<PrismaEmpty | null> {
     return this.prisma.empty.findUnique(args);
   }
   async createEmpty<T extends Prisma.EmptyCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyCreateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.create<T>(args);
   }
   async updateEmpty<T extends Prisma.EmptyUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyUpdateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.update<T>(args);
   }
   async deleteEmpty<T extends Prisma.EmptyDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyDeleteArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.delete(args);
   }
 }
@@ -5285,7 +5293,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Order, Customer } from "@prisma/client";
+import {
+  Prisma,
+  Order as PrismaOrder,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -5298,31 +5310,31 @@ export class OrderServiceBase {
 
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.order.findMany(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
-  ): Promise<Order | null> {
+  ): Promise<PrismaOrder | null> {
     return this.prisma.order.findUnique(args);
   }
   async createOrder<T extends Prisma.OrderCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderCreateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.create<T>(args);
   }
   async updateOrder<T extends Prisma.OrderUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderUpdateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.update<T>(args);
   }
   async deleteOrder<T extends Prisma.OrderDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderDeleteArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.delete(args);
   }
 
-  async getCustomer(parentId: string): Promise<Customer | null> {
+  async getCustomer(parentId: string): Promise<PrismaCustomer | null> {
     return this.prisma.order
       .findUnique({
         where: { id: parentId },
@@ -7043,7 +7055,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Organization, User, Customer } from "@prisma/client";
+
+import {
+  Prisma,
+  Organization as PrismaOrganization,
+  User as PrismaUser,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -7056,34 +7074,34 @@ export class OrganizationServiceBase {
 
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.organization.findMany(args);
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
-  ): Promise<Organization | null> {
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.organization.findUnique(args);
   }
   async createOrganization<T extends Prisma.OrganizationCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationCreateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.create<T>(args);
   }
   async updateOrganization<T extends Prisma.OrganizationUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationUpdateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.update<T>(args);
   }
   async deleteOrganization<T extends Prisma.OrganizationDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationDeleteArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.delete(args);
   }
 
   async findUsers(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -7094,7 +7112,7 @@ export class OrganizationServiceBase {
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -7105,7 +7123,7 @@ export class OrganizationServiceBase {
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -8532,7 +8550,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Profile, User } from "@prisma/client";
+import {
+  Prisma,
+  Profile as PrismaProfile,
+  User as PrismaUser,
+} from "@prisma/client";
 
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -8545,31 +8567,31 @@ export class ProfileServiceBase {
 
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
-  ): Promise<Profile[]> {
+  ): Promise<PrismaProfile[]> {
     return this.prisma.profile.findMany(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
-  ): Promise<Profile | null> {
+  ): Promise<PrismaProfile | null> {
     return this.prisma.profile.findUnique(args);
   }
   async createProfile<T extends Prisma.ProfileCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileCreateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.create<T>(args);
   }
   async updateProfile<T extends Prisma.ProfileUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileUpdateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.update<T>(args);
   }
   async deleteProfile<T extends Prisma.ProfileDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileDeleteArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.delete(args);
   }
 
-  async getUser(parentId: number): Promise<User | null> {
+  async getUser(parentId: number): Promise<PrismaUser | null> {
     return this.prisma.profile
       .findUnique({
         where: { id: parentId },
@@ -11227,7 +11249,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, User, Organization, Profile } from "@prisma/client";
+
+import {
+  Prisma,
+  User as PrismaUser,
+  Organization as PrismaOrganization,
+  Profile as PrismaProfile,
+} from "@prisma/client";
 
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -11240,34 +11268,34 @@ export class UserServiceBase {
 
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user.findMany(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>
-  ): Promise<User | null> {
+  ): Promise<PrismaUser | null> {
     return this.prisma.user.findUnique(args);
   }
   async createUser<T extends Prisma.UserCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserCreateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.create<T>(args);
   }
   async updateUser<T extends Prisma.UserUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserUpdateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.update<T>(args);
   }
   async deleteUser<T extends Prisma.UserDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserDeleteArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.delete(args);
   }
 
   async findEmployees(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -11278,7 +11306,7 @@ export class UserServiceBase {
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -11286,7 +11314,7 @@ export class UserServiceBase {
       .organizations(args);
   }
 
-  async getManager(parentId: string): Promise<User | null> {
+  async getManager(parentId: string): Promise<PrismaUser | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },
@@ -11294,7 +11322,7 @@ export class UserServiceBase {
       .manager();
   }
 
-  async getProfile(parentId: string): Promise<Profile | null> {
+  async getProfile(parentId: string): Promise<PrismaProfile | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -5446,7 +5446,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Customer, Order, Organization } from "@prisma/client";
+
+import {
+  Prisma,
+  Customer as PrismaCustomer,
+  Order as PrismaOrder,
+  Organization as PrismaOrganization,
+} from "@prisma/client";
 
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -5459,34 +5465,34 @@ export class CustomerServiceBase {
 
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.customer.findMany(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
-  ): Promise<Customer | null> {
+  ): Promise<PrismaCustomer | null> {
     return this.prisma.customer.findUnique(args);
   }
   async createCustomer<T extends Prisma.CustomerCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerCreateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.create<T>(args);
   }
   async updateCustomer<T extends Prisma.CustomerUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerUpdateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.update<T>(args);
   }
   async deleteCustomer<T extends Prisma.CustomerDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerDeleteArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.delete(args);
   }
 
   async findOrders(
     parentId: number,
     args: Prisma.OrderFindManyArgs
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -5494,7 +5500,7 @@ export class CustomerServiceBase {
       .orders(args);
   }
 
-  async getOrganization(parentId: number): Promise<Organization | null> {
+  async getOrganization(parentId: number): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -5502,7 +5508,9 @@ export class CustomerServiceBase {
       .organization();
   }
 
-  async getVipOrganization(parentId: number): Promise<Organization | null> {
+  async getVipOrganization(
+    parentId: number
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -6417,7 +6425,7 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Empty } from "@prisma/client";
+import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -6430,27 +6438,27 @@ export class EmptyServiceBase {
 
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
-  ): Promise<Empty[]> {
+  ): Promise<PrismaEmpty[]> {
     return this.prisma.empty.findMany(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
-  ): Promise<Empty | null> {
+  ): Promise<PrismaEmpty | null> {
     return this.prisma.empty.findUnique(args);
   }
   async createEmpty<T extends Prisma.EmptyCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyCreateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.create<T>(args);
   }
   async updateEmpty<T extends Prisma.EmptyUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyUpdateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.update<T>(args);
   }
   async deleteEmpty<T extends Prisma.EmptyDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyDeleteArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.delete(args);
   }
 }
@@ -7874,7 +7882,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Order, Customer } from "@prisma/client";
+import {
+  Prisma,
+  Order as PrismaOrder,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -7887,31 +7899,31 @@ export class OrderServiceBase {
 
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.order.findMany(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
-  ): Promise<Order | null> {
+  ): Promise<PrismaOrder | null> {
     return this.prisma.order.findUnique(args);
   }
   async createOrder<T extends Prisma.OrderCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderCreateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.create<T>(args);
   }
   async updateOrder<T extends Prisma.OrderUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderUpdateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.update<T>(args);
   }
   async deleteOrder<T extends Prisma.OrderDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderDeleteArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.delete(args);
   }
 
-  async getCustomer(parentId: string): Promise<Customer | null> {
+  async getCustomer(parentId: string): Promise<PrismaCustomer | null> {
     return this.prisma.order
       .findUnique({
         where: { id: parentId },
@@ -9473,7 +9485,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Organization, User, Customer } from "@prisma/client";
+
+import {
+  Prisma,
+  Organization as PrismaOrganization,
+  User as PrismaUser,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -9486,34 +9504,34 @@ export class OrganizationServiceBase {
 
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.organization.findMany(args);
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
-  ): Promise<Organization | null> {
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.organization.findUnique(args);
   }
   async createOrganization<T extends Prisma.OrganizationCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationCreateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.create<T>(args);
   }
   async updateOrganization<T extends Prisma.OrganizationUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationUpdateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.update<T>(args);
   }
   async deleteOrganization<T extends Prisma.OrganizationDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationDeleteArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.delete(args);
   }
 
   async findUsers(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -9524,7 +9542,7 @@ export class OrganizationServiceBase {
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -9535,7 +9553,7 @@ export class OrganizationServiceBase {
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -10819,7 +10837,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Profile, User } from "@prisma/client";
+import {
+  Prisma,
+  Profile as PrismaProfile,
+  User as PrismaUser,
+} from "@prisma/client";
 
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -10832,31 +10854,31 @@ export class ProfileServiceBase {
 
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
-  ): Promise<Profile[]> {
+  ): Promise<PrismaProfile[]> {
     return this.prisma.profile.findMany(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
-  ): Promise<Profile | null> {
+  ): Promise<PrismaProfile | null> {
     return this.prisma.profile.findUnique(args);
   }
   async createProfile<T extends Prisma.ProfileCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileCreateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.create<T>(args);
   }
   async updateProfile<T extends Prisma.ProfileUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileUpdateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.update<T>(args);
   }
   async deleteProfile<T extends Prisma.ProfileDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileDeleteArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.delete(args);
   }
 
-  async getUser(parentId: number): Promise<User | null> {
+  async getUser(parentId: number): Promise<PrismaUser | null> {
     return this.prisma.profile
       .findUnique({
         where: { id: parentId },
@@ -13326,7 +13348,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, User, Organization, Profile } from "@prisma/client";
+
+import {
+  Prisma,
+  User as PrismaUser,
+  Organization as PrismaOrganization,
+  Profile as PrismaProfile,
+} from "@prisma/client";
 
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -13339,34 +13367,34 @@ export class UserServiceBase {
 
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user.findMany(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>
-  ): Promise<User | null> {
+  ): Promise<PrismaUser | null> {
     return this.prisma.user.findUnique(args);
   }
   async createUser<T extends Prisma.UserCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserCreateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.create<T>(args);
   }
   async updateUser<T extends Prisma.UserUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserUpdateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.update<T>(args);
   }
   async deleteUser<T extends Prisma.UserDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserDeleteArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.delete(args);
   }
 
   async findEmployees(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -13377,7 +13405,7 @@ export class UserServiceBase {
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -13385,7 +13413,7 @@ export class UserServiceBase {
       .organizations(args);
   }
 
-  async getManager(parentId: string): Promise<User | null> {
+  async getManager(parentId: string): Promise<PrismaUser | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },
@@ -13393,7 +13421,7 @@ export class UserServiceBase {
       .manager();
   }
 
-  async getProfile(parentId: string): Promise<Profile | null> {
+  async getProfile(parentId: string): Promise<PrismaProfile | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -5046,7 +5046,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Customer, Order, Organization } from "@prisma/client";
+
+import {
+  Prisma,
+  Customer as PrismaCustomer,
+  Order as PrismaOrder,
+  Organization as PrismaOrganization,
+} from "@prisma/client";
 
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -5059,34 +5065,34 @@ export class CustomerServiceBase {
 
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.customer.findMany(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
-  ): Promise<Customer | null> {
+  ): Promise<PrismaCustomer | null> {
     return this.prisma.customer.findUnique(args);
   }
   async createCustomer<T extends Prisma.CustomerCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerCreateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.create<T>(args);
   }
   async updateCustomer<T extends Prisma.CustomerUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerUpdateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.update<T>(args);
   }
   async deleteCustomer<T extends Prisma.CustomerDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerDeleteArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.delete(args);
   }
 
   async findOrders(
     parentId: number,
     args: Prisma.OrderFindManyArgs
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -5094,7 +5100,7 @@ export class CustomerServiceBase {
       .orders(args);
   }
 
-  async getOrganization(parentId: number): Promise<Organization | null> {
+  async getOrganization(parentId: number): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -5102,7 +5108,9 @@ export class CustomerServiceBase {
       .organization();
   }
 
-  async getVipOrganization(parentId: number): Promise<Organization | null> {
+  async getVipOrganization(
+    parentId: number
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -5761,7 +5769,7 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Empty } from "@prisma/client";
+import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -5774,27 +5782,27 @@ export class EmptyServiceBase {
 
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
-  ): Promise<Empty[]> {
+  ): Promise<PrismaEmpty[]> {
     return this.prisma.empty.findMany(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
-  ): Promise<Empty | null> {
+  ): Promise<PrismaEmpty | null> {
     return this.prisma.empty.findUnique(args);
   }
   async createEmpty<T extends Prisma.EmptyCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyCreateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.create<T>(args);
   }
   async updateEmpty<T extends Prisma.EmptyUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyUpdateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.update<T>(args);
   }
   async deleteEmpty<T extends Prisma.EmptyDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyDeleteArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.delete(args);
   }
 }
@@ -6960,7 +6968,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Order, Customer } from "@prisma/client";
+import {
+  Prisma,
+  Order as PrismaOrder,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -6973,31 +6985,31 @@ export class OrderServiceBase {
 
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.order.findMany(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
-  ): Promise<Order | null> {
+  ): Promise<PrismaOrder | null> {
     return this.prisma.order.findUnique(args);
   }
   async createOrder<T extends Prisma.OrderCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderCreateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.create<T>(args);
   }
   async updateOrder<T extends Prisma.OrderUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderUpdateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.update<T>(args);
   }
   async deleteOrder<T extends Prisma.OrderDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderDeleteArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.delete(args);
   }
 
-  async getCustomer(parentId: string): Promise<Customer | null> {
+  async getCustomer(parentId: string): Promise<PrismaCustomer | null> {
     return this.prisma.order
       .findUnique({
         where: { id: parentId },
@@ -8073,7 +8085,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Organization, User, Customer } from "@prisma/client";
+
+import {
+  Prisma,
+  Organization as PrismaOrganization,
+  User as PrismaUser,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -8086,34 +8104,34 @@ export class OrganizationServiceBase {
 
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.organization.findMany(args);
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
-  ): Promise<Organization | null> {
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.organization.findUnique(args);
   }
   async createOrganization<T extends Prisma.OrganizationCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationCreateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.create<T>(args);
   }
   async updateOrganization<T extends Prisma.OrganizationUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationUpdateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.update<T>(args);
   }
   async deleteOrganization<T extends Prisma.OrganizationDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationDeleteArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.delete(args);
   }
 
   async findUsers(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -8124,7 +8142,7 @@ export class OrganizationServiceBase {
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -8135,7 +8153,7 @@ export class OrganizationServiceBase {
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -9143,7 +9161,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Profile, User } from "@prisma/client";
+import {
+  Prisma,
+  Profile as PrismaProfile,
+  User as PrismaUser,
+} from "@prisma/client";
 
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -9156,31 +9178,31 @@ export class ProfileServiceBase {
 
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
-  ): Promise<Profile[]> {
+  ): Promise<PrismaProfile[]> {
     return this.prisma.profile.findMany(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
-  ): Promise<Profile | null> {
+  ): Promise<PrismaProfile | null> {
     return this.prisma.profile.findUnique(args);
   }
   async createProfile<T extends Prisma.ProfileCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileCreateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.create<T>(args);
   }
   async updateProfile<T extends Prisma.ProfileUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileUpdateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.update<T>(args);
   }
   async deleteProfile<T extends Prisma.ProfileDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileDeleteArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.delete(args);
   }
 
-  async getUser(parentId: number): Promise<User | null> {
+  async getUser(parentId: number): Promise<PrismaUser | null> {
     return this.prisma.profile
       .findUnique({
         where: { id: parentId },
@@ -11150,7 +11172,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, User, Organization, Profile } from "@prisma/client";
+
+import {
+  Prisma,
+  User as PrismaUser,
+  Organization as PrismaOrganization,
+  Profile as PrismaProfile,
+} from "@prisma/client";
 
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -11163,34 +11191,34 @@ export class UserServiceBase {
 
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user.findMany(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>
-  ): Promise<User | null> {
+  ): Promise<PrismaUser | null> {
     return this.prisma.user.findUnique(args);
   }
   async createUser<T extends Prisma.UserCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserCreateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.create<T>(args);
   }
   async updateUser<T extends Prisma.UserUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserUpdateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.update<T>(args);
   }
   async deleteUser<T extends Prisma.UserDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserDeleteArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.delete(args);
   }
 
   async findEmployees(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -11201,7 +11229,7 @@ export class UserServiceBase {
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -11209,7 +11237,7 @@ export class UserServiceBase {
       .organizations(args);
   }
 
-  async getManager(parentId: string): Promise<User | null> {
+  async getManager(parentId: string): Promise<PrismaUser | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },
@@ -11217,7 +11245,7 @@ export class UserServiceBase {
       .manager();
   }
 
-  async getProfile(parentId: string): Promise<Profile | null> {
+  async getProfile(parentId: string): Promise<PrismaProfile | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -5640,7 +5640,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Customer, Order, Organization } from "@prisma/client";
+
+import {
+  Prisma,
+  Customer as PrismaCustomer,
+  Order as PrismaOrder,
+  Organization as PrismaOrganization,
+} from "@prisma/client";
 
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -5653,34 +5659,34 @@ export class CustomerServiceBase {
 
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.customer.findMany(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
-  ): Promise<Customer | null> {
+  ): Promise<PrismaCustomer | null> {
     return this.prisma.customer.findUnique(args);
   }
   async createCustomer<T extends Prisma.CustomerCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerCreateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.create<T>(args);
   }
   async updateCustomer<T extends Prisma.CustomerUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerUpdateArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.update<T>(args);
   }
   async deleteCustomer<T extends Prisma.CustomerDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerDeleteArgs>
-  ): Promise<Customer> {
+  ): Promise<PrismaCustomer> {
     return this.prisma.customer.delete(args);
   }
 
   async findOrders(
     parentId: number,
     args: Prisma.OrderFindManyArgs
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.customer
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -5688,7 +5694,7 @@ export class CustomerServiceBase {
       .orders(args);
   }
 
-  async getOrganization(parentId: number): Promise<Organization | null> {
+  async getOrganization(parentId: number): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -5696,7 +5702,9 @@ export class CustomerServiceBase {
       .organization();
   }
 
-  async getVipOrganization(parentId: number): Promise<Organization | null> {
+  async getVipOrganization(
+    parentId: number
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.customer
       .findUnique({
         where: { id: parentId },
@@ -6691,7 +6699,7 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Empty } from "@prisma/client";
+import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -6704,27 +6712,27 @@ export class EmptyServiceBase {
 
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
-  ): Promise<Empty[]> {
+  ): Promise<PrismaEmpty[]> {
     return this.prisma.empty.findMany(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
-  ): Promise<Empty | null> {
+  ): Promise<PrismaEmpty | null> {
     return this.prisma.empty.findUnique(args);
   }
   async createEmpty<T extends Prisma.EmptyCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyCreateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.create<T>(args);
   }
   async updateEmpty<T extends Prisma.EmptyUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyUpdateArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.update<T>(args);
   }
   async deleteEmpty<T extends Prisma.EmptyDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyDeleteArgs>
-  ): Promise<Empty> {
+  ): Promise<PrismaEmpty> {
     return this.prisma.empty.delete(args);
   }
 }
@@ -8289,7 +8297,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Order, Customer } from "@prisma/client";
+import {
+  Prisma,
+  Order as PrismaOrder,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -8302,31 +8314,31 @@ export class OrderServiceBase {
 
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
-  ): Promise<Order[]> {
+  ): Promise<PrismaOrder[]> {
     return this.prisma.order.findMany(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
-  ): Promise<Order | null> {
+  ): Promise<PrismaOrder | null> {
     return this.prisma.order.findUnique(args);
   }
   async createOrder<T extends Prisma.OrderCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderCreateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.create<T>(args);
   }
   async updateOrder<T extends Prisma.OrderUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderUpdateArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.update<T>(args);
   }
   async deleteOrder<T extends Prisma.OrderDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderDeleteArgs>
-  ): Promise<Order> {
+  ): Promise<PrismaOrder> {
     return this.prisma.order.delete(args);
   }
 
-  async getCustomer(parentId: string): Promise<Customer | null> {
+  async getCustomer(parentId: string): Promise<PrismaCustomer | null> {
     return this.prisma.order
       .findUnique({
         where: { id: parentId },
@@ -10047,7 +10059,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Organization, User, Customer } from "@prisma/client";
+
+import {
+  Prisma,
+  Organization as PrismaOrganization,
+  User as PrismaUser,
+  Customer as PrismaCustomer,
+} from "@prisma/client";
 
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -10060,34 +10078,34 @@ export class OrganizationServiceBase {
 
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.organization.findMany(args);
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
-  ): Promise<Organization | null> {
+  ): Promise<PrismaOrganization | null> {
     return this.prisma.organization.findUnique(args);
   }
   async createOrganization<T extends Prisma.OrganizationCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationCreateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.create<T>(args);
   }
   async updateOrganization<T extends Prisma.OrganizationUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationUpdateArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.update<T>(args);
   }
   async deleteOrganization<T extends Prisma.OrganizationDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationDeleteArgs>
-  ): Promise<Organization> {
+  ): Promise<PrismaOrganization> {
     return this.prisma.organization.delete(args);
   }
 
   async findUsers(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -10098,7 +10116,7 @@ export class OrganizationServiceBase {
   async findCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -10109,7 +10127,7 @@ export class OrganizationServiceBase {
   async findVipCustomers(
     parentId: string,
     args: Prisma.CustomerFindManyArgs
-  ): Promise<Customer[]> {
+  ): Promise<PrismaCustomer[]> {
     return this.prisma.organization
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -11536,7 +11554,11 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, Profile, User } from "@prisma/client";
+import {
+  Prisma,
+  Profile as PrismaProfile,
+  User as PrismaUser,
+} from "@prisma/client";
 
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -11549,31 +11571,31 @@ export class ProfileServiceBase {
 
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
-  ): Promise<Profile[]> {
+  ): Promise<PrismaProfile[]> {
     return this.prisma.profile.findMany(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
-  ): Promise<Profile | null> {
+  ): Promise<PrismaProfile | null> {
     return this.prisma.profile.findUnique(args);
   }
   async createProfile<T extends Prisma.ProfileCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileCreateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.create<T>(args);
   }
   async updateProfile<T extends Prisma.ProfileUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileUpdateArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.update<T>(args);
   }
   async deleteProfile<T extends Prisma.ProfileDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileDeleteArgs>
-  ): Promise<Profile> {
+  ): Promise<PrismaProfile> {
     return this.prisma.profile.delete(args);
   }
 
-  async getUser(parentId: number): Promise<User | null> {
+  async getUser(parentId: number): Promise<PrismaUser | null> {
     return this.prisma.profile
       .findUnique({
         where: { id: parentId },
@@ -14231,7 +14253,13 @@ https://docs.amplication.com/how-to/custom-code
 ------------------------------------------------------------------------------
   */
 import { PrismaService } from "../../prisma/prisma.service";
-import { Prisma, User, Organization, Profile } from "@prisma/client";
+
+import {
+  Prisma,
+  User as PrismaUser,
+  Organization as PrismaOrganization,
+  Profile as PrismaProfile,
+} from "@prisma/client";
 
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
@@ -14244,34 +14272,34 @@ export class UserServiceBase {
 
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user.findMany(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>
-  ): Promise<User | null> {
+  ): Promise<PrismaUser | null> {
     return this.prisma.user.findUnique(args);
   }
   async createUser<T extends Prisma.UserCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserCreateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.create<T>(args);
   }
   async updateUser<T extends Prisma.UserUpdateArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserUpdateArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.update<T>(args);
   }
   async deleteUser<T extends Prisma.UserDeleteArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserDeleteArgs>
-  ): Promise<User> {
+  ): Promise<PrismaUser> {
     return this.prisma.user.delete(args);
   }
 
   async findEmployees(
     parentId: string,
     args: Prisma.UserFindManyArgs
-  ): Promise<User[]> {
+  ): Promise<PrismaUser[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -14282,7 +14310,7 @@ export class UserServiceBase {
   async findOrganizations(
     parentId: string,
     args: Prisma.OrganizationFindManyArgs
-  ): Promise<Organization[]> {
+  ): Promise<PrismaOrganization[]> {
     return this.prisma.user
       .findUniqueOrThrow({
         where: { id: parentId },
@@ -14290,7 +14318,7 @@ export class UserServiceBase {
       .organizations(args);
   }
 
-  async getManager(parentId: string): Promise<User | null> {
+  async getManager(parentId: string): Promise<PrismaUser | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },
@@ -14298,7 +14326,7 @@ export class UserServiceBase {
       .manager();
   }
 
-  async getProfile(parentId: string): Promise<Profile | null> {
+  async getProfile(parentId: string): Promise<PrismaProfile | null> {
     return this.prisma.user
       .findUnique({
         where: { id: parentId },

--- a/packages/data-service-generator/src/utils/ast.spec.ts
+++ b/packages/data-service-generator/src/utils/ast.spec.ts
@@ -162,6 +162,38 @@ class A {
     const containedIds = findContainedIdentifiers(file, ids);
     expect(containedIds.map((id) => id.name)).toEqual(ids.map((id) => id.name));
   });
+  test("skip contained identifier in import declaration", () => {
+    const file = parse(`
+import { z, y } from "./file";
+class A {
+  @x
+  b: string;
+}
+    `);
+    const ids = [
+      builders.identifier("x"),
+      builders.identifier("y"),
+      builders.identifier("z"),
+    ];
+
+    const containedIds = findContainedIdentifiers(file, ids);
+    expect(containedIds.map((id) => id.name)).toEqual(["x"]);
+  });
+  test("skip qualified names", () => {
+    const file = parse(`
+class A {
+  f(x): y.z {}
+}
+    `);
+    const ids = [
+      builders.identifier("x"),
+      builders.identifier("y"),
+      builders.identifier("z"),
+    ];
+
+    const containedIds = findContainedIdentifiers(file, ids);
+    expect(containedIds.map((id) => id.name)).toEqual(["x"]);
+  });
 });
 
 describe("importContainedIdentifiers", () => {

--- a/packages/data-service-generator/src/utils/ast.ts
+++ b/packages/data-service-generator/src/utils/ast.ts
@@ -390,6 +390,12 @@ export function findContainedIdentifiers(
   );
   const contained: namedTypes.Identifier[] = [];
   visit(node, {
+    visitImportDeclaration(path) {
+      return false;
+    },
+    visitTSQualifiedName(path) {
+      return false;
+    },
     visitIdentifier(path) {
       if (nameToIdentifier.hasOwnProperty(path.node.name)) {
         contained.push(path.node);


### PR DESCRIPTION

Close: #8005 #8004 

This PR adds support for dynamic imports in service.base.ts files.
This feature is required for Custom Actions phase 2, where custom function may need imports for default and custom DTOs which may conflict with the imports from Prisma namespace.

In order to support that, we changed two things: 
1. The names of the entities imported from Prisma were changed using an alias to PrismaEntity, e.g. PrismaCustomer - this will allow importing DTOs from ./base/[DTO].ts with no conflict
2. instruct the dynamic import mechanism to ignore qualified names like Prisma.CreateCustomerArgs, and to ignore IDs that appear in the import declarations

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
