### PR TITLE
Feat(server): Use GPT 4o and support multiple responses per prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "normalize-path": "^3.0.0",
         "octokit": "^1.8.1",
         "octokit-plugin-create-pull-request": "^3.13.1",
-        "openai": "^4.33.0",
+        "openai": "^4.46.0",
         "opentelemetry-instrumentation-kafkajs": "^0.35.0",
         "ora": "5.4.0",
         "pacote": "^15.0.8",
@@ -46845,9 +46845,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.33.0.tgz",
-      "integrity": "sha512-Sh4KvplkvkAREuhb8yZpohqsOo08cBBu6LNWLD8YyMxe8yCxbE+ouJYUs1X2oDPrzQGANj0rFNQYiwW9gWLBOg==",
+      "version": "4.46.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.46.0.tgz",
+      "integrity": "sha512-l0Betzsx3WIjdagqQiH14hWmwYouUzUCcB1ENvKyfG5XOqh6YC2XT7OukzEBTnweutMC91pW2ToddWn8uyD4SA==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "normalize-path": "^3.0.0",
     "octokit": "^1.8.1",
     "octokit-plugin-create-pull-request": "^3.13.1",
-    "openai": "^4.33.0",
+    "openai": "^4.46.0",
     "opentelemetry-instrumentation-kafkajs": "^0.35.0",
     "ora": "5.4.0",
     "pacote": "^15.0.8",

--- a/packages/amplication-client/src/Assistant/hooks/useAssistant.tsx
+++ b/packages/amplication-client/src/Assistant/hooks/useAssistant.tsx
@@ -192,6 +192,12 @@ const useAssistant = () => {
           return;
         }
 
+        if (message.completed) {
+          //completed is send when thread run is completed or on error
+          setProcessingMessage(false);
+          if (message.snapshot === "") return; //do not continue to process empty messages
+        }
+
         //use the state setter to ensure the message is updated in order
         setMessages((currentMessages) => {
           const lastMessage = currentMessages[currentMessages.length - 1];

--- a/packages/amplication-server/src/core/assistant/assistant.service.spec.ts
+++ b/packages/amplication-server/src/core/assistant/assistant.service.spec.ts
@@ -42,6 +42,28 @@ const mockGraphqlSubscriptionKafkaService = {
   })),
 };
 
+const openAiCreateThreadMock = jest.fn(() => {
+  return {
+    id: "testThread123",
+  };
+});
+const openAiCreateMessageMock = jest.fn(() => {
+  return {
+    id: "message123",
+  };
+});
+
+const openAiMock = jest.fn(() => ({
+  beta: {
+    threads: {
+      create: openAiCreateThreadMock,
+      messages: {
+        create: openAiCreateMessageMock,
+      },
+    },
+  },
+}));
+
 describe("AssistantService", () => {
   let service: AssistantService;
 
@@ -154,5 +176,35 @@ describe("AssistantService", () => {
       EXAMPLE_ASSISTANT_CONTEXT.user.workspace.id,
       BillingFeature.JovuRequests
     );
+  });
+
+  it("should prepare Thread with existing thread ID", async () => {
+    Object.defineProperty(service, "openai", {
+      get: openAiMock,
+    });
+
+    const thread = await service.prepareThread(
+      "exampleMessage",
+      "exampleThreadId",
+      EXAMPLE_ASSISTANT_CONTEXT
+    );
+    expect(thread).toBeDefined();
+    expect(openAiCreateThreadMock).toHaveBeenCalledTimes(0);
+    expect(openAiCreateMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should create and prepare a new thread", async () => {
+    Object.defineProperty(service, "openai", {
+      get: openAiMock,
+    });
+
+    const thread = await service.prepareThread(
+      "exampleMessage",
+      null,
+      EXAMPLE_ASSISTANT_CONTEXT
+    );
+    expect(thread).toBeDefined();
+    expect(openAiCreateThreadMock).toHaveBeenCalledTimes(1);
+    expect(openAiCreateMessageMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/amplication-server/src/core/assistant/assistant.service.spec.ts
+++ b/packages/amplication-server/src/core/assistant/assistant.service.spec.ts
@@ -134,7 +134,7 @@ describe("AssistantService", () => {
     expect(pubSubPublishMock).toHaveBeenCalledWith(
       MESSAGE_UPDATED_EVENT,
       JSON.stringify({
-        id: "messageId",
+        id: messageId,
         threadId,
         text: textDelta,
         snapshot,

--- a/packages/amplication-server/src/core/assistant/assistant.service.ts
+++ b/packages/amplication-server/src/core/assistant/assistant.service.ts
@@ -20,6 +20,7 @@ import { EnumAssistantMessageType } from "./dto/EnumAssistantMessageType";
 export const MESSAGE_UPDATED_EVENT = "assistantMessageUpdated";
 
 export const PLUGIN_LATEST_VERSION_TAG = "latest";
+const THREAD_RUN_COMPLETED = "thread.run.completed";
 
 const STREAM_ERROR_MESSAGE =
   "It looks like we're experiencing a high demand right now, which might be affecting our connection to the AI model. Please give it a little time and try again later. We appreciate your patience and understanding as we work to resolve this. Thank you! 🙏";
@@ -32,8 +33,7 @@ const ASSISTANT_INSTRUCTIONS: { [key in EnumAssistantMessageType]: string } = {
   After you create entities, also create fields and relations for all entities. Aim to create as many fields and relations as needed. 
   Install any plugins that are needed for the service.
   Do not ask the user to commit changes before the onboarding is complete.
-  The user is already connected to a demo git repo. After the creation is completed, suggest the user to connect to their own git repo.
-  Your reply should start with "Welcome to Amplication!" and include a brief introduction to the service and the entities you created.`,
+  The user is already connected to a demo git repo. After the creation is completed, suggest the user to connect to their own git repo.`,
 };
 
 export type MessageLoggerContext = {
@@ -232,6 +232,15 @@ export class AssistantService {
         );
       })
       .on("event", async (event) => {
+        if (event.event === "thread.run.completed") {
+          await this.onMessageUpdated(
+            threadId,
+            THREAD_RUN_COMPLETED,
+            "",
+            "",
+            true
+          );
+        }
         if (event.event === "thread.run.requires_action") {
           const requiredActions =
             event.data.required_action.submit_tool_outputs.tool_calls;
@@ -309,7 +318,7 @@ export class AssistantService {
           messageId,
           text.value,
           text.value,
-          true
+          false
         );
         loggerContext.role = "assistant";
         this.logger.info(`Chat: ${text.value}`, loggerContext);


### PR DESCRIPTION


Close: #8482 

## PR Details

 - Update SDK to the latest version to support GPT 4o
 - Use messageId to identify different responses on the same prompt
 - Prevent the user from sending more prompts between messages as long as Jovu is still processing 

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
