### PR TITLE
feat(code-gen-types): add new dotnet event for programcs generation

### DIFF
--- a/libs/util/code-gen-types/package.json
+++ b/libs/util/code-gen-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/code-gen-types",
-  "version": "2.0.33-beta.7",
+  "version": "2.0.33-beta.8",
   "description": "This library supplies all the contracts for Amplication Code Generation. The purpose is to make the contracts available for inclusion in plugins.",
   "main": "src/index.js",
   "author": {

--- a/libs/util/code-gen-types/src/dotnet-plugin-events-params.types.ts
+++ b/libs/util/code-gen-types/src/dotnet-plugin-events-params.types.ts
@@ -124,7 +124,7 @@ export interface CreateMessageBrokerClientOptionsFactoryParams
 export interface CreateMessageBrokerServiceParams extends EventParams {}
 export interface CreateMessageBrokerServiceBaseParams extends EventParams {}
 
-export interface CreateMainFileParams extends EventParams {}
+export interface CreateProgramFileParams extends EventParams {}
 
 export interface CreateSwaggerParams extends EventParams {
   fileDir: string;

--- a/libs/util/code-gen-types/src/dotnet-plugin-events.types.ts
+++ b/libs/util/code-gen-types/src/dotnet-plugin-events.types.ts
@@ -9,12 +9,12 @@ import {
   CreateEntityInterfaceParams,
   CreateEntityServiceBaseParams,
   CreateEntityServiceParams,
-  CreateMainFileParams,
   CreateMessageBrokerClientOptionsFactoryParams,
   CreateMessageBrokerParams,
   CreateMessageBrokerServiceBaseParams,
   CreateMessageBrokerServiceParams,
   CreateMessageBrokerTopicsEnumParams,
+  CreateProgramFileParams,
   CreateSeedParams,
   CreateServerAppsettingsParams,
   CreateServerAuthParams,
@@ -64,7 +64,10 @@ export type DotnetEvents = {
   [DotnetEventNames.CreateMessageBrokerClientOptionsFactory]?: PluginEventType<CreateMessageBrokerClientOptionsFactoryParams>;
   [DotnetEventNames.CreateMessageBrokerService]?: PluginEventType<CreateMessageBrokerServiceParams>;
   [DotnetEventNames.CreateMessageBrokerServiceBase]?: PluginEventType<CreateMessageBrokerServiceBaseParams>;
-  [DotnetEventNames.CreateMainFile]?: PluginEventType<CreateMainFileParams>;
+  [DotnetEventNames.CreateProgramFile]?: PluginEventType<
+    CreateProgramFileParams,
+    CodeBlock
+  >;
   [DotnetEventNames.CreateSwagger]?: PluginEventType<CreateSwaggerParams>;
   [DotnetEventNames.CreateSeed]?: PluginEventType<CreateSeedParams>;
   [DotnetEventNames.CreateEntityControllerToManyRelationMethods]?: PluginEventType<CreateEntityControllerToManyRelationMethodsParams>;

--- a/libs/util/code-gen-types/src/dotnet-plugins.types.ts
+++ b/libs/util/code-gen-types/src/dotnet-plugins.types.ts
@@ -92,7 +92,7 @@ export enum DotnetEventNames {
   CreateAdminUI = "CreateAdminUI",
   CreateServer = "CreateServer",
   CreateServerAppModule = "CreateServerAppModule",
-  CreateMainFile = "CreateMainFile",
+  CreateProgramFile = "CreateProgramFile",
   CreateServerGitIgnore = "CreateServerGitIgnore",
   CreateAdminGitIgnore = "CreateAdminGitIgnore",
   CreateMessageBroker = "CreateMessageBroker",


### PR DESCRIPTION
Close: #8513

## PR Details

Add support for new ProgramFile event for dotnet generation. 
It plays a similar role to the nodejs CreateMainFile event

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
