### PR TITLE
fix(server): default API `meta` endpoint path

### DIFF
--- a/libs/util/dsg-utils/src/lib/entity-util.spec.ts
+++ b/libs/util/dsg-utils/src/lib/entity-util.spec.ts
@@ -93,7 +93,7 @@ describe("getDefaultActionsForEntity", () => {
         enabled: true,
         gqlOperation: EnumModuleActionGqlOperation.Query,
         restVerb: EnumModuleActionRestVerb.Get,
-        path: `/:id/meta`,
+        path: `/meta`,
       },
       [EnumModuleActionType.Create]: {
         actionType: EnumModuleActionType.Create,

--- a/libs/util/dsg-utils/src/lib/entity-util.ts
+++ b/libs/util/dsg-utils/src/lib/entity-util.ts
@@ -42,7 +42,7 @@ export const getDefaultActionsForEntity = (
       enabled: true,
       gqlOperation: EnumModuleActionGqlOperation.Query,
       restVerb: EnumModuleActionRestVerb.Get,
-      path: `/:id/meta`,
+      path: `/meta`,
     },
     [EnumModuleActionType.Create]: {
       actionType: EnumModuleActionType.Create,

--- a/packages/amplication-server/src/core/moduleAction/moduleAction.service.spec.ts
+++ b/packages/amplication-server/src/core/moduleAction/moduleAction.service.spec.ts
@@ -538,7 +538,7 @@ describe("ModuleActionService", () => {
         name: "_exampleEntitiesMeta",
         outputParameters: null,
         parentBlock: null,
-        path: "/:id/meta",
+        path: "/meta",
         restVerb: "Get",
         versionNumber: 0,
       },

--- a/packages/data-service-generator/src/tests/modules.ts
+++ b/packages/data-service-generator/src/tests/modules.ts
@@ -38,7 +38,7 @@ const userModuleDefaultActions: ModuleAction[] = [
     resourceId: "clraten1t0004c9yhz1t3o8bp",
     parentBlockId: USER_MODULE_ID,
     name: "_usersMeta",
-    path: "/:id/meta",
+    path: "/meta",
     enabled: true,
     restVerb: "Get",
     actionType: "Meta",

--- a/packages/data-service-generator/tests/e2e/data/base/modules.ts
+++ b/packages/data-service-generator/tests/e2e/data/base/modules.ts
@@ -37,7 +37,7 @@ const userModuleDefaultActions: ModuleAction[] = [
     resourceId: "clraten1t0004c9yhz1t3o8bp",
     parentBlockId: USER_MODULE_ID,
     name: "_usersMeta",
-    path: "/:id/meta",
+    path: "/meta",
     enabled: true,
     restVerb: "Get",
     actionType: "Meta",


### PR DESCRIPTION
Close: #8636

## PR Details

This PR updates  the default meta action endpoint path. 
It does NOT contain DB data migration for already created meta actions

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
