### PR TITLE
feat(client):resource type group - split commit to two groups of resource types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
     "clonedeep",
     "cloudbuild",
     "codebrew",
+    "commitable",
     "cronstrue",
     "curveness",
     "Datagrid",

--- a/packages/amplication-client/src/Platform/ProjectPlatformPage.tsx
+++ b/packages/amplication-client/src/Platform/ProjectPlatformPage.tsx
@@ -7,6 +7,7 @@ import useTabRoutes from "../Layout/useTabRoutes";
 import { AppContext } from "../context/appContext";
 import { AppRouteProps } from "../routes/routesUtil";
 import ServiceTemplateList from "./ServiceTemplateList";
+import { useProjectBaseUrl } from "../util/useProjectBaseUrl";
 
 type Props = AppRouteProps & {
   match: match<{
@@ -25,7 +26,13 @@ const ProjectPlatformPage: React.FC<Props> = ({
 }) => {
   const { currentProject } = useContext(AppContext);
 
-  useBreadcrumbs(`${currentProject?.name} - Platform`, match.url);
+  const { baseUrl: projectUrl } = useProjectBaseUrl({
+    overrideIsPlatformConsole: false,
+  });
+
+  useBreadcrumbs(`${currentProject?.name} `, projectUrl);
+
+  useBreadcrumbs(`Platform Console`, match.url);
   const { tabs, currentRouteIsTab } = useTabRoutes(tabRoutesDef);
 
   const tabItems: TabItem[] = useMemo(() => {

--- a/packages/amplication-client/src/Project/ArchitectureConsole/ApplyChangesNextSteps.tsx
+++ b/packages/amplication-client/src/Project/ArchitectureConsole/ApplyChangesNextSteps.tsx
@@ -19,6 +19,7 @@ import { CommitBtnType } from "../../VersionControl/Commit";
 import { CompletePreviewSignupButton } from "../../User/CompletePreviewSignupButton";
 import CommitButton from "../../VersionControl/CommitButton";
 import { useProjectBaseUrl } from "../../util/useProjectBaseUrl";
+import { EnumCommitStrategy, EnumResourceTypeGroup } from "../../models";
 
 const className = "apply-changes-next-steps";
 
@@ -65,6 +66,10 @@ export const ApplyChangesNextSteps = ({
           <CommitButton
             commitBtnType={CommitBtnType.JumboButton}
             commitMessage={""}
+            resourceTypeGroup={EnumResourceTypeGroup.Services} //this will always be services for BTM
+            hasPendingChanges={true}
+            hasMultipleServices={true}
+            commitStrategy={EnumCommitStrategy.AllWithPendingChanges} //commit all with pending changes
           ></CommitButton>
         )}
         <JumboButton

--- a/packages/amplication-client/src/Resource/constants.ts
+++ b/packages/amplication-client/src/Resource/constants.ts
@@ -232,7 +232,7 @@ export const resourceThemeMap: {
 } = {
   [models.EnumResourceType.ProjectConfiguration]: {
     icon: "app-settings",
-    color: "#FFBD70",
+    color: "#f685a1",
   },
   [models.EnumResourceType.Service]: {
     icon: "services",

--- a/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
@@ -73,6 +73,7 @@ const CreateServiceWizard: React.FC<Props> = ({
     loadingCreateService,
     setNewService,
     createServiceWithEntitiesResult: createResult,
+    addBlock,
   } = useContext(AppContext);
   const { baseUrl } = useProjectBaseUrl({ overrideIsPlatformConsole: true });
 
@@ -81,7 +82,9 @@ const CreateServiceWizard: React.FC<Props> = ({
     loadingCreateServiceTemplate,
     errorCreateServiceTemplate,
     createdServiceTemplateResults,
-  } = useServiceTemplate(currentProject);
+  } = useServiceTemplate(currentProject, (ServiceTemplate) => {
+    addBlock(ServiceTemplate.id);
+  });
 
   const { trackEvent } = useTracking();
   const history = useHistory();

--- a/packages/amplication-client/src/Resource/create-resource/constants.ts
+++ b/packages/amplication-client/src/Resource/create-resource/constants.ts
@@ -49,7 +49,7 @@ export const FLOW_SETTINGS: {
       successPluginsLine1: "Add plugins to",
       successPluginsLine2: "the service template",
       successDoneLine1: "I'm done!",
-      successDoneLine2: "View my template",
+      successDoneLine2: "View my templates",
     },
   },
 };

--- a/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceCodeGeneration.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceCodeGeneration.tsx
@@ -109,6 +109,7 @@ const CreateServiceCodeGeneration: React.FC<
       variables: {
         message: "Initial commit",
         projectId: currentProject.id,
+        resourceTypeGroup: models.EnumResourceTypeGroup.Services, //when creating new service, this will always be services
       },
     }).catch(console.error);
   }, [commit, currentProject?.id, trackWizardPageEvent]);

--- a/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceNextSteps.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/wizard-pages/CreateServiceNextSteps.tsx
@@ -53,8 +53,8 @@ export const CreateServiceNextSteps: React.FC<
       AnalyticsEventNames.ServiceWizardStep_Finish_CTAClicked,
       { action: "View Service" }
     );
-    history.push(`${baseUrl}/${createdResource?.id}`);
-  }, [baseUrl, history, trackWizardPageEvent, createdResource]);
+    history.push(`${baseUrl}`);
+  }, [baseUrl, history, trackWizardPageEvent]);
 
   return (
     <div className={className}>
@@ -109,7 +109,7 @@ export const CreateServiceNextSteps: React.FC<
           <div className={`${className}__link_box__description`}>
             <div>{flowSettings.texts?.successDoneLine1 || "I'm done!"}</div>
             <div>
-              {flowSettings.texts?.successDoneLine2 || "View my service"}
+              {flowSettings.texts?.successDoneLine2 || "View my services"}
             </div>
             <div></div>
           </div>

--- a/packages/amplication-client/src/Resource/create-resource/wizardResourceSchema.ts
+++ b/packages/amplication-client/src/Resource/create-resource/wizardResourceSchema.ts
@@ -153,7 +153,7 @@ export const ResourceInitialValues = {
   baseDir: "./apps",
   databaseType: "db-postgres",
   templateType: "empty",
-  authType: "auth-jwt",
+  authType: "no",
   gitProvider: null,
   connectToDemoRepo: false,
 };

--- a/packages/amplication-client/src/Resource/git/SyncWithGithubPage.tsx
+++ b/packages/amplication-client/src/Resource/git/SyncWithGithubPage.tsx
@@ -12,6 +12,7 @@ import {
   EnumGitOrganizationType,
   EnumGitProvider,
   EnumResourceType,
+  EnumResourceTypeGroup,
   EnumSubscriptionPlan,
   Resource,
 } from "../../models";
@@ -96,6 +97,7 @@ const SyncWithGithubPage: React.FC = () => {
       message: "",
       project: { connect: { id: currentProject?.id } },
       bypassLimitations: false,
+      resourceTypeGroup: EnumResourceTypeGroup.Services, //because we push to git, this will always be services
     });
     setOpenPr(false);
   }, [commitChanges, currentProject]);

--- a/packages/amplication-client/src/ServiceTemplate/hooks/useServiceTemplate.ts
+++ b/packages/amplication-client/src/ServiceTemplate/hooks/useServiceTemplate.ts
@@ -14,7 +14,10 @@ type TCreateServiceTemplate = {
   createServiceTemplate: models.Resource;
 };
 
-const useServiceTemplate = (currentProject: models.Project | undefined) => {
+const useServiceTemplate = (
+  currentProject: models.Project | undefined,
+  onServiceTemplateCreated?: (serviceTemplate: models.Resource) => void
+) => {
   const [searchPhrase, setSearchPhrase] = useState<string>("");
 
   const {
@@ -44,8 +47,10 @@ const useServiceTemplate = (currentProject: models.Project | undefined) => {
 
   const createServiceTemplate = (data: models.ServiceTemplateCreateInput) => {
     createServiceTemplateInternal({ variables: { data: data } })
-      .then(() => {
+      .then((result) => {
         reloadServiceTemplates();
+        onServiceTemplateCreated &&
+          onServiceTemplateCreated(result.data.createServiceTemplate);
       })
       .catch(console.error);
   };

--- a/packages/amplication-client/src/VersionControl/Commit.tsx
+++ b/packages/amplication-client/src/VersionControl/Commit.tsx
@@ -268,21 +268,26 @@ const Commit = ({
                     autoFocus
                     hideLabel
                     placeholder={
-                      noChanges ? "Build message" : "Commit message..."
+                      resourceTypeGroup === EnumResourceTypeGroup.Platform
+                        ? "Version message"
+                        : noChanges
+                        ? "Build message"
+                        : "Commit message..."
                     }
                     autoComplete="off"
                   />
                 )}
-                {!dotNetGeneratorEnabled && (
-                  <MultiStateToggle
-                    className={`${CLASS_NAME}__technology-toggle`}
-                    label=""
-                    name="action_"
-                    options={OPTIONS}
-                    onChange={handleOnSelectLanguageChange}
-                    selectedValue={"node"}
-                  />
-                )}
+                {!dotNetGeneratorEnabled &&
+                  resourceTypeGroup === EnumResourceTypeGroup.Services && (
+                    <MultiStateToggle
+                      className={`${CLASS_NAME}__technology-toggle`}
+                      label=""
+                      name="action_"
+                      options={OPTIONS}
+                      onChange={handleOnSelectLanguageChange}
+                      selectedValue={"node"}
+                    />
+                  )}
                 <div>
                   <FlexItem
                     direction={EnumFlexDirection.Row}
@@ -301,27 +306,29 @@ const Commit = ({
                         );
                       }}
                     ></CommitButton>
-                    <SelectMenu
-                      title=""
-                      icon="chevron_down"
-                      buttonStyle={EnumButtonStyle.Text}
-                      className={`${CLASS_NAME}__commit-strategy`}
-                    >
-                      <SelectMenuModal align="right" withCaret>
-                        <SelectMenuList>
-                          {COMMIT_STRATEGY_OPTIONS.map((item, index) => (
-                            <CreateCommitStrategyButtonItem
-                              key={index}
-                              item={item}
-                              hasPendingChanges={hasPendingChanges}
-                              onCommitStrategySelected={
-                                handleOnSelectCommitStrategyChange
-                              }
-                            ></CreateCommitStrategyButtonItem>
-                          ))}
-                        </SelectMenuList>
-                      </SelectMenuModal>
-                    </SelectMenu>
+                    {resourceTypeGroup === EnumResourceTypeGroup.Services && (
+                      <SelectMenu
+                        title=""
+                        icon="chevron_down"
+                        buttonStyle={EnumButtonStyle.Text}
+                        className={`${CLASS_NAME}__commit-strategy`}
+                      >
+                        <SelectMenuModal align="right" withCaret>
+                          <SelectMenuList>
+                            {COMMIT_STRATEGY_OPTIONS.map((item, index) => (
+                              <CreateCommitStrategyButtonItem
+                                key={index}
+                                item={item}
+                                hasPendingChanges={hasPendingChanges}
+                                onCommitStrategySelected={
+                                  handleOnSelectCommitStrategyChange
+                                }
+                              ></CreateCommitStrategyButtonItem>
+                            ))}
+                          </SelectMenuList>
+                        </SelectMenuModal>
+                      </SelectMenu>
+                    )}
                   </FlexItem>
                 </div>
               </Form>

--- a/packages/amplication-client/src/VersionControl/CommitButton.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitButton.tsx
@@ -111,31 +111,47 @@ const CommitButton = ({
 
   const errorMessage = formatError(commitChangesError);
 
+  const element =
+    commitBtnType === CommitBtnType.Button ? (
+      resourceTypeGroup === EnumResourceTypeGroup.Services ? (
+        <Button
+          onClick={handleClick}
+          buttonStyle={EnumButtonStyle.Primary}
+          eventData={{
+            eventName: AnalyticsEventNames.CommitClicked,
+          }}
+          disabled={commitChangesLoading}
+        >
+          Generate the code
+        </Button>
+      ) : (
+        <Button
+          onClick={handleClick}
+          buttonStyle={EnumButtonStyle.Primary}
+          eventData={{
+            eventName: AnalyticsEventNames.CommitClicked,
+          }}
+          disabled={commitChangesLoading}
+        >
+          Publish New Version
+        </Button>
+      )
+    ) : commitBtnType === CommitBtnType.JumboButton ? (
+      <JumboButton
+        text="Generate the code for my new architecture"
+        icon="pending_changes"
+        onClick={handleClick}
+        circleColor={EnumTextColor.ThemeTurquoise}
+      ></JumboButton>
+    ) : null;
+
   return (
     <>
       <LicenseIndicatorContainer
         blockByFeatureId={BillingFeature.BlockBuild}
         licensedResourceType={LicensedResourceType.Project}
       >
-        {commitBtnType === CommitBtnType.Button ? (
-          <Button
-            onClick={handleClick}
-            buttonStyle={EnumButtonStyle.Primary}
-            eventData={{
-              eventName: AnalyticsEventNames.CommitClicked,
-            }}
-            disabled={commitChangesLoading}
-          >
-            <>Generate the code </>
-          </Button>
-        ) : commitBtnType === CommitBtnType.JumboButton ? (
-          <JumboButton
-            text="Generate the code for my new architecture"
-            icon="pending_changes"
-            onClick={handleClick}
-            circleColor={EnumTextColor.ThemeTurquoise}
-          ></JumboButton>
-        ) : null}
+        {element}
       </LicenseIndicatorContainer>
       {commitChangesError && isLimitationError ? (
         <LimitationDialog

--- a/packages/amplication-client/src/VersionControl/CommitButton.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitButton.tsx
@@ -8,7 +8,7 @@ import { useCallback, useContext, useRef, useState } from "react";
 import { useHistory, useRouteMatch } from "react-router-dom";
 import { Button, EnumButtonStyle } from "../Components/Button";
 import { AppContext } from "../context/appContext";
-import { EnumCommitStrategy } from "../models";
+import { EnumCommitStrategy, EnumResourceTypeGroup } from "../models";
 import { useTracking } from "../util/analytics";
 import { AnalyticsEventNames } from "../util/analytics-events.types";
 import { formatError } from "../util/error";
@@ -24,6 +24,11 @@ type Props = {
   commitMessage?: string;
   commitBtnType?: CommitBtnType;
   onCommitChanges?: () => void;
+  resourceTypeGroup: EnumResourceTypeGroup;
+  hasPendingChanges: boolean;
+  hasMultipleServices: boolean;
+  commitStrategy?: EnumCommitStrategy;
+  onCommitSpecificService?: () => void;
 };
 
 type RouteMatchProps = {
@@ -39,6 +44,11 @@ const CommitButton = ({
   commitBtnType = CommitBtnType.Button,
   commitMessage = "",
   onCommitChanges,
+  resourceTypeGroup,
+  hasPendingChanges,
+  hasMultipleServices,
+  commitStrategy,
+  onCommitSpecificService,
 }: Props) => {
   const history = useHistory();
   const { trackEvent } = useTracking();
@@ -64,15 +74,38 @@ const CommitButton = ({
   };
 
   const handleClick = useCallback(() => {
+    const strategy =
+      commitStrategy ?? hasPendingChanges //use the default strategy when provided
+        ? EnumCommitStrategy.AllWithPendingChanges //default when there are pending changes
+        : hasMultipleServices && onCommitSpecificService
+        ? EnumCommitStrategy.Specific //let the user choose when there are multiple services and no changes
+        : EnumCommitStrategy.All; //use all when there is only one service
+
+    if (strategy === EnumCommitStrategy.Specific) {
+      onCommitSpecificService();
+      return;
+    }
+
     commitChanges({
       message: commitMessage,
       project: { connect: { id: currentProject?.id } },
       bypassLimitations: bypassLimitationsRef.current ?? false,
-      commitStrategy: EnumCommitStrategy.All,
+      commitStrategy: strategy,
+      resourceTypeGroup,
     });
 
     onCommitChanges && onCommitChanges();
-  }, [commitChanges, currentProject, commitMessage, onCommitChanges]);
+  }, [
+    onCommitSpecificService,
+    commitStrategy,
+    hasPendingChanges,
+    hasMultipleServices,
+    commitChanges,
+    currentProject,
+    commitMessage,
+    onCommitChanges,
+    resourceTypeGroup,
+  ]);
 
   const isLimitationError = commitChangesLimitationError !== undefined ?? false;
 

--- a/packages/amplication-client/src/VersionControl/CommitsPage.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitsPage.tsx
@@ -10,6 +10,7 @@ import "./CommitsPage.scss";
 import BuildPage from "./BuildPage";
 import CommitButton from "./CommitButton";
 import { useProjectBaseUrl } from "../util/useProjectBaseUrl";
+import { EnumCommitStrategy, EnumResourceTypeGroup } from "../models";
 
 type Props = AppRouteProps & {
   match: match<{
@@ -86,7 +87,12 @@ const CommitsPage: React.FC<Props> = ({ moduleClass, innerRoutes }) => {
               message="There are no commits to show. "
               image={EnumImages.CommitEmptyState}
             >
-              <CommitButton />
+              <CommitButton
+                resourceTypeGroup={EnumResourceTypeGroup.Services}
+                hasMultipleServices={true}
+                hasPendingChanges={true}
+                commitStrategy={EnumCommitStrategy.All}
+              />
             </EmptyState>
           )}
         </>

--- a/packages/amplication-client/src/VersionControl/CreateCommitStrategyButtonItem.tsx
+++ b/packages/amplication-client/src/VersionControl/CreateCommitStrategyButtonItem.tsx
@@ -5,7 +5,7 @@ import { EnumCommitStrategy } from "../models";
 type props = {
   item: commitStrategyOption;
   hasPendingChanges: boolean;
-  onCommitStrategySelected: (itemSelected: commitStrategyOption) => void;
+  onCommitStrategySelected: (itemSelected: EnumCommitStrategy) => void;
 };
 
 const CreateCommitStrategyButtonItem = ({
@@ -24,7 +24,9 @@ const CreateCommitStrategyButtonItem = ({
       closeAfterSelectionChange
       as="span"
       itemData={item}
-      onSelectionChange={onCommitStrategySelected}
+      onSelectionChange={(item: commitStrategyOption) => {
+        onCommitStrategySelected(item.strategyType);
+      }}
     >
       {item.label}
     </SelectMenuItem>

--- a/packages/amplication-client/src/VersionControl/DiscardChanges.tsx
+++ b/packages/amplication-client/src/VersionControl/DiscardChanges.tsx
@@ -11,6 +11,7 @@ import { useTracking } from "../util/analytics";
 type Props = {
   isOpen: boolean;
   projectId: string;
+  resourceTypeGroup: models.EnumResourceTypeGroup;
   onComplete: () => void;
   onDismiss: () => void;
 };
@@ -18,6 +19,7 @@ type Props = {
 const DiscardChanges = ({
   isOpen,
   projectId,
+  resourceTypeGroup,
   onComplete,
   onDismiss,
 }: Props) => {
@@ -65,9 +67,10 @@ const DiscardChanges = ({
     discardChanges({
       variables: {
         projectId,
+        resourceTypeGroup,
       },
     }).catch(console.error);
-  }, [projectId, discardChanges]);
+  }, [trackEvent, discardChanges, projectId, resourceTypeGroup]);
 
   const errorMessage = formatError(error);
 
@@ -103,7 +106,15 @@ const DiscardChanges = ({
 export default DiscardChanges;
 
 const DISCARD_CHANGES = gql`
-  mutation discardChanges($projectId: String!) {
-    discardPendingChanges(data: { project: { connect: { id: $projectId } } })
+  mutation discardChanges(
+    $projectId: String!
+    $resourceTypeGroup: EnumResourceTypeGroup!
+  ) {
+    discardPendingChanges(
+      data: {
+        project: { connect: { id: $projectId } }
+        resourceTypeGroup: $resourceTypeGroup
+      }
+    )
   }
 `;

--- a/packages/amplication-client/src/VersionControl/PendingChanges.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChanges.tsx
@@ -24,6 +24,7 @@ import "./PendingChanges.scss";
 import PendingChangesList from "./PendingChangesList";
 import { useResourceBaseUrl } from "../util/useResourceBaseUrl";
 import { useProjectBaseUrl } from "../util/useProjectBaseUrl";
+import { EnumResourceTypeGroup } from "../models";
 
 const CLASS_NAME = "pending-changes";
 
@@ -37,7 +38,11 @@ const PendingChanges = ({ projectId }: Props) => {
   const { currentProject, pendingChanges, isPreviewPlan } =
     useContext(AppContext);
   const { baseUrl } = useResourceBaseUrl();
-  const { baseUrl: projectBaseUrl } = useProjectBaseUrl();
+  const { baseUrl: projectBaseUrl, isPlatformConsole } = useProjectBaseUrl();
+
+  const resourceTypeGroup = isPlatformConsole
+    ? EnumResourceTypeGroup.Platform
+    : EnumResourceTypeGroup.Services;
 
   const entityMatch = useRouteMatch<{
     workspace: string;
@@ -45,11 +50,13 @@ const PendingChanges = ({ projectId }: Props) => {
     resource: string;
     entity: string;
   }>("/:workspace/:project/:resource/entities/:entity");
+
   const {
     pendingChangesDataError,
     pendingChangesIsError,
     pendingChangesDataLoading,
-  } = usePendingChanges(currentProject);
+  } = usePendingChanges(currentProject, resourceTypeGroup);
+
   const handleToggleDiscardDialog = useCallback(() => {
     setDiscardDialogOpen(!discardDialogOpen);
   }, [discardDialogOpen, setDiscardDialogOpen]);
@@ -79,12 +86,14 @@ const PendingChanges = ({ projectId }: Props) => {
             projectId={projectId}
             noChanges={noChanges}
             commitBtnType={CommitBtnType.Button}
+            resourceTypeGroup={resourceTypeGroup}
           />
         )}
 
         <DiscardChanges
           isOpen={discardDialogOpen}
           projectId={projectId}
+          resourceTypeGroup={resourceTypeGroup}
           onComplete={handleDiscardDialogCompleted}
           onDismiss={handleToggleDiscardDialog}
         />

--- a/packages/amplication-client/src/VersionControl/PendingChanges.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChanges.tsx
@@ -4,6 +4,7 @@ import {
   EnumFlexItemMargin,
   EnumGapSize,
   EnumItemsAlign,
+  EnumTextColor,
   EnumTextStyle,
   FlexItem,
   Snackbar,
@@ -74,7 +75,17 @@ const PendingChanges = ({ projectId }: Props) => {
 
   return (
     <div className={CLASS_NAME}>
-      <Text textStyle={EnumTextStyle.H4}>Pending changes</Text>
+      {resourceTypeGroup === EnumResourceTypeGroup.Platform ? (
+        <Text
+          textStyle={EnumTextStyle.H4}
+          textColor={EnumTextColor.ThemeOrange}
+        >
+          Platform Changes
+        </Text>
+      ) : (
+        <Text textStyle={EnumTextStyle.H4}>Pending changes</Text>
+      )}
+
       <FlexItem
         itemsAlign={EnumItemsAlign.Stretch}
         direction={EnumFlexDirection.Column}
@@ -102,7 +113,7 @@ const PendingChanges = ({ projectId }: Props) => {
           {pendingChangesDataLoading ? (
             <CircularProgress centerToParent />
           ) : (
-            <PendingChangesList />
+            <PendingChangesList resourceTypeGroup={resourceTypeGroup} />
           )}
           <hr className={`${CLASS_NAME}__divider`} />
           <div className={`${CLASS_NAME}__changes-header`}>

--- a/packages/amplication-client/src/VersionControl/PendingChangesList.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChangesList.tsx
@@ -1,26 +1,33 @@
 import { useContext } from "react";
 
-import { EnumTextStyle, Text } from "@amplication/ui/design-system";
+import {
+  EnumFlexDirection,
+  EnumItemsAlign,
+  EnumTextAlign,
+  EnumTextStyle,
+  FlexItem,
+  Text,
+} from "@amplication/ui/design-system";
 import ResourceCircleBadge from "../Components/ResourceCircleBadge";
 import { EnumImages, SvgThemeImage } from "../Components/SvgThemeImage";
 import usePendingChanges from "../Workspaces/hooks/usePendingChanges";
 import { AppContext } from "../context/appContext";
 import "./PendingChangesList.scss";
 import PendingChangesListGroup from "./PendingChangesListGroup";
-import { useProjectBaseUrl } from "../util/useProjectBaseUrl";
 import { EnumResourceTypeGroup } from "../models";
 
 const CLASS_NAME = "pending-changes-list";
 
-const PendingChangesList = () => {
+type Props = {
+  resourceTypeGroup: EnumResourceTypeGroup;
+};
+
+const PendingChangesList = ({ resourceTypeGroup }: Props) => {
   const { currentProject } = useContext(AppContext);
-  const { isPlatformConsole } = useProjectBaseUrl();
 
   const { pendingChangesByResourceAndType } = usePendingChanges(
     currentProject,
-    isPlatformConsole
-      ? EnumResourceTypeGroup.Platform
-      : EnumResourceTypeGroup.Services
+    resourceTypeGroup
   );
 
   return (
@@ -41,10 +48,26 @@ const PendingChangesList = () => {
       ))}
       {pendingChangesByResourceAndType.length === 0 && (
         <>
-          <SvgThemeImage image={EnumImages.NoChanges} />
-          <Text textStyle={EnumTextStyle.Description}>
-            No pending changes! keep working.
-          </Text>
+          <FlexItem
+            direction={EnumFlexDirection.Column}
+            itemsAlign={EnumItemsAlign.Center}
+          >
+            <SvgThemeImage
+              image={
+                resourceTypeGroup === EnumResourceTypeGroup.Platform
+                  ? EnumImages.AddResource
+                  : EnumImages.NoChanges
+              }
+            />
+            <Text
+              textStyle={EnumTextStyle.Description}
+              textAlign={EnumTextAlign.Center}
+            >
+              {resourceTypeGroup === EnumResourceTypeGroup.Platform
+                ? "No platform changes! keep working."
+                : "No pending changes! keep working."}
+            </Text>
+          </FlexItem>
         </>
       )}
     </div>

--- a/packages/amplication-client/src/VersionControl/PendingChangesList.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChangesList.tsx
@@ -7,13 +7,21 @@ import usePendingChanges from "../Workspaces/hooks/usePendingChanges";
 import { AppContext } from "../context/appContext";
 import "./PendingChangesList.scss";
 import PendingChangesListGroup from "./PendingChangesListGroup";
+import { useProjectBaseUrl } from "../util/useProjectBaseUrl";
+import { EnumResourceTypeGroup } from "../models";
 
 const CLASS_NAME = "pending-changes-list";
 
 const PendingChangesList = () => {
   const { currentProject } = useContext(AppContext);
+  const { isPlatformConsole } = useProjectBaseUrl();
 
-  const { pendingChangesByResourceAndType } = usePendingChanges(currentProject);
+  const { pendingChangesByResourceAndType } = usePendingChanges(
+    currentProject,
+    isPlatformConsole
+      ? EnumResourceTypeGroup.Platform
+      : EnumResourceTypeGroup.Services
+  );
 
   return (
     <div className={CLASS_NAME}>

--- a/packages/amplication-client/src/VersionControl/PendingChangesPage.tsx
+++ b/packages/amplication-client/src/VersionControl/PendingChangesPage.tsx
@@ -8,6 +8,8 @@ import { AppContext } from "../context/appContext";
 import { gql } from "@apollo/client";
 import usePendingChanges from "../Workspaces/hooks/usePendingChanges";
 import { formatError } from "../util/error";
+import { useProjectBaseUrl } from "../util/useProjectBaseUrl";
+import { EnumResourceTypeGroup } from "../models";
 
 const CLASS_NAME = "pending-changes-page";
 const SPLIT = "Split";
@@ -22,11 +24,19 @@ const PendingChangesPage = () => {
   const [splitView, setSplitView] = useState<boolean>(false);
   const pageTitle = "Pending Changes";
   const { currentProject } = useContext(AppContext);
+
+  const { isPlatformConsole } = useProjectBaseUrl();
+
   const {
     pendingChangesByResource,
     pendingChangesDataError,
     pendingChangesIsError,
-  } = usePendingChanges(currentProject);
+  } = usePendingChanges(
+    currentProject,
+    isPlatformConsole
+      ? EnumResourceTypeGroup.Platform
+      : EnumResourceTypeGroup.Services
+  );
 
   const handleChangeType = useCallback(
     (type: string) => {

--- a/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
+++ b/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
@@ -7,6 +7,7 @@ import {
   Build,
   EnumBuildStatus,
   EnumSubscriptionPlan,
+  CommitCreateInput,
 } from "../../models";
 import { ApolloError, useLazyQuery, useMutation } from "@apollo/client";
 import { cloneDeep, groupBy } from "lodash";
@@ -184,7 +185,7 @@ const useCommits = (currentProjectId: string, maxCommits?: number) => {
     });
 
   const commitChanges = useCallback(
-    (data) => {
+    (data: CommitCreateInput) => {
       if (!data) return;
       setCommitRunning(true);
       commit({

--- a/packages/amplication-client/src/Workspaces/DeleteResourceButton.tsx
+++ b/packages/amplication-client/src/Workspaces/DeleteResourceButton.tsx
@@ -50,6 +50,12 @@ function DeleteResourceButton({ resource }: Props) {
                 deletedResourceId !== readField("id", resourceRef)
             );
           },
+          serviceTemplates(existingResourceRefs, { readField }) {
+            return existingResourceRefs.filter(
+              (resourceRef: Reference) =>
+                deletedResourceId !== readField("id", resourceRef)
+            );
+          },
         },
       });
       refreshData();

--- a/packages/amplication-client/src/Workspaces/ResourceGitRepo.tsx
+++ b/packages/amplication-client/src/Workspaces/ResourceGitRepo.tsx
@@ -50,7 +50,7 @@ function ResourceGitRepo({ resource }: Props) {
       ) : (
         <Text
           textStyle={EnumTextStyle.Subtle}
-          textColor={EnumTextColor.ThemeOrange}
+          textColor={EnumTextColor.ThemeRed}
         >
           Not connected
         </Text>

--- a/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
@@ -259,7 +259,7 @@ const WorkspaceLayout: React.FC<Props> = ({
                     {currentProject ? (
                       <div className={`${moduleClass}__changes_menu`}>
                         <PendingChanges projectId={currentProject.id} />
-                        {commitUtils.lastCommit && (
+                        {!isPlatformConsole && commitUtils.lastCommit && (
                           <LastCommit lastCommit={commitUtils.lastCommit} />
                         )}
                       </div>

--- a/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
@@ -28,10 +28,11 @@ import useCommits from "../VersionControl/hooks/useCommits";
 import RedeemCoupon from "../User/RedeemCoupon";
 import PendingChanges from "../VersionControl/PendingChanges";
 import LastCommit from "../VersionControl/LastCommit";
-import { EnumSubscriptionStatus } from "../models";
+import { EnumResourceTypeGroup, EnumSubscriptionStatus } from "../models";
 import Assistant from "../Assistant/Assistant";
 import ResponsiveContainer from "../Components/ResponsiveContainer";
 import { AssistantContextProvider } from "../Assistant/context/AssistantContext";
+import { useProjectBaseUrl } from "../util/useProjectBaseUrl";
 
 const MobileMessage = lazy(() => import("../Layout/MobileMessage"));
 
@@ -73,6 +74,8 @@ const WorkspaceLayout: React.FC<Props> = ({
     currentProjectConfiguration,
   } = useProjectSelector(authenticated, currentWorkspace);
 
+  const { isPlatformConsole } = useProjectBaseUrl();
+
   const {
     pendingChanges,
     commitRunning,
@@ -85,7 +88,12 @@ const WorkspaceLayout: React.FC<Props> = ({
     setPendingChangesError,
     resetPendingChangesIndicator,
     setResetPendingChangesIndicator,
-  } = usePendingChanges(currentProject);
+  } = usePendingChanges(
+    currentProject,
+    isPlatformConsole
+      ? EnumResourceTypeGroup.Platform
+      : EnumResourceTypeGroup.Services
+  );
 
   const commitUtils = useCommits(currentProject?.id);
 

--- a/packages/amplication-client/src/Workspaces/hooks/usePendingChanges.ts
+++ b/packages/amplication-client/src/Workspaces/hooks/usePendingChanges.ts
@@ -23,7 +23,10 @@ export type PendingChangesByResourceAndType = {
   changes: PendingChangesByType[];
 };
 
-const usePendingChanges = (currentProject: models.Project | undefined) => {
+const usePendingChanges = (
+  currentProject: models.Project | undefined,
+  resourceTypeGroup: models.EnumResourceTypeGroup
+) => {
   const [pendingChangesMap, setPendingChangesMap] = useState<string[]>([]);
   const [pendingChanges, setPendingChanges] = useState<PendingChangeItem[]>([]);
   const [commitRunning, setCommitRunning] = useState<boolean>(false);
@@ -39,6 +42,7 @@ const usePendingChanges = (currentProject: models.Project | undefined) => {
     skip: !currentProject,
     variables: {
       projectId: currentProject?.id,
+      resourceTypeGroup: resourceTypeGroup,
     },
   });
 

--- a/packages/amplication-client/src/Workspaces/queries/projectQueries.ts
+++ b/packages/amplication-client/src/Workspaces/queries/projectQueries.ts
@@ -42,8 +42,16 @@ export const CREATE_PROJECT = gql`
 `;
 
 export const GET_PENDING_CHANGES_STATUS = gql`
-  query pendingChanges($projectId: String!) {
-    pendingChanges(where: { project: { id: $projectId } }) {
+  query pendingChanges(
+    $projectId: String!
+    $resourceTypeGroup: EnumResourceTypeGroup!
+  ) {
+    pendingChanges(
+      where: {
+        project: { id: $projectId }
+        resourceTypeGroup: $resourceTypeGroup
+      }
+    ) {
       originId
       action
       originType


### PR DESCRIPTION

Part of: https://github.com/amplication/amplication/issues/8935

## PR Details

- Support the new param ResourceTypeGroup for pending changes and commits 
- Add dynamic default behavior for the commit button to prevent from large build processes when not needed
- When there are pending changes - build only the services with pending changes
- When there is a single service - build the single service (using the ALL option)
- When there are multiple services - let the user choose which service 


## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
