### PR TITLE
fix(client):avoid duplicate page events and standardize page name

### DIFF
--- a/packages/amplication-client/src/Layout/RouteWithAnalytics.tsx
+++ b/packages/amplication-client/src/Layout/RouteWithAnalytics.tsx
@@ -31,7 +31,7 @@ function RouteWithAnalytics(props: Props) {
   );
 }
 
-function RouteWithAnalyticsContent({
+export function RouteWithAnalyticsContent({
   children,
 }: {
   children: React.ReactNode;

--- a/packages/amplication-client/src/routes/resourceEntitiesRoutes.tsx
+++ b/packages/amplication-client/src/routes/resourceEntitiesRoutes.tsx
@@ -8,7 +8,7 @@ const resourceEntitiesRoutes = [
     routeTrackType: "",
     exactPath: false,
     routes: [],
-    isAnalytics: true,
+    isAnalytics: false,
   },
 
   {

--- a/packages/amplication-client/src/routes/resourceTabRoutes.tsx
+++ b/packages/amplication-client/src/routes/resourceTabRoutes.tsx
@@ -10,6 +10,7 @@ const resourceTabRoutes = [
     routeTrackType: "",
     exactPath: false,
     routes: resourceEntitiesRoutes,
+    isAnalytics: true,
   },
   {
     path: "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})/:resource([A-Za-z0-9-]{20,})/modules",

--- a/packages/amplication-client/src/routes/routesUtil.tsx
+++ b/packages/amplication-client/src/routes/routesUtil.tsx
@@ -1,9 +1,8 @@
 import React, { Suspense, lazy } from "react";
 import { Redirect, Route, Switch } from "react-router-dom";
-import { RouteDef } from "./appRoutes";
 import useAuthenticated from "../authentication/use-authenticated";
-import * as analytics from "../util/analytics";
-import { monitoring } from "../util/monitoring";
+import { RouteWithAnalyticsContent } from "../Layout/RouteWithAnalytics";
+import { RouteDef } from "./appRoutes";
 
 //use lazy loading imports to prevent inclusion of the components CSS in the main bundle
 const CircularProgress = lazy(
@@ -43,9 +42,6 @@ const LazyRouteWrapper: React.FC<{
         exact={route.exactPath}
         render={(props) => {
           const { location, match } = props;
-
-          route.isAnalytics &&
-            pageTracking(match.path, match.url, match.params);
 
           const nestedRoutes =
             route.routes && routesGenerator(route.routes, route.path);
@@ -96,11 +92,21 @@ const LazyRouteWrapper: React.FC<{
               />
             ) : (
               <>
-                {/* <div>{route.path}</div> */}
-                {React.createElement(route.Component, {
-                  ...props,
-                  ...appRouteProps,
-                })}
+                {route.isAnalytics ? (
+                  <RouteWithAnalyticsContent key={match.url}>
+                    {React.createElement(route.Component, {
+                      ...props,
+                      ...appRouteProps,
+                    })}
+                  </RouteWithAnalyticsContent>
+                ) : (
+                  <>
+                    {React.createElement(route.Component, {
+                      ...props,
+                      ...appRouteProps,
+                    })}
+                  </>
+                )}
               </>
             ))
           );
@@ -125,18 +131,4 @@ export const routesGenerator: (
       <Route component={NotFoundPage} />
     </Switch>
   );
-};
-
-const pageTracking = (path: string, url: string, params: any) => {
-  analytics.page(path.replaceAll("/", "-"), {
-    path,
-    url,
-    params: params,
-  });
-
-  const cleanPath = path.replaceAll("([A-Za-z0-9-]{20,})", "");
-  monitoring.recordPageView({
-    pageId: cleanPath,
-    pageAttributes: params,
-  });
 };

--- a/packages/amplication-client/src/util/usePageTracking.ts
+++ b/packages/amplication-client/src/util/usePageTracking.ts
@@ -7,7 +7,10 @@ const usePageTracking = () => {
 
   useEffect(() => {
     const url = `${window.location.origin}${match.path}`;
-    const path = match.path.replaceAll(":", "");
+    const path = match.path
+      .replaceAll(":", "")
+      .replaceAll("([A-Za-z0-9-]{20,})", "");
+
     analytics.page(path.replaceAll("/", "-"), {
       path,
       url,


### PR DESCRIPTION


Close: https://github.com/amplication/private-issues/issues/6 https://github.com/amplication/amplication/issues/6050 

## PR Details

Use the <RouteWithAnalyticsContent component to record the page view with useEffect 
Standardize the page event name - and remove the regex from the url

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
