### PR TITLE
chore(ci): fix ci release template

### DIFF
--- a/.github/workflows/release.template.yml
+++ b/.github/workflows/release.template.yml
@@ -43,7 +43,7 @@ env:
   BRANCH: ${{ inputs.branch }}
 
 jobs:
-  package:
+  package-container:
     if: ${{ inputs.affected-package-container != '[]' && inputs.affected-package-container != ''}}
     name: Package
     runs-on: ubuntu-20.04
@@ -131,7 +131,7 @@ jobs:
 
   deploy-container:
     name: Deployment container
-    needs: [package, configure]
+    needs: [package-container, configure]
     if: ${{ inputs.affected-deploy-container != '[]' && inputs.affected-deploy-container != ''}}
     strategy:
       matrix:
@@ -147,7 +147,7 @@ jobs:
 
   deploy-static:
     name: Deployment static
-    needs: [package, configure]
+    needs: [configure]
     if: ${{ inputs.affected-deploy-static != '[]' && inputs.affected-deploy-static != ''}}
     strategy:
       matrix:


### PR DESCRIPTION
Close: #8169

## PR Details

Fix the issue related to release pipeline to be skipped.
When only client is affected, since it is not released as a container, it will not be present in the `affected package:container`, but currently the `deploy:static` was dependent on the `package` step that was never run for the client app.

## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
