### PR TITLE
fix(dsg):use bigint for relation functions

### DIFF
--- a/packages/data-service-generator/src/server/resource/service/create-service.ts
+++ b/packages/data-service-generator/src/server/resource/service/create-service.ts
@@ -369,7 +369,7 @@ function getParentIdType(entityName: string): namedTypes.Identifier {
     [key in types.Id["idType"]]: namedTypes.Identifier;
   } = {
     AUTO_INCREMENT: builders.identifier("number"),
-    AUTO_INCREMENT_BIG_INT: builders.identifier("number"),
+    AUTO_INCREMENT_BIG_INT: builders.identifier("bigint"),
     UUID: builders.identifier("string"),
     CUID: builders.identifier("string"),
   };


### PR DESCRIPTION


Close: #8128 

## PR Details

use bigint for parentId param for relations on the service.base.ts 

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
