### PR TITLE
fix(client):use empty string for default value for fkFieldName

### DIFF
--- a/libs/util/code-gen-types/src/schemas/lookup.json
+++ b/libs/util/code-gen-types/src/schemas/lookup.json
@@ -23,7 +23,7 @@
     "fkFieldName": {
       "title": "Foreign Key Field Name (Optional)",
       "type": "string",
-      "default": null
+      "default": ""
     },
     "relatedFieldId": {
       "title": "Related Field",


### PR DESCRIPTION

Close: https://github.com/amplication/amplication/issues/8886

## PR Details

Use empty string for the default value of fkFieldName to prevent the validation error 

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
