### PR TITLE
feat(client):improve the UX to get to the generated code 

### DIFF
--- a/libs/ui/design-system/src/lib/components/Button/Button.scss
+++ b/libs/ui/design-system/src/lib/components/Button/Button.scss
@@ -76,6 +76,19 @@ $split-icon-font-size: 20px;
         outline: none;
       }
     }
+
+    &--success {
+      background-color: var(--color-positive);
+      border: 1px solid var(--color-positive);
+
+      &:hover,
+      &:active,
+      &:focus {
+        background-color: var(--color-positive);
+        border-color: var(--color-positive);
+        outline: none;
+      }
+    }
   }
 
   &.amp-button--text {
@@ -110,6 +123,17 @@ $split-icon-font-size: 20px;
       &:active,
       &:focus {
         color: var(--theme-red);
+        outline: none;
+      }
+    }
+
+    &--success {
+      color: var(--color-positive);
+
+      &:hover,
+      &:active,
+      &:focus {
+        color: var(--color-positive);
         outline: none;
       }
     }
@@ -173,6 +197,19 @@ $split-icon-font-size: 20px;
       &:focus {
         color: var(--theme-red);
         border-color: var(--theme-red);
+        outline: none;
+      }
+    }
+
+    &--success {
+      color: var(--color-positive);
+      border-color: var(--color-positive);
+
+      &:hover,
+      &:active,
+      &:focus {
+        color: var(--color-positive);
+        border-color: var(--color-positive);
         outline: none;
       }
     }

--- a/libs/ui/design-system/src/lib/components/Button/Button.tsx
+++ b/libs/ui/design-system/src/lib/components/Button/Button.tsx
@@ -19,6 +19,7 @@ export enum EnumButtonStyle {
 export enum EnumButtonState {
   Default = "default",
   Danger = "danger",
+  Success = "success",
 }
 
 export enum EnumIconPosition {

--- a/packages/amplication-client/src/Components/TitleAndIcon.tsx
+++ b/packages/amplication-client/src/Components/TitleAndIcon.tsx
@@ -12,11 +12,16 @@ import "./TitleAndIcon.scss";
 type Props = {
   icon: string;
   title: string;
+  color?: EnumTextColor;
 };
 
 const CLASS_NAME = "title-and-icon";
 
-export const TitleAndIcon = ({ icon, title }: Props) => {
+export const TitleAndIcon = ({
+  icon,
+  title,
+  color = EnumTextColor.White,
+}: Props) => {
   return (
     <FlexItem
       className={CLASS_NAME}
@@ -24,7 +29,7 @@ export const TitleAndIcon = ({ icon, title }: Props) => {
       gap={EnumGapSize.Small}
     >
       <Icon icon={icon} color={EnumTextColor.White} />
-      <Text textStyle={EnumTextStyle.Tag} textColor={EnumTextColor.White}>
+      <Text textStyle={EnumTextStyle.Tag} textColor={color}>
         {title}
       </Text>
     </FlexItem>

--- a/packages/amplication-client/src/VersionControl/BuildGitLink.tsx
+++ b/packages/amplication-client/src/VersionControl/BuildGitLink.tsx
@@ -1,7 +1,8 @@
 import {
+  Button,
+  EnumButtonState,
+  EnumButtonStyle,
   EnumTextColor,
-  EnumTextStyle,
-  Text,
 } from "@amplication/ui/design-system";
 import * as models from "../models";
 import useBuildGitUrl from "./useBuildGitUrl";
@@ -15,14 +16,17 @@ const BuildGitLink = ({
   build,
   textColor = EnumTextColor.ThemeTurquoise,
 }: Props) => {
-  const buildGitUrl = useBuildGitUrl(build);
+  const { gitUrl, gitPrTitle } = useBuildGitUrl(build);
 
   return (
-    buildGitUrl && (
-      <a href={buildGitUrl} target={"git"}>
-        <Text textStyle={EnumTextStyle.Subtle} textColor={textColor}>
-          {buildGitUrl}
-        </Text>
+    gitUrl && (
+      <a href={gitUrl} target={"git"}>
+        <Button
+          buttonStyle={EnumButtonStyle.Outline}
+          buttonState={EnumButtonState.Success}
+        >
+          {gitPrTitle}
+        </Button>
       </a>
     )
   );

--- a/packages/amplication-client/src/VersionControl/CommitResourceList.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitResourceList.tsx
@@ -1,17 +1,16 @@
-import React from "react";
-import CommitResourceListItem from "./CommitResourceListItem";
-import * as models from "../models";
-import DataPanel, { TitleDataType } from "./DataPanel";
-import { EnumImages } from "../Components/SvgThemeImage";
-import { EmptyState } from "../Components/EmptyState";
-import { CommitChangesByResource } from "./hooks/useCommits";
 import {
   EnumFlexItemMargin,
   EnumTextStyle,
   FlexItem,
-  List,
   Text,
 } from "@amplication/ui/design-system";
+import React from "react";
+import { EmptyState } from "../Components/EmptyState";
+import { EnumImages } from "../Components/SvgThemeImage";
+import * as models from "../models";
+import CommitResourceListItem from "./CommitResourceListItem";
+import DataPanel, { TitleDataType } from "./DataPanel";
+import { CommitChangesByResource } from "./hooks/useCommits";
 
 type Props = {
   commit: models.Commit;
@@ -35,12 +34,12 @@ const CommitResourceList: React.FC<Props> = ({
       {commit.builds && commit.builds.length > 0 && (
         <FlexItem margin={EnumFlexItemMargin.Bottom}>
           <Text textStyle={EnumTextStyle.Tag}>
-            {commit.builds.length} resources
+            {commit.builds.length} builds
           </Text>
         </FlexItem>
       )}
       {commit.builds && commit.builds.length ? (
-        <List>
+        <>
           {commit.builds.map((build: models.Build) => (
             <CommitResourceListItem
               key={build.id}
@@ -48,7 +47,7 @@ const CommitResourceList: React.FC<Props> = ({
               commitChangesByResource={commitChangesByResource}
             />
           ))}
-        </List>
+        </>
       ) : (
         <EmptyState
           message="There are no builds to show"

--- a/packages/amplication-client/src/VersionControl/CommitResourceListItem.scss
+++ b/packages/amplication-client/src/VersionControl/CommitResourceListItem.scss
@@ -14,7 +14,6 @@
   &__description-row {
     box-sizing: border-box;
     border-top: 1px solid var(--gray-80);
-    margin: 0 var(--default-spacing);
     width: calc(100% - var(--default-spacing) * 2);
     padding: var(--default-spacing);
   }

--- a/packages/amplication-client/src/VersionControl/CommitResourceListItem.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitResourceListItem.tsx
@@ -2,27 +2,27 @@ import {
   EnumFlexDirection,
   EnumGapSize,
   EnumItemsAlign,
+  EnumPanelStyle,
   EnumTextColor,
   EnumTextStyle,
   FlexItem,
-  HorizontalRule,
   Icon,
+  List,
   ListItem,
+  Panel,
   Text,
 } from "@amplication/ui/design-system";
-import { useCallback, useContext, useMemo } from "react";
+import { useContext, useMemo } from "react";
 import { Link } from "react-router-dom";
-import ResourceCircleBadge from "../Components/ResourceCircleBadge";
-import { AppContext } from "../context/appContext";
-import { Build } from "../models";
-import { CommitChangesByResource } from "./hooks/useCommits";
-import useBuildWatchStatus from "./useBuildWatchStatus";
-import "./CommitResourceListItem.scss";
-import { resourceThemeMap } from "../Resource/constants";
+import { CodeGeneratorImage } from "../Components/CodeGeneratorImage";
 import { TruncatedId } from "../Components/TruncatedId";
+import { AppContext } from "../context/appContext";
+import { Build, EnumBuildStatus } from "../models";
 import BuildGitLink from "./BuildGitLink";
 import { CommitBuildsStatusIcon } from "./CommitBuildsStatusIcon";
-import { CodeGeneratorImage } from "../Components/CodeGeneratorImage";
+import "./CommitResourceListItem.scss";
+import { CommitChangesByResource } from "./hooks/useCommits";
+import useBuildWatchStatus from "./useBuildWatchStatus";
 
 type Props = {
   build: Build;
@@ -34,9 +34,6 @@ const CLASS_NAME = "commit-resource-list-item";
 const CommitResourceListItem = ({ build, commitChangesByResource }: Props) => {
   const { currentWorkspace, currentProject } = useContext(AppContext);
   const { data } = useBuildWatchStatus(build);
-  const handleBuildLinkClick = useCallback((event) => {
-    event.stopPropagation();
-  }, []);
 
   const resourceChangesCount = useMemo(() => {
     const resourcesChanges = commitChangesByResource(build.commitId);
@@ -45,53 +42,93 @@ const CommitResourceListItem = ({ build, commitChangesByResource }: Props) => {
     )?.changes.length;
   }, [build.commitId, build.resourceId, commitChangesByResource]);
 
+  const logMessage = useMemo(() => {
+    if (data.build.status === EnumBuildStatus.Failed) {
+      return (
+        <Text textStyle={EnumTextStyle.Tag} textColor={EnumTextColor.ThemeRed}>
+          Error. See logs for details
+        </Text>
+      );
+    }
+
+    const lastStep = build.action.steps[build.action.steps.length - 1];
+    if (!lastStep) {
+      return <></>;
+    }
+    return (
+      <Text textStyle={EnumTextStyle.Tag}>
+        {lastStep.logs[lastStep.logs.length - 1]?.message}
+      </Text>
+    );
+  }, [build.action.steps, data.build.status]);
+
   return (
     build &&
     build.resource && (
-      <ListItem
-        gap={EnumGapSize.None}
-        className={CLASS_NAME}
-        removeDefaultPadding
-      >
-        <Link
-          to={`/${currentWorkspace?.id}/${currentProject?.id}/commits/${build.commitId}/builds/${build.id}`}
-          className={`${CLASS_NAME}__link`}
-        >
-          <FlexItem itemsAlign={EnumItemsAlign.Center}>
-            <FlexItem.FlexStart>
-              <ResourceCircleBadge
-                type={build.resource.resourceType}
-                size="xsmall"
-              />
-            </FlexItem.FlexStart>
-            <Text textStyle={EnumTextStyle.Normal}>{build.resource.name}</Text>
-            <CodeGeneratorImage resource={build.resource} />
-            <FlexItem.FlexEnd>
-              <Icon
-                icon="chevron_right"
-                color={EnumTextColor.White}
-                size="xsmall"
-              />
-            </FlexItem.FlexEnd>
-          </FlexItem>
-        </Link>
-        <FlexItem
-          direction={EnumFlexDirection.Column}
-          gap={EnumGapSize.Small}
-          className={`${CLASS_NAME}__description-row`}
-        >
-          {/* <HorizontalRule smallSpacing  /> */}
-          <FlexItem
-            itemsAlign={EnumItemsAlign.Center}
-            direction={EnumFlexDirection.Row}
-            end={
+      <Panel panelStyle={EnumPanelStyle.Transparent}>
+        <List>
+          <ListItem
+            gap={EnumGapSize.None}
+            className={CLASS_NAME}
+            removeDefaultPadding
+          >
+            <Link
+              to={`/${currentWorkspace?.id}/${currentProject?.id}/commits/${build.commitId}/builds/${build.id}`}
+              className={`${CLASS_NAME}__link`}
+            >
               <FlexItem itemsAlign={EnumItemsAlign.Center}>
-                <BuildGitLink
-                  build={build}
-                  textColor={EnumTextColor.ThemeTurquoise}
-                />
-                <hr className={`${CLASS_NAME}__vertical_border`} />
-
+                <FlexItem.FlexStart>
+                  <FlexItem
+                    itemsAlign={EnumItemsAlign.Center}
+                    direction={EnumFlexDirection.Row}
+                  >
+                    <CommitBuildsStatusIcon
+                      commitBuildStatus={data.build.status}
+                    />
+                    <Text textStyle={EnumTextStyle.Tag}>Build ID </Text>
+                    <Text
+                      textStyle={EnumTextStyle.Tag}
+                      textColor={EnumTextColor.White}
+                    >
+                      <TruncatedId id={build.id} />
+                    </Text>
+                  </FlexItem>
+                </FlexItem.FlexStart>
+                <Text textStyle={EnumTextStyle.Normal}>
+                  {build.resource.name}
+                </Text>
+                <CodeGeneratorImage resource={build.resource} />
+                <FlexItem.FlexEnd>
+                  <Icon
+                    icon="chevron_right"
+                    color={EnumTextColor.White}
+                    size="xsmall"
+                  />
+                </FlexItem.FlexEnd>
+              </FlexItem>
+            </Link>
+            <FlexItem
+              direction={EnumFlexDirection.Column}
+              gap={EnumGapSize.Small}
+              className={`${CLASS_NAME}__description-row`}
+            >
+              <FlexItem
+                itemsAlign={EnumItemsAlign.Center}
+                direction={EnumFlexDirection.Row}
+                end={
+                  <FlexItem itemsAlign={EnumItemsAlign.Center}>
+                    <Link
+                      to={`/${currentWorkspace?.id}/${currentProject?.id}/commits/${build.commitId}/builds/${build.id}`}
+                    >
+                      {logMessage}
+                    </Link>
+                    <BuildGitLink
+                      build={build}
+                      textColor={EnumTextColor.ThemeTurquoise}
+                    />
+                  </FlexItem>
+                }
+              >
                 <Link
                   to={`/${currentWorkspace?.id}/${currentProject?.id}/${build.resourceId}/changes/${build.commitId}`}
                 >
@@ -115,41 +152,11 @@ const CommitResourceListItem = ({ build, commitChangesByResource }: Props) => {
                     </Text>
                   </FlexItem>
                 </Link>
-                <hr className={`${CLASS_NAME}__vertical_border`} />
-
-                <Link
-                  to={`/${currentWorkspace?.id}/${currentProject?.id}/${build.resourceId}`}
-                >
-                  <FlexItem
-                    gap={EnumGapSize.Small}
-                    itemsAlign={EnumItemsAlign.Center}
-                  >
-                    <Icon
-                      icon={
-                        resourceThemeMap[build.resource?.resourceType]?.icon
-                      }
-                      color={EnumTextColor.ThemeTurquoise}
-                      size="xsmall"
-                    />
-                    <Text
-                      textColor={EnumTextColor.ThemeTurquoise}
-                      textStyle={EnumTextStyle.Subtle}
-                    >
-                      Go to resource
-                    </Text>
-                  </FlexItem>
-                </Link>
               </FlexItem>
-            }
-          >
-            <Text textStyle={EnumTextStyle.Tag}>Build ID </Text>
-            <Text textStyle={EnumTextStyle.Tag} textColor={EnumTextColor.White}>
-              <TruncatedId id={build.id} />
-            </Text>
-            <CommitBuildsStatusIcon commitBuildStatus={data.build.status} />
-          </FlexItem>
-        </FlexItem>
-      </ListItem>
+            </FlexItem>
+          </ListItem>
+        </List>
+      </Panel>
     )
   );
 };

--- a/packages/amplication-client/src/VersionControl/LastCommit.tsx
+++ b/packages/amplication-client/src/VersionControl/LastCommit.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  EnumButtonState,
   EnumButtonStyle,
   EnumFlexDirection,
   EnumFlexItemMargin,
@@ -16,11 +17,12 @@ import { useContext } from "react";
 import { Link } from "react-router-dom";
 import { ClickableId } from "../Components/ClickableId";
 import { AppContext } from "../context/appContext";
-import { Commit } from "../models";
+import { Commit, EnumBuildStatus } from "../models";
 import { AnalyticsEventNames } from "../util/analytics-events.types";
 import { CommitBuildsStatusIcon } from "./CommitBuildsStatusIcon";
 import "./LastCommit.scss";
 import { useCommitStatus } from "./hooks/useCommitStatus";
+import BuildGitLink from "./BuildGitLink";
 
 type Props = {
   lastCommit: Commit;
@@ -34,6 +36,8 @@ const LastCommit = ({ lastCommit }: Props) => {
 
   const { commitStatus, commitLastError } = useCommitStatus(lastCommit);
   if (!lastCommit) return null;
+
+  const singleBuild = lastCommit.builds && lastCommit.builds.length === 1;
 
   const ClickableCommitId = (
     <ClickableId
@@ -95,16 +99,21 @@ const LastCommit = ({ lastCommit }: Props) => {
           </Text>
         </FlexItem>
 
-        {lastCommit && (
+        {singleBuild ? (
+          <BuildGitLink build={lastCommit.builds[0]} />
+        ) : (
           <Link
-            to={`/${currentWorkspace?.id}/${currentProject?.id}/code-view`}
+            to={`/${currentWorkspace?.id}/${currentProject?.id}/commits/${lastCommit.id}`}
             className={`${CLASS_NAME}__view-code`}
           >
             <Button
               buttonStyle={EnumButtonStyle.Outline}
-              disabled={commitRunning}
+              disabled={
+                commitRunning || commitStatus === EnumBuildStatus.Running
+              }
+              buttonState={EnumButtonState.Success}
             >
-              Go to view code
+              View code (multiple builds)
             </Button>
           </Link>
         )}

--- a/packages/amplication-client/src/VersionControl/useBuildGitUrl.tsx
+++ b/packages/amplication-client/src/VersionControl/useBuildGitUrl.tsx
@@ -20,7 +20,27 @@ const useBuildGitUrl = (build?: models.Build) => {
     return log?.meta?.githubUrl || null;
   }, [build?.action]);
 
-  return gitUrl;
+  const gitPrTitle = useMemo<string | null>(() => {
+    if (gitUrl) {
+      if (gitUrl.includes("github")) {
+        const url = new URL(gitUrl);
+        const prNumber = url.pathname.split("/").pop();
+        return `View code (PR #${prNumber})`;
+      } else if (gitUrl.includes("gitlab")) {
+        const url = new URL(gitUrl);
+        const prNumber = url.pathname.split("/").pop();
+        return `View code (MR #${prNumber})`;
+      } else if (gitUrl.includes("bitbucket")) {
+        const url = new URL(gitUrl);
+        const prNumber = url.pathname.split("/").pop();
+        return `View code (PR #${prNumber})`;
+      } else {
+        return "View code";
+      }
+    }
+  }, [gitUrl]);
+
+  return { gitUrl, gitPrTitle };
 };
 
 export default useBuildGitUrl;

--- a/packages/amplication-client/src/Workspaces/WorkspaceFooter.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceFooter.tsx
@@ -110,7 +110,7 @@ const WorkspaceFooter: React.FC<{ lastCommit: Commit }> = ({ lastCommit }) => {
                 <Link
                   className={`${CLASS_NAME}__connect-to-git`}
                   title={`Connect to git`}
-                  to={`/${currentWorkspace?.id}/${currentProject?.id}/${projectConfigurationResource?.id}/git-sync`}
+                  to={`/${currentWorkspace?.id}/${currentProject?.id}/git-sync`}
                 >
                   <Text
                     textStyle={EnumTextStyle.Description}

--- a/packages/amplication-client/src/Workspaces/WorkspaceFooter.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceFooter.tsx
@@ -64,7 +64,7 @@ const WorkspaceFooter: React.FC<{ lastCommit: Commit }> = ({ lastCommit }) => {
     />
   );
 
-  const gitUrl = useBuildGitUrl(lastResourceBuild);
+  const { gitUrl } = useBuildGitUrl(lastResourceBuild);
 
   return (
     currentProject && (

--- a/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
@@ -116,7 +116,9 @@ const WorkspaceLayout: React.FC<Props> = ({
   useEffect(() => {
     if (!currentProject?.id) return;
     commitUtils.refetchCommitsData(true);
-  }, [currentProject?.id]);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentProject?.id]); //do not include commitUtils to avoid infinite loop
 
   const { trackEvent, Track } = useTracking<{ [key: string]: any }>({
     workspaceId: currentWorkspace?.id,

--- a/packages/amplication-server/src/core/build/build.controller.ts
+++ b/packages/amplication-server/src/core/build/build.controller.ts
@@ -51,12 +51,12 @@ export class BuildController {
     @Payload() message: CodeGenerationSuccess.Value
   ): Promise<void> {
     const args = plainToInstance(CodeGenerationSuccess.Value, message);
+    await this.buildService.saveToGitProvider(args.buildId);
     await this.buildService.completeCodeGenerationStep(
       args.buildId,
       EnumActionStepStatus.Success,
       args.codeGeneratorVersion
     );
-    await this.buildService.saveToGitProvider(args.buildId);
   }
 
   @EventPattern(KAFKA_TOPICS.CODE_GENERATION_FAILURE_TOPIC)


### PR DESCRIPTION
Close:  
https://github.com/amplication/amplication/issues/8524
https://github.com/amplication/amplication/issues/8506


## PR Details

- Improve the UX to let the user get to their code on git 
- highlight the link to the PR on the build list
- redesign the build list to focus on the status, show the last message, and error
- update the view code button on the side panel to send the user to the PR when there is a single service, or to the build list when there are multiple builds

<img width="1512" alt="image" src="https://github.com/amplication/amplication/assets/43705455/df996e93-ffd2-49fa-b79e-8b114e82e663">

<img width="1512" alt="image" src="https://github.com/amplication/amplication/assets/43705455/7deca2e1-d557-434b-b731-a34f61617ae8">



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
