### PR TITLE
fix(dsg): Update nest cli to copy swagger assets during build

### DIFF
--- a/packages/data-service-generator/src/server/static/nest-cli.json
+++ b/packages/data-service-generator/src/server/static/nest-cli.json
@@ -1,6 +1,10 @@
 {
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["swagger"]
+    "assets": [
+      {
+        "include": "swagger/**/*"
+      }
+    ]
   }
 }

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -3085,7 +3085,11 @@ volumes:
   "test/nest-cli.json": "{
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["swagger"]
+    "assets": [
+      {
+        "include": "swagger/**/*"
+      }
+    ]
   }
 }
 ",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -3085,7 +3085,11 @@ volumes:
   "server/nest-cli.json": "{
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["swagger"]
+    "assets": [
+      {
+        "include": "swagger/**/*"
+      }
+    ]
   }
 }
 ",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
@@ -3089,7 +3089,11 @@ volumes:
   "server/nest-cli.json": "{
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["swagger"]
+    "assets": [
+      {
+        "include": "swagger/**/*"
+      }
+    ]
   }
 }
 ",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-disabled-module.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-disabled-module.spec.ts.snap
@@ -3085,7 +3085,11 @@ volumes:
   "server/nest-cli.json": "{
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["swagger"]
+    "assets": [
+      {
+        "include": "swagger/**/*"
+      }
+    ]
   }
 }
 ",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
@@ -3086,7 +3086,11 @@ volumes:
   "server/nest-cli.json": "{
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["swagger"]
+    "assets": [
+      {
+        "include": "swagger/**/*"
+      }
+    ]
   }
 }
 ",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -3165,7 +3165,11 @@ volumes:
   "server/nest-cli.json": "{
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["swagger"]
+    "assets": [
+      {
+        "include": "swagger/**/*"
+      }
+    ]
   }
 }
 ",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
@@ -81,7 +81,11 @@ volumes:
   "server/nest-cli.json": "{
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["swagger"]
+    "assets": [
+      {
+        "include": "swagger/**/*"
+      }
+    ]
   }
 }
 ",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-default-actions.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-default-actions.spec.ts.snap
@@ -3085,7 +3085,11 @@ volumes:
   "server/nest-cli.json": "{
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["swagger"]
+    "assets": [
+      {
+        "include": "swagger/**/*"
+      }
+    ]
   }
 }
 ",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -3085,7 +3085,11 @@ volumes:
   "server/nest-cli.json": "{
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["swagger"]
+    "assets": [
+      {
+        "include": "swagger/**/*"
+      }
+    ]
   }
 }
 ",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -3085,7 +3085,11 @@ volumes:
   "server/nest-cli.json": "{
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["swagger"]
+    "assets": [
+      {
+        "include": "swagger/**/*"
+      }
+    ]
   }
 }
 ",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -3085,7 +3085,11 @@ volumes:
   "server/nest-cli.json": "{
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["swagger"]
+    "assets": [
+      {
+        "include": "swagger/**/*"
+      }
+    ]
   }
 }
 ",


### PR DESCRIPTION
Close: #[8044](https://github.com/amplication/amplication/issues/8044)

## PR Details

Updated nest-cli settings to automatically copy the Swagger folder during project build

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
