### PR TITLE
fix(server): add validation to dto properties when creating a new DTO

### DIFF
--- a/packages/amplication-server/src/core/moduleDto/moduleDto.service.ts
+++ b/packages/amplication-server/src/core/moduleDto/moduleDto.service.ts
@@ -232,12 +232,14 @@ export class ModuleDtoService extends BlockTypeService<
       };
     });
 
-    for (const property of properties) {
-      await this.validateTypes(
-        args.data.resource.connect.id,
-        property.propertyTypes,
-        UNSUPPORTED_TYPES
-      );
+    if (properties) {
+      for (const property of properties) {
+        await this.validateTypes(
+          args.data.resource.connect.id,
+          property.propertyTypes,
+          UNSUPPORTED_TYPES
+        );
+      }
     }
 
     return super.create(

--- a/packages/amplication-server/src/core/moduleDto/moduleDto.service.ts
+++ b/packages/amplication-server/src/core/moduleDto/moduleDto.service.ts
@@ -232,6 +232,14 @@ export class ModuleDtoService extends BlockTypeService<
       };
     });
 
+    for (const property of properties) {
+      await this.validateTypes(
+        args.data.resource.connect.id,
+        property.propertyTypes,
+        UNSUPPORTED_TYPES
+      );
+    }
+
     return super.create(
       {
         ...args,


### PR DESCRIPTION
Add validation to dto properties when creating a new DTO - validate that props of type DTO reference an existing DTO (correct dtoId)

Fixes: https://github.com/amplication/private-issues/issues/217


## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
