### PR TITLE
fet(server):recalc build status

### DIFF
--- a/packages/amplication-server/src/core/build/build.resolver.ts
+++ b/packages/amplication-server/src/core/build/build.resolver.ts
@@ -14,6 +14,7 @@ import { BuildService } from "./build.service";
 import { Build } from "./dto/Build";
 import { FindManyBuildArgs } from "./dto/FindManyBuildArgs";
 import { FindOneBuildArgs } from "./dto/FindOneBuildArgs";
+import { EnumBuildStatus } from "./dto/EnumBuildStatus";
 
 @Resolver(() => Build)
 @UseFilters(GqlResolverExceptionsFilter)
@@ -62,5 +63,13 @@ export class BuildResolver {
   @ResolveField()
   archiveURI(@Parent() build: Build): string {
     return `/generated-apps/${build.id}.zip`;
+  }
+
+  @ResolveField()
+  status(@Parent() build: Build): Promise<EnumBuildStatus> {
+    if (build.status === EnumBuildStatus.Unknown) {
+      return this.service.calcBuildStatus(build.id);
+    }
+    return Promise.resolve(EnumBuildStatus[build.status]);
   }
 }

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -1344,7 +1344,12 @@ export class BuildService {
     if (build.status !== EnumBuildStatus.Unknown)
       return build.status as EnumBuildStatus;
 
-    if (!build.action?.steps?.length) return EnumBuildStatus.Invalid;
+    if (!build.action?.steps?.length) {
+      this.logger.error(
+        `calcBuildStatus: Could not find steps for build with id ${buildId}`
+      );
+      return EnumBuildStatus.Invalid;
+    }
     const steps = build.action.steps;
 
     if (steps.every((step) => step.status === EnumActionStepStatus.Success)) {

--- a/packages/amplication-server/src/core/project/project.resolver.spec.ts
+++ b/packages/amplication-server/src/core/project/project.resolver.spec.ts
@@ -208,6 +208,8 @@ const PENDING_CHANGE_QUERY = gql`
           actionId
           createdAt
           commitId
+          status
+          gitStatus
         }
         environments {
           id

--- a/packages/amplication-server/src/core/resource/resource.resolver.spec.ts
+++ b/packages/amplication-server/src/core/resource/resource.resolver.spec.ts
@@ -134,6 +134,8 @@ const FIND_ONE_RESOURCE_QUERY = gql`
         actionId
         createdAt
         commitId
+        status
+        gitStatus
       }
       environments {
         id
@@ -175,6 +177,8 @@ const FIND_MANY_BUILDS_QUERY = gql`
         actionId
         createdAt
         commitId
+        status
+        gitStatus
       }
     }
   }
@@ -224,6 +228,8 @@ const CREATE_SERVICE_MUTATION = gql`
         actionId
         createdAt
         commitId
+        status
+        gitStatus
       }
       environments {
         id
@@ -265,6 +271,8 @@ const DELETE_RESOURCE_MUTATION = gql`
         actionId
         createdAt
         commitId
+        status
+        gitStatus
       }
       environments {
         id
@@ -306,6 +314,8 @@ const UPDATE_RESOURCE_MUTATION = gql`
         actionId
         createdAt
         commitId
+        status
+        gitStatus
       }
       environments {
         id

--- a/packages/amplication-server/src/core/resource/resource.service.spec.ts
+++ b/packages/amplication-server/src/core/resource/resource.service.spec.ts
@@ -151,6 +151,8 @@ const EXAMPLE_RESOURCE: Resource = {
       message: "new build",
       actionId: "ExampleActionId",
       commitId: "exampleCommitId",
+      status: EnumBuildStatus.Completed,
+      gitStatus: EnumBuildGitStatus.Completed,
     },
   ],
   gitRepository: EXAMPLE_GIT_REPOSITORY,


### PR DESCRIPTION
part of https://github.com/amplication/amplication/issues/8997



## PR Details

Recalculate the build status of old builds with lazy data migration.
The default value of the new field is Unknown - so use the @FieldResolver to recalculate and update the build status when the status is Unknown, otherwise return the status already saved in the DB

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
