### PR TITLE
feat(server):use dynamic dir name for services created with templates

### DIFF
--- a/packages/amplication-client/src/Project/ProjectList.scss
+++ b/packages/amplication-client/src/Project/ProjectList.scss
@@ -3,7 +3,7 @@
 .project-list {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
-  gap: var(--default-spacing);
+  gap: var(--double-spacing);
 
   .project-card {
     height: 200px;

--- a/packages/amplication-client/src/Project/ProjectListItem.tsx
+++ b/packages/amplication-client/src/Project/ProjectListItem.tsx
@@ -39,6 +39,7 @@ export const ProjectListItem = ({ project, workspaceId }: Props) => {
   return (
     <Link to={`/${workspaceId}/${project.id}`}>
       <Panel
+        themeColor={EnumTextColor.Secondary}
         className={CLASS_NAME}
         panelStyle={EnumPanelStyle.Bordered}
         clickable
@@ -81,7 +82,7 @@ export const ProjectListItem = ({ project, workspaceId }: Props) => {
 
             <FlexItem
               direction={EnumFlexDirection.Row}
-              gap={EnumGapSize.Small}
+              gap={EnumGapSize.Large}
               itemsAlign={EnumItemsAlign.Center}
             >
               <Link to={`/${workspaceId}/platform/${project.id}`}>

--- a/packages/amplication-client/src/Resource/constants.ts
+++ b/packages/amplication-client/src/Resource/constants.ts
@@ -235,7 +235,7 @@ export const resourceThemeMap: {
     color: "#f685a1",
   },
   [models.EnumResourceType.Service]: {
-    icon: "services",
+    icon: "code",
     color: "#A787FF",
   },
   [models.EnumResourceType.MessageBroker]: {

--- a/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
+++ b/packages/amplication-client/src/Resource/create-resource/CreateServiceWizard.tsx
@@ -235,12 +235,16 @@ const CreateServiceWizard: React.FC<Props> = ({
 
       const kebabCaseServiceName = kebabCase(serviceName);
 
-      const serverDir =
-        structureType === "Mono" ? `${baseDir}/${kebabCaseServiceName}` : "";
-      const adminDir =
-        structureType === "Mono"
-          ? `${baseDir}/${kebabCaseServiceName}-admin`
-          : "";
+      const serverDir = isServiceTemplateFlow
+        ? `${baseDir}/{{SERVICE_NAME}}`
+        : structureType === "Mono"
+        ? `${baseDir}/${kebabCaseServiceName}`
+        : "";
+      const adminDir = isServiceTemplateFlow
+        ? `${baseDir}/{{SERVICE_NAME}}-admin`
+        : structureType === "Mono"
+        ? `${baseDir}/${kebabCaseServiceName}-admin`
+        : "";
 
       if (currentProject) {
         const pluginIds: string[] = [databaseType];

--- a/packages/amplication-client/src/Resource/resourceSettings/DirectoriesServiceSettingsForm.tsx
+++ b/packages/amplication-client/src/Resource/resourceSettings/DirectoriesServiceSettingsForm.tsx
@@ -83,7 +83,6 @@ const DirectoriesServiceSettingsForm: React.FC<{}> = () => {
                     value={
                       data?.serviceSettings.serverSettings.serverPath || ""
                     }
-                    helpText={data?.serviceSettings.serverSettings.serverPath}
                     labelType="normal"
                   />
                 </>
@@ -98,9 +97,6 @@ const DirectoriesServiceSettingsForm: React.FC<{}> = () => {
                       }
                       value={
                         data?.serviceSettings.adminUISettings.adminUIPath || ""
-                      }
-                      helpText={
-                        data?.serviceSettings.adminUISettings.adminUIPath
                       }
                       labelType="normal"
                     />

--- a/packages/amplication-server/src/core/resource/serviceTemplate.service.ts
+++ b/packages/amplication-server/src/core/resource/serviceTemplate.service.ts
@@ -17,6 +17,7 @@ import { EnumEventType } from "../../services/segmentAnalytics/segmentAnalytics.
 import { PluginInstallationCreateInput } from "../pluginInstallation/dto/PluginInstallationCreateInput";
 import { PluginInstallationService } from "../pluginInstallation/pluginInstallation.service";
 import { EnumCodeGenerator } from "./dto/EnumCodeGenerator";
+import { kebabCase } from "lodash";
 
 @Injectable()
 export class ServiceTemplateService {
@@ -115,6 +116,20 @@ export class ServiceTemplateService {
       serviceTemplateId: args.data.serviceTemplate.id,
       version: "1",
     };
+
+    const kebabCaseServiceName = kebabCase(args.data.name);
+
+    serviceSettings.adminUISettings.adminUIPath =
+      serviceSettings.adminUISettings.adminUIPath.replace(
+        "{{SERVICE_NAME}}",
+        kebabCaseServiceName
+      );
+
+    serviceSettings.serverSettings.serverPath =
+      serviceSettings.serverSettings.serverPath.replace(
+        "{{SERVICE_NAME}}",
+        kebabCaseServiceName
+      );
 
     const newService = await this.resourceService.createService(
       {


### PR DESCRIPTION

Part of: https://github.com/amplication/amplication/issues/8935

## PR Details

Use a new placeholder for {{SERVICE_NAME}} on the template settings, and replace with the actual service name when creating a service from template

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
