### PR TITLE
fix(client):show loading state in commit list

### DIFF
--- a/packages/amplication-client/src/VersionControl/CommitsPage.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitsPage.tsx
@@ -83,12 +83,19 @@ const CommitsPage: React.FC<Props> = ({ moduleClass, innerRoutes }) => {
         innerRoutes
       ) : (
         <>
-          <EmptyState
-            message="There are no commits to show. "
-            image={EnumImages.CommitEmptyState}
-          >
-            <CommitButton />
-          </EmptyState>
+          {commitUtils.commitsLoading ? (
+            <EmptyState
+              message="Loading commits..."
+              image={EnumImages.CommitEmptyState}
+            ></EmptyState>
+          ) : (
+            <EmptyState
+              message="There are no commits to show. "
+              image={EnumImages.CommitEmptyState}
+            >
+              <CommitButton />
+            </EmptyState>
+          )}
         </>
       )}
     </PageContent>


### PR DESCRIPTION

Close: #8864 

## PR Details

Show a loading message while commit list is loading

<img width="1285" alt="image" src="https://github.com/user-attachments/assets/f3677edd-1e75-471a-8dfb-7995e56dc269">


## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
