### PR TITLE
fix(code-gen-types): add codeBlock type to LoadStaticFiles PluginEventType

### DIFF
--- a/libs/util/code-gen-types/package.json
+++ b/libs/util/code-gen-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/code-gen-types",
-  "version": "2.0.33-beta.14",
+  "version": "2.0.33-beta.17",
   "description": "This library supplies all the contracts for Amplication Code Generation. The purpose is to make the contracts available for inclusion in plugins.",
   "main": "src/index.js",
   "author": {
@@ -13,7 +13,9 @@
     "json-schema": "^0.4.0",
     "prisma-schema-dsl-types": "^1.1.2",
     "tslib": "^2.6.2",
-    "type-fest": "^3.11.0",
-    "@amplication/csharp-ast": "^0.0.2"
+    "type-fest": "^3.11.0"
+  },
+  "peerDependencies": {
+    "@amplication/csharp-ast": "*"
   }
 }

--- a/libs/util/code-gen-types/src/dotnet-plugin-events.types.ts
+++ b/libs/util/code-gen-types/src/dotnet-plugin-events.types.ts
@@ -68,7 +68,10 @@ export type DotnetEvents = {
   [DotnetEventNames.CreateSeed]?: PluginEventType<CreateSeedParams>;
   [DotnetEventNames.CreateEntityControllerToManyRelationMethods]?: PluginEventType<CreateEntityControllerToManyRelationMethodsParams>;
   [DotnetEventNames.CreateDTOs]?: PluginEventType<CreateDTOsParams>;
-  [DotnetEventNames.LoadStaticFiles]?: PluginEventType<LoadStaticFilesParams>;
+  [DotnetEventNames.LoadStaticFiles]?: PluginEventType<
+    LoadStaticFilesParams,
+    CodeBlock
+  >;
   [DotnetEventNames.CreateServerSecretsManager]?: PluginEventType<CreateServerSecretsManagerParams>;
   [DotnetEventNames.CreateEntityInterface]?: PluginEventType<
     CreateEntityInterfaceParams,


### PR DESCRIPTION
Close: #8574 

## PR Details

add codeBlock type to LoadStaticFiles PluginEventType.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

