### PR TITLE
feat(server):custom DTO Enums

### DIFF
--- a/ee/packages/git-sync-manager/src/models.ts
+++ b/ee/packages/git-sync-manager/src/models.ts
@@ -833,6 +833,7 @@ export enum EnumModuleDtoType {
   CreateInput = 'CreateInput',
   CreateNestedManyInput = 'CreateNestedManyInput',
   Custom = 'Custom',
+  CustomEnum = 'CustomEnum',
   DeleteArgs = 'DeleteArgs',
   Entity = 'Entity',
   Enum = 'Enum',
@@ -1291,6 +1292,7 @@ export type Mutation = {
   createModule: Module;
   createModuleAction: ModuleAction;
   createModuleDto: ModuleDto;
+  createModuleDtoEnum: ModuleDto;
   createModuleDtoProperty: ModuleDtoProperty;
   createOneEntity: Entity;
   createOrganization: GitOrganization;
@@ -1464,6 +1466,11 @@ export type MutationCreateModuleActionArgs = {
 
 
 export type MutationCreateModuleDtoArgs = {
+  data: ModuleDtoCreateInput;
+};
+
+
+export type MutationCreateModuleDtoEnumArgs = {
   data: ModuleDtoCreateInput;
 };
 

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -833,6 +833,7 @@ export enum EnumModuleDtoType {
   CreateInput = 'CreateInput',
   CreateNestedManyInput = 'CreateNestedManyInput',
   Custom = 'Custom',
+  CustomEnum = 'CustomEnum',
   DeleteArgs = 'DeleteArgs',
   Entity = 'Entity',
   Enum = 'Enum',
@@ -1291,6 +1292,7 @@ export type Mutation = {
   createModule: Module;
   createModuleAction: ModuleAction;
   createModuleDto: ModuleDto;
+  createModuleDtoEnum: ModuleDto;
   createModuleDtoProperty: ModuleDtoProperty;
   createOneEntity: Entity;
   createOrganization: GitOrganization;
@@ -1464,6 +1466,11 @@ export type MutationCreateModuleActionArgs = {
 
 
 export type MutationCreateModuleDtoArgs = {
+  data: ModuleDtoCreateInput;
+};
+
+
+export type MutationCreateModuleDtoEnumArgs = {
   data: ModuleDtoCreateInput;
 };
 

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -836,6 +836,7 @@ export enum EnumModuleDtoType {
   CreateInput = 'CreateInput',
   CreateNestedManyInput = 'CreateNestedManyInput',
   Custom = 'Custom',
+  CustomEnum = 'CustomEnum',
   DeleteArgs = 'DeleteArgs',
   Entity = 'Entity',
   Enum = 'Enum',
@@ -1294,6 +1295,7 @@ export type Mutation = {
   createModule: Module;
   createModuleAction: ModuleAction;
   createModuleDto: ModuleDto;
+  createModuleDtoEnum: ModuleDto;
   createModuleDtoProperty: ModuleDtoProperty;
   createOneEntity: Entity;
   createOrganization: GitOrganization;
@@ -1467,6 +1469,11 @@ export type MutationCreateModuleActionArgs = {
 
 
 export type MutationCreateModuleDtoArgs = {
+  data: ModuleDtoCreateInput;
+};
+
+
+export type MutationCreateModuleDtoEnumArgs = {
   data: ModuleDtoCreateInput;
 };
 

--- a/packages/amplication-code-gen-types/src/code-gen-types.ts
+++ b/packages/amplication-code-gen-types/src/code-gen-types.ts
@@ -356,6 +356,7 @@ export type entityDefaultActions = {
 type defaultDtoTypes = Exclude<
   models.EnumModuleDtoType,
   | models.EnumModuleDtoType.Custom
+  | models.EnumModuleDtoType.CustomEnum
   | models.EnumModuleDtoType.Enum
   | models.EnumModuleDtoType.CreateNestedManyInput
   | models.EnumModuleDtoType.UpdateNestedManyInput

--- a/packages/amplication-code-gen-types/src/models.ts
+++ b/packages/amplication-code-gen-types/src/models.ts
@@ -833,6 +833,7 @@ export enum EnumModuleDtoType {
   CreateInput = 'CreateInput',
   CreateNestedManyInput = 'CreateNestedManyInput',
   Custom = 'Custom',
+  CustomEnum = 'CustomEnum',
   DeleteArgs = 'DeleteArgs',
   Entity = 'Entity',
   Enum = 'Enum',
@@ -1291,6 +1292,7 @@ export type Mutation = {
   createModule: Module;
   createModuleAction: ModuleAction;
   createModuleDto: ModuleDto;
+  createModuleDtoEnum: ModuleDto;
   createModuleDtoProperty: ModuleDtoProperty;
   createOneEntity: Entity;
   createOrganization: GitOrganization;
@@ -1464,6 +1466,11 @@ export type MutationCreateModuleActionArgs = {
 
 
 export type MutationCreateModuleDtoArgs = {
+  data: ModuleDtoCreateInput;
+};
+
+
+export type MutationCreateModuleDtoEnumArgs = {
   data: ModuleDtoCreateInput;
 };
 

--- a/packages/amplication-git-pull-request-service/src/models.ts
+++ b/packages/amplication-git-pull-request-service/src/models.ts
@@ -833,6 +833,7 @@ export enum EnumModuleDtoType {
   CreateInput = 'CreateInput',
   CreateNestedManyInput = 'CreateNestedManyInput',
   Custom = 'Custom',
+  CustomEnum = 'CustomEnum',
   DeleteArgs = 'DeleteArgs',
   Entity = 'Entity',
   Enum = 'Enum',
@@ -1291,6 +1292,7 @@ export type Mutation = {
   createModule: Module;
   createModuleAction: ModuleAction;
   createModuleDto: ModuleDto;
+  createModuleDtoEnum: ModuleDto;
   createModuleDtoProperty: ModuleDtoProperty;
   createOneEntity: Entity;
   createOrganization: GitOrganization;
@@ -1464,6 +1466,11 @@ export type MutationCreateModuleActionArgs = {
 
 
 export type MutationCreateModuleDtoArgs = {
+  data: ModuleDtoCreateInput;
+};
+
+
+export type MutationCreateModuleDtoEnumArgs = {
   data: ModuleDtoCreateInput;
 };
 

--- a/packages/amplication-server/src/core/moduleDto/dto/EnumModuleDtoType.ts
+++ b/packages/amplication-server/src/core/moduleDto/dto/EnumModuleDtoType.ts
@@ -18,6 +18,7 @@ export enum EnumModuleDtoType {
   UpdateArgs = "UpdateArgs",
   Custom = "Custom",
   Enum = "Enum",
+  CustomEnum = "CustomEnum",
 }
 
 registerEnumType(EnumModuleDtoType, {

--- a/packages/amplication-server/src/core/moduleDto/moduleDto.resolver.ts
+++ b/packages/amplication-server/src/core/moduleDto/moduleDto.resolver.ts
@@ -45,6 +45,20 @@ export class ModuleDtoResolver extends BlockTypeResolver(
     return this.service.availableDtosForResource(args);
   }
 
+  @Mutation(() => ModuleDto, {
+    nullable: false,
+  })
+  @AuthorizeContext(
+    AuthorizableOriginParameter.ResourceId,
+    "data.resource.connect.id"
+  )
+  async createModuleDtoEnum(
+    @UserEntity() user: User,
+    @Args() args: CreateModuleDtoArgs
+  ): Promise<ModuleDto> {
+    return this.service.createEnum(args, user);
+  }
+
   @Mutation(() => ModuleDtoProperty, {
     nullable: false,
   })

--- a/packages/amplication-server/src/core/moduleDto/moduleDto.service.spec.ts
+++ b/packages/amplication-server/src/core/moduleDto/moduleDto.service.spec.ts
@@ -368,6 +368,24 @@ describe("ModuleDtoService", () => {
     );
   });
 
+  it("should throw an error when updating missing DTO", async () => {
+    blockServiceFindOneMock.mockReturnValueOnce(null);
+
+    const args: UpdateModuleDtoArgs = {
+      where: {
+        id: EXAMPLE_DTO_ID,
+      },
+      data: {
+        displayName: EXAMPLE_DTO_DISPLAY_NAME,
+        name: EXAMPLE_DTO_NAME,
+        enabled: true,
+      },
+    };
+    await expect(service.update(args, EXAMPLE_USER)).rejects.toThrow(
+      new AmplicationError(`Module DTO not found, ID: ${args.where.id}`)
+    );
+  });
+
   it("should delete custom dto", async () => {
     const args: DeleteModuleDtoArgs = {
       where: {
@@ -761,6 +779,48 @@ describe("ModuleDtoService", () => {
     ]);
 
     expect(blockServiceCreateMock).toBeCalledTimes(2);
+  });
+
+  it("should not create default dtos for relation field when it is not one-to-many ", async () => {
+    const entityField: EntityField = {
+      ...EXAMPLE_ENTITY_FIELD,
+      properties: {
+        relatedEntityId: "exampleRelatedEntityId",
+        allowMultipleSelection: false,
+        relatedFieldId: "relatedFieldId",
+      },
+    };
+
+    expect(
+      await service.createDefaultDtosForRelatedEntity(
+        EXAMPLE_ENTITY,
+        entityField,
+        { ...EXAMPLE_ENTITY, id: "relatedEntityId" },
+        EXAMPLE_MODULE.id,
+        EXAMPLE_USER
+      )
+    ).toEqual(null);
+  });
+
+  it("should not update default dtos for relation field when it is not one-to-many ", async () => {
+    const entityField: EntityField = {
+      ...EXAMPLE_ENTITY_FIELD,
+      properties: {
+        relatedEntityId: "exampleRelatedEntityId",
+        allowMultipleSelection: false,
+        relatedFieldId: "relatedFieldId",
+      },
+    };
+
+    expect(
+      await service.updateDefaultDtosForRelatedEntity(
+        EXAMPLE_ENTITY,
+        entityField,
+        { ...EXAMPLE_ENTITY, id: "relatedEntityId" },
+        EXAMPLE_MODULE.id,
+        EXAMPLE_USER
+      )
+    ).toEqual(null);
   });
 
   it("should delete default dtos for relation field", async () => {

--- a/packages/amplication-server/src/core/moduleDto/moduleDto.service.spec.ts
+++ b/packages/amplication-server/src/core/moduleDto/moduleDto.service.spec.ts
@@ -1,0 +1,631 @@
+import { EnumModuleDtoType } from "./dto/EnumModuleDtoType";
+import { Test, TestingModule } from "@nestjs/testing";
+import { FindOneArgs } from "../../dto";
+import { EnumBlockType } from "../../enums/EnumBlockType";
+import { EnumDataType } from "../../enums/EnumDataType";
+import { AmplicationError } from "../../errors/AmplicationError";
+import { Account, Entity, EntityField, User } from "../../models";
+import { PrismaService } from "../../prisma/prisma.service";
+import { EnumPreviewAccountType } from "../auth/dto/EnumPreviewAccountType";
+import { BlockService } from "../block/block.service";
+import { EntityService } from "../entity/entity.service";
+import { Module } from "../module/dto/Module";
+import { CreateModuleDtoArgs } from "./dto/CreateModuleDtoArgs";
+import { ModuleDto } from "./dto/ModuleDto";
+import { UpdateModuleDtoArgs } from "./dto/UpdateModuleDtoArgs";
+import { ModuleDtoService } from "./moduleDto.service";
+import { ConfigService } from "@nestjs/config";
+import { Env } from "../../env";
+
+const EXAMPLE_ACCOUNT_ID = "exampleAccountId";
+const EXAMPLE_EMAIL = "exampleEmail";
+const EXAMPLE_FIRST_NAME = "exampleFirstName";
+const EXAMPLE_LAST_NAME = "exampleLastName";
+const EXAMPLE_PASSWORD = "examplePassword";
+const EXAMPLE_USER_ID = "exampleUserId";
+
+const EXAMPLE_ACCOUNT: Account = {
+  id: EXAMPLE_ACCOUNT_ID,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  email: EXAMPLE_EMAIL,
+  firstName: EXAMPLE_FIRST_NAME,
+  lastName: EXAMPLE_LAST_NAME,
+  password: EXAMPLE_PASSWORD,
+  previewAccountType: EnumPreviewAccountType.None,
+  previewAccountEmail: null,
+};
+
+const EXAMPLE_USER: User = {
+  id: EXAMPLE_USER_ID,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  isOwner: true,
+  account: EXAMPLE_ACCOUNT,
+};
+
+const EXAMPLE_DTO_NAME = "createCustomer";
+const EXAMPLE_INVALID_DTO_NAME = "create Customer Input";
+const EXAMPLE_DTO_DISPLAY_NAME = "Create Customer";
+const EXAMPLE_DTO_DESCRIPTION = "Create One Customer";
+const EXAMPLE_RESOURCE_ID = "exampleResourceId";
+const EXAMPLE_DTO_ID = "exampleDtoId";
+
+const EXAMPLE_DTO: ModuleDto = {
+  id: EXAMPLE_DTO_ID,
+  dtoType: EnumModuleDtoType.Custom,
+  name: EXAMPLE_DTO_NAME,
+  displayName: EXAMPLE_DTO_DISPLAY_NAME,
+  description: EXAMPLE_DTO_DESCRIPTION,
+  enabled: true,
+  createdAt: expect.any(Date),
+  updatedAt: expect.any(Date),
+  parentBlock: null,
+  blockType: EnumBlockType.ModuleDto,
+  inputParameters: null,
+  outputParameters: null,
+  versionNumber: 0,
+  properties: [],
+};
+
+const EXAMPLE_ENTITY: Entity = {
+  id: "exampleEntityId",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  resourceId: "exampleResource",
+  name: "ExampleEntity",
+  displayName: "Example entity",
+  pluralDisplayName: "exampleEntities",
+  customAttributes: "customAttributes",
+  description: "Example entity",
+  lockedByUserId: undefined,
+  lockedAt: null,
+};
+
+const EXAMPLE_MODULE: Module = {
+  id: "exampleModuleId",
+  name: "exampleModule",
+  displayName: "example module",
+  description: "example module",
+  enabled: true,
+  createdAt: expect.any(Date),
+  updatedAt: expect.any(Date),
+  parentBlock: null,
+  blockType: EnumBlockType.Module,
+  inputParameters: null,
+  outputParameters: null,
+  versionNumber: 0,
+};
+
+const EXAMPLE_ENTITY_FIELD: EntityField = {
+  id: "exampleEntityFieldId",
+  permanentId: "examplePermanentId",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  name: "exampleEntityFieldName",
+  displayName: "exampleEntityFieldDisplayName",
+  dataType: EnumDataType.Lookup,
+  required: false,
+  unique: false,
+  searchable: true,
+  description: "exampleDescription",
+  customAttributes: "ExampleCustomAttributes",
+  properties: {
+    relatedEntityId: "exampleRelatedEntityId",
+    allowMultipleSelection: true,
+    relatedFieldId: "relatedFieldId",
+  },
+};
+
+const blockServiceFindOneMock = jest.fn(() => {
+  return EXAMPLE_DTO;
+});
+
+const blockServiceDeleteMock = jest.fn(() => {
+  return EXAMPLE_DTO;
+});
+
+const blockServiceCreateMock = jest.fn(
+  (args: CreateModuleDtoArgs): ModuleDto => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { resource, parentBlock, ...data } = args.data;
+
+    return {
+      ...data,
+      id: EXAMPLE_DTO_ID,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      blockType: EnumBlockType.ModuleDto,
+      enabled: true,
+      dtoType: EnumModuleDtoType.Custom,
+      versionNumber: 0,
+      parentBlock: null,
+      description: data.description,
+      inputParameters: null,
+      outputParameters: null,
+      properties: [],
+    };
+  }
+);
+
+const blockServiceUpdateMock = jest.fn(() => {
+  return EXAMPLE_DTO;
+});
+
+const blockServiceFindManyByBlockTypeAndSettingsMock = jest.fn(() => {
+  return [
+    {
+      ...EXAMPLE_DTO,
+      dtoType: EnumModuleDtoType.CreateArgs,
+    },
+  ];
+});
+
+describe("ModuleDtoService", () => {
+  let service: ModuleDtoService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [],
+      providers: [
+        {
+          provide: BlockService,
+          useClass: jest.fn(() => ({
+            findOne: blockServiceFindOneMock,
+            create: blockServiceCreateMock,
+            delete: blockServiceDeleteMock,
+            update: blockServiceUpdateMock,
+            findManyByBlockTypeAndSettings:
+              blockServiceFindManyByBlockTypeAndSettingsMock,
+          })),
+        },
+        {
+          provide: PrismaService,
+          useClass: jest.fn(() => ({})),
+        },
+        {
+          provide: EntityService,
+          useValue: {},
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (variable) => {
+              switch (variable) {
+                case Env.FEATURE_CUSTOM_ACTIONS_ENABLED:
+                  return "true";
+                default:
+                  return "";
+              }
+            },
+          },
+        },
+        ModuleDtoService,
+      ],
+    }).compile();
+
+    service = module.get<ModuleDtoService>(ModuleDtoService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  it("should create one dto", async () => {
+    const args: CreateModuleDtoArgs = {
+      data: {
+        resource: {
+          connect: {
+            id: EXAMPLE_RESOURCE_ID,
+          },
+        },
+        description: EXAMPLE_DTO_DESCRIPTION,
+        displayName: EXAMPLE_DTO_DISPLAY_NAME,
+        name: EXAMPLE_DTO_NAME,
+      },
+    };
+    expect(await service.create(args, EXAMPLE_USER)).toEqual(EXAMPLE_DTO);
+    expect(blockServiceCreateMock).toBeCalledTimes(1);
+    expect(blockServiceCreateMock).toBeCalledWith(
+      {
+        ...args,
+        data: {
+          ...args.data,
+          blockType: EnumBlockType.ModuleDto,
+          enabled: true,
+          dtoType: EnumModuleDtoType.Custom,
+          properties: [],
+        },
+      },
+      EXAMPLE_USER_ID
+    );
+  });
+
+  it("should create one Enum Dto", async () => {
+    const args: CreateModuleDtoArgs = {
+      data: {
+        resource: {
+          connect: {
+            id: EXAMPLE_RESOURCE_ID,
+          },
+        },
+        description: EXAMPLE_DTO_DESCRIPTION,
+        displayName: EXAMPLE_DTO_DISPLAY_NAME,
+        name: EXAMPLE_DTO_NAME,
+      },
+    };
+    expect(await service.createEnum(args, EXAMPLE_USER)).toEqual(EXAMPLE_DTO);
+    expect(blockServiceCreateMock).toBeCalledTimes(1);
+    expect(blockServiceCreateMock).toBeCalledWith(
+      {
+        ...args,
+        data: {
+          ...args.data,
+          blockType: EnumBlockType.ModuleDto,
+          enabled: true,
+          dtoType: EnumModuleDtoType.CustomEnum,
+          properties: [],
+        },
+      },
+      EXAMPLE_USER_ID
+    );
+  });
+
+  it("should throw an error when creating a dto with invalid name", async () => {
+    const args: CreateModuleDtoArgs = {
+      data: {
+        resource: {
+          connect: {
+            id: EXAMPLE_RESOURCE_ID,
+          },
+        },
+        displayName: EXAMPLE_DTO_DISPLAY_NAME,
+        name: EXAMPLE_INVALID_DTO_NAME,
+      },
+    };
+    await expect(service.create(args, EXAMPLE_USER)).rejects.toThrow(
+      new AmplicationError("Invalid moduleDto name")
+    );
+  });
+  it("should get one dto", async () => {
+    const args: FindOneArgs = {
+      where: {
+        id: EXAMPLE_DTO_ID,
+      },
+    };
+
+    const result = await service.findOne(args);
+    expect(result).toEqual(EXAMPLE_DTO);
+    expect(blockServiceFindOneMock).toBeCalledTimes(1);
+    expect(blockServiceFindOneMock).toBeCalledWith(args);
+  });
+
+  it("should update one dto", async () => {
+    const args: UpdateModuleDtoArgs = {
+      where: {
+        id: EXAMPLE_DTO_ID,
+      },
+      data: {
+        displayName: EXAMPLE_DTO_DISPLAY_NAME,
+        name: EXAMPLE_DTO_NAME,
+        enabled: true,
+      },
+    };
+    expect(await service.update(args, EXAMPLE_USER)).toEqual(EXAMPLE_DTO);
+    expect(blockServiceUpdateMock).toBeCalledTimes(1);
+    expect(blockServiceUpdateMock).toBeCalledWith(
+      args,
+      EXAMPLE_USER,
+      undefined
+    );
+  });
+
+  it("should throw an error when updating a dto with invalid name", async () => {
+    const args: UpdateModuleDtoArgs = {
+      where: {
+        id: EXAMPLE_DTO_ID,
+      },
+      data: {
+        displayName: EXAMPLE_DTO_DISPLAY_NAME,
+        name: EXAMPLE_INVALID_DTO_NAME,
+        enabled: true,
+      },
+    };
+    await expect(service.update(args, EXAMPLE_USER)).rejects.toThrow(
+      new AmplicationError("Invalid moduleDto name")
+    );
+  });
+
+  it("should throw an error when updating the name of a default dto", async () => {
+    //return a default dto
+    blockServiceFindOneMock.mockReturnValue({
+      ...EXAMPLE_DTO,
+      dtoType: EnumModuleDtoType.CreateInput,
+    });
+
+    const args: UpdateModuleDtoArgs = {
+      where: {
+        id: EXAMPLE_DTO_ID,
+      },
+      data: {
+        displayName: EXAMPLE_DTO_DISPLAY_NAME,
+        name: "newName",
+        enabled: false,
+      },
+    };
+
+    await expect(service.update(args, EXAMPLE_USER)).rejects.toThrow(
+      new AmplicationError("Cannot update the name of a default DTO")
+    );
+  });
+
+  it("should create default dtos for entity", async () => {
+    expect(
+      await service.createDefaultDtosForEntityModule(
+        EXAMPLE_ENTITY,
+        EXAMPLE_MODULE,
+        EXAMPLE_USER
+      )
+    ).toEqual([
+      {
+        dtoType: "Custom",
+        blockType: "ModuleDto",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        description: "the Example entity model",
+        displayName: "ExampleEntity",
+        enabled: true,
+        id: "exampleDtoId",
+        inputParameters: null,
+        name: "ExampleEntity",
+        outputParameters: null,
+        parentBlock: null,
+        versionNumber: 0,
+        properties: [],
+      },
+      {
+        dtoType: "Custom",
+        blockType: "ModuleDto",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        description: "Input type for Example entity count",
+        displayName: "ExampleEntityCountArgs",
+        enabled: true,
+        id: "exampleDtoId",
+        inputParameters: null,
+        name: "ExampleEntityCountArgs",
+        outputParameters: null,
+        parentBlock: null,
+        properties: [],
+        versionNumber: 0,
+      },
+      {
+        dtoType: "Custom",
+        blockType: "ModuleDto",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        description: "Args type for Example entity creation",
+        displayName: "CreateExampleEntityArgs",
+        enabled: true,
+        id: "exampleDtoId",
+        inputParameters: null,
+        name: "CreateExampleEntityArgs",
+        outputParameters: null,
+        parentBlock: null,
+        properties: [],
+        versionNumber: 0,
+      },
+      {
+        dtoType: "Custom",
+        blockType: "ModuleDto",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        description: "Input type for Example entity creation",
+        displayName: "ExampleEntityCreateInput",
+        enabled: true,
+        id: "exampleDtoId",
+        inputParameters: null,
+        name: "ExampleEntityCreateInput",
+        outputParameters: null,
+        parentBlock: null,
+        properties: [],
+        versionNumber: 0,
+      },
+      {
+        dtoType: "Custom",
+        blockType: "ModuleDto",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        description: "Args type for Example entity deletion",
+        displayName: "DeleteExampleEntityArgs",
+        enabled: true,
+        id: "exampleDtoId",
+        inputParameters: null,
+        name: "DeleteExampleEntityArgs",
+        outputParameters: null,
+        parentBlock: null,
+        properties: [],
+        versionNumber: 0,
+      },
+      {
+        dtoType: "Custom",
+        blockType: "ModuleDto",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        description: "Args type for Example entity search",
+        displayName: "ExampleEntityFindManyArgs",
+        enabled: true,
+        id: "exampleDtoId",
+        inputParameters: null,
+        name: "ExampleEntityFindManyArgs",
+        outputParameters: null,
+        parentBlock: null,
+        properties: [],
+        versionNumber: 0,
+      },
+      {
+        dtoType: "Custom",
+        blockType: "ModuleDto",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        description: "Args type for Example entity retrieval",
+        displayName: "ExampleEntityFindUniqueArgs",
+        enabled: true,
+        id: "exampleDtoId",
+        inputParameters: null,
+        name: "ExampleEntityFindUniqueArgs",
+        outputParameters: null,
+        parentBlock: null,
+        properties: [],
+        versionNumber: 0,
+      },
+      {
+        dtoType: "Custom",
+        blockType: "ModuleDto",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        description: "Input type for Example entity relation filter",
+        displayName: "ExampleEntityListRelationFilter",
+        enabled: true,
+        id: "exampleDtoId",
+        inputParameters: null,
+        name: "ExampleEntityListRelationFilter",
+        outputParameters: null,
+        parentBlock: null,
+        properties: [],
+        versionNumber: 0,
+      },
+      {
+        dtoType: "Custom",
+        blockType: "ModuleDto",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        description: "Input type for Example entity sorting",
+        displayName: "ExampleEntityOrderByInput",
+        enabled: true,
+        id: "exampleDtoId",
+        inputParameters: null,
+        name: "ExampleEntityOrderByInput",
+        outputParameters: null,
+        parentBlock: null,
+        properties: [],
+        versionNumber: 0,
+      },
+      {
+        dtoType: "Custom",
+        blockType: "ModuleDto",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        description: "Args type for Example entity update",
+        displayName: "UpdateExampleEntityArgs",
+        enabled: true,
+        id: "exampleDtoId",
+        inputParameters: null,
+        name: "UpdateExampleEntityArgs",
+        outputParameters: null,
+        parentBlock: null,
+        properties: [],
+        versionNumber: 0,
+      },
+      {
+        dtoType: "Custom",
+        blockType: "ModuleDto",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        description: "Input type for Example entity update",
+        displayName: "ExampleEntityUpdateInput",
+        enabled: true,
+        id: "exampleDtoId",
+        inputParameters: null,
+        name: "ExampleEntityUpdateInput",
+        outputParameters: null,
+        parentBlock: null,
+        properties: [],
+        versionNumber: 0,
+      },
+      {
+        dtoType: "Custom",
+        blockType: "ModuleDto",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        description: "Input type for Example entity search",
+        displayName: "ExampleEntityWhereInput",
+        enabled: true,
+        id: "exampleDtoId",
+        inputParameters: null,
+        name: "ExampleEntityWhereInput",
+        outputParameters: null,
+        parentBlock: null,
+        properties: [],
+        versionNumber: 0,
+      },
+      {
+        dtoType: "Custom",
+        blockType: "ModuleDto",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        description: "Input type for Example entity retrieval",
+        displayName: "ExampleEntityWhereUniqueInput",
+        enabled: true,
+        id: "exampleDtoId",
+        inputParameters: null,
+        name: "ExampleEntityWhereUniqueInput",
+        outputParameters: null,
+        parentBlock: null,
+        properties: [],
+        versionNumber: 0,
+      },
+    ]);
+    expect(blockServiceCreateMock).toBeCalledTimes(13);
+  });
+
+  it("should update default dtos for entity", async () => {
+    await service.updateDefaultDtosForEntityModule(
+      EXAMPLE_ENTITY,
+      EXAMPLE_MODULE,
+      EXAMPLE_USER
+    );
+    expect(blockServiceUpdateMock).toBeCalledTimes(1);
+  });
+
+  it("should update default dtos for relation field", async () => {
+    blockServiceFindManyByBlockTypeAndSettingsMock.mockReturnValue([
+      {
+        ...EXAMPLE_DTO,
+        id: "shouldBeUpdated",
+        name: "shouldBeUpdated",
+        dtoType: EnumModuleDtoType.CreateNestedManyInput,
+      },
+    ]);
+
+    await service.updateDefaultDtosForRelatedEntity(
+      EXAMPLE_ENTITY,
+      EXAMPLE_ENTITY_FIELD,
+      { ...EXAMPLE_ENTITY, id: "relatedEntityId" },
+      EXAMPLE_MODULE.id,
+      EXAMPLE_USER
+    );
+    expect(blockServiceUpdateMock).toBeCalledTimes(1);
+    expect(blockServiceUpdateMock).toBeCalledWith(
+      {
+        where: {
+          id: "shouldBeUpdated",
+        },
+        data: {
+          description:
+            "Input type for Example entity creation with related ExampleEntity",
+          displayName:
+            "ExampleEntityCreateNestedManyWithoutExampleEntitiesInput",
+          enabled: true,
+          dtoType: "CreateNestedManyInput",
+          name: "ExampleEntityCreateNestedManyWithoutExampleEntitiesInput",
+          properties: [],
+        },
+      },
+      EXAMPLE_USER,
+      undefined
+    );
+  });
+});

--- a/packages/amplication-server/src/core/moduleDto/moduleDto.service.spec.ts
+++ b/packages/amplication-server/src/core/moduleDto/moduleDto.service.spec.ts
@@ -1081,4 +1081,71 @@ describe("ModuleDtoService", () => {
       true
     );
   });
+
+  it("should not allow manipulating custom actions the feature is disabled", async () => {
+    service.customActionsEnabled = false;
+
+    const args: CreateModuleDtoArgs = {
+      data: {
+        resource: {
+          connect: {
+            id: EXAMPLE_RESOURCE_ID,
+          },
+        },
+        description: EXAMPLE_DTO_DESCRIPTION,
+        displayName: EXAMPLE_DTO_DISPLAY_NAME,
+        name: EXAMPLE_DTO_NAME,
+      },
+    };
+    expect(await service.create(args, EXAMPLE_USER)).toEqual(null);
+    expect(
+      await service.createDefaultDtosForEntityModule(
+        EXAMPLE_ENTITY,
+        EXAMPLE_MODULE,
+        EXAMPLE_USER
+      )
+    ).toEqual([]);
+    expect(
+      await service.updateDefaultDtosForEntityModule(
+        EXAMPLE_ENTITY,
+        EXAMPLE_MODULE,
+        EXAMPLE_USER
+      )
+    ).toEqual([]);
+    expect(
+      await service.createDefaultDtosForRelatedEntity(
+        EXAMPLE_ENTITY,
+        EXAMPLE_ENTITY_FIELD,
+        { ...EXAMPLE_ENTITY, id: "relatedEntityId" },
+        EXAMPLE_MODULE.id,
+        EXAMPLE_USER
+      )
+    ).toEqual([]);
+    expect(
+      await service.updateDefaultDtosForRelatedEntity(
+        EXAMPLE_ENTITY,
+        EXAMPLE_ENTITY_FIELD,
+        { ...EXAMPLE_ENTITY, id: "relatedEntityId" },
+        EXAMPLE_MODULE.id,
+        EXAMPLE_USER
+      )
+    ).toEqual([]);
+    expect(
+      await service.createDefaultDtoForEnumField(
+        EXAMPLE_ENTITY,
+        EXAMPLE_ENTITY_ENUM_FIELD,
+        EXAMPLE_MODULE.id,
+        EXAMPLE_USER
+      )
+    ).toEqual(null);
+    expect(
+      await service.updateDefaultDtoForEnumField(
+        EXAMPLE_ENTITY,
+        EXAMPLE_ENTITY_ENUM_FIELD,
+        EXAMPLE_MODULE.id,
+        EXAMPLE_USER
+      )
+    ).toEqual(null);
+    expect(await service.createEnum(args, EXAMPLE_USER)).toEqual(null);
+  });
 });

--- a/packages/amplication-server/src/core/moduleDto/moduleDto.service.ts
+++ b/packages/amplication-server/src/core/moduleDto/moduleDto.service.ts
@@ -722,4 +722,25 @@ export class ModuleDtoService extends BlockTypeService<
       )
     );
   }
+
+  async createEnum(args: CreateModuleDtoArgs, user: User): Promise<ModuleDto> {
+    if (!this.customActionsEnabled) {
+      return null;
+    }
+
+    this.validateModuleDtoName(args.data.name);
+
+    return super.create(
+      {
+        ...args,
+        data: {
+          ...args.data,
+          properties: [],
+          enabled: true,
+          dtoType: EnumModuleDtoType.CustomEnum,
+        },
+      },
+      user
+    );
+  }
 }

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -797,6 +797,7 @@ enum EnumModuleDtoType {
   CreateInput
   CreateNestedManyInput
   Custom
+  CustomEnum
   DeleteArgs
   Entity
   Enum
@@ -1265,6 +1266,7 @@ type Mutation {
   createModule(data: ModuleCreateInput!): Module!
   createModuleAction(data: ModuleActionCreateInput!): ModuleAction!
   createModuleDto(data: ModuleDtoCreateInput!): ModuleDto!
+  createModuleDtoEnum(data: ModuleDtoCreateInput!): ModuleDto!
   createModuleDtoProperty(data: ModuleDtoPropertyCreateInput!): ModuleDtoProperty!
   createOneEntity(data: EntityCreateInput!): Entity!
   createOrganization(data: GitOrganizationCreateInput!): GitOrganization!

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -833,6 +833,7 @@ export enum EnumModuleDtoType {
   CreateInput = 'CreateInput',
   CreateNestedManyInput = 'CreateNestedManyInput',
   Custom = 'Custom',
+  CustomEnum = 'CustomEnum',
   DeleteArgs = 'DeleteArgs',
   Entity = 'Entity',
   Enum = 'Enum',
@@ -1291,6 +1292,7 @@ export type Mutation = {
   createModule: Module;
   createModuleAction: ModuleAction;
   createModuleDto: ModuleDto;
+  createModuleDtoEnum: ModuleDto;
   createModuleDtoProperty: ModuleDtoProperty;
   createOneEntity: Entity;
   createOrganization: GitOrganization;
@@ -1464,6 +1466,11 @@ export type MutationCreateModuleActionArgs = {
 
 
 export type MutationCreateModuleDtoArgs = {
+  data: ModuleDtoCreateInput;
+};
+
+
+export type MutationCreateModuleDtoEnumArgs = {
   data: ModuleDtoCreateInput;
 };
 

--- a/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
+++ b/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
@@ -20,9 +20,9 @@ import { omit } from "lodash";
 import env from "./env";
 import entities from "./data/base/entities";
 import {
-  moduleActions,
+  defaultActions,
+  defaultDtos,
   moduleContainers,
-  moduleDtos,
 } from "./data/base/modules";
 import { resourceInfo } from "./data/base/resourceInfo";
 import roles from "./data/base/roles";
@@ -112,8 +112,8 @@ describe("Data Service Generator", () => {
           buildId: "example_build_id",
           resourceType: EnumResourceType.Service,
           pluginInstallations: plugins,
-          moduleActions: moduleActions,
-          moduleDtos: moduleDtos,
+          moduleActions: defaultActions,
+          moduleDtos: defaultDtos,
           moduleContainers: moduleContainers,
         };
 

--- a/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
+++ b/packages/data-service-generator/tests/e2e/data-service-generator.e2e.spec.ts
@@ -19,6 +19,11 @@ import { Logger, LogLevel } from "@amplication/util/logging";
 import { omit } from "lodash";
 import env from "./env";
 import entities from "./data/base/entities";
+import {
+  moduleActions,
+  moduleContainers,
+  moduleDtos,
+} from "./data/base/modules";
 import { resourceInfo } from "./data/base/resourceInfo";
 import roles from "./data/base/roles";
 import { basicAuth, mongo, mysql, postgres } from "./plugins";
@@ -107,8 +112,9 @@ describe("Data Service Generator", () => {
           buildId: "example_build_id",
           resourceType: EnumResourceType.Service,
           pluginInstallations: plugins,
-          moduleActions: [],
-          moduleContainers: [],
+          moduleActions: moduleActions,
+          moduleDtos: moduleDtos,
+          moduleContainers: moduleContainers,
         };
 
         logger.info("Starting code generation", {

--- a/packages/data-service-generator/tests/e2e/data/base/modules.ts
+++ b/packages/data-service-generator/tests/e2e/data/base/modules.ts
@@ -4,7 +4,6 @@ import {
   ModuleDto,
 } from "@amplication/code-gen-types";
 import { USER_ID as USER_ENTITY_ID } from "./entities";
-
 const USER_MODULE_ID = "clraten4g000fc9yhr62nxheo";
 const PROMOTE_USER_INPUT_DTO_ID = "promoteUserInputDtoId";
 const PROMOTE_USER_ARGS_DTO_ID = "promoteUserArgsDtoId";
@@ -105,7 +104,7 @@ const userModuleCustomActions: ModuleAction[] = [
     description: "Promote one User to admin",
     resourceId: "clraten1t0004c9yhz1t3o8bp",
     parentBlockId: USER_MODULE_ID,
-    name: "promoteUser2",
+    name: "promoteUser",
     path: "/:id/promote",
     enabled: true,
     restVerb: "Post",
@@ -121,6 +120,10 @@ const userModuleCustomActions: ModuleAction[] = [
       type: "Dto",
       dtoId: PROMOTE_USER_ARGS_DTO_ID,
     },
+    restInputSource: "Split",
+    restInputParamsPropertyName: "where",
+    restInputBodyPropertyName: "data",
+    restInputQueryPropertyName: "query",
   },
   {
     id: "clraten5x000rc9yh29927zwf",
@@ -214,6 +217,16 @@ const userModuleDefaultDtos: ModuleDto[] = [
     enabled: true,
     properties: [],
   },
+  {
+    id: "UserWhereUniqueInput_ID",
+    description: "",
+    resourceId: "clraten1t0004c9yhz1t3o8bp",
+    parentBlockId: "clraten4g000fc9yhr62nxheo",
+    name: "UserWhereUniqueInput",
+    dtoType: "WhereUniqueInput",
+    enabled: true,
+    properties: [],
+  },
 ];
 
 const userModuleCustomDtos: ModuleDto[] = [
@@ -234,6 +247,30 @@ const userModuleCustomDtos: ModuleDto[] = [
           {
             type: "Dto",
             dtoId: PROMOTE_USER_INPUT_DTO_ID,
+            isArray: false,
+          },
+        ],
+      },
+      {
+        name: "where",
+        isArray: false,
+        isOptional: false,
+        propertyTypes: [
+          {
+            type: "Dto",
+            dtoId: "UserWhereUniqueInput_ID",
+            isArray: false,
+          },
+        ],
+      },
+      {
+        name: "query",
+        isArray: false,
+        isOptional: false,
+        propertyTypes: [
+          {
+            type: "Dto",
+            dtoId: "UserWhereUniqueInput_ID",
             isArray: false,
           },
         ],


### PR DESCRIPTION


Close: #8123
## PR Details

Add support for creation of custom DTO of type "Enum"

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
