### PR TITLE
fix(client):fix default purchase return url

### DIFF
--- a/packages/amplication-client/src/Purchase/PurchasePage.tsx
+++ b/packages/amplication-client/src/Purchase/PurchasePage.tsx
@@ -109,6 +109,9 @@ const PurchasePage = (props) => {
   const errorMessage =
     provisionSubscriptionError && formatError(provisionSubscriptionError);
 
+  const returnUrl =
+    props.location.state?.from?.pathname || `/${currentWorkspace?.id}`;
+
   const handleContactUsClick = useCallback(() => {
     window.open(data?.contactUsLink, "_blank");
     trackEvent({
@@ -135,8 +138,8 @@ const PurchasePage = (props) => {
             planId: BillingPlan.Essential,
             billingPeriod: selectedBillingPeriod,
             intentionType,
-            successUrl: props.location.state?.from?.pathname,
-            cancelUrl: props.location.state?.from?.pathname,
+            successUrl: returnUrl,
+            cancelUrl: returnUrl,
           },
         },
       });


### PR DESCRIPTION
Close: #8679

## PR Details

Add a default return URL for the purchase process when no specific return URL is provided from the calling page

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
