### PR TITLE
fix(git-sync):throw error when a private plugin is missing

### DIFF
--- a/ee/packages/git-sync-manager/src/private-plugin/private-plugin.service.ts
+++ b/ee/packages/git-sync-manager/src/private-plugin/private-plugin.service.ts
@@ -8,7 +8,7 @@ import { Inject, Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { DownloadPrivatePluginsRequest } from "@amplication/schema-registry";
 import { TraceWrapper, Traceable } from "@amplication/opentelemetry-nestjs";
-import { copy } from "fs-extra";
+import { copy, pathExists } from "fs-extra";
 import { join } from "path";
 
 @Traceable()
@@ -122,6 +122,13 @@ export class PrivatePluginService {
     for (const pluginPath of pluginPaths) {
       const pluginName = pluginPath.split("/").pop();
       const pluginPathInAssets = join(dsgAssetsPath, pluginName);
+
+      const pathExist = await pathExists(pluginPath);
+      if (!pathExist) {
+        throw new Error(
+          `Can't find plugin '${pluginName}' in the source repository`
+        );
+      }
       await copy(pluginPath, pluginPathInAssets);
       newPluginPaths.push(pluginPathInAssets);
     }


### PR DESCRIPTION


Close: #8827 

## PR Details

<img width="1164" alt="image" src="https://github.com/user-attachments/assets/11ee4ac2-82b2-49c9-a138-7b5c23f84d1b">


## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
