### PR TITLE
fix(client): add the end text for disabled features

### DIFF
--- a/packages/amplication-client/src/Components/FeatureIndicatorContainer.tsx
+++ b/packages/amplication-client/src/Components/FeatureIndicatorContainer.tsx
@@ -136,9 +136,6 @@ export const FeatureIndicatorContainer: FC<Props> = ({
   }, [disabled, subscriptionPlan, status, limitationText, fullEnterpriseText]);
 
   const textEnd = useMemo(() => {
-    if (disabled) {
-      return "";
-    }
     if (
       subscriptionPlan === EnumSubscriptionPlan.Enterprise &&
       status !== EnumSubscriptionStatus.Trailing
@@ -147,7 +144,7 @@ export const FeatureIndicatorContainer: FC<Props> = ({
     }
 
     return defaultTextEnd;
-  }, [disabled, subscriptionPlan, status]);
+  }, [subscriptionPlan, status]);
 
   const showTooltipLink = useMemo(() => {
     if (


### PR DESCRIPTION
Close: https://github.com/amplication/private-issues/issues/172

## PR Details

Add the end text for disabled features: 

<img width="612" alt="image" src="https://github.com/amplication/amplication/assets/97830649/2f4425b9-809e-4534-8a1c-0b8adb2e3667">

And not: 

<img width="582" alt="image" src="https://github.com/amplication/amplication/assets/97830649/adc7e67d-d32d-451e-b032-90faa033887c">


## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
