### PR TITLE
chore(tracing): remove prisma instrumentation

### DIFF
--- a/libs/util/nestjs/tracing/src/lib/tracing.ts
+++ b/libs/util/nestjs/tracing/src/lib/tracing.ts
@@ -6,7 +6,6 @@ import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-node";
 import { CompositePropagator } from "@opentelemetry/core";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
 // import { KafkaJsInstrumentation } from "opentelemetry-instrumentation-kafkajs";
-// import { PrismaInstrumentation } from "@prisma/instrumentation";
 import {
   Tracing as OtelTracing,
   TracingDefaultConfig,
@@ -64,12 +63,9 @@ export class Tracing extends OtelTracing {
   static init(configuration: TracingConfig): void {
     configuration.instrumentations = [
       // new KafkaJsInstrumentation({}),
-      // new PrismaInstrumentation({
-      //   middleware: false,
-      // }),
     ];
     const sdkConfig =
-      process.env.NODE_ENV === "production"
+      process.env.NODE_ENV === "production" || process.env.DEBUG_XRAY
         ? addAwsXRayConfiguration(configuration)
         : addLocalConfiguration(configuration);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "@opentelemetry/id-generator-aws-xray": "^1.2.1",
         "@primer/react": "^35.14.1",
         "@prisma/client": "^5.10.2",
-        "@prisma/instrumentation": "^5.10.2",
         "@segment/analytics-node": "^2.0.0",
         "@sendgrid/mail": "^7.7.0",
         "@stigg/node-server-sdk": "v2.49.0",
@@ -14661,6 +14660,7 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.21.0.tgz",
       "integrity": "sha512-1Z86FUxPKL6zWVy2LdhueEGl9AHDJcx+bvHStxomruz6Whd02mE3lNUMjVJ+FGRoktx/xYQcxccYb03DiUP6Yw==",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.21.0",
         "@opentelemetry/semantic-conventions": "1.21.0"
@@ -15683,69 +15683,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@prisma/instrumentation": {
-      "version": "5.10.2",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.10.2.tgz",
-      "integrity": "sha512-5ncGbvwFQMmubMBbTJ38JS5CEKW5x9GTxVtCk37IQRHyqMdJkLyC86pfPdHHrCsozljG/DBcK/OdND0CF8rfLg==",
-      "dependencies": {
-        "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
-      }
-    },
-    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
-      "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.48.0.tgz",
-      "integrity": "sha512-sjtZQB5PStIdCw5ovVTDGwnmQC+GGYArJNgIcydrDSqUTdYBnMrN9P4pwQZgS3vTGIp+TU1L8vMXGe51NVmIKQ==",
-      "dependencies": {
-        "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.1",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.21.0.tgz",
-      "integrity": "sha512-yrElGX5Fv0umzp8Nxpta/XqU71+jCAyaLk34GmBzNcrW43nqbrqvdPs4gj4MVy/HcTjr6hifCDCYA3rMkajxxA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
-      "dependencies": {
-        "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
-        "cjs-module-lexer": "^1.2.2",
-        "module-details-from-path": "^1.0.3"
       }
     },
     "node_modules/@prisma/internals": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@opentelemetry/id-generator-aws-xray": "^1.2.1",
     "@primer/react": "^35.14.1",
     "@prisma/client": "^5.10.2",
-    "@prisma/instrumentation": "^5.10.2",
     "@segment/analytics-node": "^2.0.0",
     "@sendgrid/mail": "^7.7.0",
     "@stigg/node-server-sdk": "v2.49.0",


### PR DESCRIPTION
Close: #8154

## PR Details

As sandbox tracing seems off and the only change was prisma v5, we are trying to remove this dep.

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
