### PR TITLE
fix(client): fix subscription null issue

### DIFF
--- a/packages/amplication-client/src/Components/FeatureIndicatorContainer.tsx
+++ b/packages/amplication-client/src/Components/FeatureIndicatorContainer.tsx
@@ -127,19 +127,13 @@ export const FeatureIndicatorContainer: FC<Props> = ({
     }
     if (
       subscriptionPlan === EnumSubscriptionPlan.Enterprise &&
-      subscription.status !== EnumSubscriptionStatus.Trailing
+      status !== EnumSubscriptionStatus.Trailing
     ) {
       return fullEnterpriseText;
     }
 
     return defaultTextStart;
-  }, [
-    disabled,
-    subscriptionPlan,
-    subscription.status,
-    limitationText,
-    fullEnterpriseText,
-  ]);
+  }, [disabled, subscriptionPlan, status, limitationText, fullEnterpriseText]);
 
   const textEnd = useMemo(() => {
     if (disabled) {
@@ -147,25 +141,25 @@ export const FeatureIndicatorContainer: FC<Props> = ({
     }
     if (
       subscriptionPlan === EnumSubscriptionPlan.Enterprise &&
-      subscription.status !== EnumSubscriptionStatus.Trailing
+      status !== EnumSubscriptionStatus.Trailing
     ) {
       return "";
     }
 
     return defaultTextEnd;
-  }, [disabled, subscriptionPlan, subscription.status]);
+  }, [disabled, subscriptionPlan, status]);
 
   const showTooltipLink = useMemo(() => {
     if (
       isPreviewPlan(subscriptionPlan) ||
       (subscriptionPlan === EnumSubscriptionPlan.Enterprise &&
-        subscription.status !== EnumSubscriptionStatus.Trailing)
+        status !== EnumSubscriptionStatus.Trailing)
     ) {
       return false; // don't show the upgrade link when the plan is preview
     }
 
     return true; // in case of null, it falls back to the default link text
-  }, [subscriptionPlan, subscription]);
+  }, [subscriptionPlan, status]);
 
   useEffect(() => {
     if (!subscriptionPlan || !status || !featureId) {


### PR DESCRIPTION
Close: #8407 

## PR Details
This pull request resolves the issue when the user gets the error `subscription is null` when trying to develop the application locally. This fixes this issue by checking for the subscription status with the `subscription?.status` expression in the `FeatureIndicatorContainer.tsx` file
## PR Checklist

- [x] `npm test` doesn't throw any error