### PR TITLE
chore(code-gen-types): remove dotnet plugin redundant event

### DIFF
--- a/libs/util/code-gen-types/package.json
+++ b/libs/util/code-gen-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/code-gen-types",
-  "version": "2.0.33-beta.10",
+  "version": "2.0.33-beta.11",
   "description": "This library supplies all the contracts for Amplication Code Generation. The purpose is to make the contracts available for inclusion in plugins.",
   "main": "src/index.js",
   "author": {

--- a/libs/util/code-gen-types/src/dotnet-plugin-events-params.types.ts
+++ b/libs/util/code-gen-types/src/dotnet-plugin-events-params.types.ts
@@ -96,12 +96,6 @@ export interface CreateServerDockerComposeParams extends EventParams {
   outputFileName: string;
 }
 
-export interface CreateServerDockerComposeDevParams extends EventParams {
-  fileContent: string;
-  updateProperties: { [key: string]: any }[];
-  outputFileName: string;
-}
-
 export interface CreateServerCsprojParams extends EventParams {
   packageReferences: {
     include: string;

--- a/libs/util/code-gen-types/src/dotnet-plugin-events.types.ts
+++ b/libs/util/code-gen-types/src/dotnet-plugin-events.types.ts
@@ -19,7 +19,6 @@ import {
   CreateServerAppsettingsParams,
   CreateServerAuthParams,
   CreateServerCsprojParams,
-  CreateServerDockerComposeDevParams,
   CreateServerDockerComposeParams,
   CreateServerGitIgnoreParams,
   CreateServerParams,
@@ -53,10 +52,6 @@ export type DotnetEvents = {
   [DotnetEventNames.CreateEntityGrpcControllerBase]?: PluginEventType<CreateEntityGrpcControllerBaseParams>;
   [DotnetEventNames.CreateServerDockerCompose]?: PluginEventType<
     CreateServerDockerComposeParams,
-    CodeBlock
-  >;
-  [DotnetEventNames.CreateServerDockerComposeDev]?: PluginEventType<
-    CreateServerDockerComposeDevParams,
     CodeBlock
   >;
   [DotnetEventNames.CreateMessageBroker]?: PluginEventType<CreateMessageBrokerParams>;

--- a/libs/util/code-gen-types/src/dotnet-plugins.types.ts
+++ b/libs/util/code-gen-types/src/dotnet-plugins.types.ts
@@ -104,7 +104,6 @@ export enum DotnetEventNames {
   CreateEntityService = "CreateEntityService",
   CreateEntityServiceBase = "CreateEntityServiceBase",
   CreateServerDockerCompose = "CreateServerDockerCompose",
-  CreateServerDockerComposeDev = "CreateServerDockerComposeDev",
   CreatePrismaSchema = "CreatePrismaSchema",
   CreateServerCsproj = "CreateServerCsproj",
   CreateServerAppsettings = "CreateServerAppsettings",


### PR DESCRIPTION



Close: #8528

## PR Details

Removing the event that handle the docker-compose dev creation. This won't be necessary as the docker-compose event will generate a file that can be used for starting only the dependencies or dependencies with the service leveraging docker compose profiles:
https://docs.docker.com/compose/profiles/

## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
