### PR TITLE
Feat/private-208

### DIFF
--- a/libs/util/billing-types/src/lib/billing-feature.types.ts
+++ b/libs/util/billing-types/src/lib/billing-feature.types.ts
@@ -21,7 +21,6 @@ export enum BillingFeature {
   RedesignArchitecture = "feature-redesign-architecture",
   Services = "feature-services",
   ServicesAboveEntitiesPerServiceLimit = "feature-services-above-entities-per-service-limit",
-  ServicesWithManyEntities = "feature-services-wth-many-entities",
   SmartGitSync = "feature-smart-git-sync",
   TeamMembers = "feature-team-members",
 }

--- a/packages/amplication-client/src/Components/CreateResourceButton.tsx
+++ b/packages/amplication-client/src/Components/CreateResourceButton.tsx
@@ -40,15 +40,21 @@ const ITEMS: CreateResourceButtonItemType[] = [
 
 type Props = {
   resourcesLength: number;
+  servicesLength: number;
 };
 
-const CreateResourceButton: React.FC<Props> = ({ resourcesLength }) => {
+const CreateResourceButton: React.FC<Props> = ({
+  resourcesLength,
+  servicesLength,
+}) => {
   return (
     <div className={CLASS_NAME}>
       <FeatureIndicatorContainer
         featureId={BillingFeature.Services}
         entitlementType={EntitlementType.Metered}
         limitationText="You have reached the maximum number of services allowed. "
+        actualUsage={servicesLength}
+        paidPlansExclusive={false}
       >
         <SelectMenu title="Add Resource" buttonStyle={EnumButtonStyle.Primary}>
           <SelectMenuModal align="right" withCaret>

--- a/packages/amplication-client/src/Components/FeatureIndicator.tsx
+++ b/packages/amplication-client/src/Components/FeatureIndicator.tsx
@@ -34,7 +34,7 @@ const WarningTooltip = styled(
 const CLASS_NAME = "amp-feature-indicator";
 
 export const DEFAULT_TEXT_START =
-  "Explore this feature, included in your 7-day Enterprise trial.";
+  "Explore this feature, included in your 7-day trial.";
 export const DEFAULT_TEXT_END =
   " to ensure continued access and discover additional hidden functionalities!";
 

--- a/packages/amplication-client/src/Components/FeatureIndicatorContainer.tsx
+++ b/packages/amplication-client/src/Components/FeatureIndicatorContainer.tsx
@@ -52,6 +52,8 @@ export type Props = {
   reversePosition?: boolean;
   showTooltip?: boolean;
   ctaType?: EnumCtaType;
+  actualUsage?: number | null;
+  paidPlansExclusive?: boolean;
 };
 
 export const FeatureIndicatorContainer: FC<Props> = ({
@@ -65,6 +67,8 @@ export const FeatureIndicatorContainer: FC<Props> = ({
   reversePosition,
   showTooltip = true,
   ctaType = EnumCtaType.Upgrade,
+  actualUsage,
+  paidPlansExclusive = true,
 }) => {
   const { stigg } = useStiggContext();
   const { currentWorkspace } = useContext(AppContext);
@@ -105,14 +109,16 @@ export const FeatureIndicatorContainer: FC<Props> = ({
     }
 
     if (entitlementType === EntitlementType.Metered) {
-      const usageExceeded = usageLimit && currentUsage >= usageLimit;
+      const actualCurrentUsage =
+        actualUsage != null ? actualUsage : currentUsage;
+      const usageExceeded = usageLimit && actualCurrentUsage >= usageLimit;
       const isDisabled = usageExceeded ?? !hasMeteredAccess;
       if (isPreviewPlan(subscriptionPlan) && !isDisabled) {
         setDisabled(null);
         setIcon(null);
         return;
       }
-      setDisabled(isDisabled);
+      setDisabled(actualUsage != null ? usageExceeded : isDisabled);
     }
   }, [
     featureId,
@@ -123,6 +129,7 @@ export const FeatureIndicatorContainer: FC<Props> = ({
     subscriptionPlan,
     status,
     entitlementType,
+    actualUsage,
   ]);
 
   const textStart = useMemo(() => {
@@ -130,7 +137,8 @@ export const FeatureIndicatorContainer: FC<Props> = ({
       return limitationText;
     }
     if (
-      subscriptionPlan === EnumSubscriptionPlan.Enterprise &&
+      (subscriptionPlan === EnumSubscriptionPlan.Enterprise ||
+        subscriptionPlan === EnumSubscriptionPlan.Essential) &&
       status !== EnumSubscriptionStatus.Trailing
     ) {
       return fullEnterpriseText;
@@ -144,7 +152,8 @@ export const FeatureIndicatorContainer: FC<Props> = ({
       return DISABLED_DEFAULT_TEXT_END;
     }
     if (
-      subscriptionPlan === EnumSubscriptionPlan.Enterprise &&
+      (subscriptionPlan === EnumSubscriptionPlan.Enterprise ||
+        subscriptionPlan === EnumSubscriptionPlan.Essential) &&
       status !== EnumSubscriptionStatus.Trailing
     ) {
       return "";
@@ -156,7 +165,8 @@ export const FeatureIndicatorContainer: FC<Props> = ({
   const showTooltipLink = useMemo(() => {
     if (
       isPreviewPlan(subscriptionPlan) ||
-      (subscriptionPlan === EnumSubscriptionPlan.Enterprise &&
+      ((subscriptionPlan === EnumSubscriptionPlan.Enterprise ||
+        subscriptionPlan === EnumSubscriptionPlan.Essential) &&
         status !== EnumSubscriptionStatus.Trailing)
     ) {
       return false; // don't show the upgrade link when the plan is preview
@@ -176,12 +186,14 @@ export const FeatureIndicatorContainer: FC<Props> = ({
     }
 
     if (
-      subscriptionPlan === EnumSubscriptionPlan.Enterprise &&
-      status === EnumSubscriptionStatus.Trailing
+      (subscriptionPlan === EnumSubscriptionPlan.Enterprise ||
+        subscriptionPlan === EnumSubscriptionPlan.Essential) &&
+      status === EnumSubscriptionStatus.Trailing &&
+      paidPlansExclusive
     ) {
       setIcon(IconType.Diamond);
     }
-  }, [featureId, subscriptionPlan, status, disabled]);
+  }, [featureId, subscriptionPlan, status, disabled, paidPlansExclusive]);
 
   const renderProps = {
     disabled: disabled,

--- a/packages/amplication-client/src/Project/AddNewProject.tsx
+++ b/packages/amplication-client/src/Project/AddNewProject.tsx
@@ -10,7 +10,11 @@ import { Button } from "../Components/Button";
 
 const CLASS_NAME = "add-new-project";
 
-const AddNewProject = () => {
+type Props = {
+  projectsLength: number;
+};
+
+const AddNewProject = ({ projectsLength }: Props) => {
   const [projectDialogStatus, setProjectDialogStatus] =
     useState<boolean>(false);
 
@@ -36,6 +40,8 @@ const AddNewProject = () => {
         featureId={BillingFeature.Projects}
         entitlementType={EntitlementType.Metered}
         limitationText="You have reached the maximum number of projects allowed. "
+        actualUsage={projectsLength}
+        paidPlansExclusive={false}
       >
         <Button
           onClick={handleNewProjectClick}

--- a/packages/amplication-client/src/Resource/create-resource/ServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/ServiceWizard.tsx
@@ -328,7 +328,12 @@ const ServiceWizard: React.FC<ServiceWizardProps> = ({
                                 }
                               : goNextPage
                           }
-                          disabled={isInvalidStep}
+                          disabled={
+                            isInvalidStep ||
+                            (activePageIndex ===
+                              wizardPattern[wizardPattern.length - 2] &&
+                              (keepLoadingAnimation || submitLoader)) // disable continue button on the create service animation page
+                          }
                           buttonName={"Continue"}
                         />
                       )}

--- a/packages/amplication-client/src/Workspaces/ResourceList.tsx
+++ b/packages/amplication-client/src/Workspaces/ResourceList.tsx
@@ -18,7 +18,7 @@ import {
 } from "@amplication/ui/design-system";
 import { Reference, gql, useMutation } from "@apollo/client";
 import { isEmpty } from "lodash";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import CreateResourceButton from "../Components/CreateResourceButton";
 import { EmptyState } from "../Components/EmptyState";
 import { EnumImages } from "../Components/SvgThemeImage";
@@ -54,6 +54,12 @@ function ResourceList() {
     errorResources,
     currentProject,
   } = useContext(AppContext);
+
+  const servicesLength = useMemo(() => {
+    return resources.filter(
+      (resource) => resource.resourceType === models.EnumResourceType.Service
+    ).length;
+  }, [resources]);
 
   const clearError = useCallback(() => {
     setError(null);
@@ -118,7 +124,10 @@ function ResourceList() {
               itemsAlign={EnumItemsAlign.Center}
               direction={EnumFlexDirection.Row}
             >
-              <CreateResourceButton resourcesLength={resources.length} />
+              <CreateResourceButton
+                resourcesLength={resources.length}
+                servicesLength={servicesLength}
+              />
             </FlexItem>
           </>
         }

--- a/packages/amplication-client/src/Workspaces/WorkspaceOverview.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceOverview.tsx
@@ -65,7 +65,7 @@ export const WorkspaceOverview = () => {
       <FlexItem
         itemsAlign={EnumItemsAlign.Center}
         start={<TabContentTitle title="Workspace" />}
-        end={<AddNewProject />}
+        end={<AddNewProject projectsLength={projectsList.length} />}
         margin={EnumFlexItemMargin.None}
       />
       <HorizontalRule doubleSpacing />

--- a/packages/amplication-server/src/core/resource/resource.service.spec.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.spec.ts
@@ -904,8 +904,20 @@ describe("ResourceService", () => {
     ).resolves.toEqual(EXAMPLE_CREATE_RESOURCE_RESULTS);
     expect(prismaResourceCreateMock).toBeCalledTimes(1);
 
-    expect(prismaResourceFindManyMock).toBeCalledTimes(1);
+    expect(prismaResourceFindManyMock).toBeCalledTimes(2);
     expect(prismaResourceFindManyMock.mock.calls).toEqual([
+      [
+        {
+          where: {
+            deletedAt: null,
+            archived: {
+              not: true,
+            },
+            project: { id: EXAMPLE_PROJECT_ID },
+            resourceType: { equals: EnumResourceType.Service },
+          },
+        },
+      ],
       [
         {
           where: {

--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -26,6 +26,8 @@ import {
   Prisma,
   PrismaService,
 } from "../../prisma";
+import { EnumResourceType as AmplicationEnumResourceType } from "../resource/dto/EnumResourceType";
+
 import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.types";
 import { SegmentAnalyticsService } from "../../services/segmentAnalytics/segmentAnalytics.service";
 import { prepareDeletedItemName } from "../../util/softDelete";
@@ -231,10 +233,17 @@ export class ResourceService {
           BillingFeature.Services
         );
 
+      const existingProjectResources = await this.resources({
+        where: {
+          project: { id: args.data.project.connect.id },
+          resourceType: { equals: AmplicationEnumResourceType.Service },
+        },
+      });
+
       if (
         serviceEntitlement &&
-        (!serviceEntitlement.hasAccess ||
-          serviceEntitlement.currentUsage >= serviceEntitlement.usageLimit)
+        existingProjectResources &&
+        existingProjectResources.length >= serviceEntitlement.usageLimit
       ) {
         const message = `You have reached the maximum number of services allowed. To continue using additional services, please upgrade your plan.`;
         throw new BillingLimitationError(message, BillingFeature.Services);


### PR DESCRIPTION

Fixes: https://github.com/amplication/private-issues/issues/208


## PR Details

- Enforce number of services per project
- Enforce number of projects based on actual current number of projects
- Fix FeatureIndicatorContainer to care about Essential Plan and not just Enterprise (as a paid plan / trial)
- Fix service creation wizard not to allow creating the same service twice (clicking continue again while the animation is playing)

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
