### PR TITLE
style(client):arrange content when Jovu is open

### DIFF
--- a/packages/amplication-client/src/Entity/EntityList.scss
+++ b/packages/amplication-client/src/Entity/EntityList.scss
@@ -4,4 +4,16 @@
   .toggle-field {
     margin: 0;
   }
+
+  .search-field {
+    max-width: 120px;
+  }
+}
+
+.workspaces-layout__main_content--xl {
+  .entity-list {
+    .search-field {
+      max-width: none;
+    }
+  }
 }

--- a/packages/amplication-client/src/Entity/EntityList.tsx
+++ b/packages/amplication-client/src/Entity/EntityList.tsx
@@ -235,7 +235,7 @@ const EntityList: React.FC<Props> = ({ match, innerRoutes }) => {
                       eventName: AnalyticsEventNames.ImportPrismaSchemaClick,
                     }}
                   >
-                    Upload Prisma Schema
+                    Upload Schema
                   </Button>
                 </FeatureIndicatorContainer>
               </Link>

--- a/packages/amplication-client/src/Modules/ModulesToolbar.scss
+++ b/packages/amplication-client/src/Modules/ModulesToolbar.scss
@@ -2,19 +2,13 @@
 
 .modules-toolbar {
   margin-top: calc(var(--default-spacing) * -1);
-  overflow: hidden;
 
   .search-field {
     max-width: 100px;
   }
 
   .beta-feature-tag__tag {
-    max-width: 80px;
-    text-wrap: nowrap;
-    .amp-text {
-      max-width: 50px;
-      overflow: hidden;
-    }
+    display: none;
   }
 }
 
@@ -26,12 +20,7 @@
   }
 
   .beta-feature-tag__tag {
-    max-width: 120px;
-    text-wrap: nowrap;
-    .amp-text {
-      max-width: 90px;
-      overflow: hidden;
-    }
+    display: flex;
   }
 }
 
@@ -39,15 +28,6 @@
   .modules-toolbar {
     .search-field {
       max-width: none;
-    }
-  }
-
-  .beta-feature-tag__tag {
-    max-width: 150px;
-    text-wrap: nowrap;
-    .amp-text {
-      max-width: 120px;
-      overflow: hidden;
     }
   }
 }

--- a/packages/amplication-client/src/Modules/ModulesToolbar.scss
+++ b/packages/amplication-client/src/Modules/ModulesToolbar.scss
@@ -2,4 +2,52 @@
 
 .modules-toolbar {
   margin-top: calc(var(--default-spacing) * -1);
+  overflow: hidden;
+
+  .search-field {
+    max-width: 100px;
+  }
+
+  .beta-feature-tag__tag {
+    max-width: 80px;
+    text-wrap: nowrap;
+    .amp-text {
+      max-width: 50px;
+      overflow: hidden;
+    }
+  }
+}
+
+.workspaces-layout__main_content--lg {
+  .modules-toolbar {
+    .search-field {
+      max-width: 150px;
+    }
+  }
+
+  .beta-feature-tag__tag {
+    max-width: 120px;
+    text-wrap: nowrap;
+    .amp-text {
+      max-width: 90px;
+      overflow: hidden;
+    }
+  }
+}
+
+.workspaces-layout__main_content--xl {
+  .modules-toolbar {
+    .search-field {
+      max-width: none;
+    }
+  }
+
+  .beta-feature-tag__tag {
+    max-width: 150px;
+    text-wrap: nowrap;
+    .amp-text {
+      max-width: 120px;
+      overflow: hidden;
+    }
+  }
 }

--- a/packages/amplication-client/src/Project/ProjectList.tsx
+++ b/packages/amplication-client/src/Project/ProjectList.tsx
@@ -24,7 +24,7 @@ type Props = {
 export const ProjectList = ({ projects, workspaceId }: Props) => {
   return (
     <Panel
-      panelStyle={EnumPanelStyle.Bordered}
+      panelStyle={EnumPanelStyle.Bold}
       className={CLASS_NAME}
       themeColor={EnumTextColor.ThemeBlue}
     >

--- a/packages/amplication-client/src/Resource/PluginsTile.scss
+++ b/packages/amplication-client/src/Resource/PluginsTile.scss
@@ -5,7 +5,7 @@ $icon-overlap: 10px;
 
 .plugins-tile {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: var(--default-spacing);
   margin-bottom: var(--default-spacing);
 
@@ -13,6 +13,12 @@ $icon-overlap: 10px;
     height: $description-height;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+}
+
+.workspaces-layout__main_content--xl {
+  .plugins-tile {
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 

--- a/packages/amplication-client/src/UsageInsights/UsageInsights.tsx
+++ b/packages/amplication-client/src/UsageInsights/UsageInsights.tsx
@@ -108,7 +108,7 @@ export const UsageInsights: React.FC<Props> = ({ projectIds }) => {
 
   return (
     <Panel
-      panelStyle={EnumPanelStyle.Default}
+      panelStyle={EnumPanelStyle.Bordered}
       themeColor={EnumTextColor.ThemeTurquoise}
       className={CLASS_NAME}
     >
@@ -126,18 +126,18 @@ export const UsageInsights: React.FC<Props> = ({ projectIds }) => {
         <Text textStyle={EnumTextStyle.H4}>Productivity Metrics</Text>
       </FlexItem>
       <FlexItem
-        direction={EnumFlexDirection.Row}
+        direction={EnumFlexDirection.Column}
         className={`${CLASS_NAME}__chart-container`}
         itemsAlign={EnumItemsAlign.Stretch}
-        gap={EnumGapSize.Large}
+        gap={EnumGapSize.Small}
       >
         <Panel
           className={`${CLASS_NAME}__chart`}
-          panelStyle={EnumPanelStyle.Bold}
+          panelStyle={EnumPanelStyle.Surface}
         >
           {usageInsightsDataset && (
             <BarChart
-              height={300}
+              height={250}
               dataset={usageInsightsDataset}
               yAxis={[
                 {
@@ -186,9 +186,10 @@ export const UsageInsights: React.FC<Props> = ({ projectIds }) => {
         {(evaluationInsightsLoading ||
           (evaluationInsights && evaluationInsights.loc !== 0)) && (
           <FlexItem
-            direction={EnumFlexDirection.Column}
+            direction={EnumFlexDirection.Row}
             className={`${CLASS_NAME}__chart-side`}
-            gap={EnumGapSize.Large}
+            itemsAlign={EnumItemsAlign.Stretch}
+            gap={EnumGapSize.Small}
           >
             <>
               <UsageInsightsDataBox
@@ -223,7 +224,7 @@ export const UsageInsights: React.FC<Props> = ({ projectIds }) => {
       {(evaluationInsightsLoading ||
         (evaluationInsights && evaluationInsights.loc !== 0)) && (
         <>
-          <FlexItem gap={EnumGapSize.Large}>
+          <FlexItem gap={EnumGapSize.Small}>
             <UsageInsightsDataBox
               loading={evaluationInsightsLoading}
               value={evaluationInsights?.costSaved}

--- a/packages/amplication-client/src/UsageInsights/UsageInsightsDataBox.scss
+++ b/packages/amplication-client/src/UsageInsights/UsageInsightsDataBox.scss
@@ -27,10 +27,6 @@ $skeleton-width: 100px;
     }
   }
 
-  &__content {
-    height: 100%;
-  }
-
   &__tooltip {
     align-self: flex-end;
   }

--- a/packages/amplication-client/src/UsageInsights/UsageInsightsDataBox.tsx
+++ b/packages/amplication-client/src/UsageInsights/UsageInsightsDataBox.tsx
@@ -76,7 +76,7 @@ export const UsageInsightsDataBox: React.FC<Props> = ({
   const formattedValue = valueFormat ? formatValue(value, valueFormat) : value;
 
   return (
-    <Panel panelStyle={EnumPanelStyle.Bold} className={`${CLASS_NAME}`}>
+    <Panel panelStyle={EnumPanelStyle.Surface} className={`${CLASS_NAME}`}>
       <FlexItem
         direction={EnumFlexDirection.Column}
         itemsAlign={EnumItemsAlign.Start}

--- a/packages/amplication-client/src/VersionControl/Commit.scss
+++ b/packages/amplication-client/src/VersionControl/Commit.scss
@@ -26,12 +26,18 @@ $padding-top-toggle: 16px;
     }
 
     textarea {
-      height: var(--textarea-height);
+      height: var(--textarea-height-small);
       background-color: var(--gray-80);
 
       @media only screen and (max-width: $breakpoint-desktop) {
         height: var(--textare-height-small);
       }
+    }
+  }
+
+  &__technology-toggle {
+    label {
+      margin-bottom: 0;
     }
   }
 }

--- a/packages/amplication-client/src/VersionControl/Commit.tsx
+++ b/packages/amplication-client/src/VersionControl/Commit.tsx
@@ -222,6 +222,7 @@ const Commit = ({
                 />
               )}
               <MultiStateToggle
+                className={`${CLASS_NAME}__technology-toggle`}
                 label=""
                 name="action_"
                 options={OPTIONS}

--- a/packages/amplication-client/src/Workspaces/ResourceList.tsx
+++ b/packages/amplication-client/src/Workspaces/ResourceList.tsx
@@ -160,7 +160,7 @@ function ResourceList() {
         itemsAlign={EnumItemsAlign.Stretch}
       >
         <Panel
-          panelStyle={EnumPanelStyle.Bordered}
+          panelStyle={EnumPanelStyle.Bold}
           className={`${CLASS_NAME}__resources`}
           themeColor={EnumTextColor.ThemeBlue}
         >


### PR DESCRIPTION


Close: #8392 8392

## PR Details

## Arrange resource overview with two column
<img width="1510" alt="image" src="https://github.com/amplication/amplication/assets/43705455/56cb3d6b-957a-45eb-ae7e-1a3f22df7060">

## Arrange the insight layout on Project and Workspace overview 
<img width="1510" alt="image" src="https://github.com/amplication/amplication/assets/43705455/d68a1a2d-066d-48e5-b46a-83f401a0c834">
<img width="1510" alt="image" src="https://github.com/amplication/amplication/assets/43705455/81a92416-f805-4e7d-96d9-fe09b9742fde">

## Arrange Entity and API header on smaller viewport
<img width="1510" alt="image" src="https://github.com/amplication/amplication/assets/43705455/b8555438-cad6-4fe6-a7ff-231b15a7217f">
<img width="1510" alt="image" src="https://github.com/amplication/amplication/assets/43705455/3c359a6c-c90c-4804-9f24-85054e1dd837">


## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
