### PR TITLE
fix(client):scope chat enter hook

### DIFF
--- a/packages/amplication-client/src/Assistant/AssistantChatInput.tsx
+++ b/packages/amplication-client/src/Assistant/AssistantChatInput.tsx
@@ -44,7 +44,7 @@ const AssistantChatInput = ({ disabled, sendMessage }: Props) => {
 
   const formRef = useRef(null);
 
-  const ref = useHotkeys<HTMLInputElement>(
+  const ref = useHotkeys<HTMLFormElement>(
     KEY_MAP,
     (event, handler) => {
       if (handler.keys.includes("enter") && handler.shift) {
@@ -67,7 +67,7 @@ const AssistantChatInput = ({ disabled, sendMessage }: Props) => {
         onSubmit={handleSubmit}
         innerRef={formRef}
       >
-        <Form>
+        <Form ref={ref}>
           <TextField
             textarea
             name="message"
@@ -76,7 +76,6 @@ const AssistantChatInput = ({ disabled, sendMessage }: Props) => {
             autoComplete="off"
             hideLabel
             rows={2}
-            ref={ref}
             style={{
               "--input-lines": rowCount, //set the css variable to the theme color to be used from the css file
             }}

--- a/packages/amplication-client/src/Entity/NewEntityField.scss
+++ b/packages/amplication-client/src/Entity/NewEntityField.scss
@@ -14,6 +14,7 @@
       top: 0;
       right: 0;
       display: none !important;
+      height: 100% !important;
 
       &--show {
         display: flex !important;


### PR DESCRIPTION

Close: #8427 

## PR Details

Scope the hotkeys hooks in the assistant chat on the form instead of the textbox to enforce scoping

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
