### PR TITLE
fix(client):fix jovu send button state

### DIFF
--- a/packages/amplication-client/src/Assistant/hooks/useAssistant.tsx
+++ b/packages/amplication-client/src/Assistant/hooks/useAssistant.tsx
@@ -215,8 +215,6 @@ const useAssistant = () => {
             currentMessages.pop();
           }
 
-          setProcessingMessage(!message.completed);
-
           if (lastMessage.id === message.id) {
             lastMessage.text = message.snapshot;
             lastMessage.loading = false;


### PR DESCRIPTION


Close:https://github.com/amplication/private-issues/issues/188

## PR Details

The issue probably happens when the last message in the stream is not processed last - so, instead of setting the state based on the current value on each message, we only set it to True when sending the request, and set it back to false when we get the relevant variable from the server 



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
