### PR TITLE
feat(Notifications): Support custom SendGrid Templates 

### DIFF
--- a/packages/notification-service/src/notification-packages/previewUserGenerationCompleted.ts
+++ b/packages/notification-service/src/notification-packages/previewUserGenerationCompleted.ts
@@ -2,6 +2,7 @@ import { KAFKA_TOPICS } from "@amplication/schema-registry";
 import { NotificationContext } from "../util/novuTypes";
 
 const NOTIFICATION_KEY = "complete-preview-onboarding";
+const SENDGRID_TEMPLATE_ID = "d-f8d34551e2c7436681b34f8af0782788";
 
 export const previewUserGenerationCompleted = async (
   notificationCtx: NotificationContext
@@ -21,9 +22,17 @@ export const previewUserGenerationCompleted = async (
         notificationCtx.novuService.triggerNotificationToSubscriber,
       subscriberId: externalId,
       eventName: NOTIFICATION_KEY,
-      payload: {
-        payload: {
-          ...restParams,
+      payload: {},
+      overrides: {
+        sendgrid: {
+          customData: {
+            // sendgrid template templateId
+            templateId: SENDGRID_TEMPLATE_ID,
+            // sendgrid template variables
+            dynamicTemplateData: {
+              ...restParams,
+            },
+          },
         },
       },
     });

--- a/packages/notification-service/src/util/novuService.ts
+++ b/packages/notification-service/src/util/novuService.ts
@@ -78,9 +78,10 @@ export class NovuService {
     subscriberId: string;
     eventName: string;
     payload?: { [key: string]: any };
+    overrides?: { [key: string]: any };
   }) {
     try {
-      const { subscriberId, eventName, payload } = obj;
+      const { subscriberId, eventName, payload, overrides } = obj;
       if (!subscriberId)
         throw Error("subscriberId is missing in triggerNotification !");
 
@@ -94,6 +95,7 @@ export class NovuService {
             subscriberId,
           },
           payload: payload,
+          overrides: overrides,
         }
       );
 

--- a/packages/notification-service/src/util/novuTypes.ts
+++ b/packages/notification-service/src/util/novuTypes.ts
@@ -15,6 +15,7 @@ export interface NovuService {
     subscriberId: string;
     eventName: string;
     payload?: { [key: string]: any };
+    overrides?: { [key: string]: any };
   }) => Promise<void>;
   broadCastEventToAll: (obj: {
     eventName: string;
@@ -36,6 +37,7 @@ export interface Notification {
   eventName?: string;
   topicKey?: string;
   payload?: { [key: string]: any } | ISubscriberPayload;
+  overrides?: { [key: string]: any };
 }
 
 export interface NotificationContext {


### PR DESCRIPTION


Close: #8220
## PR Details

Allow using the overrides property in Novu API to use custom template when sending emails from SendGrid via Novu

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
