### PR TITLE
Feat/filter commit list by resource type group

### DIFF
--- a/ee/packages/git-sync-manager/src/models.ts
+++ b/ee/packages/git-sync-manager/src/models.ts
@@ -359,6 +359,7 @@ export type CommitWhereInput = {
   id?: InputMaybe<StringFilter>;
   message?: InputMaybe<StringFilter>;
   project: WhereUniqueInput;
+  resourceTypeGroup: EnumResourceTypeGroup;
   user?: InputMaybe<WhereUniqueInput>;
 };
 
@@ -2535,7 +2536,7 @@ export type QueryCommitsArgs = {
   orderBy?: InputMaybe<CommitOrderByInput>;
   skip?: InputMaybe<Scalars['Int']['input']>;
   take?: InputMaybe<Scalars['Int']['input']>;
-  where?: InputMaybe<CommitWhereInput>;
+  where: CommitWhereInput;
 };
 
 

--- a/libs/util/code-gen-types/src/models.ts
+++ b/libs/util/code-gen-types/src/models.ts
@@ -359,6 +359,7 @@ export type CommitWhereInput = {
   id?: InputMaybe<StringFilter>;
   message?: InputMaybe<StringFilter>;
   project: WhereUniqueInput;
+  resourceTypeGroup: EnumResourceTypeGroup;
   user?: InputMaybe<WhereUniqueInput>;
 };
 
@@ -2535,7 +2536,7 @@ export type QueryCommitsArgs = {
   orderBy?: InputMaybe<CommitOrderByInput>;
   skip?: InputMaybe<Scalars['Int']['input']>;
   take?: InputMaybe<Scalars['Int']['input']>;
-  where?: InputMaybe<CommitWhereInput>;
+  where: CommitWhereInput;
 };
 
 

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -359,6 +359,7 @@ export type CommitWhereInput = {
   id?: InputMaybe<StringFilter>;
   message?: InputMaybe<StringFilter>;
   project: WhereUniqueInput;
+  resourceTypeGroup: EnumResourceTypeGroup;
   user?: InputMaybe<WhereUniqueInput>;
 };
 
@@ -2535,7 +2536,7 @@ export type QueryCommitsArgs = {
   orderBy?: InputMaybe<CommitOrderByInput>;
   skip?: InputMaybe<Scalars['Int']['input']>;
   take?: InputMaybe<Scalars['Int']['input']>;
-  where?: InputMaybe<CommitWhereInput>;
+  where: CommitWhereInput;
 };
 
 

--- a/packages/amplication-client/src/VersionControl/CommitButton.tsx
+++ b/packages/amplication-client/src/VersionControl/CommitButton.tsx
@@ -74,8 +74,17 @@ const CommitButton = ({
   };
 
   const handleClick = useCallback(() => {
+    if (
+      resourceTypeGroup === EnumResourceTypeGroup.Platform &&
+      !hasPendingChanges
+    ) {
+      return;
+    }
+
     const strategy =
-      commitStrategy ?? hasPendingChanges //use the default strategy when provided
+      commitStrategy ?? resourceTypeGroup === EnumResourceTypeGroup.Platform
+        ? EnumCommitStrategy.AllWithPendingChanges
+        : hasPendingChanges //use the default strategy when provided
         ? EnumCommitStrategy.AllWithPendingChanges //default when there are pending changes
         : hasMultipleServices && onCommitSpecificService
         ? EnumCommitStrategy.Specific //let the user choose when there are multiple services and no changes
@@ -131,7 +140,7 @@ const CommitButton = ({
           eventData={{
             eventName: AnalyticsEventNames.CommitClicked,
           }}
-          disabled={commitChangesLoading}
+          disabled={!hasPendingChanges || commitChangesLoading}
         >
           Publish New Version
         </Button>

--- a/packages/amplication-client/src/VersionControl/hooks/commitQueries.ts
+++ b/packages/amplication-client/src/VersionControl/hooks/commitQueries.ts
@@ -98,12 +98,16 @@ export const GET_COMMITS = gql`
   ${COMMIT_FIELDS_FRAGMENT}
   query commits(
     $projectId: String!
+    $resourceTypeGroup: EnumResourceTypeGroup!
     $take: Int!
     $skip: Int!
     $orderBy: CommitOrderByInput
   ) {
     commits(
-      where: { project: { id: $projectId } }
+      where: {
+        project: { id: $projectId }
+        resourceTypeGroup: $resourceTypeGroup
+      }
       take: $take
       skip: $skip
       orderBy: $orderBy

--- a/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
+++ b/packages/amplication-client/src/VersionControl/hooks/useCommits.ts
@@ -8,6 +8,7 @@ import {
   EnumBuildStatus,
   EnumSubscriptionPlan,
   CommitCreateInput,
+  EnumResourceTypeGroup,
 } from "../../models";
 import { ApolloError, useLazyQuery, useMutation } from "@apollo/client";
 import { cloneDeep, groupBy } from "lodash";
@@ -102,6 +103,7 @@ const useCommits = (currentProjectId: string, maxCommits?: number) => {
   ] = useLazyQuery<{ commits: Commit[] }>(GET_COMMITS, {
     variables: {
       projectId: currentProjectId,
+      resourceTypeGroup: EnumResourceTypeGroup.Services,
       skip: 0,
       take: 1,
       orderBy: {
@@ -228,6 +230,7 @@ const useCommits = (currentProjectId: string, maxCommits?: number) => {
     notifyOnNetworkStatusChange: true,
     variables: {
       projectId: currentProjectId,
+      resourceTypeGroup: EnumResourceTypeGroup.Services,
       take: maxCommits || MAX_ITEMS_PER_LOADING,
       skip: 0,
       orderBy: {

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -362,6 +362,7 @@ export type CommitWhereInput = {
   id?: InputMaybe<StringFilter>;
   message?: InputMaybe<StringFilter>;
   project: WhereUniqueInput;
+  resourceTypeGroup: EnumResourceTypeGroup;
   user?: InputMaybe<WhereUniqueInput>;
 };
 
@@ -2538,7 +2539,7 @@ export type QueryCommitsArgs = {
   orderBy?: InputMaybe<CommitOrderByInput>;
   skip?: InputMaybe<Scalars['Int']['input']>;
   take?: InputMaybe<Scalars['Int']['input']>;
-  where?: InputMaybe<CommitWhereInput>;
+  where: CommitWhereInput;
 };
 
 

--- a/packages/amplication-server/src/core/commit/commit.service.ts
+++ b/packages/amplication-server/src/core/commit/commit.service.ts
@@ -6,6 +6,7 @@ import { Commit } from "../../models";
 import { PendingChange } from "../resource/dto";
 import { EntityService } from "../entity/entity.service";
 import { BlockService } from "../block/block.service";
+import { RESOURCE_TYPE_GROUP_TO_RESOURCE_TYPE } from "../resource/constants";
 @Injectable()
 export class CommitService {
   constructor(
@@ -19,7 +20,29 @@ export class CommitService {
   }
 
   async findMany(args: FindManyCommitArgs): Promise<Commit[]> {
-    return this.prisma.commit.findMany(args);
+    const { resourceTypeGroup } = args.where;
+
+    const resourceTypes =
+      RESOURCE_TYPE_GROUP_TO_RESOURCE_TYPE[resourceTypeGroup];
+
+    const { where } = args;
+    delete where.resourceTypeGroup;
+
+    return this.prisma.commit.findMany({
+      ...args,
+      where: {
+        ...where,
+        builds: {
+          some: {
+            resource: {
+              resourceType: {
+                in: resourceTypes,
+              },
+            },
+          },
+        },
+      },
+    });
   }
 
   async getChanges(commitId: string): Promise<PendingChange[]> {

--- a/packages/amplication-server/src/core/commit/dto/CommitWhereInput.ts
+++ b/packages/amplication-server/src/core/commit/dto/CommitWhereInput.ts
@@ -1,5 +1,6 @@
 import { Field, InputType } from "@nestjs/graphql";
 import { WhereUniqueInput, DateTimeFilter, StringFilter } from "../../../dto";
+import { EnumResourceTypeGroup } from "../../resource/dto/EnumResourceTypeGroup";
 
 @InputType({
   isAbstract: true,
@@ -27,4 +28,7 @@ export class CommitWhereInput {
     nullable: true,
   })
   message?: StringFilter | null;
+
+  @Field(() => EnumResourceTypeGroup, { nullable: false })
+  resourceTypeGroup!: keyof typeof EnumResourceTypeGroup;
 }

--- a/packages/amplication-server/src/core/commit/dto/FindManyCommitArgs.ts
+++ b/packages/amplication-server/src/core/commit/dto/FindManyCommitArgs.ts
@@ -5,8 +5,8 @@ import { ArgsType, Field, Int } from "@nestjs/graphql";
 
 @ArgsType()
 export class FindManyCommitArgs {
-  @Field(() => CommitWhereInput, { nullable: true })
-  where?: CommitWhereInput | null | undefined;
+  @Field(() => CommitWhereInput, { nullable: false })
+  where!: CommitWhereInput;
 
   @Field(() => CommitOrderByInput, { nullable: true })
   orderBy?: CommitOrderByInput | null | undefined;

--- a/packages/amplication-server/src/core/project/project.service.ts
+++ b/packages/amplication-server/src/core/project/project.service.ts
@@ -32,6 +32,7 @@ import { SubscriptionService } from "../subscription/subscription.service";
 import { EnumCommitStrategy } from "../resource/dto/EnumCommitStrategy";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
 import { EnumResourceTypeGroup } from "../resource/dto/EnumResourceTypeGroup";
+import { RESOURCE_TYPE_GROUP_TO_RESOURCE_TYPE } from "../resource/constants";
 
 @Injectable()
 export class ProjectService {
@@ -347,6 +348,9 @@ export class ProjectService {
     const resourceTypeGroup =
       EnumResourceTypeGroup[args.data.resourceTypeGroup];
 
+    const resourceTypes =
+      RESOURCE_TYPE_GROUP_TO_RESOURCE_TYPE[resourceTypeGroup];
+
     if (await this.shouldBlockBuild(userId)) {
       const message = "Your current plan does not allow code generation.";
       throw new BillingLimitationError(message, BillingFeature.BlockBuild);
@@ -357,6 +361,9 @@ export class ProjectService {
         projectId: projectId,
         deletedAt: null,
         archived: { not: true },
+        resourceType: {
+          in: resourceTypes,
+        },
         project: {
           workspace: {
             users: {

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -334,6 +334,7 @@ input CommitWhereInput {
   id: StringFilter
   message: StringFilter
   project: WhereUniqueInput!
+  resourceTypeGroup: EnumResourceTypeGroup!
   user: WhereUniqueInput
 }
 
@@ -1867,7 +1868,7 @@ type Query {
   build(where: WhereUniqueInput!): Build!
   builds(orderBy: BuildOrderByInput, skip: Int, take: Int, where: BuildWhereInput): [Build!]!
   commit(where: CommitWhereUniqueInput!): Commit
-  commits(cursor: CommitWhereUniqueInput, orderBy: CommitOrderByInput, skip: Int, take: Int, where: CommitWhereInput): [Commit!]
+  commits(cursor: CommitWhereUniqueInput, orderBy: CommitOrderByInput, skip: Int, take: Int, where: CommitWhereInput!): [Commit!]
   contactUsLink(where: WhereUniqueInput!): String
   currentWorkspace: Workspace
   entities(orderBy: EntityOrderByInput, skip: Int, take: Int, where: EntityWhereInput): [Entity!]!

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -359,6 +359,7 @@ export type CommitWhereInput = {
   id?: InputMaybe<StringFilter>;
   message?: InputMaybe<StringFilter>;
   project: WhereUniqueInput;
+  resourceTypeGroup: EnumResourceTypeGroup;
   user?: InputMaybe<WhereUniqueInput>;
 };
 
@@ -2535,7 +2536,7 @@ export type QueryCommitsArgs = {
   orderBy?: InputMaybe<CommitOrderByInput>;
   skip?: InputMaybe<Scalars['Int']['input']>;
   take?: InputMaybe<Scalars['Int']['input']>;
-  where?: InputMaybe<CommitWhereInput>;
+  where: CommitWhereInput;
 };
 
 


### PR DESCRIPTION

Part of: https://github.com/amplication/amplication/issues/8935

## PR Details

Filter the commit list based on resource type group.
Only display the commits for services in the project commit list.
Disable the commit button for the platform console when there are no pending changes.
Use "Pending changes" strategy for platform commit 



## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
