### PR TITLE
fix(client): end text content for disabled

### DIFF
--- a/packages/amplication-client/src/Components/FeatureIndicator.tsx
+++ b/packages/amplication-client/src/Components/FeatureIndicator.tsx
@@ -37,6 +37,9 @@ export const defaultTextStart =
 export const defaultTextEnd =
   "today to ensure continued access and discover additional hidden functionalities!";
 
+export const disabledDefaultTextEnd =
+  "today to access it and discover additional hidden functionalities";
+
 type Props = {
   featureName: string;
   icon?: IconType;
@@ -73,8 +76,8 @@ export const FeatureIndicator = ({
   }, [featureName, trackEvent, upgradeCtaVariationData]);
 
   const renderTooltipTextWithUpgradeLink = useMemo(() => {
-    const currentStartText = textStart ?? defaultTextStart;
-    const currentEndText = textEnd ?? defaultTextEnd;
+    const currentStartText = textStart ? textStart : defaultTextStart;
+    const currentEndText = textEnd ? textEnd : defaultTextEnd;
     return (
       <>
         <span>{currentStartText}</span>

--- a/packages/amplication-client/src/Components/FeatureIndicatorContainer.tsx
+++ b/packages/amplication-client/src/Components/FeatureIndicatorContainer.tsx
@@ -16,6 +16,7 @@ import {
   FeatureIndicator,
   defaultTextEnd,
   defaultTextStart,
+  disabledDefaultTextEnd,
 } from "./FeatureIndicator";
 import "./FeatureIndicatorContainer.scss";
 import { omit } from "lodash";
@@ -136,6 +137,9 @@ export const FeatureIndicatorContainer: FC<Props> = ({
   }, [disabled, subscriptionPlan, status, limitationText, fullEnterpriseText]);
 
   const textEnd = useMemo(() => {
+    if (disabled) {
+      return disabledDefaultTextEnd;
+    }
     if (
       subscriptionPlan === EnumSubscriptionPlan.Enterprise &&
       status !== EnumSubscriptionStatus.Trailing
@@ -144,7 +148,7 @@ export const FeatureIndicatorContainer: FC<Props> = ({
     }
 
     return defaultTextEnd;
-  }, [subscriptionPlan, status]);
+  }, [disabled, subscriptionPlan, status]);
 
   const showTooltipLink = useMemo(() => {
     if (

--- a/packages/amplication-client/src/Resource/break-the-monolith/BtmButton.tsx
+++ b/packages/amplication-client/src/Resource/break-the-monolith/BtmButton.tsx
@@ -33,6 +33,7 @@ import {
   FeatureIndicator,
   defaultTextEnd,
   defaultTextStart,
+  disabledDefaultTextEnd,
 } from "../../Components/FeatureIndicator";
 import { getCookie, setCookie } from "../../util/cookie";
 import useAbTesting from "../../VersionControl/hooks/useABTesting";
@@ -116,6 +117,7 @@ export const BtmButton: React.FC<Props> = ({
 
     if (!hasRedesignArchitectureFeature) {
       setTooltipTextStart(NO_ACCESS_TEXT);
+      setTooltipTextEnd(disabledDefaultTextEnd);
       setShowTooltipLink(true);
     }
 


### PR DESCRIPTION
Close: https://github.com/amplication/private-issues/issues/172

## PR Details

Update the end text for the disabled feature. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
