### PR TITLE
feat(client):add settings fields on private plugin version

### DIFF
--- a/packages/amplication-client/src/PrivatePluginVersion/PrivatePluginVersionCodeField.tsx
+++ b/packages/amplication-client/src/PrivatePluginVersion/PrivatePluginVersionCodeField.tsx
@@ -33,7 +33,6 @@ const PrivatePluginVersionCodeField = ({
 
       if (validateChange) {
         const jsonValue = JsonFormatting(value);
-        console.log(jsonValue);
         setValue(JSON.parse(jsonValue));
         setError(undefined);
       } else {

--- a/packages/amplication-client/src/PrivatePluginVersion/PrivatePluginVersionCodeField.tsx
+++ b/packages/amplication-client/src/PrivatePluginVersion/PrivatePluginVersionCodeField.tsx
@@ -1,0 +1,72 @@
+import {
+  CodeEditor,
+  EnumContentAlign,
+  EnumFlexDirection,
+  EnumItemsAlign,
+  EnumTextStyle,
+  FlexItem,
+  Text,
+} from "@amplication/ui/design-system";
+import { JsonFormatting, isValidJSON } from "@amplication/util/json";
+import { useField } from "formik";
+import { useCallback } from "react";
+
+type Props = {
+  name: string;
+  label: string;
+  initialValue: string;
+};
+
+const CLASS_NAME = "private-plugin-version-code-field";
+
+const PrivatePluginVersionCodeField = ({
+  name,
+  label,
+  initialValue,
+}: Props) => {
+  const [field, meta, { setValue, setError }] = useField({
+    name: name,
+  });
+  const handleChange = useCallback(
+    (value: string) => {
+      const validateChange = isValidJSON(value);
+
+      if (validateChange) {
+        const jsonValue = JsonFormatting(value);
+        console.log(jsonValue);
+        setValue(JSON.parse(jsonValue));
+        setError(undefined);
+      } else {
+        setError("Invalid JSON");
+      }
+    },
+    [setError, setValue]
+  );
+
+  const formattedValue = JsonFormatting(initialValue);
+
+  return (
+    <FlexItem
+      className={CLASS_NAME}
+      direction={EnumFlexDirection.Column}
+      contentAlign={EnumContentAlign.Center}
+      itemsAlign={EnumItemsAlign.Stretch}
+    >
+      <Text textStyle={EnumTextStyle.Label}>{label}</Text>
+      <CodeEditor
+        height={"100px"}
+        width="100%"
+        defaultValue={formattedValue}
+        onChange={handleChange}
+        defaultLanguage={"json"}
+        options={{
+          selectOnLineNumbers: false,
+          readOnly: false,
+          renderLineHighlight: "none",
+        }}
+      />
+    </FlexItem>
+  );
+};
+
+export default PrivatePluginVersionCodeField;

--- a/packages/amplication-client/src/PrivatePluginVersion/PrivatePluginVersionForm.scss
+++ b/packages/amplication-client/src/PrivatePluginVersion/PrivatePluginVersionForm.scss
@@ -1,0 +1,5 @@
+@import "../style/index.scss";
+
+.private-plugin-version-form {
+  width: 100%;
+}

--- a/packages/amplication-client/src/PrivatePluginVersion/PrivatePluginVersionForm.tsx
+++ b/packages/amplication-client/src/PrivatePluginVersion/PrivatePluginVersionForm.tsx
@@ -1,5 +1,8 @@
 import {
+  Button,
+  EnumButtonStyle,
   EnumFlexDirection,
+  EnumFlexItemMargin,
   EnumItemsAlign,
   EnumPanelStyle,
   EnumVersionTagState,
@@ -11,10 +14,11 @@ import {
 } from "@amplication/ui/design-system";
 import { Formik } from "formik";
 import { omit } from "lodash";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import * as models from "../models";
-import FormikAutoSave from "../util/formikAutoSave";
 import { validate } from "../util/formikValidateJsonSchema";
+import PrivatePluginVersionCodeField from "./PrivatePluginVersionCodeField";
+import "./PrivatePluginVersionForm.scss";
 
 type Props = {
   onSubmit: (values: models.PrivatePluginVersion) => void;
@@ -36,6 +40,8 @@ export const INITIAL_VALUES: Partial<models.PrivatePluginVersion> = {
 
 const FORM_SCHEMA = {};
 
+const CLASS_NAME = "private-plugin-version-form";
+
 const PrivatePluginVersionForm = ({
   onSubmit,
   onVersionClose,
@@ -43,6 +49,8 @@ const PrivatePluginVersionForm = ({
   disabled,
   privatePlugin,
 }: Props) => {
+  const [showDetails, setShowDetails] = useState<boolean>(false);
+
   const initialValues = useMemo(() => {
     const sanitizedDefaultValues = omit(
       {
@@ -57,6 +65,11 @@ const PrivatePluginVersionForm = ({
     } as models.PrivatePluginVersion;
   }, [defaultValues]);
 
+  //we are not using auto-save to allow the use to save the changes only after they have finished editing
+  const handleChange = (formik) => {
+    formik.submitForm();
+  };
+
   return (
     <Formik
       initialValues={initialValues}
@@ -68,13 +81,22 @@ const PrivatePluginVersionForm = ({
     >
       {(formik) => {
         return (
-          <Panel style={{ padding: 0 }} panelStyle={EnumPanelStyle.Transparent}>
+          <Panel className={CLASS_NAME} panelStyle={EnumPanelStyle.Transparent}>
             <Form>
-              {!disabled && <FormikAutoSave debounceMS={1000} />}
-
               <FlexItem
                 itemsAlign={EnumItemsAlign.Center}
                 direction={EnumFlexDirection.Row}
+                end={
+                  <>
+                    <Button
+                      buttonStyle={EnumButtonStyle.Text}
+                      icon="edit_2"
+                      onClick={() => {
+                        setShowDetails(!showDetails);
+                      }}
+                    />
+                  </>
+                }
               >
                 <VersionTag
                   version={initialValues.version}
@@ -87,9 +109,52 @@ const PrivatePluginVersionForm = ({
                   }
                 />
 
-                <ToggleField label="Enabled" name="enabled" />
-                <ToggleField label="Deprecated" name="deprecated" />
+                <ToggleField
+                  label="Enabled"
+                  name="enabled"
+                  onValueChange={() => {
+                    handleChange(formik);
+                  }}
+                />
+                <ToggleField
+                  label="Deprecated"
+                  name="deprecated"
+                  onValueChange={() => {
+                    handleChange(formik);
+                  }}
+                />
               </FlexItem>
+              {showDetails && (
+                <FlexItem
+                  direction={EnumFlexDirection.Column}
+                  itemsAlign={EnumItemsAlign.End}
+                >
+                  <FlexItem
+                    direction={EnumFlexDirection.Row}
+                    margin={EnumFlexItemMargin.Top}
+                  >
+                    <PrivatePluginVersionCodeField
+                      name="settings"
+                      label="Settings"
+                      initialValue={initialValues.settings}
+                    />
+                    <PrivatePluginVersionCodeField
+                      name="configurations"
+                      label="Configurations"
+                      initialValue={initialValues.configurations}
+                    />
+                  </FlexItem>
+                  <Button
+                    buttonStyle={EnumButtonStyle.Primary}
+                    disabled={disabled || !formik.isValid || !formik.dirty}
+                    onClick={() => {
+                      handleChange(formik);
+                    }}
+                  >
+                    Save
+                  </Button>
+                </FlexItem>
+              )}
             </Form>
           </Panel>
         );


### PR DESCRIPTION

part of Close: https://github.com/amplication/amplication/issues/8990

## PR Details

Add json fields to edit the settings and configurations fields

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
