### PR TITLE
feat(client):create service from template dialog

### DIFF
--- a/packages/amplication-client/src/Components/CreateResourceButton.tsx
+++ b/packages/amplication-client/src/Components/CreateResourceButton.tsx
@@ -14,6 +14,7 @@ import {
   FeatureIndicatorContainer,
 } from "./FeatureIndicatorContainer";
 import { useStiggContext } from "@stigg/react-sdk";
+import { CREATE_SERVICE_FROM_TEMPLATE_TRIGGER_URL } from "../ServiceTemplate/NewServiceFromTemplateDialogWithUrlTrigger";
 
 const CLASS_NAME = "create-resource-button";
 
@@ -31,6 +32,12 @@ const ITEMS: CreateResourceButtonItemType[] = [
     label: "Service",
     route: "create-resource",
     info: "Create a service with your choice of APIs, database, and authentication",
+  },
+  {
+    type: models.EnumResourceType.ServiceTemplate,
+    label: "Service From Template",
+    route: `?${CREATE_SERVICE_FROM_TEMPLATE_TRIGGER_URL}`,
+    info: "Create a service from a pre-configured template",
   },
   {
     type: models.EnumResourceType.MessageBroker,

--- a/packages/amplication-client/src/Entity/EntityList.tsx
+++ b/packages/amplication-client/src/Entity/EntityList.tsx
@@ -17,7 +17,7 @@ import {
 } from "@amplication/ui/design-system";
 import { gql, useQuery } from "@apollo/client";
 import React, { useCallback, useEffect, useState } from "react";
-import { Link, match, useLocation } from "react-router-dom";
+import { Link, match } from "react-router-dom";
 import PageContent, { EnumPageWidth } from "../Layout/PageContent";
 import * as models from "../models";
 import { AnalyticsEventNames } from "../util/analytics-events.types";
@@ -41,6 +41,7 @@ import { pluralize } from "../util/pluralize";
 import { useResourceBaseUrl } from "../util/useResourceBaseUrl";
 import EntitiesERD from "./EntityERD/EntitiesERD";
 import "./EntityList.scss";
+import { useUrlQuery } from "../util/useUrlQuery";
 
 type TData = {
   entities: models.Entity[];
@@ -60,10 +61,6 @@ const NAME_FIELD = "displayName";
 const CLASS_NAME = "entity-list";
 
 const POLL_INTERVAL = 30000;
-
-function useUrlQuery() {
-  return new URLSearchParams(useLocation().search);
-}
 
 const EntityList: React.FC<Props> = ({ match, innerRoutes }) => {
   const { resource } = match.params;

--- a/packages/amplication-client/src/ServiceTemplate/NewServiceFromTemplate.tsx
+++ b/packages/amplication-client/src/ServiceTemplate/NewServiceFromTemplate.tsx
@@ -29,7 +29,7 @@ type CreateType = Omit<
 };
 
 type Props = {
-  serviceTemplateId: string;
+  serviceTemplateId?: string;
   projectId: string;
 };
 
@@ -88,7 +88,7 @@ const NewServiceFromTemplate = ({ serviceTemplateId, projectId }: Props) => {
 
   const initialValues = {
     ...INITIAL_VALUES,
-    serviceTemplateId,
+    serviceTemplateId: serviceTemplateId || options[0]?.value,
   };
 
   return (

--- a/packages/amplication-client/src/ServiceTemplate/NewServiceFromTemplateDialogWithUrlTrigger.tsx
+++ b/packages/amplication-client/src/ServiceTemplate/NewServiceFromTemplateDialogWithUrlTrigger.tsx
@@ -1,0 +1,46 @@
+import { Dialog } from "@amplication/ui/design-system";
+import { useCallback, useEffect, useState } from "react";
+import { useHistory } from "react-router-dom";
+import { useAppContext } from "../context/appContext";
+import { useUrlQuery } from "../util/useUrlQuery";
+import NewServiceFromTemplate from "./NewServiceFromTemplate";
+
+export const CREATE_SERVICE_FROM_TEMPLATE_TRIGGER_URL =
+  "create-service-from-template";
+
+const NewServiceFromTemplateDialogWithUrlTrigger = () => {
+  const history = useHistory();
+  const { currentProject } = useAppContext();
+
+  const [createFromTemplateIsOpen, setCreateFromTemplateIsOpen] =
+    useState(false);
+
+  const query = useUrlQuery();
+
+  const handleDismissCreateFromTemplate = useCallback(() => {
+    setCreateFromTemplateIsOpen(false);
+    query.delete(CREATE_SERVICE_FROM_TEMPLATE_TRIGGER_URL);
+
+    history.replace({
+      search: query.toString(),
+    });
+  }, [history, query]);
+
+  useEffect(() => {
+    if (query.has(CREATE_SERVICE_FROM_TEMPLATE_TRIGGER_URL)) {
+      setCreateFromTemplateIsOpen(true);
+    }
+  }, [query]);
+
+  return (
+    <Dialog
+      isOpen={createFromTemplateIsOpen}
+      onDismiss={handleDismissCreateFromTemplate}
+      title="Create Service"
+    >
+      <NewServiceFromTemplate projectId={currentProject?.id} />
+    </Dialog>
+  );
+};
+
+export default NewServiceFromTemplateDialogWithUrlTrigger;

--- a/packages/amplication-client/src/Workspaces/ResourceList.tsx
+++ b/packages/amplication-client/src/Workspaces/ResourceList.tsx
@@ -33,6 +33,7 @@ import "./ResourceList.scss";
 import { RESOURCE_LIST_COLUMNS } from "./ResourceListDataColumns";
 import ResourceListItem from "./ResourceListItem";
 import { useProjectBaseUrl } from "../util/useProjectBaseUrl";
+import NewServiceFromTemplateDialogWithUrlTrigger from "../ServiceTemplate/NewServiceFromTemplateDialogWithUrlTrigger";
 
 const CLASS_NAME = "resource-list";
 const PAGE_TITLE = "Project Overview";
@@ -84,6 +85,7 @@ function ResourceList() {
 
   return (
     <PageContent className={CLASS_NAME} pageTitle={PAGE_TITLE}>
+      <NewServiceFromTemplateDialogWithUrlTrigger />
       <FlexItem
         itemsAlign={EnumItemsAlign.Center}
         contentAlign={EnumContentAlign.Start}

--- a/packages/amplication-client/src/util/useUrlQuery.tsx
+++ b/packages/amplication-client/src/util/useUrlQuery.tsx
@@ -1,0 +1,5 @@
+import { useLocation } from "react-router-dom";
+
+export const useUrlQuery = () => {
+  return new URLSearchParams(useLocation().search);
+};


### PR DESCRIPTION
Part of: https://github.com/amplication/amplication/issues/8935

## PR Details

Add an option to create a service from a template in the resource list

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
