### PR TITLE
fix(server):create resource with git

### DIFF
--- a/packages/amplication-server/src/core/resource/resource.service.spec.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.spec.ts
@@ -707,7 +707,7 @@ describe("ResourceService", () => {
       await service.createService(
         createResourceArgs.args,
         createResourceArgs.user,
-        null,
+        false,
         true
       )
     ).toEqual(EXAMPLE_RESOURCE);
@@ -750,12 +750,12 @@ describe("ResourceService", () => {
       const nonDefaultPluginsToInstall = [];
       const requireAuthenticationEntity = true;
 
-      const result = await service.createPreviewService({
-        args: createResourceArgs.args,
+      const result = await service.createPreviewService(
+        createResourceArgs.args,
         user,
         nonDefaultPluginsToInstall,
-        requireAuthenticationEntity,
-      });
+        requireAuthenticationEntity
+      );
 
       expect(result).toEqual(EXAMPLE_RESOURCE);
       expect(prismaResourceCreateMock).toBeCalledTimes(1);

--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -43,7 +43,6 @@ import {
   EntityService,
 } from "../entity/entity.service";
 import { EnvironmentService } from "../environment/environment.service";
-import { ConnectGitRepositoryInput } from "../git/dto/inputs/ConnectGitRepositoryInput";
 import { PluginInstallationCreateInput } from "../pluginInstallation/dto/PluginInstallationCreateInput";
 import { PluginInstallationService } from "../pluginInstallation/pluginInstallation.service";
 import { ProjectService } from "../project/project.service";
@@ -797,13 +796,6 @@ export class ResourceService {
       );
 
       // 2. create new resources
-      const currentProjectConfiguration = await this.prisma.resource.findFirst({
-        where: {
-          projectId: projectId,
-          resourceType: EnumResourceType.ProjectConfiguration,
-        },
-      });
-
       const newResourcesMap = new Map<string, Resource>();
 
       for (const newService of newServices) {

--- a/packages/amplication-server/src/core/workspace/workspace.service.ts
+++ b/packages/amplication-server/src/core/workspace/workspace.service.ts
@@ -61,6 +61,7 @@ import { types } from "@amplication/code-gen-types";
 import { DefaultModuleForEntityNotFoundError } from "../module/DefaultModuleForEntityNotFoundError";
 import { ModuleDto } from "../moduleDto/dto/ModuleDto";
 import { EnumCodeGenerator } from "../resource/dto/EnumCodeGenerator";
+import { CreateOneResourceArgs } from "../resource/dto";
 
 const INVITATION_EXPIRATION_DAYS = 7;
 
@@ -1512,12 +1513,12 @@ export class WorkspaceService {
       generateRestApi: true,
     });
 
-    const resource = await this.resourceService.createPreviewService({
-      args: previewServiceSettings,
+    const resource = await this.resourceService.createPreviewService(
+      previewServiceSettings,
       user,
-      nonDefaultPluginsToInstall: [],
-      requireAuthenticationEntity: false,
-    });
+      [],
+      false
+    );
 
     return resource;
   }
@@ -1531,7 +1532,7 @@ export class WorkspaceService {
     generateGraphQL,
     generateRestApi,
     projectId,
-  }: CreatePreviewServiceSettingsArgs) {
+  }: CreatePreviewServiceSettingsArgs): CreateOneResourceArgs {
     return {
       data: {
         name,


### PR DESCRIPTION

Close: https://github.com/amplication/amplication/issues/8612

## PR Details

Rewrite the logic for creating a git repository when creating a resource. 
Simplify the logic of the function createResource(), so:
1. We use a single object for git repository data. Instead of using a separate parameter, we are using the property from the `CreateOneResourceArgs` object 
2. Remove the `wizardType` parameter.
3. Add a new `updateProjectGitRepository` 
4. Inherit the project git settings unless gitRepository.isOverrideGitRepository is true or updateProjectGitRepository is true


## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
