### PR TITLE
chore(ci): fix issue related to github default_branch not being populated in templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
     uses: ./.github/workflows/release.template.yml
     if: ${{ github.ref_name == 'master' || github.ref_name == 'next' }}
     with:
+      default-branch: ${{ github.event.repository.default_branch }}
       branch: ${{ github.ref_name }}
       affected-apps: ${{ needs.nx.outputs.affected-apps }}
       affected-lib: ${{ needs.nx.outputs.affected-lib }}

--- a/.github/workflows/release.template.yml
+++ b/.github/workflows/release.template.yml
@@ -3,6 +3,11 @@ name: _Reusable Release template
 on:
   workflow_call:
     inputs:
+      default-branch:
+        type: string
+        description: Default branch of the repository. i.e github.event.repository.default_branch
+        required: true
+        default: main
       branch:
         type: string
         description: Name of the git branch
@@ -107,7 +112,7 @@ jobs:
             type=ref,event=tag,prefix=tag-
             type=raw,value=${{ github.run_id }},prefix=gh-
             type=raw,value=${{ env.BRANCH }}
-            type=raw,value=latest,enable=${{ env.BRANCH == github.event.repository.default_branch }}
+            type=raw,value=latest,enable=${{ env.BRANCH == inputs.default-branch }}
             type=raw,value=next,enable=${{ env.ENABLE_CUSTOM_TAGS }}
             type=raw,value=master,enable=${{ env.ENABLE_CUSTOM_TAGS }}
 
@@ -132,7 +137,7 @@ jobs:
           if [[ "${{ env.BRANCH }}" == "next" ]];
           then
             echo environment="sandbox" >> $GITHUB_OUTPUT
-          elif [[ "${{ env.BRANCH }}" == github.event.repository.default_branch ]];
+          elif [[ "${{ env.BRANCH }}" == inputs.default-branch ]];
           then
             echo environment="staging" >> $GITHUB_OUTPUT
           fi;


### PR DESCRIPTION

Fixes: https://github.com/amplication/amplication-cluster-configuration/issues/221

## PR Details

Fix issue related to github.event.repository.default_branch not being populated for template ci (using trigger `workflow_call`)

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
