### PR TITLE
fix(dsg): Updating nest-cli to copy swagger assets during build

### DIFF
--- a/packages/data-service-generator/src/server/static/nest-cli.json
+++ b/packages/data-service-generator/src/server/static/nest-cli.json
@@ -1,6 +1,10 @@
 {
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["swagger"]
+    "assets": [
+      {
+        "include": "swagger/**/*"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Close: #[8044](https://github.com/amplication/amplication/issues/8044)

## PR Details

Updated nest-cli settings to automatically copy the Swagger folder during project build

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
