### PR TITLE
feat(server):alter reserved name on creation

### DIFF
--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -299,7 +299,7 @@ export class EntityService {
       enforceValidation &&
       isReservedName(args.data?.name?.toLowerCase().trim())
     ) {
-      throw new ReservedNameError(args.data?.name?.toLowerCase().trim());
+      args.data.name = `${args.data?.name}Model`;
     }
 
     const newEntity = await this.prisma.entity.create({
@@ -2511,7 +2511,7 @@ export class EntityService {
       enforceValidation &&
       isReservedName(args.data?.name?.toLowerCase().trim())
     ) {
-      throw new ReservedNameError(args.data?.name?.toLowerCase().trim());
+      args.data.name = `${args.data?.name}Field`;
     }
 
     // Omit entity from received data


### PR DESCRIPTION


Close: #8521 

## PR Details

Alter the requested name when creating a field of an entity instead of throwing an exception.
This behavior helps Jovu but will also impact creation from other sources like the UI
This only changes the name of the entity and field and leave the display name and plural display name as it is

The behavior on update left the same and it will still throw an error when trying to update the name to a reserved one.

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
