### PR TITLE
Feat(server): handle auth entity for jovu

### DIFF
--- a/packages/amplication-server/src/core/assistant/assistantFunctions.service.ts
+++ b/packages/amplication-server/src/core/assistant/assistantFunctions.service.ts
@@ -2,9 +2,9 @@ import { EnumModuleDtoType } from "@amplication/code-gen-types";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
 import { Inject, Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { get } from "lodash";
+import { get, isEmpty } from "lodash";
 import { pascalCase } from "pascal-case";
-import { plural } from "pluralize";
+import { plural, singular } from "pluralize";
 import { AuthorizableOriginParameter } from "../../enums/AuthorizableOriginParameter";
 import { Env } from "../../env";
 import { Block } from "../../models";
@@ -15,7 +15,10 @@ import { ModuleActionService } from "../moduleAction/moduleAction.service";
 import { ModuleDtoService } from "../moduleDto/moduleDto.service";
 import { PermissionsService } from "../permissions/permissions.service";
 import { PluginCatalogService } from "../pluginCatalog/pluginCatalog.service";
-import { PluginInstallationService } from "../pluginInstallation/pluginInstallation.service";
+import {
+  PluginInstallationService,
+  REQUIRES_AUTHENTICATION_ENTITY,
+} from "../pluginInstallation/pluginInstallation.service";
 import { ProjectService } from "../project/project.service";
 import { EnumPendingChangeOriginType } from "../resource/dto";
 import { EnumResourceType } from "../resource/dto/EnumResourceType";
@@ -26,6 +29,7 @@ import { EnumAssistantFunctions } from "./dto/EnumAssistantFunctions";
 
 import * as functionArgsSchemas from "./functions/";
 import * as functionsArgsTypes from "./functions/types";
+import { USER_ENTITY_NAME } from "../entity/constants";
 
 export const MESSAGE_UPDATED_EVENT = "assistantMessageUpdated";
 
@@ -278,6 +282,8 @@ export class AssistantFunctionsService {
     //iterate over the pluginIds and install each plugin synchronously
     //to support synchronous installation of multiple plugins we need first to fix the plugins order code in the pluginInstallation Service
     const installations = [];
+    let authEntityExist = false;
+
     for (const pluginId of pluginIds) {
       const plugin = await this.pluginCatalogService.getPluginWithLatestVersion(
         pluginId
@@ -285,6 +291,27 @@ export class AssistantFunctionsService {
       const pluginVersion = plugin.versions[0];
 
       const { version, settings, configurations } = pluginVersion;
+
+      if (
+        configurations &&
+        configurations[REQUIRES_AUTHENTICATION_ENTITY] === "true" &&
+        !authEntityExist
+      ) {
+        const authEntityName = await this.resourceService.getAuthEntityName(
+          serviceId,
+          context.user
+        );
+        if (!isEmpty(authEntityName)) {
+          authEntityExist = true;
+        } else {
+          //create auth entity
+          await this.resourceService.createDefaultAuthEntity(
+            serviceId,
+            context.user
+          );
+          authEntityExist = true;
+        }
+      }
 
       const installation = await this.pluginInstallationService.create(
         {
@@ -334,21 +361,44 @@ export class AssistantFunctionsService {
             pluralDisplayName = `${entityName}Items`;
           }
           try {
-            const entity = await this.entityService.createOneEntity(
-              {
-                data: {
-                  displayName: entityName,
-                  pluralDisplayName: pluralDisplayName,
-                  name: pascalCase(entityName),
-                  resource: {
-                    connect: {
-                      id: args.serviceId,
+            let entity;
+            if (
+              singular(entityName.toLowerCase()) ===
+              USER_ENTITY_NAME.toLowerCase()
+            ) {
+              try {
+                entity = await this.resourceService.createDefaultAuthEntity(
+                  args.serviceId,
+                  context.user
+                );
+              } catch (error) {
+                this.logger.warn(
+                  `Chat: Error creating default auth entity ${entityName}. Continue creating regular entity`,
+                  error,
+                  loggerContext
+                );
+              }
+            }
+
+            if (!entity) {
+              entity = await this.entityService.createOneEntity(
+                {
+                  data: {
+                    displayName: entityName,
+                    pluralDisplayName: pluralDisplayName,
+                    name: pascalCase(entityName),
+                    resource: {
+                      connect: {
+                        id: args.serviceId,
+                      },
                     },
                   },
                 },
-              },
-              context.user
-            );
+                context.user
+              );
+            }
+
+            const fields = await this.entityService.getFields(entity.id, {});
 
             const defaultModuleId =
               await this.moduleService.getDefaultModuleIdForEntity(
@@ -358,6 +408,11 @@ export class AssistantFunctionsService {
 
             return {
               entityLink: `${this.clientHost}/${context.workspaceId}/${context.projectId}/${args.serviceId}/entities/${entity.id}`,
+              entityFields: fields.map((field) => ({
+                id: field.id,
+                name: field.name,
+                type: field.dataType,
+              })),
               apisLink: `${this.clientHost}/${context.workspaceId}/${context.projectId}/${args.serviceId}/modules/${defaultModuleId}`,
               result: entity,
             };

--- a/packages/amplication-server/src/core/entity/constants.ts
+++ b/packages/amplication-server/src/core/entity/constants.ts
@@ -100,7 +100,7 @@ type EntityData = Omit<
 
 export const DEFAULT_SINGLE_LINE_TEXT_MAX_LENGTH = 256;
 
-export const DEFAULT_ENTITIES: EntityData[] = [
+export const DEFAULT_USER_ENTITY: EntityData[] = [
   {
     name: USER_ENTITY_NAME,
     displayName: "User",

--- a/packages/amplication-server/src/core/entity/entity.resolver.ts
+++ b/packages/amplication-server/src/core/entity/entity.resolver.ts
@@ -92,7 +92,7 @@ export class EntityResolver {
     @UserEntity() user: User,
     @Args() args: CreateDefaultEntitiesArgs
   ): Promise<Entity[]> {
-    return await this.entityService.createDefaultEntities(
+    return await this.entityService.createDefaultUserEntity(
       args.data.resourceId,
       user
     );

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -36,7 +36,7 @@ import {
   CURRENT_VERSION_NUMBER,
   INITIAL_ENTITY_FIELDS,
   USER_ENTITY_NAME,
-  DEFAULT_ENTITIES,
+  DEFAULT_USER_ENTITY,
   DEFAULT_PERMISSIONS,
   SYSTEM_DATA_TYPES,
   DATA_TYPE_TO_DEFAULT_PROPERTIES,
@@ -758,12 +758,12 @@ export class EntityService {
     return entities;
   }
 
-  async createDefaultEntities(
+  async createDefaultUserEntity(
     resourceId: string,
     user: User
   ): Promise<Entity[]> {
     return await Promise.all(
-      DEFAULT_ENTITIES.map(async (entity) => {
+      DEFAULT_USER_ENTITY.map(async (entity) => {
         const { fields, ...rest } = entity;
         const newEntity = await this.createOneEntity(
           {

--- a/packages/amplication-server/src/core/pluginInstallation/pluginInstallation.service.ts
+++ b/packages/amplication-server/src/core/pluginInstallation/pluginInstallation.service.ts
@@ -20,7 +20,7 @@ import { AmplicationError } from "../../errors/AmplicationError";
 import { JsonValue } from "type-fest";
 import { isEmpty } from "lodash";
 
-const REQUIRES_AUTHENTICATION_ENTITY = "requireAuthenticationEntity";
+export const REQUIRES_AUTHENTICATION_ENTITY = "requireAuthenticationEntity";
 
 const reOrderPlugins = (
   argsData: PluginOrderItem,

--- a/packages/amplication-server/src/core/resource/resource.service.spec.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.spec.ts
@@ -473,9 +473,12 @@ const blockServiceReleaseLockMock = jest.fn(async () => EXAMPLE_BLOCK);
 
 const USER_ENTITY_MOCK = {
   id: "USER_ENTITY_MOCK_ID",
+  name: USER_ENTITY_NAME,
 };
 
-const entityServiceCreateDefaultEntitiesMock = jest.fn();
+const entityServiceCreateDefaultUserEntityMock = jest.fn(() => {
+  return [USER_ENTITY_MOCK];
+});
 const entityServiceFindFirstMock = jest.fn(() => USER_ENTITY_MOCK);
 const entityServiceBulkCreateEntities = jest.fn();
 const entityServiceBulkCreateFields = jest.fn();
@@ -590,7 +593,7 @@ describe("ResourceService", () => {
             createFieldByDisplayName: entityServiceCreateFieldByDisplayNameMock,
             createOneEntity: entityServiceCreateOneEntityMock,
             releaseLock: entityServiceReleaseLockMock,
-            createDefaultEntities: entityServiceCreateDefaultEntitiesMock,
+            createDefaultUserEntity: entityServiceCreateDefaultUserEntityMock,
             getChangedEntities: entityServiceGetChangedEntitiesMock,
             findFirst: entityServiceFindFirstMock,
             bulkCreateEntities: entityServiceBulkCreateEntities,
@@ -703,8 +706,8 @@ describe("ResourceService", () => {
       )
     ).toEqual(EXAMPLE_RESOURCE);
     expect(prismaResourceCreateMock).toBeCalledTimes(1);
-    expect(entityServiceCreateDefaultEntitiesMock).toBeCalledTimes(1);
-    expect(entityServiceCreateDefaultEntitiesMock).toBeCalledWith(
+    expect(entityServiceCreateDefaultUserEntityMock).toBeCalledTimes(1);
+    expect(entityServiceCreateDefaultUserEntityMock).toBeCalledWith(
       EXAMPLE_RESOURCE_ID,
       EXAMPLE_USER
     );
@@ -796,7 +799,7 @@ describe("ResourceService", () => {
       )
     );
     expect(prismaResourceCreateMock).toBeCalledTimes(0);
-    expect(entityServiceCreateDefaultEntitiesMock).toBeCalledTimes(0);
+    expect(entityServiceCreateDefaultUserEntityMock).toBeCalledTimes(0);
   });
 
   it("should fail to create resource with entities with a reserved name", async () => {

--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -8,17 +8,12 @@ import {
 import { KAFKA_TOPICS } from "@amplication/schema-registry";
 import { BillingFeature } from "@amplication/util-billing-types";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
-import {
-  ConflictException,
-  Inject,
-  Injectable,
-  forwardRef,
-} from "@nestjs/common";
+import { Inject, Injectable, forwardRef } from "@nestjs/common";
 import cuid from "cuid";
 import { isEmpty, kebabCase } from "lodash";
 import { pascalCase } from "pascal-case";
 import pluralize from "pluralize";
-import { JsonObject, JsonValue } from "type-fest";
+import { JsonObject } from "type-fest";
 import { FindOneArgs } from "../../dto";
 import { EnumDataType } from "../../enums/EnumDataType";
 import { QueryMode } from "../../enums/QueryMode";

--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -504,6 +504,60 @@ export class ResourceService {
     return resource;
   }
 
+  async createDefaultAuthEntity(
+    resourceId: string,
+    user: User
+  ): Promise<Entity> {
+    const serviceSettings =
+      await this.serviceSettingsService.getServiceSettingsValues(
+        {
+          where: {
+            id: resourceId,
+          },
+        },
+        user
+      );
+
+    if (!isEmpty(serviceSettings.authEntityName)) {
+      throw new AmplicationError(
+        `Auth entity already exists for resource "${resourceId} `
+      );
+    }
+
+    const existingUserEntity = await this.entityService.entities({
+      where: {
+        resourceId: resourceId,
+        name: USER_ENTITY_NAME,
+      },
+    });
+
+    if (!isEmpty(existingUserEntity)) {
+      throw new AmplicationError(
+        `An entity with the default Auth entity name already exists for resource "${resourceId} `
+      );
+    }
+
+    const [userEntity] = await this.entityService.createDefaultUserEntity(
+      resourceId,
+      user
+    );
+
+    await this.serviceSettingsService.updateServiceSettings(
+      {
+        data: {
+          ...serviceSettings,
+          authEntityName: userEntity.displayName,
+        },
+        where: {
+          id: resourceId,
+        },
+      },
+      user
+    );
+
+    return userEntity;
+  }
+
   async createPreviewService({
     args,
     user,


### PR DESCRIPTION


Close: https://github.com/amplication/private-issues/issues/191

## PR Details

1. When jovu creates a new entity with the name "User" or "Users" (or any upper or lower case version of that) - we create the default user entity with all the default fields, and set it as the auth entity, and we also let jovu know that we created the default fields (so it will not try to create the same fields again)
  - if another auth entity already exist we create the new entity as a regular entity with the requested name

2. When jovu installs a plugin that requires auth entity, 
 - if there is already auth entity - all good (probably it alreadt created an entity with the name "User" or in case we are working on an existing service).
 - if there is no auth entity - and the name "User" is available - we create a new user entity with all default fields and set the auth entity
 - if the name "user" is already take - we throw an error back to jovu


## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
