### PR TITLE
fix(server): update graphql schema generation script to not depend on kafka

### DIFF
--- a/packages/amplication-server/scripts/generate-graphql-schema.ts
+++ b/packages/amplication-server/scripts/generate-graphql-schema.ts
@@ -6,6 +6,8 @@ import { NestFactory } from "@nestjs/core";
 import { PrismaClient } from "../src/prisma";
 import { AppModule } from "../src/app.module";
 import { Logger } from "@amplication/util/logging";
+import { Consumer, Kafka, Producer } from "kafkajs";
+
 const logger = new Logger({
   isProduction: false,
   component: "generate-graphql-schema",
@@ -15,6 +17,21 @@ export default async function generateGraphQLSchema(): Promise<void> {
   PrismaClient.prototype.$connect = async function () {
     return;
   };
+
+  // Override KafkaPubSub connectProducer and runConsumer to prevent connections to Kafka
+  Kafka.prototype.consumer = () =>
+    ({
+      connect: async () => Promise.resolve(),
+      subscribe: async () => Promise.resolve(),
+      run: async () => Promise.resolve(),
+      on: async () => Promise.resolve(),
+    } as unknown as Consumer);
+  Kafka.prototype.producer = () =>
+    ({
+      connect: async () => Promise.resolve(),
+      on: async () => Promise.resolve(),
+    } as unknown as Producer);
+
   // Use the side effect of initializing the nest application for generating
   // the Nest.js schema
   const app = await NestFactory.create(AppModule);


### PR DESCRIPTION
Close: #8329

## PR Details

This change alters the schema generation script to remove its dependency on Kafka by mocking Kafka-related functionalities, allowing it to function without needing Kafka connections.

## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
