### PR TITLE
feat(server): update create pr topic schema to allow parallel consumption of PRs touching difference repository branches

### DIFF
--- a/libs/schema-registry/src/lib/create-pr-request/key.ts
+++ b/libs/schema-registry/src/lib/create-pr-request/key.ts
@@ -3,4 +3,7 @@ import { IsString } from "class-validator";
 export class Key {
   @IsString()
   resourceRepositoryId!: string;
+
+  @IsString()
+  resourceId!: string | null;
 }

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -848,6 +848,14 @@ export class BuildService {
           const createPullRequestEvent: CreatePrRequest.KafkaEvent = {
             key: {
               resourceRepositoryId: kafkaEventKey,
+              /**
+                  If the branch is not per resource, we want to create a PR for the entire project
+                  so we set the resourceId to null to indicate avoid
+                  git force action issues due to creating PR for specific resources in parallel
+                  */
+              resourceId: createPullRequestMessage.isBranchPerResource
+                ? resource.id
+                : null,
             },
             value: createPullRequestMessage,
           };


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).
2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.
3. You are giving a descriptive title to your PR following CONTRIBUTING.md conventions
4. You are providing enough information about your changes for others to review your pull request.
5. Ensure the PR is targeting `next` branch

-->

Close: #8593

## PR Details

This PR add resourceId to the create-pull-request-request topic key to allow:
- for prs per service: sync-manager to process pr requests in parallel as they won't collide
- for prs per project: sync-manager to process pr request in FIFO order per repository

## PR Checklist

- [ ] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
