### PR TITLE
feat(client):show code gen version in resource list

### DIFF
--- a/libs/ui/design-system/src/lib/components/DataGrid/DataGrid.tsx
+++ b/libs/ui/design-system/src/lib/components/DataGrid/DataGrid.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import "react-data-grid/lib/styles.css";
 
 import ReactDataGrid, {
+  ColumnOrColumnGroup,
   DataGridProps,
   RenderSortStatusProps,
   SortColumn,
@@ -12,8 +13,13 @@ import "./DataGrid.scss";
 import classNames from "classnames";
 import { Icon } from "../Icon/Icon";
 
-export type Props<T> = DataGridProps<T> & {
+export type DataGridColumn<T> = ColumnOrColumnGroup<T> & {
+  getValue?: (row: T) => any;
+};
+
+export type Props<T> = Omit<DataGridProps<T>, "columns"> & {
   clientSideSort?: boolean;
+  columns: DataGridColumn<T>[];
 };
 
 const CLASS_NAME = "amp-data-grid";
@@ -23,6 +29,7 @@ export const DataGrid: React.FC<Props<any>> = ({
   rowHeight = 50,
   clientSideSort = true,
   rows,
+  columns,
   ...rest
 }) => {
   const [sortColumns, setSortColumns] = useState<SortColumn[]>([]);
@@ -30,13 +37,28 @@ export const DataGrid: React.FC<Props<any>> = ({
   const onSortColumnsChange = useCallback((sortColumns: SortColumn[]) => {
     setSortColumns(sortColumns);
   }, []);
+
+  const columnValueGetters = useMemo(() => {
+    return columns.reduce((acc, column) => {
+      if (column.getValue && "key" in column) {
+        acc[column.key] = column.getValue;
+      }
+      return acc;
+    }, {} as Record<string, (row: any) => any>);
+  }, [columns]);
+
   const sortedRows = useMemo(() => {
     if (clientSideSort) {
       // Sort the rows based on the sort columns
       return [...rows].sort((a, b) => {
         for (const { columnKey, direction } of sortColumns) {
-          const valueA = a[columnKey];
-          const valueB = b[columnKey];
+          const valueA = columnValueGetters[columnKey]
+            ? columnValueGetters[columnKey](a)
+            : a[columnKey];
+
+          const valueB = columnValueGetters[columnKey]
+            ? columnValueGetters[columnKey](b)
+            : b[columnKey];
 
           if (valueA < valueB) {
             return direction === "ASC" ? -1 : 1;
@@ -54,6 +76,7 @@ export const DataGrid: React.FC<Props<any>> = ({
 
   return (
     <ReactDataGrid
+      columns={columns}
       style={{ maxHeight: "100%", height: "auto" }}
       rowHeight={rowHeight}
       defaultColumnOptions={{}}

--- a/libs/ui/design-system/src/lib/index.ts
+++ b/libs/ui/design-system/src/lib/index.ts
@@ -265,6 +265,7 @@ export type { Props as NavigationFilterItemProps } from "./components/Navigation
 export {
   DataGrid,
   Props as DataGridProps,
+  DataGridColumn,
 } from "./components/DataGrid/DataGrid";
 
 export {

--- a/packages/amplication-client/src/Workspaces/ResourceGitRepo.tsx
+++ b/packages/amplication-client/src/Workspaces/ResourceGitRepo.tsx
@@ -44,7 +44,7 @@ function ResourceGitRepo({ resource }: Props) {
             textStyle={EnumTextStyle.Subtle}
             textColor={EnumTextColor.White}
           >
-            gitRepo
+            {gitRepo}
           </Text>
         </>
       ) : (

--- a/packages/amplication-client/src/Workspaces/ResourceGitRepo.tsx
+++ b/packages/amplication-client/src/Workspaces/ResourceGitRepo.tsx
@@ -34,13 +34,27 @@ function ResourceGitRepo({ resource }: Props) {
       gap={EnumGapSize.Small}
       margin={EnumFlexItemMargin.None}
     >
-      <Icon
-        icon={gitProviderIconMap[provider || models.EnumGitProvider.Github]}
-        size="xsmall"
-      />
-      <Text textStyle={EnumTextStyle.Subtle} textColor={EnumTextColor.White}>
-        {gitRepo ? gitRepo : "Not connected"}
-      </Text>
+      {gitRepo ? (
+        <>
+          <Icon
+            icon={gitProviderIconMap[provider || models.EnumGitProvider.Github]}
+            size="xsmall"
+          />
+          <Text
+            textStyle={EnumTextStyle.Subtle}
+            textColor={EnumTextColor.White}
+          >
+            gitRepo
+          </Text>
+        </>
+      ) : (
+        <Text
+          textStyle={EnumTextStyle.Subtle}
+          textColor={EnumTextColor.ThemeOrange}
+        >
+          Not connected
+        </Text>
+      )}
     </FlexItem>
   );
 }

--- a/packages/amplication-client/src/Workspaces/ResourceLastBuildVersion.tsx
+++ b/packages/amplication-client/src/Workspaces/ResourceLastBuildVersion.tsx
@@ -1,0 +1,22 @@
+import {
+  EnumTextColor,
+  EnumTextStyle,
+  Text,
+} from "@amplication/ui/design-system";
+import * as models from "../models";
+
+type Props = {
+  resource: models.Resource;
+};
+
+function ResourceLastBuildVersion({ resource }: Props) {
+  const lastBuild = resource.builds[0];
+
+  return (
+    <Text textStyle={EnumTextStyle.Tag} textColor={EnumTextColor.Secondary}>
+      {lastBuild?.codeGeneratorVersion}
+    </Text>
+  );
+}
+
+export default ResourceLastBuildVersion;

--- a/packages/amplication-client/src/Workspaces/ResourceListDataColumns.tsx
+++ b/packages/amplication-client/src/Workspaces/ResourceListDataColumns.tsx
@@ -1,14 +1,15 @@
 import { EnumTextStyle, Text } from "@amplication/ui/design-system";
-import { ColumnOrColumnGroup } from "react-data-grid";
 import { CodeGeneratorImage } from "../Components/CodeGeneratorImage";
 import ResourceCircleBadge from "../Components/ResourceCircleBadge";
-import { Resource } from "../models";
+import { EnumResourceType, Resource } from "../models";
 import DeleteResourceButton from "./DeleteResourceButton";
 import ResourceGitRepo from "./ResourceGitRepo";
 import ResourceLastBuild from "./ResourceLastBuild";
 import ResourceNameLink from "./ResourceNameLink";
+import ResourceLastBuildVersion from "./ResourceLastBuildVersion";
+import { DataGridColumn } from "@amplication/ui/design-system";
 
-export const RESOURCE_LIST_COLUMNS: ColumnOrColumnGroup<Resource>[] = [
+export const RESOURCE_LIST_COLUMNS: DataGridColumn<Resource>[] = [
   {
     key: "resourceType",
     name: "Type",
@@ -35,6 +36,8 @@ export const RESOURCE_LIST_COLUMNS: ColumnOrColumnGroup<Resource>[] = [
     width: 150,
     resizable: true,
     sortable: true,
+    getValue: (row) =>
+      row.resourceType === EnumResourceType.Service ? row.codeGenerator : null,
   },
   {
     key: "git",
@@ -48,6 +51,8 @@ export const RESOURCE_LIST_COLUMNS: ColumnOrColumnGroup<Resource>[] = [
     },
     resizable: true,
     sortable: true,
+    getValue: (row) =>
+      row.gitRepository?.gitOrganization?.name && row.gitRepository?.name,
   },
   {
     key: "description",
@@ -69,13 +74,24 @@ export const RESOURCE_LIST_COLUMNS: ColumnOrColumnGroup<Resource>[] = [
     renderCell: (props) => {
       return (
         <div style={{ display: "inline-flex" }}>
-          {" "}
           <ResourceLastBuild hideLabel resource={props.row} />
         </div>
       );
     },
+    getValue: (row) =>
+      row.builds[0] ? new Date(row.builds[0]?.createdAt).getTime() : 0,
     resizable: true,
     sortable: true,
+  },
+  {
+    key: "codeGeneratorVersion",
+    name: "Code Gen Version",
+    resizable: true,
+    sortable: true,
+    renderCell: (props) => {
+      return <ResourceLastBuildVersion resource={props.row} />;
+    },
+    getValue: (row) => row.builds[0]?.codeGeneratorVersion ?? "",
   },
   {
     key: "actions",

--- a/packages/amplication-client/src/Workspaces/queries/resourcesQueries.ts
+++ b/packages/amplication-client/src/Workspaces/queries/resourcesQueries.ts
@@ -56,6 +56,7 @@ export const GET_RESOURCES = gql`
         version
         createdAt
         status
+        codeGeneratorVersion
         commit {
           user {
             account {


### PR DESCRIPTION


Close: https://github.com/amplication/amplication/issues/8930

## PR Details

Show the code gen version in the resource list and add support to sort non-string solumns

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
