### PR TITLE
fix(client): open pr dialog only from gitSync page

### DIFF
--- a/packages/amplication-client/src/Resource/git/SyncWithGithubPage.tsx
+++ b/packages/amplication-client/src/Resource/git/SyncWithGithubPage.tsx
@@ -80,11 +80,14 @@ const SyncWithGithubPage: React.FC = () => {
   const [openPr, setOpenPr] = useState<boolean>(false);
   const isLimitationError = commitChangesLimitationError !== undefined ?? false;
 
-  const handleOnDone = useCallback(() => {
-    refreshCurrentWorkspace();
-    refetch();
-    setOpenPr(true);
-  }, [refreshCurrentWorkspace, refetch]);
+  const handleOnDone = useCallback(
+    (openPr = true) => {
+      refreshCurrentWorkspace();
+      refetch();
+      openPr && setOpenPr(true);
+    },
+    [refreshCurrentWorkspace, refetch]
+  );
 
   const handleCommit = useCallback(() => {
     commitChanges({
@@ -111,17 +114,29 @@ const SyncWithGithubPage: React.FC = () => {
         <AuthWithGitProvider
           type="resource"
           resource={data.resource}
-          onDone={handleOnDone}
-          gitRepositorySelectedCb={handleOnDone}
-          gitRepositoryCreatedCb={handleOnDone}
+          onDone={() => {
+            handleOnDone(false);
+          }}
+          gitRepositorySelectedCb={() => {
+            handleOnDone();
+          }}
+          gitRepositoryCreatedCb={() => {
+            handleOnDone();
+          }}
         />
       )}
       {!isProjectConfiguration && data?.resource && (
         <ServiceConfigurationGitSettings
           resource={data.resource}
-          onDone={handleOnDone}
-          gitRepositorySelectedCb={handleOnDone}
-          gitRepositoryCreatedCb={handleOnDone}
+          onDone={() => {
+            handleOnDone(false);
+          }}
+          gitRepositorySelectedCb={() => {
+            handleOnDone();
+          }}
+          gitRepositoryCreatedCb={() => {
+            handleOnDone();
+          }}
         />
       )}
       <ConfirmationDialog


### PR DESCRIPTION
Fixes: https://github.com/amplication/private-issues/issues/192

## PR Details

Open pr dialog only from gitSync page.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

