### PR TITLE
fix(server): always sort the entity fields alphabetically when creating the DSGResourceData

### DIFF
--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -13,7 +13,7 @@ import { DataConflictError } from "../../errors/DataConflictError";
 import { Prisma, PrismaService } from "../../prisma";
 import { AmplicationError } from "../../errors/AmplicationError";
 import { camelCase } from "camel-case";
-import { isEmpty, pick, last, head, omit, isEqual } from "lodash";
+import { isEmpty, pick, last, head, omit, isEqual, orderBy } from "lodash";
 import {
   Entity,
   EntityField,
@@ -252,7 +252,10 @@ export class EntityService {
     return entityVersions.map(({ entity, fields, permissions }) => {
       return {
         ...entity,
-        fields: this.addDBNumericTypesIfMissing(fields),
+        fields: orderBy(
+          this.addDBNumericTypesIfMissing(fields),
+          (field) => field.name
+        ),
         permissions: permissions,
       };
     });


### PR DESCRIPTION
Fix the method `getEntitiesByVersions` to return the fields ordered alphabetically.
This method is called from `build.service.getOrderedEntities` which is called from `build.service.getDSGResourceData`

Close: #8789
## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
