### PR TITLE
feat(client):move private plugins to project tabs

### DIFF
--- a/packages/amplication-client/src/Components/CreateResourceButton.tsx
+++ b/packages/amplication-client/src/Components/CreateResourceButton.tsx
@@ -38,13 +38,6 @@ const ITEMS: CreateResourceButtonItemType[] = [
     route: "create-broker",
     info: "Create a message broker to facilitate communication between services",
   },
-  {
-    type: models.EnumResourceType.PluginRepository,
-    label: "Plugin Repository",
-    route: "create-plugin-repository",
-    info: "Create a plugin repository to upload and manage plugins",
-    licenseRequired: BillingFeature.PrivatePlugins,
-  },
 ];
 
 type Props = {

--- a/packages/amplication-client/src/PrivatePlugins/PrivatePlugin.tsx
+++ b/packages/amplication-client/src/PrivatePlugins/PrivatePlugin.tsx
@@ -22,13 +22,16 @@ import {
 } from "@amplication/ui/design-system";
 import usePrivatePlugin from "./hooks/usePrivatePlugin";
 
-const PrivatePlugin = () => {
-  const match = useRouteMatch<{
-    resource: string;
-    privatePluginId: string;
-  }>("/:workspace/:project/:resource/private-plugins/:privatePluginId");
+type Props = {
+  pluginRepositoryResourceId: string;
+};
 
-  const { privatePluginId, resource } = match?.params ?? {};
+const PrivatePlugin = ({ pluginRepositoryResourceId }: Props) => {
+  const match = useRouteMatch<{
+    privatePluginId: string;
+  }>("/:workspace/:project/private-plugins/:privatePluginId");
+
+  const { privatePluginId } = match?.params ?? {};
   const {
     currentWorkspace,
     currentProject,
@@ -46,7 +49,7 @@ const PrivatePlugin = () => {
     getPrivatePluginRefetch: refetch,
     updatePrivatePlugin,
     updatePrivatePluginError: updateError,
-  } = usePrivatePlugin(resource);
+  } = usePrivatePlugin(pluginRepositoryResourceId);
 
   useEffect(() => {
     if (!resetPendingChangesIndicator) return;
@@ -85,9 +88,9 @@ const PrivatePlugin = () => {
 
   const handleDeletePrivatePlugin = useCallback(() => {
     history.push(
-      `/${currentWorkspace?.id}/${currentProject?.id}/${resource}/private-plugins`
+      `/${currentWorkspace?.id}/${currentProject?.id}/private-plugins`
     );
-  }, [history, currentWorkspace?.id, currentProject?.id, resource]);
+  }, [history, currentWorkspace?.id, currentProject?.id]);
 
   useEffect(() => {
     getPrivatePlugin(privatePluginId);

--- a/packages/amplication-client/src/PrivatePlugins/PrivatePluginGitSettings.tsx
+++ b/packages/amplication-client/src/PrivatePlugins/PrivatePluginGitSettings.tsx
@@ -1,0 +1,27 @@
+import { useCallback, useContext } from "react";
+import { AppContext } from "../context/appContext";
+import ServiceConfigurationGitSettings from "../Resource/git/ServiceConfigurationGitSettings";
+
+const PrivatePluginGitSettings = () => {
+  const { refreshCurrentWorkspace, pluginRepositoryResource } =
+    useContext(AppContext);
+
+  const handleOnDone = useCallback(() => {
+    refreshCurrentWorkspace();
+  }, [refreshCurrentWorkspace]);
+
+  const handleRepositorySelected = useCallback(() => {
+    refreshCurrentWorkspace();
+  }, [refreshCurrentWorkspace]);
+
+  return (
+    <ServiceConfigurationGitSettings
+      resource={pluginRepositoryResource}
+      onDone={handleOnDone}
+      gitRepositorySelectedCb={handleRepositorySelected}
+      gitRepositoryCreatedCb={handleRepositorySelected}
+    />
+  );
+};
+
+export default PrivatePluginGitSettings;

--- a/packages/amplication-client/src/PrivatePlugins/PrivatePluginList.scss
+++ b/packages/amplication-client/src/PrivatePlugins/PrivatePluginList.scss
@@ -14,14 +14,4 @@
   &__header {
     margin-bottom: var(--default-spacing);
   }
-
-  &__list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--default-spacing-small);
-    margin-bottom: var(--default-spacing);
-    overflow-x: hidden;
-    overflow-y: auto;
-    @include scrollbars(16px, var(--gray-30), transparent);
-  }
 }

--- a/packages/amplication-client/src/PrivatePlugins/PrivatePluginList.tsx
+++ b/packages/amplication-client/src/PrivatePlugins/PrivatePluginList.tsx
@@ -3,6 +3,7 @@ import {
   EnabledIndicator,
   EnumItemsAlign,
   FlexItem,
+  HorizontalRule,
   SearchField,
   Snackbar,
 } from "@amplication/ui/design-system";
@@ -20,14 +21,13 @@ import usePrivatePlugin from "./hooks/usePrivatePlugin";
 const CLASS_NAME = "private-plugin-list";
 
 type Props = {
-  resourceId: string;
   selectFirst?: boolean;
 };
 
 export const PrivatePluginList = React.memo(
-  ({ resourceId, selectFirst = false }: Props) => {
+  ({ selectFirst = false }: Props) => {
     const [searchPhrase, setSearchPhrase] = useState<string>("");
-    const { currentWorkspace, currentProject, currentResource } =
+    const { currentWorkspace, currentProject, pluginRepositoryResource } =
       useContext(AppContext);
 
     const {
@@ -35,7 +35,7 @@ export const PrivatePluginList = React.memo(
       getPrivatePlugins,
       getPrivatePluginsError: error,
       getPrivatePluginsLoading: loading,
-    } = usePrivatePlugin(currentResource?.id);
+    } = usePrivatePlugin(pluginRepositoryResource?.id);
 
     const handleSearchChange = useCallback(
       (value) => {
@@ -49,33 +49,33 @@ export const PrivatePluginList = React.memo(
 
     const handlePrivatePluginChange = useCallback(
       (privatePlugin: models.PrivatePlugin) => {
-        const fieldUrl = `/${currentWorkspace?.id}/${currentProject?.id}/${resourceId}/private-plugins/${privatePlugin.id}`;
+        const fieldUrl = `/${currentWorkspace?.id}/${currentProject?.id}/private-plugins/${privatePlugin.id}`;
         history.push(fieldUrl);
       },
-      [history, resourceId, currentWorkspace, currentProject]
+      [history, currentWorkspace, currentProject]
     );
 
     useEffect(() => {
       if (selectFirst && data && !isEmpty(data.privatePlugins)) {
         const privatePlugin = data.privatePlugins[0];
-        const fieldUrl = `/${currentWorkspace?.id}/${currentProject?.id}/${resourceId}/private-plugins/${privatePlugin.id}`;
+        const fieldUrl = `/${currentWorkspace?.id}/${currentProject?.id}/private-plugins/${privatePlugin.id}`;
         history.push(fieldUrl);
       }
-    }, [
-      data,
-      selectFirst,
-      resourceId,
-      history,
-      currentWorkspace,
-      currentProject,
-    ]);
+    }, [data, selectFirst, history, currentWorkspace, currentProject]);
 
     useEffect(() => {
       getPrivatePlugins(searchPhrase);
-    }, [getPrivatePlugins, resourceId, searchPhrase]);
+    }, [getPrivatePlugins, searchPhrase]);
 
     return (
       <div className={CLASS_NAME}>
+        <InnerTabLink
+          icon="settings"
+          to={`/${currentWorkspace?.id}/${currentProject?.id}/private-plugins/git-settings`}
+        >
+          <FlexItem itemsAlign={EnumItemsAlign.Center}>Git Settings</FlexItem>
+        </InnerTabLink>
+        <HorizontalRule />
         <SearchField
           label="search"
           placeholder="search"
@@ -85,26 +85,25 @@ export const PrivatePluginList = React.memo(
         {loading && <CircularProgress />}
         <div className={`${CLASS_NAME}__list`}>
           {data?.privatePlugins?.map((privatePlugin) => (
-            <div key={privatePlugin.id} className={`${CLASS_NAME}__list__item`}>
-              <InnerTabLink
-                icon="plugin"
-                to={`/${currentWorkspace?.id}/${currentProject?.id}/${resourceId}/private-plugins/${privatePlugin.id}`}
+            <InnerTabLink
+              key={privatePlugin.id}
+              icon="plugin"
+              to={`/${currentWorkspace?.id}/${currentProject?.id}/private-plugins/${privatePlugin.id}`}
+            >
+              <FlexItem
+                itemsAlign={EnumItemsAlign.Center}
+                end={<EnabledIndicator enabled={privatePlugin.enabled} />}
+                singeChildWithEllipsis
               >
-                <FlexItem
-                  itemsAlign={EnumItemsAlign.Center}
-                  end={<EnabledIndicator enabled={privatePlugin.enabled} />}
-                  singeChildWithEllipsis
-                >
-                  {privatePlugin.displayName}
-                </FlexItem>
-              </InnerTabLink>
-            </div>
+                {privatePlugin.displayName}
+              </FlexItem>
+            </InnerTabLink>
           ))}
         </div>
         {data?.privatePlugins && (
           <NewPrivatePlugin
             onPrivatePluginAdd={handlePrivatePluginChange}
-            resourceId={resourceId}
+            resourceId={pluginRepositoryResource?.id}
           />
         )}
         <Snackbar open={Boolean(error)} message={errorMessage} />

--- a/packages/amplication-client/src/Project/ProjectPage.tsx
+++ b/packages/amplication-client/src/Project/ProjectPage.tsx
@@ -23,7 +23,7 @@ type Props = AppRouteProps & {
     project: string;
   }>;
 };
-const OVERVIEW = "Overview";
+const OVERVIEW = "Services";
 
 const ProjectPage: React.FC<Props> = ({
   innerRoutes,

--- a/packages/amplication-client/src/Resource/git/ServiceConfigurationGitSettings.tsx
+++ b/packages/amplication-client/src/Resource/git/ServiceConfigurationGitSettings.tsx
@@ -1,4 +1,4 @@
-import { Toggle } from "@amplication/ui/design-system";
+import { HorizontalRule, Toggle } from "@amplication/ui/design-system";
 import { useMutation } from "@apollo/client";
 import React, { useCallback, useState } from "react";
 import {
@@ -102,7 +102,7 @@ const ServiceConfigurationGitSettings: React.FC<Props> = ({
   return (
     <div className={CLASS_NAME}>
       <ProjectConfigurationGitSettings isOverride={isOverride} />
-
+      <HorizontalRule doubleSpacing />
       <Toggle
         label="Override default settings"
         onValueChange={handleToggleChange}

--- a/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
@@ -92,6 +92,7 @@ const WorkspaceLayout: React.FC<Props> = ({
   const {
     resources,
     projectConfigurationResource,
+    pluginRepositoryResource,
     handleSearchChange,
     loadingResources,
     errorResources,
@@ -182,6 +183,7 @@ const WorkspaceLayout: React.FC<Props> = ({
         resources,
         setNewService: createService,
         projectConfigurationResource,
+        pluginRepositoryResource,
         handleSearchChange,
         loadingResources,
         reloadResources,

--- a/packages/amplication-client/src/Workspaces/hooks/useResources.ts
+++ b/packages/amplication-client/src/Workspaces/hooks/useResources.ts
@@ -93,6 +93,11 @@ const useResources = (
   const [resources, setResources] = useState<models.Resource[]>([]);
   const [projectConfigurationResource, setProjectConfigurationResource] =
     useState<models.Resource | undefined>(undefined);
+
+  const [pluginRepositoryResource, setPluginRepositoryResource] = useState<
+    models.Resource | undefined
+  >(undefined);
+
   const [searchPhrase, setSearchPhrase] = useState<string>("");
   const [gitRepositoryFullName, setGitRepositoryFullName] = useState<string>(
     createGitRepositoryFullName(
@@ -228,7 +233,9 @@ const useResources = (
           addBlock(result.data.createPluginRepository.id);
         result.data?.createPluginRepository.id &&
           reloadResources().then(() => {
-            resourceRedirect(result.data?.createPluginRepository.id as string);
+            history.push({
+              pathname: `/${currentWorkspace?.id}/${currentProject?.id}/private-plugins/git-settings`,
+            });
           });
       }
     );
@@ -332,8 +339,17 @@ const useResources = (
     );
     setProjectConfigurationResource(projectConfigurationResource);
 
+    const pluginRepositoryResource = resourcesData.resources.find(
+      (r) => r.resourceType === models.EnumResourceType.PluginRepository
+    );
+    setPluginRepositoryResource(pluginRepositoryResource);
+
     const resources = resourcesData.resources.filter(
-      (r) => r.resourceType !== models.EnumResourceType.ProjectConfiguration
+      (r) =>
+        ![
+          models.EnumResourceType.ProjectConfiguration,
+          models.EnumResourceType.PluginRepository,
+        ].includes(r.resourceType)
     );
     setResources(resources);
   }, [resourcesData, loadingResources]);
@@ -362,6 +378,7 @@ const useResources = (
   return {
     resources,
     projectConfigurationResource,
+    pluginRepositoryResource,
     handleSearchChange,
     loadingResources,
     errorResources,

--- a/packages/amplication-client/src/context/appContext.tsx
+++ b/packages/amplication-client/src/context/appContext.tsx
@@ -27,6 +27,7 @@ export interface AppContextInterface {
   ) => void;
   setResource: (resource: models.Resource) => void;
   projectConfigurationResource: models.Resource | undefined;
+  pluginRepositoryResource: models.Resource | undefined;
   handleSearchChange: (searchResults: string) => void;
   loadingResources: boolean;
   reloadResources: () => void;
@@ -86,6 +87,7 @@ const initialContext: AppContextInterface = {
   setNewService: () => {},
   setResource: () => {},
   projectConfigurationResource: undefined,
+  pluginRepositoryResource: undefined,
   handleSearchChange: () => {},
   loadingResources: true,
   errorResources: undefined,

--- a/packages/amplication-client/src/routes/appRoutes.tsx
+++ b/packages/amplication-client/src/routes/appRoutes.tsx
@@ -86,6 +86,40 @@ export const Routes: RouteDef[] = [
                 isAnalytics: true,
               },
               {
+                path: "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})/private-plugins",
+                Component: lazy(
+                  () => import("../PrivatePlugins/PrivatePluginsPage")
+                ),
+                moduleName: "",
+                displayName: "Private Plugins",
+                routeTrackType: "",
+                exactPath: false,
+                routes: [
+                  {
+                    path: "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})/private-plugins/git-settings",
+                    Component: lazy(
+                      () => import("../PrivatePlugins/PrivatePluginGitSettings")
+                    ),
+                    moduleName: "",
+                    routeTrackType: "",
+                    exactPath: true,
+                    routes: [],
+                    isAnalytics: true,
+                  },
+                  {
+                    path: "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})/private-plugins/:pluginId([A-Za-z0-9-]{20,})",
+                    Component: lazy(
+                      () => import("../PrivatePlugins/PrivatePlugin")
+                    ),
+                    moduleName: "",
+                    routeTrackType: "",
+                    exactPath: true,
+                    routes: [],
+                    isAnalytics: true,
+                  },
+                ],
+              },
+              {
                 path: "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})/commits",
                 Component: lazy(() => import("../VersionControl/CommitsPage")),
                 moduleName: "CommitsPage",

--- a/packages/amplication-client/src/routes/resourceTabRoutes.tsx
+++ b/packages/amplication-client/src/routes/resourceTabRoutes.tsx
@@ -116,24 +116,6 @@ const resourceTabRoutes = [
     ],
   },
   {
-    path: "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})/:resource([A-Za-z0-9-]{20,})/private-plugins",
-    Component: lazy(() => import("../PrivatePlugins/PrivatePluginsPage")),
-    moduleName: "",
-    routeTrackType: "",
-    exactPath: false,
-    routes: [
-      {
-        path: "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})/:resource([A-Za-z0-9-]{20,})/private-plugins/:pluginId",
-        Component: lazy(() => import("../PrivatePlugins/PrivatePlugin")),
-        moduleName: "",
-        routeTrackType: "",
-        exactPath: true,
-        routes: [],
-        isAnalytics: true,
-      },
-    ],
-  },
-  {
     path: "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})/:resource([A-Za-z0-9-]{20,})/services",
     Component: lazy(() => import("../MessageBrokerServices/ServicesPage")),
     moduleName: "",

--- a/packages/amplication-server/src/core/privatePlugin/privatePlugin.service.ts
+++ b/packages/amplication-server/src/core/privatePlugin/privatePlugin.service.ts
@@ -53,6 +53,10 @@ export class PrivatePluginService extends BlockTypeService<
       where: {
         ...args.where,
         resource: {
+          deletedAt: null,
+          archived: {
+            not: true,
+          },
           projectId: resource.projectId,
         },
       },

--- a/packages/amplication-server/src/core/resource/dto/ResourceWhereInput.ts
+++ b/packages/amplication-server/src/core/resource/dto/ResourceWhereInput.ts
@@ -1,5 +1,5 @@
 import { Field, InputType } from "@nestjs/graphql";
-import { DateTimeFilter, StringFilter } from "../../../dto";
+import { BooleanFilter, DateTimeFilter, StringFilter } from "../../../dto";
 import { ProjectWhereInput } from "../../project/dto/ProjectWhereInput";
 import { EnumResourceTypeFilter } from "./EnumResourceTypeFilter";
 
@@ -42,4 +42,9 @@ export class ResourceWhereInput {
     nullable: true,
   })
   resourceType?: EnumResourceTypeFilter | null;
+
+  //do not expose to graphql
+  deletedAt?: DateTimeFilter;
+
+  archived?: BooleanFilter;
 }


### PR DESCRIPTION


Close: https://github.com/amplication/amplication/issues/8932

## PR Details

Move the private plugins' settings to a separate tab on the project page. 



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
