### PR TITLE
fix(client):disable default actions

### DIFF
--- a/packages/amplication-client/src/ModuleActions/ModuleAction.tsx
+++ b/packages/amplication-client/src/ModuleActions/ModuleAction.tsx
@@ -21,6 +21,7 @@ import { formatError } from "../util/error";
 import { DeleteModuleAction } from "./DeleteModuleAction";
 import ModuleActionForm from "./ModuleActionForm";
 import useModuleAction from "./hooks/useModuleAction";
+import { useModulesContext } from "../Modules/modulesContext";
 
 type Props = AppRouteProps & {
   match: match<{
@@ -35,6 +36,7 @@ type Props = AppRouteProps & {
 const ModuleAction = ({ match }: Props) => {
   const { moduleAction: moduleActionId } = match?.params ?? {};
 
+  const { customActionsLicenseEnabled } = useModulesContext();
   const {
     addEntity,
     resetPendingChangesIndicator,
@@ -116,6 +118,7 @@ const ModuleAction = ({ match }: Props) => {
             name={"enabled"}
             onValueChange={onEnableChanged}
             checked={data?.moduleAction?.enabled}
+            disabled={!customActionsLicenseEnabled}
           ></Toggle>
           {data?.moduleAction && isCustomAction && (
             <DeleteModuleAction moduleAction={data?.moduleAction} />
@@ -139,6 +142,7 @@ const ModuleAction = ({ match }: Props) => {
           isCustomAction={isCustomAction}
           onSubmit={handleSubmit}
           defaultValues={data?.moduleAction}
+          disabled={!customActionsLicenseEnabled}
         />
       )}
       <Snackbar open={hasError} message={errorMessage} />


### PR DESCRIPTION

Close: #8222

## PR Details

Disable and toggle and other fields in the Action Form when the entire Custom Action Module is disbaled

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
