### PR TITLE
Feat/code gen types version bump

### DIFF
--- a/libs/util/code-gen-types/package.json
+++ b/libs/util/code-gen-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplication/code-gen-types",
-  "version": "2.0.33-beta.23",
+  "version": "2.0.34",
   "description": "This library supplies all the contracts for Amplication Code Generation. The purpose is to make the contracts available for inclusion in plugins.",
   "main": "src/index.js",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "amplication",
       "dependencies": {
-        "@amplication/csharp-ast": "^0.0.2",
+        "@amplication/csharp-ast": "^0.0.3",
         "@amplication/opentelemetry-nestjs": "^5.0.3",
         "@amplication/react-compound-timer": "^2.1.0",
         "@amplication/react-diff-viewer-continued": "^3.4.3",
@@ -349,9 +349,9 @@
       "dev": true
     },
     "node_modules/@amplication/csharp-ast": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@amplication/csharp-ast/-/csharp-ast-0.0.2.tgz",
-      "integrity": "sha512-UMUUg0x1bF7ihhjlWUC1QCUwokpN4cg4cEaFohWx+XAXDW7x0DNKaTWVYFX3HvIQ+MV3O3JkoWjK97nkpM+wtg==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@amplication/csharp-ast/-/csharp-ast-0.0.3.tgz",
+      "integrity": "sha512-29tSgnmM7QH1ZGj5Kt1Ijp8phL3r2h3REvi9ThTGIn2TC6DnwJr4dzStwSt8vM613WOxqrF+V0GSJLITJ8jD4w==",
       "dependencies": {
         "tslib": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "dependencies": {
-    "@amplication/csharp-ast": "^0.0.2",
+    "@amplication/csharp-ast": "^0.0.3",
     "@amplication/opentelemetry-nestjs": "^5.0.3",
     "@amplication/react-compound-timer": "^2.1.0",
     "@amplication/react-diff-viewer-continued": "^3.4.3",

--- a/packages/data-service-generator/package.json
+++ b/packages/data-service-generator/package.json
@@ -66,6 +66,6 @@
     "validator": "13.11.0",
     "winston": "3.8.2",
     "yaml": "2.2.2",
-    "@amplication/csharp-ast": "^0.0.2"
+    "@amplication/csharp-ast": "*"
   }
 }


### PR DESCRIPTION
Close: https://github.com/amplication/private-issues/issues/195

## PR Details

- code-gen-types version bump 
- update csharp-ast version
## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
