### PR TITLE
fix(code-gen-types): CreateResourceDbContextFile to pascal case

### DIFF
--- a/libs/util/code-gen-types/package.json
+++ b/libs/util/code-gen-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/code-gen-types",
-  "version": "2.0.33-beta.19",
+  "version": "2.0.33-beta.21",
   "description": "This library supplies all the contracts for Amplication Code Generation. The purpose is to make the contracts available for inclusion in plugins.",
   "main": "src/index.js",
   "author": {

--- a/libs/util/code-gen-types/src/dotnet-plugin-events-params.types.ts
+++ b/libs/util/code-gen-types/src/dotnet-plugin-events-params.types.ts
@@ -63,7 +63,7 @@ export interface CreateEntityModelParams extends EventParams {
   apisDir: string;
 }
 
-export interface createResourceDbContextFileParams extends EventParams {
+export interface CreateResourceDbContextFileParams extends EventParams {
   entities: Entity[];
   resourceName: string;
   resourceDbContextPath: string;

--- a/libs/util/code-gen-types/src/dotnet-plugin-events.types.ts
+++ b/libs/util/code-gen-types/src/dotnet-plugin-events.types.ts
@@ -26,7 +26,7 @@ import {
   CreateServerSecretsManagerParams,
   CreateSwaggerParams,
   LoadStaticFilesParams,
-  createResourceDbContextFileParams,
+  CreateResourceDbContextFileParams,
 } from "./dotnet-plugin-events-params.types";
 import { DotnetEventNames, PluginEventType } from "./dotnet-plugins.types";
 import { CodeBlock, Interface } from "@amplication/csharp-ast";
@@ -80,5 +80,5 @@ export type DotnetEvents = {
   >;
   [DotnetEventNames.CreateEntityExtensions]?: PluginEventType<CreateEntityExtensionsParams>;
   [DotnetEventNames.CreateEntityModel]?: PluginEventType<CreateEntityModelParams>;
-  [DotnetEventNames.createResourceDbContextFile]?: PluginEventType<createResourceDbContextFileParams>;
+  [DotnetEventNames.CreateResourceDbContextFile]?: PluginEventType<CreateResourceDbContextFileParams>;
 };

--- a/libs/util/code-gen-types/src/dotnet-plugins.types.ts
+++ b/libs/util/code-gen-types/src/dotnet-plugins.types.ts
@@ -128,7 +128,7 @@ export enum DotnetEventNames {
   CreateEntityInterface = "CreateEntityInterface",
   CreateEntityExtensions = "CreateEntityExtensions",
   CreateEntityModel = "CreateEntityModel",
-  createResourceDbContextFile = "createResourceDbContextFile",
+  CreateResourceDbContextFile = "CreateResourceDbContextFile",
 }
 
 export interface AmplicationPlugin {


### PR DESCRIPTION
Close: #8577 

## PR Details

CreateResourceDbContextFile to pascal case. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
