### PR TITLE
test(dsg): fix auth-core plugin version to latest in dsg e2e tests

### DIFF
--- a/packages/data-service-generator/tests/e2e/plugins.ts
+++ b/packages/data-service-generator/tests/e2e/plugins.ts
@@ -36,7 +36,7 @@ export const basicAuth: PluginInstallation[] = [
     pluginId: "auth-core",
     npm: "@amplication/plugin-auth-core",
     enabled: true,
-    version: "2.0.3-beta.0",
+    version: "latest",
   },
   {
     id: "auth-basic-id",


### PR DESCRIPTION
Close: #8203
## PR Details

Fix dsg e2e tests requirements to use always the latest version of all the plugin used in the tests

## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
