### PR TITLE
fix(dsg): add stringLiteral("args") for primitive input type in resolver

### DIFF
--- a/packages/data-service-generator/src/server/custom-module/custom-resolver/create-resolver-custom-actions.ts
+++ b/packages/data-service-generator/src/server/custom-module/custom-resolver/create-resolver-custom-actions.ts
@@ -46,10 +46,11 @@ export function generateResolverCustomActionMethod(
   const inputParam = builders.identifier("args");
   inputParam.typeAnnotation = builders.tsTypeAnnotation(inputType);
 
-  const hasArgument = action.inputType.type !== EnumModuleDtoPropertyType.Dto;
+  const isPrimitiveArgs =
+    action.inputType.type !== EnumModuleDtoPropertyType.Dto;
 
   //@ts-ignore
-  inputParam.decorators = [createGraphqlArgsDecorator(hasArgument)];
+  inputParam.decorators = [createGraphqlArgsDecorator(isPrimitiveArgs)];
 
   //generate this code within the function
   //return this.service.[name]](args);

--- a/packages/data-service-generator/src/server/custom-module/custom-resolver/create-resolver-custom-actions.ts
+++ b/packages/data-service-generator/src/server/custom-module/custom-resolver/create-resolver-custom-actions.ts
@@ -1,4 +1,7 @@
-import { ModuleAction } from "@amplication/code-gen-types";
+import {
+  EnumModuleDtoPropertyType,
+  ModuleAction,
+} from "@amplication/code-gen-types";
 import { builders, namedTypes } from "ast-types";
 import { createGraphQLOperationDecorator } from "./create-graphql-operation-decorator";
 import { PROMISE_ID } from "../../../utils/ast";
@@ -43,8 +46,10 @@ export function generateResolverCustomActionMethod(
   const inputParam = builders.identifier("args");
   inputParam.typeAnnotation = builders.tsTypeAnnotation(inputType);
 
+  const hasArgument = action.inputType.type !== EnumModuleDtoPropertyType.Dto;
+
   //@ts-ignore
-  inputParam.decorators = [createGraphqlArgsDecorator()];
+  inputParam.decorators = [createGraphqlArgsDecorator(hasArgument)];
 
   //generate this code within the function
   //return this.service.[name]](args);

--- a/packages/data-service-generator/src/server/resource/resolver/create-resolver-custom-actions.ts
+++ b/packages/data-service-generator/src/server/resource/resolver/create-resolver-custom-actions.ts
@@ -46,10 +46,11 @@ export function generateResolverCustomActionMethod(
   const inputParam = builders.identifier("args");
   inputParam.typeAnnotation = builders.tsTypeAnnotation(inputType);
 
-  const hasArgument = action.inputType.type !== EnumModuleDtoPropertyType.Dto;
+  const isPrimitiveArgs =
+    action.inputType.type !== EnumModuleDtoPropertyType.Dto;
 
   //@ts-ignore
-  inputParam.decorators = [createGraphqlArgsDecorator(hasArgument)];
+  inputParam.decorators = [createGraphqlArgsDecorator(isPrimitiveArgs)];
 
   //generate this code within the function
   //return this.service.[name]](args);

--- a/packages/data-service-generator/src/server/resource/resolver/create-resolver-custom-actions.ts
+++ b/packages/data-service-generator/src/server/resource/resolver/create-resolver-custom-actions.ts
@@ -1,4 +1,7 @@
-import { ModuleAction } from "@amplication/code-gen-types";
+import {
+  EnumModuleDtoPropertyType,
+  ModuleAction,
+} from "@amplication/code-gen-types";
 import { builders, namedTypes } from "ast-types";
 import { createPropTypeFromTypeDefList } from "../dto/custom-types/create-property-type";
 import { createGraphQLOperationDecorator } from "./create-graphql-operation-decorator";
@@ -43,8 +46,10 @@ export function generateResolverCustomActionMethod(
   const inputParam = builders.identifier("args");
   inputParam.typeAnnotation = builders.tsTypeAnnotation(inputType);
 
+  const hasArgument = action.inputType.type !== EnumModuleDtoPropertyType.Dto;
+
   //@ts-ignore
-  inputParam.decorators = [createGraphqlArgsDecorator()];
+  inputParam.decorators = [createGraphqlArgsDecorator(hasArgument)];
 
   //generate this code within the function
   //return this.service.[name]](args);

--- a/packages/data-service-generator/src/utils/create-graphql-args-decorator.ts
+++ b/packages/data-service-generator/src/utils/create-graphql-args-decorator.ts
@@ -2,6 +2,9 @@ import { builders, namedTypes } from "ast-types";
 
 const ARGS_ID = builders.identifier("graphql.Args");
 
-export function createGraphqlArgsDecorator(): namedTypes.Decorator {
-  return builders.decorator(builders.callExpression(ARGS_ID, []));
+export function createGraphqlArgsDecorator(
+  hasArgument = false
+): namedTypes.Decorator {
+  const args = hasArgument ? [builders.stringLiteral("args")] : [];
+  return builders.decorator(builders.callExpression(ARGS_ID, args));
 }

--- a/packages/data-service-generator/src/utils/create-graphql-args-decorator.ts
+++ b/packages/data-service-generator/src/utils/create-graphql-args-decorator.ts
@@ -3,8 +3,8 @@ import { builders, namedTypes } from "ast-types";
 const ARGS_ID = builders.identifier("graphql.Args");
 
 export function createGraphqlArgsDecorator(
-  hasArgument = false
+  isPrimitiveArgs = false
 ): namedTypes.Decorator {
-  const args = hasArgument ? [builders.stringLiteral("args")] : [];
+  const args = isPrimitiveArgs ? [builders.stringLiteral("args")] : [];
   return builders.decorator(builders.callExpression(ARGS_ID, args));
 }


### PR DESCRIPTION
Close: https://github.com/amplication/private-issues/issues/211

## PR Details

Add stringLiteral("args") for primitive input type in resolver.

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error
