### PR TITLE
feat(client):  replace the select menu with a button if there are only one/zero resources

### DIFF
--- a/packages/amplication-client/src/Components/RedesignResourceButton.tsx
+++ b/packages/amplication-client/src/Components/RedesignResourceButton.tsx
@@ -8,6 +8,7 @@ import {
   SelectMenuList,
   SelectMenuModal,
   Text,
+  Button,
 } from "@amplication/ui/design-system";
 import { BillingFeature } from "@amplication/util-billing-types";
 import React from "react";
@@ -39,7 +40,7 @@ const RedesignResourceButton: React.FC<Props> = ({
         fullEnterpriseText="Redesign your system architecture by breaking a monolith Service into microservices"
         render={({ disabled, icon }) => (
           <>
-            {
+            {resources.length > 1 ? (
               <SelectMenu
                 icon={icon}
                 title="Redesign"
@@ -70,7 +71,18 @@ const RedesignResourceButton: React.FC<Props> = ({
                   </SelectMenuList>
                 </SelectMenuModal>
               </SelectMenu>
-            }
+            ) : (
+              <Button
+                buttonStyle={EnumButtonStyle.Primary}
+                icon={icon}
+                disabled={resources.length === 0}
+                onClick={() => {
+                  onSelectResource(resources[0]);
+                }}
+              >
+                Redesign
+              </Button>
+            )}
           </>
         )}
       ></FeatureIndicatorContainer>


### PR DESCRIPTION
Close: #7972

## PR Details

 Replace the select menu with a button if there are only one/zero resources. 
## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
