### PR TITLE
fix(server):create project git repo for new projects

### DIFF
--- a/packages/amplication-server/src/core/resource/resource.service.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.ts
@@ -299,6 +299,10 @@ export class ResourceService {
     const { gitRepository } = args.data;
     let overrideGitRepository = false;
 
+    if (!projectConfiguration.gitRepositoryId) {
+      updateProjectGitRepository = true;
+    }
+
     //when requested, create a new git repository and connect to the resource, otherwise inherit the project's git repository
     if (
       gitRepository &&


### PR DESCRIPTION

Close: https://github.com/amplication/amplication/issues/8769

## PR Details

For new projects, which are not connected already to a git repo - when creating the first service, connect the repo to the project and inherit in the service



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
