### PR TITLE
Feat/jovu create serviec with plugins

### DIFF
--- a/packages/amplication-server/src/core/assistant/assistantFunctions.service.ts
+++ b/packages/amplication-server/src/core/assistant/assistantFunctions.service.ts
@@ -270,6 +270,51 @@ export class AssistantFunctionsService {
     }
   }
 
+  async installMultiplePlugins(
+    pluginIds: string[],
+    serviceId: string,
+    context: AssistantContext
+  ): Promise<any> {
+    //iterate over the pluginIds and install each plugin synchronously
+    //to support synchronous installation of multiple plugins we need first to fix the plugins order code in the pluginInstallation Service
+    const installations = [];
+    for (const pluginId of pluginIds) {
+      const plugin = await this.pluginCatalogService.getPluginWithLatestVersion(
+        pluginId
+      );
+      const pluginVersion = plugin.versions[0];
+
+      const { version, settings, configurations } = pluginVersion;
+
+      const installation = await this.pluginInstallationService.create(
+        {
+          data: {
+            displayName: plugin.name,
+            pluginId: pluginId,
+            enabled: true,
+            npm: plugin.npm,
+            version: version,
+            settings: settings,
+            configurations: configurations,
+            resource: { connect: { id: serviceId } },
+          },
+        },
+        context.user
+      );
+
+      installations.push({
+        result: installation,
+        link: `${this.clientHost}/${context.workspaceId}/${context.projectId}/${serviceId}/plugins/installed/${installation.id}`,
+      });
+    }
+
+    return {
+      installations,
+      pluginsCatalogLink: `${this.clientHost}/${context.workspaceId}/${context.projectId}/${serviceId}/plugins/catalog`,
+      allInstalledPluginsLink: `${this.clientHost}/${context.workspaceId}/${context.projectId}/${serviceId}/plugins/installed`,
+    };
+  }
+
   private assistantFunctions: {
     [key in EnumAssistantFunctions]: (
       args: any,
@@ -418,13 +463,29 @@ export class AssistantFunctionsService {
       args: functionsArgsTypes.CreateService,
       context: AssistantContext
     ) => {
+      const needDefaultDbPlugin = !(
+        args.pluginIds &&
+        args.pluginIds.find((pluginId) => pluginId.startsWith("db-"))
+      );
+
       const resource =
         await this.resourceService.createServiceWithDefaultSettings(
           args.serviceName,
           args.serviceDescription || "",
           args.projectId,
-          context.user
+          context.user,
+          needDefaultDbPlugin
         );
+
+      let pluginsResults = null;
+      if (args.pluginIds && args.pluginIds.length > 0) {
+        pluginsResults = await this.installMultiplePlugins(
+          args.pluginIds,
+          resource.id,
+          context
+        );
+      }
+
       return {
         link: `${this.clientHost}/${context.workspaceId}/${args.projectId}/${resource.id}`,
         result: {
@@ -432,6 +493,7 @@ export class AssistantFunctionsService {
           name: resource.name,
           description: resource.description,
         },
+        pluginsResults,
       };
     },
     createProject: async (
@@ -524,43 +586,11 @@ export class AssistantFunctionsService {
       args: functionsArgsTypes.InstallPlugins,
       context: AssistantContext
     ) => {
-      //iterate over the pluginIds and install each plugin synchronously
-      //to support synchronous installation of multiple plugins we need first to fix the plugins order code in the pluginInstallation Service
-      const installations = [];
-      for (const pluginId of args.pluginIds) {
-        const plugin =
-          await this.pluginCatalogService.getPluginWithLatestVersion(pluginId);
-        const pluginVersion = plugin.versions[0];
-
-        const { version, settings, configurations } = pluginVersion;
-
-        const installation = await this.pluginInstallationService.create(
-          {
-            data: {
-              displayName: plugin.name,
-              pluginId: pluginId,
-              enabled: true,
-              npm: plugin.npm,
-              version: version,
-              settings: settings,
-              configurations: configurations,
-              resource: { connect: { id: args.serviceId } },
-            },
-          },
-          context.user
-        );
-
-        installations.push({
-          result: installation,
-          link: `${this.clientHost}/${context.workspaceId}/${context.projectId}/${args.serviceId}/plugins/installed/${installation.id}`,
-        });
-      }
-
-      return {
-        installations,
-        pluginsCatalogLink: `${this.clientHost}/${context.workspaceId}/${context.projectId}/${args.serviceId}/plugins/catalog`,
-        allInstalledPluginsLink: `${this.clientHost}/${context.workspaceId}/${context.projectId}/${args.serviceId}/plugins/installed`,
-      };
+      return this.installMultiplePlugins(
+        args.pluginIds,
+        args.serviceId,
+        context
+      );
     },
     getServiceModules: async (
       args: functionsArgsTypes.GetServiceModules,

--- a/packages/amplication-server/src/core/assistant/assistantFunctions.service.ts
+++ b/packages/amplication-server/src/core/assistant/assistantFunctions.service.ts
@@ -423,8 +423,6 @@ export class AssistantFunctionsService {
           args.serviceName,
           args.serviceDescription || "",
           args.projectId,
-          args.adminUIPath,
-          args.serverPath,
           context.user
         );
       return {

--- a/packages/amplication-server/src/core/assistant/functions/createService.json
+++ b/packages/amplication-server/src/core/assistant/functions/createService.json
@@ -1,6 +1,6 @@
 {
   "name": "createService",
-  "description": "Create a service in a project. When using this function, it is best to also create a few default entities and fields unless specifically requested not to do so",
+  "description": "Create a service in a project, with a list of plugins to install on the service. After using this function, it is best to also create a few default entities and fields unless specifically requested not to do so",
   "parameters": {
     "type": "object",
     "properties": {
@@ -14,17 +14,16 @@
       },
       "projectId": {
         "type": "string",
-        "description": "the ID of the service in which to create the project"
+        "description": "the ID of the project in which to create the service"
       },
-      "adminUIPath": {
-        "type": "string",
-        "description": "the path in the repo where to save the generated files of the admin UI. e.g. 'apps/my-admin'"
-      },
-      "serverPath": {
-        "type": "string",
-        "description": "the path in the repo where to save the generated files of the server. e.g. 'apps/my-server'"
+      "pluginIds": {
+        "type": "array",
+        "description": "a list of IDs of the plugins to install.",
+        "items": {
+          "type": "string"
+        }
       }
     },
-    "required": ["serviceName", "projectId", "adminUIPath", "serverPath"]
+    "required": ["serviceName", "projectId"]
   }
 }

--- a/packages/amplication-server/src/core/assistant/functions/types/createService.ts
+++ b/packages/amplication-server/src/core/assistant/functions/types/createService.ts
@@ -15,15 +15,11 @@ export interface CreateService {
    */
   serviceDescription?: string;
   /**
-   * the ID of the service in which to create the project
+   * the ID of the project in which to create the service
    */
   projectId: string;
   /**
-   * the path in the repo where to save the generated files of the admin UI. e.g. 'apps/my-admin'
+   * a list of IDs of the plugins to install.
    */
-  adminUIPath: string;
-  /**
-   * the path in the repo where to save the generated files of the server. e.g. 'apps/my-server'
-   */
-  serverPath: string;
+  pluginIds?: string[];
 }

--- a/packages/amplication-server/src/core/resource/resource.service.spec.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.spec.ts
@@ -482,6 +482,7 @@ const entityServiceBulkCreateFields = jest.fn();
 
 const mockedUpdateServiceLicensed = jest.fn();
 
+const pluginInstallationServiceCreateMock = jest.fn();
 const buildServiceCreateMock = jest.fn(() => EXAMPLE_BUILD);
 
 const environmentServiceCreateDefaultEnvironmentMock = jest.fn(() => {
@@ -525,7 +526,7 @@ describe("ResourceService", () => {
           provide: PluginInstallationService,
           useValue: { get: () => "" },
           useClass: jest.fn(() => ({
-            create: jest.fn(),
+            create: pluginInstallationServiceCreateMock,
           })),
         },
         MockedSegmentAnalyticsProvider(),
@@ -1133,5 +1134,31 @@ describe("ResourceService", () => {
         new Error(INVALID_RESOURCE_ID)
       );
     });
+  });
+
+  it("should create a service with default settings and install the default DB plugin", async () => {
+    await service.createServiceWithDefaultSettings(
+      EXAMPLE_RESOURCE_NAME,
+      EXAMPLE_RESOURCE_DESCRIPTION,
+      EXAMPLE_PROJECT_ID,
+      EXAMPLE_USER,
+      true
+    );
+
+    expect(prismaResourceCreateMock).toBeCalledTimes(1);
+    expect(pluginInstallationServiceCreateMock).toBeCalledTimes(1);
+  });
+
+  it("should create a service with default settings without installing the default DB plugin", async () => {
+    await service.createServiceWithDefaultSettings(
+      EXAMPLE_RESOURCE_NAME,
+      EXAMPLE_RESOURCE_DESCRIPTION,
+      EXAMPLE_PROJECT_ID,
+      EXAMPLE_USER,
+      false
+    );
+
+    expect(prismaResourceCreateMock).toBeCalledTimes(1);
+    expect(pluginInstallationServiceCreateMock).toBeCalledTimes(0);
   });
 });

--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -15,7 +15,7 @@ import {
   forwardRef,
 } from "@nestjs/common";
 import cuid from "cuid";
-import { isEmpty } from "lodash";
+import { isEmpty, kebabCase } from "lodash";
 import { pascalCase } from "pascal-case";
 import pluralize from "pluralize";
 import { JsonObject, JsonValue } from "type-fest";
@@ -568,10 +568,13 @@ export class ResourceService {
     serviceName: string,
     serviceDescription: string,
     projectId: string,
-    adminUIPath: string,
-    serverPath: string,
     user: User
   ): Promise<Resource> {
+    const pathBase = `apps/${kebabCase(serviceName)}`;
+
+    const adminUIPath = `${pathBase}-admin`;
+    const serverPath = `${pathBase}-server`;
+
     const args: CreateOneResourceArgs = {
       data: {
         name: serviceName,

--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -568,7 +568,8 @@ export class ResourceService {
     serviceName: string,
     serviceDescription: string,
     projectId: string,
-    user: User
+    user: User,
+    installDefaultDbPlugin = true
   ): Promise<Resource> {
     const pathBase = `apps/${kebabCase(serviceName)}`;
 
@@ -610,7 +611,9 @@ export class ResourceService {
 
     const resource = await this.createService(args, user);
 
-    await this.installPlugins(resource.id, [DEFAULT_DB_PLUGIN], user);
+    if (installDefaultDbPlugin) {
+      await this.installPlugins(resource.id, [DEFAULT_DB_PLUGIN], user);
+    }
 
     return resource;
   }


### PR DESCRIPTION


Close: #8472

## PR Details

- Add a new param for createService for a list of plugin IDs
- remove the params for base paths, and use default values instead 
- do not install the default DB plugin when jovu asks to install any DB plugin 

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
