### PR TITLE
fix(dsg): type issues related to ts v5.4+ changes

### DIFF
--- a/packages/data-service-generator/src/server/package-json/package.json
+++ b/packages/data-service-generator/src/server/package-json/package.json
@@ -44,7 +44,7 @@
     "passport-jwt": "4.0.1",
     "passport": "0.6.0",
     "reflect-metadata": "0.1.13",
-    "ts-node": "10.9.1",
+    "ts-node": "10.9.2",
     "type-fest": "2.19.0",
     "validator": "13.11.0"
   },
@@ -64,7 +64,7 @@
     "prisma": "^5.4.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "typescript": "~5.3.0"
+    "typescript": "^5.4.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/data-service-generator/src/server/resource/service/service.base.template.ts
+++ b/packages/data-service-generator/src/server/resource/service/service.base.template.ts
@@ -14,7 +14,7 @@ export class SERVICE_BASE {
   async FIND_MANY_ENTITY_FUNCTION<T extends Prisma.FIND_MANY_ARGS>(
     args: Prisma.SelectSubset<T, Prisma.FIND_MANY_ARGS>
   ): Promise<PRISMA_ENTITY[]> {
-    return this.prisma.DELEGATE.findMany(args);
+    return this.prisma.DELEGATE.findMany<Prisma.FIND_MANY_ARGS>(args);
   }
   async FIND_ONE_ENTITY_FUNCTION<T extends Prisma.FIND_ONE_ARGS>(
     args: Prisma.SelectSubset<T, Prisma.FIND_ONE_ARGS>

--- a/packages/data-service-generator/src/server/resource/service/service.base.template.ts
+++ b/packages/data-service-generator/src/server/resource/service/service.base.template.ts
@@ -7,9 +7,7 @@ declare const UPDATE_ARGS_MAPPING: Prisma.UPDATE_ARGS;
 export class SERVICE_BASE {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.COUNT_ARGS>(
-    args: Prisma.SelectSubset<T, Prisma.COUNT_ARGS>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.COUNT_ARGS, "select">): Promise<number> {
     return this.prisma.DELEGATE.count(args);
   }
 

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -5651,9 +5651,7 @@ import {
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.CustomerCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.CustomerCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.CustomerCountArgs, "select">): Promise<number> {
     return this.prisma.customer.count(args);
   }
 
@@ -6704,9 +6702,7 @@ import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.EmptyCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.EmptyCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.EmptyCountArgs, "select">): Promise<number> {
     return this.prisma.empty.count(args);
   }
 
@@ -8307,9 +8303,7 @@ import {
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrderCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrderCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.OrderCountArgs, "select">): Promise<number> {
     return this.prisma.order.count(args);
   }
 
@@ -10071,8 +10065,8 @@ import {
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrganizationCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrganizationCountArgs>
+  async count(
+    args: Omit<Prisma.OrganizationCountArgs, "select">
   ): Promise<number> {
     return this.prisma.organization.count(args);
   }
@@ -11564,9 +11558,7 @@ import {
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.ProfileCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.ProfileCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.ProfileCountArgs, "select">): Promise<number> {
     return this.prisma.profile.count(args);
   }
 
@@ -14369,9 +14361,7 @@ import { PromoteUserInput } from "./PromoteUserInput";
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.UserCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.UserCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.UserCountArgs, "select">): Promise<number> {
     return this.prisma.user.count(args);
   }
 

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -3136,7 +3136,7 @@ volumes:
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.1",
     "reflect-metadata": "0.1.13",
-    "ts-node": "10.9.1",
+    "ts-node": "10.9.2",
     "type-fest": "2.19.0",
     "validator": "13.11.0"
   },
@@ -3156,7 +3156,7 @@ volumes:
     "prisma": "^5.4.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "typescript": "~5.3.0"
+    "typescript": "^5.4.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -5658,7 +5658,7 @@ export class CustomerServiceBase {
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
   ): Promise<PrismaCustomer[]> {
-    return this.prisma.customer.findMany(args);
+    return this.prisma.customer.findMany<Prisma.CustomerFindManyArgs>(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
@@ -6709,7 +6709,7 @@ export class EmptyServiceBase {
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
   ): Promise<PrismaEmpty[]> {
-    return this.prisma.empty.findMany(args);
+    return this.prisma.empty.findMany<Prisma.EmptyFindManyArgs>(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
@@ -8310,7 +8310,7 @@ export class OrderServiceBase {
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
   ): Promise<PrismaOrder[]> {
-    return this.prisma.order.findMany(args);
+    return this.prisma.order.findMany<Prisma.OrderFindManyArgs>(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
@@ -10074,7 +10074,9 @@ export class OrganizationServiceBase {
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
   ): Promise<PrismaOrganization[]> {
-    return this.prisma.organization.findMany(args);
+    return this.prisma.organization.findMany<Prisma.OrganizationFindManyArgs>(
+      args
+    );
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
@@ -11565,7 +11567,7 @@ export class ProfileServiceBase {
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
   ): Promise<PrismaProfile[]> {
-    return this.prisma.profile.findMany(args);
+    return this.prisma.profile.findMany<Prisma.ProfileFindManyArgs>(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
@@ -14368,7 +14370,7 @@ export class UserServiceBase {
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
   ): Promise<PrismaUser[]> {
-    return this.prisma.user.findMany(args);
+    return this.prisma.user.findMany<Prisma.UserFindManyArgs>(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -5651,9 +5651,7 @@ import {
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.CustomerCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.CustomerCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.CustomerCountArgs, "select">): Promise<number> {
     return this.prisma.customer.count(args);
   }
 
@@ -6704,9 +6702,7 @@ import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.EmptyCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.EmptyCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.EmptyCountArgs, "select">): Promise<number> {
     return this.prisma.empty.count(args);
   }
 
@@ -8307,9 +8303,7 @@ import {
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrderCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrderCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.OrderCountArgs, "select">): Promise<number> {
     return this.prisma.order.count(args);
   }
 
@@ -10071,8 +10065,8 @@ import {
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrganizationCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrganizationCountArgs>
+  async count(
+    args: Omit<Prisma.OrganizationCountArgs, "select">
   ): Promise<number> {
     return this.prisma.organization.count(args);
   }
@@ -11564,9 +11558,7 @@ import {
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.ProfileCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.ProfileCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.ProfileCountArgs, "select">): Promise<number> {
     return this.prisma.profile.count(args);
   }
 
@@ -14373,9 +14365,7 @@ import { PromoteUserInput } from "./PromoteUserInput";
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.UserCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.UserCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.UserCountArgs, "select">): Promise<number> {
     return this.prisma.user.count(args);
   }
 

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -5658,7 +5658,7 @@ export class CustomerServiceBase {
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
   ): Promise<PrismaCustomer[]> {
-    return this.prisma.customer.findMany(args);
+    return this.prisma.customer.findMany<Prisma.CustomerFindManyArgs>(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
@@ -6709,7 +6709,7 @@ export class EmptyServiceBase {
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
   ): Promise<PrismaEmpty[]> {
-    return this.prisma.empty.findMany(args);
+    return this.prisma.empty.findMany<Prisma.EmptyFindManyArgs>(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
@@ -8310,7 +8310,7 @@ export class OrderServiceBase {
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
   ): Promise<PrismaOrder[]> {
-    return this.prisma.order.findMany(args);
+    return this.prisma.order.findMany<Prisma.OrderFindManyArgs>(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
@@ -10074,7 +10074,9 @@ export class OrganizationServiceBase {
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
   ): Promise<PrismaOrganization[]> {
-    return this.prisma.organization.findMany(args);
+    return this.prisma.organization.findMany<Prisma.OrganizationFindManyArgs>(
+      args
+    );
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
@@ -11565,7 +11567,7 @@ export class ProfileServiceBase {
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
   ): Promise<PrismaProfile[]> {
-    return this.prisma.profile.findMany(args);
+    return this.prisma.profile.findMany<Prisma.ProfileFindManyArgs>(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
@@ -14372,7 +14374,7 @@ export class UserServiceBase {
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
   ): Promise<PrismaUser[]> {
-    return this.prisma.user.findMany(args);
+    return this.prisma.user.findMany<Prisma.UserFindManyArgs>(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -3136,7 +3136,7 @@ volumes:
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.1",
     "reflect-metadata": "0.1.13",
-    "ts-node": "10.9.1",
+    "ts-node": "10.9.2",
     "type-fest": "2.19.0",
     "validator": "13.11.0"
   },
@@ -3156,7 +3156,7 @@ volumes:
     "prisma": "^5.4.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "typescript": "~5.3.0"
+    "typescript": "^5.4.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
@@ -6517,7 +6517,7 @@ export class CustomerServiceBase {
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
   ): Promise<PrismaCustomer[]> {
-    return this.prisma.customer.findMany(args);
+    return this.prisma.customer.findMany<Prisma.CustomerFindManyArgs>(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
@@ -7668,7 +7668,7 @@ export class EmptyServiceBase {
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
   ): Promise<PrismaEmpty[]> {
-    return this.prisma.empty.findMany(args);
+    return this.prisma.empty.findMany<Prisma.EmptyFindManyArgs>(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
@@ -9873,7 +9873,7 @@ export class OrderServiceBase {
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
   ): Promise<PrismaOrder[]> {
-    return this.prisma.order.findMany(args);
+    return this.prisma.order.findMany<Prisma.OrderFindManyArgs>(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
@@ -11831,7 +11831,9 @@ export class OrganizationServiceBase {
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
   ): Promise<PrismaOrganization[]> {
-    return this.prisma.organization.findMany(args);
+    return this.prisma.organization.findMany<Prisma.OrganizationFindManyArgs>(
+      args
+    );
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
@@ -13441,7 +13443,7 @@ export class ProfileServiceBase {
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
   ): Promise<PrismaProfile[]> {
-    return this.prisma.profile.findMany(args);
+    return this.prisma.profile.findMany<Prisma.ProfileFindManyArgs>(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
@@ -16499,7 +16501,7 @@ export class UserServiceBase {
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
   ): Promise<PrismaUser[]> {
-    return this.prisma.user.findMany(args);
+    return this.prisma.user.findMany<Prisma.UserFindManyArgs>(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
@@ -3141,7 +3141,7 @@ volumes:
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.1",
     "reflect-metadata": "0.1.13",
-    "ts-node": "10.9.1",
+    "ts-node": "10.9.2",
     "type-fest": "2.19.0",
     "validator": "13.11.0"
   },
@@ -3161,7 +3161,7 @@ volumes:
     "prisma": "^5.4.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "typescript": "~5.3.0"
+    "typescript": "^5.4.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
@@ -6510,9 +6510,7 @@ import {
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.CustomerCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.CustomerCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.CustomerCountArgs, "select">): Promise<number> {
     return this.prisma.customer.count(args);
   }
 
@@ -7663,9 +7661,7 @@ import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.EmptyCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.EmptyCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.EmptyCountArgs, "select">): Promise<number> {
     return this.prisma.empty.count(args);
   }
 
@@ -9870,9 +9866,7 @@ import {
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrderCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrderCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.OrderCountArgs, "select">): Promise<number> {
     return this.prisma.order.count(args);
   }
 
@@ -11828,8 +11822,8 @@ import {
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrganizationCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrganizationCountArgs>
+  async count(
+    args: Omit<Prisma.OrganizationCountArgs, "select">
   ): Promise<number> {
     return this.prisma.organization.count(args);
   }
@@ -13440,9 +13434,7 @@ import {
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.ProfileCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.ProfileCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.ProfileCountArgs, "select">): Promise<number> {
     return this.prisma.profile.count(args);
   }
 
@@ -16500,9 +16492,7 @@ export class UserServiceBase {
     protected readonly passwordService: PasswordService
   ) {}
 
-  async count<T extends Prisma.UserCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.UserCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.UserCountArgs, "select">): Promise<number> {
     return this.prisma.user.count(args);
   }
 

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-disabled-module.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-disabled-module.spec.ts.snap
@@ -5651,9 +5651,7 @@ import {
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.CustomerCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.CustomerCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.CustomerCountArgs, "select">): Promise<number> {
     return this.prisma.customer.count(args);
   }
 
@@ -6704,9 +6702,7 @@ import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.EmptyCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.EmptyCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.EmptyCountArgs, "select">): Promise<number> {
     return this.prisma.empty.count(args);
   }
 
@@ -8307,9 +8303,7 @@ import {
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrderCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrderCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.OrderCountArgs, "select">): Promise<number> {
     return this.prisma.order.count(args);
   }
 
@@ -10071,8 +10065,8 @@ import {
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrganizationCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrganizationCountArgs>
+  async count(
+    args: Omit<Prisma.OrganizationCountArgs, "select">
   ): Promise<number> {
     return this.prisma.organization.count(args);
   }
@@ -11564,9 +11558,7 @@ import {
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.ProfileCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.ProfileCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.ProfileCountArgs, "select">): Promise<number> {
     return this.prisma.profile.count(args);
   }
 
@@ -14065,9 +14057,7 @@ import { PromoteUserInput } from "./PromoteUserInput";
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.UserCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.UserCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.UserCountArgs, "select">): Promise<number> {
     return this.prisma.user.count(args);
   }
 

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-disabled-module.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-disabled-module.spec.ts.snap
@@ -5658,7 +5658,7 @@ export class CustomerServiceBase {
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
   ): Promise<PrismaCustomer[]> {
-    return this.prisma.customer.findMany(args);
+    return this.prisma.customer.findMany<Prisma.CustomerFindManyArgs>(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
@@ -6709,7 +6709,7 @@ export class EmptyServiceBase {
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
   ): Promise<PrismaEmpty[]> {
-    return this.prisma.empty.findMany(args);
+    return this.prisma.empty.findMany<Prisma.EmptyFindManyArgs>(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
@@ -8310,7 +8310,7 @@ export class OrderServiceBase {
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
   ): Promise<PrismaOrder[]> {
-    return this.prisma.order.findMany(args);
+    return this.prisma.order.findMany<Prisma.OrderFindManyArgs>(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
@@ -10074,7 +10074,9 @@ export class OrganizationServiceBase {
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
   ): Promise<PrismaOrganization[]> {
-    return this.prisma.organization.findMany(args);
+    return this.prisma.organization.findMany<Prisma.OrganizationFindManyArgs>(
+      args
+    );
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
@@ -11565,7 +11567,7 @@ export class ProfileServiceBase {
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
   ): Promise<PrismaProfile[]> {
-    return this.prisma.profile.findMany(args);
+    return this.prisma.profile.findMany<Prisma.ProfileFindManyArgs>(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
@@ -14064,7 +14066,7 @@ export class UserServiceBase {
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
   ): Promise<PrismaUser[]> {
-    return this.prisma.user.findMany(args);
+    return this.prisma.user.findMany<Prisma.UserFindManyArgs>(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-disabled-module.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-disabled-module.spec.ts.snap
@@ -3136,7 +3136,7 @@ volumes:
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.1",
     "reflect-metadata": "0.1.13",
-    "ts-node": "10.9.1",
+    "ts-node": "10.9.2",
     "type-fest": "2.19.0",
     "validator": "13.11.0"
   },
@@ -3156,7 +3156,7 @@ volumes:
     "prisma": "^5.4.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "typescript": "~5.3.0"
+    "typescript": "^5.4.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
@@ -5845,7 +5845,7 @@ export class CustomerServiceBase {
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
   ): Promise<PrismaCustomer[]> {
-    return this.prisma.customer.findMany(args);
+    return this.prisma.customer.findMany<Prisma.CustomerFindManyArgs>(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
@@ -7070,7 +7070,7 @@ export class EmptyServiceBase {
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
   ): Promise<PrismaEmpty[]> {
-    return this.prisma.empty.findMany(args);
+    return this.prisma.empty.findMany<Prisma.EmptyFindManyArgs>(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
@@ -8798,7 +8798,7 @@ export class OrderServiceBase {
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
   ): Promise<PrismaOrder[]> {
-    return this.prisma.order.findMany(args);
+    return this.prisma.order.findMany<Prisma.OrderFindManyArgs>(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
@@ -10912,7 +10912,9 @@ export class OrganizationServiceBase {
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
   ): Promise<PrismaOrganization[]> {
-    return this.prisma.organization.findMany(args);
+    return this.prisma.organization.findMany<Prisma.OrganizationFindManyArgs>(
+      args
+    );
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
@@ -12609,7 +12611,7 @@ export class ProfileServiceBase {
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
   ): Promise<PrismaProfile[]> {
-    return this.prisma.profile.findMany(args);
+    return this.prisma.profile.findMany<Prisma.ProfileFindManyArgs>(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
@@ -15720,7 +15722,7 @@ export class UserServiceBase {
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
   ): Promise<PrismaUser[]> {
-    return this.prisma.user.findMany(args);
+    return this.prisma.user.findMany<Prisma.UserFindManyArgs>(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
@@ -3140,7 +3140,7 @@ volumes:
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.1",
     "reflect-metadata": "0.1.13",
-    "ts-node": "10.9.1",
+    "ts-node": "10.9.2",
     "type-fest": "2.19.0",
     "validator": "13.11.0"
   },
@@ -3160,7 +3160,7 @@ volumes:
     "prisma": "^5.4.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "typescript": "~5.3.0"
+    "typescript": "^5.4.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
@@ -5838,9 +5838,7 @@ import {
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.CustomerCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.CustomerCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.CustomerCountArgs, "select">): Promise<number> {
     return this.prisma.customer.count(args);
   }
 
@@ -7065,9 +7063,7 @@ import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.EmptyCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.EmptyCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.EmptyCountArgs, "select">): Promise<number> {
     return this.prisma.empty.count(args);
   }
 
@@ -8795,9 +8791,7 @@ import {
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrderCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrderCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.OrderCountArgs, "select">): Promise<number> {
     return this.prisma.order.count(args);
   }
 
@@ -10909,8 +10903,8 @@ import {
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrganizationCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrganizationCountArgs>
+  async count(
+    args: Omit<Prisma.OrganizationCountArgs, "select">
   ): Promise<number> {
     return this.prisma.organization.count(args);
   }
@@ -12608,9 +12602,7 @@ import {
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.ProfileCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.ProfileCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.ProfileCountArgs, "select">): Promise<number> {
     return this.prisma.profile.count(args);
   }
 
@@ -15721,9 +15713,7 @@ import { PromoteUserInput } from "./PromoteUserInput";
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.UserCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.UserCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.UserCountArgs, "select">): Promise<number> {
     return this.prisma.user.count(args);
   }
 

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -3218,7 +3218,7 @@ volumes:
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.1",
     "reflect-metadata": "0.1.13",
-    "ts-node": "10.9.1",
+    "ts-node": "10.9.2",
     "type-fest": "2.19.0",
     "validator": "13.11.0"
   },
@@ -3238,7 +3238,7 @@ volumes:
     "prisma": "^5.4.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "typescript": "~5.3.0"
+    "typescript": "^5.4.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -5745,7 +5745,7 @@ export class CustomerServiceBase {
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
   ): Promise<PrismaCustomer[]> {
-    return this.prisma.customer.findMany(args);
+    return this.prisma.customer.findMany<Prisma.CustomerFindManyArgs>(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
@@ -6796,7 +6796,7 @@ export class EmptyServiceBase {
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
   ): Promise<PrismaEmpty[]> {
-    return this.prisma.empty.findMany(args);
+    return this.prisma.empty.findMany<Prisma.EmptyFindManyArgs>(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
@@ -8533,7 +8533,7 @@ export class OrderServiceBase {
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
   ): Promise<PrismaOrder[]> {
-    return this.prisma.order.findMany(args);
+    return this.prisma.order.findMany<Prisma.OrderFindManyArgs>(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
@@ -10297,7 +10297,9 @@ export class OrganizationServiceBase {
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
   ): Promise<PrismaOrganization[]> {
-    return this.prisma.organization.findMany(args);
+    return this.prisma.organization.findMany<Prisma.OrganizationFindManyArgs>(
+      args
+    );
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
@@ -11788,7 +11790,7 @@ export class ProfileServiceBase {
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
   ): Promise<PrismaProfile[]> {
-    return this.prisma.profile.findMany(args);
+    return this.prisma.profile.findMany<Prisma.ProfileFindManyArgs>(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
@@ -14591,7 +14593,7 @@ export class UserServiceBase {
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
   ): Promise<PrismaUser[]> {
-    return this.prisma.user.findMany(args);
+    return this.prisma.user.findMany<Prisma.UserFindManyArgs>(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -5738,9 +5738,7 @@ import {
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.CustomerCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.CustomerCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.CustomerCountArgs, "select">): Promise<number> {
     return this.prisma.customer.count(args);
   }
 
@@ -6791,9 +6789,7 @@ import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.EmptyCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.EmptyCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.EmptyCountArgs, "select">): Promise<number> {
     return this.prisma.empty.count(args);
   }
 
@@ -8530,9 +8526,7 @@ import {
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrderCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrderCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.OrderCountArgs, "select">): Promise<number> {
     return this.prisma.order.count(args);
   }
 
@@ -10294,8 +10288,8 @@ import {
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrganizationCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrganizationCountArgs>
+  async count(
+    args: Omit<Prisma.OrganizationCountArgs, "select">
   ): Promise<number> {
     return this.prisma.organization.count(args);
   }
@@ -11787,9 +11781,7 @@ import {
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.ProfileCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.ProfileCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.ProfileCountArgs, "select">): Promise<number> {
     return this.prisma.profile.count(args);
   }
 
@@ -14592,9 +14584,7 @@ import { PromoteUserInput } from "./PromoteUserInput";
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.UserCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.UserCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.UserCountArgs, "select">): Promise<number> {
     return this.prisma.user.count(args);
   }
 

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
@@ -132,7 +132,7 @@ volumes:
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.1",
     "reflect-metadata": "0.1.13",
-    "ts-node": "10.9.1",
+    "ts-node": "10.9.2",
     "type-fest": "2.19.0",
     "validator": "13.11.0"
   },
@@ -152,7 +152,7 @@ volumes:
     "prisma": "^5.4.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "typescript": "~5.3.0"
+    "typescript": "^5.4.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
@@ -2654,7 +2654,7 @@ export class CustomerServiceBase {
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
   ): Promise<PrismaCustomer[]> {
-    return this.prisma.customer.findMany(args);
+    return this.prisma.customer.findMany<Prisma.CustomerFindManyArgs>(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
@@ -3705,7 +3705,7 @@ export class EmptyServiceBase {
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
   ): Promise<PrismaEmpty[]> {
-    return this.prisma.empty.findMany(args);
+    return this.prisma.empty.findMany<Prisma.EmptyFindManyArgs>(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
@@ -5306,7 +5306,7 @@ export class OrderServiceBase {
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
   ): Promise<PrismaOrder[]> {
-    return this.prisma.order.findMany(args);
+    return this.prisma.order.findMany<Prisma.OrderFindManyArgs>(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
@@ -7070,7 +7070,9 @@ export class OrganizationServiceBase {
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
   ): Promise<PrismaOrganization[]> {
-    return this.prisma.organization.findMany(args);
+    return this.prisma.organization.findMany<Prisma.OrganizationFindManyArgs>(
+      args
+    );
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
@@ -8561,7 +8563,7 @@ export class ProfileServiceBase {
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
   ): Promise<PrismaProfile[]> {
-    return this.prisma.profile.findMany(args);
+    return this.prisma.profile.findMany<Prisma.ProfileFindManyArgs>(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
@@ -11364,7 +11366,7 @@ export class UserServiceBase {
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
   ): Promise<PrismaUser[]> {
-    return this.prisma.user.findMany(args);
+    return this.prisma.user.findMany<Prisma.UserFindManyArgs>(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
@@ -2647,9 +2647,7 @@ import {
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.CustomerCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.CustomerCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.CustomerCountArgs, "select">): Promise<number> {
     return this.prisma.customer.count(args);
   }
 
@@ -3700,9 +3698,7 @@ import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.EmptyCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.EmptyCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.EmptyCountArgs, "select">): Promise<number> {
     return this.prisma.empty.count(args);
   }
 
@@ -5303,9 +5299,7 @@ import {
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrderCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrderCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.OrderCountArgs, "select">): Promise<number> {
     return this.prisma.order.count(args);
   }
 
@@ -7067,8 +7061,8 @@ import {
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrganizationCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrganizationCountArgs>
+  async count(
+    args: Omit<Prisma.OrganizationCountArgs, "select">
   ): Promise<number> {
     return this.prisma.organization.count(args);
   }
@@ -8560,9 +8554,7 @@ import {
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.ProfileCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.ProfileCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.ProfileCountArgs, "select">): Promise<number> {
     return this.prisma.profile.count(args);
   }
 
@@ -11365,9 +11357,7 @@ import { PromoteUserInput } from "./PromoteUserInput";
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.UserCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.UserCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.UserCountArgs, "select">): Promise<number> {
     return this.prisma.user.count(args);
   }
 

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-default-actions.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-default-actions.spec.ts.snap
@@ -5651,9 +5651,7 @@ import {
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.CustomerCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.CustomerCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.CustomerCountArgs, "select">): Promise<number> {
     return this.prisma.customer.count(args);
   }
 
@@ -6704,9 +6702,7 @@ import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.EmptyCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.EmptyCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.EmptyCountArgs, "select">): Promise<number> {
     return this.prisma.empty.count(args);
   }
 
@@ -8307,9 +8303,7 @@ import {
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrderCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrderCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.OrderCountArgs, "select">): Promise<number> {
     return this.prisma.order.count(args);
   }
 
@@ -10071,8 +10065,8 @@ import {
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrganizationCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrganizationCountArgs>
+  async count(
+    args: Omit<Prisma.OrganizationCountArgs, "select">
   ): Promise<number> {
     return this.prisma.organization.count(args);
   }
@@ -11564,9 +11558,7 @@ import {
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.ProfileCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.ProfileCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.ProfileCountArgs, "select">): Promise<number> {
     return this.prisma.profile.count(args);
   }
 
@@ -14065,9 +14057,7 @@ import { PromoteUserInput } from "./PromoteUserInput";
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.UserCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.UserCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.UserCountArgs, "select">): Promise<number> {
     return this.prisma.user.count(args);
   }
 

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-default-actions.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-default-actions.spec.ts.snap
@@ -5658,7 +5658,7 @@ export class CustomerServiceBase {
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
   ): Promise<PrismaCustomer[]> {
-    return this.prisma.customer.findMany(args);
+    return this.prisma.customer.findMany<Prisma.CustomerFindManyArgs>(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
@@ -6709,7 +6709,7 @@ export class EmptyServiceBase {
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
   ): Promise<PrismaEmpty[]> {
-    return this.prisma.empty.findMany(args);
+    return this.prisma.empty.findMany<Prisma.EmptyFindManyArgs>(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
@@ -8310,7 +8310,7 @@ export class OrderServiceBase {
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
   ): Promise<PrismaOrder[]> {
-    return this.prisma.order.findMany(args);
+    return this.prisma.order.findMany<Prisma.OrderFindManyArgs>(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
@@ -10074,7 +10074,9 @@ export class OrganizationServiceBase {
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
   ): Promise<PrismaOrganization[]> {
-    return this.prisma.organization.findMany(args);
+    return this.prisma.organization.findMany<Prisma.OrganizationFindManyArgs>(
+      args
+    );
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
@@ -11565,7 +11567,7 @@ export class ProfileServiceBase {
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
   ): Promise<PrismaProfile[]> {
-    return this.prisma.profile.findMany(args);
+    return this.prisma.profile.findMany<Prisma.ProfileFindManyArgs>(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
@@ -14064,7 +14066,7 @@ export class UserServiceBase {
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
   ): Promise<PrismaUser[]> {
-    return this.prisma.user.findMany(args);
+    return this.prisma.user.findMany<Prisma.UserFindManyArgs>(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-default-actions.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-default-actions.spec.ts.snap
@@ -3136,7 +3136,7 @@ volumes:
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.1",
     "reflect-metadata": "0.1.13",
-    "ts-node": "10.9.1",
+    "ts-node": "10.9.2",
     "type-fest": "2.19.0",
     "validator": "13.11.0"
   },
@@ -3156,7 +3156,7 @@ volumes:
     "prisma": "^5.4.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "typescript": "~5.3.0"
+    "typescript": "^5.4.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -5457,9 +5457,7 @@ import {
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.CustomerCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.CustomerCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.CustomerCountArgs, "select">): Promise<number> {
     return this.prisma.customer.count(args);
   }
 
@@ -6430,9 +6428,7 @@ import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.EmptyCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.EmptyCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.EmptyCountArgs, "select">): Promise<number> {
     return this.prisma.empty.count(args);
   }
 
@@ -7892,9 +7888,7 @@ import {
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrderCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrderCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.OrderCountArgs, "select">): Promise<number> {
     return this.prisma.order.count(args);
   }
 
@@ -9497,8 +9491,8 @@ import {
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrganizationCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrganizationCountArgs>
+  async count(
+    args: Omit<Prisma.OrganizationCountArgs, "select">
   ): Promise<number> {
     return this.prisma.organization.count(args);
   }
@@ -10847,9 +10841,7 @@ import {
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.ProfileCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.ProfileCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.ProfileCountArgs, "select">): Promise<number> {
     return this.prisma.profile.count(args);
   }
 
@@ -13428,9 +13420,7 @@ import { PromoteUserInput } from "./PromoteUserInput";
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.UserCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.UserCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.UserCountArgs, "select">): Promise<number> {
     return this.prisma.user.count(args);
   }
 

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -5464,7 +5464,7 @@ export class CustomerServiceBase {
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
   ): Promise<PrismaCustomer[]> {
-    return this.prisma.customer.findMany(args);
+    return this.prisma.customer.findMany<Prisma.CustomerFindManyArgs>(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
@@ -6435,7 +6435,7 @@ export class EmptyServiceBase {
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
   ): Promise<PrismaEmpty[]> {
-    return this.prisma.empty.findMany(args);
+    return this.prisma.empty.findMany<Prisma.EmptyFindManyArgs>(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
@@ -7895,7 +7895,7 @@ export class OrderServiceBase {
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
   ): Promise<PrismaOrder[]> {
-    return this.prisma.order.findMany(args);
+    return this.prisma.order.findMany<Prisma.OrderFindManyArgs>(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
@@ -9500,7 +9500,9 @@ export class OrganizationServiceBase {
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
   ): Promise<PrismaOrganization[]> {
-    return this.prisma.organization.findMany(args);
+    return this.prisma.organization.findMany<Prisma.OrganizationFindManyArgs>(
+      args
+    );
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
@@ -10848,7 +10850,7 @@ export class ProfileServiceBase {
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
   ): Promise<PrismaProfile[]> {
-    return this.prisma.profile.findMany(args);
+    return this.prisma.profile.findMany<Prisma.ProfileFindManyArgs>(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
@@ -13427,7 +13429,7 @@ export class UserServiceBase {
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
   ): Promise<PrismaUser[]> {
-    return this.prisma.user.findMany(args);
+    return this.prisma.user.findMany<Prisma.UserFindManyArgs>(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -3136,7 +3136,7 @@ volumes:
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.1",
     "reflect-metadata": "0.1.13",
-    "ts-node": "10.9.1",
+    "ts-node": "10.9.2",
     "type-fest": "2.19.0",
     "validator": "13.11.0"
   },
@@ -3156,7 +3156,7 @@ volumes:
     "prisma": "^5.4.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "typescript": "~5.3.0"
+    "typescript": "^5.4.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -5057,9 +5057,7 @@ import {
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.CustomerCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.CustomerCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.CustomerCountArgs, "select">): Promise<number> {
     return this.prisma.customer.count(args);
   }
 
@@ -5774,9 +5772,7 @@ import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.EmptyCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.EmptyCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.EmptyCountArgs, "select">): Promise<number> {
     return this.prisma.empty.count(args);
   }
 
@@ -6978,9 +6974,7 @@ import {
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrderCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrderCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.OrderCountArgs, "select">): Promise<number> {
     return this.prisma.order.count(args);
   }
 
@@ -8097,8 +8091,8 @@ import {
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrganizationCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrganizationCountArgs>
+  async count(
+    args: Omit<Prisma.OrganizationCountArgs, "select">
   ): Promise<number> {
     return this.prisma.organization.count(args);
   }
@@ -9171,9 +9165,7 @@ import {
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.ProfileCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.ProfileCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.ProfileCountArgs, "select">): Promise<number> {
     return this.prisma.profile.count(args);
   }
 
@@ -11272,9 +11264,7 @@ import { PromoteUserInput } from "./PromoteUserInput";
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.UserCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.UserCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.UserCountArgs, "select">): Promise<number> {
     return this.prisma.user.count(args);
   }
 

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -5064,7 +5064,7 @@ export class CustomerServiceBase {
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
   ): Promise<PrismaCustomer[]> {
-    return this.prisma.customer.findMany(args);
+    return this.prisma.customer.findMany<Prisma.CustomerFindManyArgs>(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
@@ -5779,7 +5779,7 @@ export class EmptyServiceBase {
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
   ): Promise<PrismaEmpty[]> {
-    return this.prisma.empty.findMany(args);
+    return this.prisma.empty.findMany<Prisma.EmptyFindManyArgs>(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
@@ -6981,7 +6981,7 @@ export class OrderServiceBase {
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
   ): Promise<PrismaOrder[]> {
-    return this.prisma.order.findMany(args);
+    return this.prisma.order.findMany<Prisma.OrderFindManyArgs>(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
@@ -8100,7 +8100,9 @@ export class OrganizationServiceBase {
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
   ): Promise<PrismaOrganization[]> {
-    return this.prisma.organization.findMany(args);
+    return this.prisma.organization.findMany<Prisma.OrganizationFindManyArgs>(
+      args
+    );
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
@@ -9172,7 +9174,7 @@ export class ProfileServiceBase {
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
   ): Promise<PrismaProfile[]> {
-    return this.prisma.profile.findMany(args);
+    return this.prisma.profile.findMany<Prisma.ProfileFindManyArgs>(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
@@ -11271,7 +11273,7 @@ export class UserServiceBase {
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
   ): Promise<PrismaUser[]> {
-    return this.prisma.user.findMany(args);
+    return this.prisma.user.findMany<Prisma.UserFindManyArgs>(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -3136,7 +3136,7 @@ volumes:
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.1",
     "reflect-metadata": "0.1.13",
-    "ts-node": "10.9.1",
+    "ts-node": "10.9.2",
     "type-fest": "2.19.0",
     "validator": "13.11.0"
   },
@@ -3156,7 +3156,7 @@ volumes:
     "prisma": "^5.4.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "typescript": "~5.3.0"
+    "typescript": "^5.4.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -5651,9 +5651,7 @@ import {
 export class CustomerServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.CustomerCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.CustomerCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.CustomerCountArgs, "select">): Promise<number> {
     return this.prisma.customer.count(args);
   }
 
@@ -6704,9 +6702,7 @@ import { Prisma, Empty as PrismaEmpty } from "@prisma/client";
 export class EmptyServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.EmptyCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.EmptyCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.EmptyCountArgs, "select">): Promise<number> {
     return this.prisma.empty.count(args);
   }
 
@@ -8307,9 +8303,7 @@ import {
 export class OrderServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrderCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrderCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.OrderCountArgs, "select">): Promise<number> {
     return this.prisma.order.count(args);
   }
 
@@ -10071,8 +10065,8 @@ import {
 export class OrganizationServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.OrganizationCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.OrganizationCountArgs>
+  async count(
+    args: Omit<Prisma.OrganizationCountArgs, "select">
   ): Promise<number> {
     return this.prisma.organization.count(args);
   }
@@ -11564,9 +11558,7 @@ import {
 export class ProfileServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.ProfileCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.ProfileCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.ProfileCountArgs, "select">): Promise<number> {
     return this.prisma.profile.count(args);
   }
 
@@ -14369,9 +14361,7 @@ import { PromoteUserInput } from "./PromoteUserInput";
 export class UserServiceBase {
   constructor(protected readonly prisma: PrismaService) {}
 
-  async count<T extends Prisma.UserCountArgs>(
-    args: Prisma.SelectSubset<T, Prisma.UserCountArgs>
-  ): Promise<number> {
+  async count(args: Omit<Prisma.UserCountArgs, "select">): Promise<number> {
     return this.prisma.user.count(args);
   }
 

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -3136,7 +3136,7 @@ volumes:
     "passport-http": "0.3.0",
     "passport-jwt": "4.0.1",
     "reflect-metadata": "0.1.13",
-    "ts-node": "10.9.1",
+    "ts-node": "10.9.2",
     "type-fest": "2.19.0",
     "validator": "13.11.0"
   },
@@ -3156,7 +3156,7 @@ volumes:
     "prisma": "^5.4.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "typescript": "~5.3.0"
+    "typescript": "^5.4.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -5658,7 +5658,7 @@ export class CustomerServiceBase {
   async customers<T extends Prisma.CustomerFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindManyArgs>
   ): Promise<PrismaCustomer[]> {
-    return this.prisma.customer.findMany(args);
+    return this.prisma.customer.findMany<Prisma.CustomerFindManyArgs>(args);
   }
   async customer<T extends Prisma.CustomerFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.CustomerFindUniqueArgs>
@@ -6709,7 +6709,7 @@ export class EmptyServiceBase {
   async empties<T extends Prisma.EmptyFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindManyArgs>
   ): Promise<PrismaEmpty[]> {
-    return this.prisma.empty.findMany(args);
+    return this.prisma.empty.findMany<Prisma.EmptyFindManyArgs>(args);
   }
   async empty<T extends Prisma.EmptyFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.EmptyFindUniqueArgs>
@@ -8310,7 +8310,7 @@ export class OrderServiceBase {
   async orders<T extends Prisma.OrderFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindManyArgs>
   ): Promise<PrismaOrder[]> {
-    return this.prisma.order.findMany(args);
+    return this.prisma.order.findMany<Prisma.OrderFindManyArgs>(args);
   }
   async order<T extends Prisma.OrderFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrderFindUniqueArgs>
@@ -10074,7 +10074,9 @@ export class OrganizationServiceBase {
   async organizations<T extends Prisma.OrganizationFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindManyArgs>
   ): Promise<PrismaOrganization[]> {
-    return this.prisma.organization.findMany(args);
+    return this.prisma.organization.findMany<Prisma.OrganizationFindManyArgs>(
+      args
+    );
   }
   async organization<T extends Prisma.OrganizationFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.OrganizationFindUniqueArgs>
@@ -11565,7 +11567,7 @@ export class ProfileServiceBase {
   async profiles<T extends Prisma.ProfileFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindManyArgs>
   ): Promise<PrismaProfile[]> {
-    return this.prisma.profile.findMany(args);
+    return this.prisma.profile.findMany<Prisma.ProfileFindManyArgs>(args);
   }
   async profile<T extends Prisma.ProfileFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.ProfileFindUniqueArgs>
@@ -14368,7 +14370,7 @@ export class UserServiceBase {
   async users<T extends Prisma.UserFindManyArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindManyArgs>
   ): Promise<PrismaUser[]> {
-    return this.prisma.user.findMany(args);
+    return this.prisma.user.findMany<Prisma.UserFindManyArgs>(args);
   }
   async user<T extends Prisma.UserFindUniqueArgs>(
     args: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>


### PR DESCRIPTION
Close: #8180

## PR Details

This pr contains two fixes:
- improve args type for the count methods in generated resource base services to match the expectations
- fix findMany methods in generated resource base services to not error with TS v5.4+ (More info about new TS intersection of constrained types behaviour here: https://github.com/microsoft/TypeScript/pull/56515)

## PR Checklist

- [x]  Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
