### PR TITLE
Add infra for messages to notify plugin versions used in build process

### DIFF
--- a/libs/schema-registry/src/index.ts
+++ b/libs/schema-registry/src/index.ts
@@ -23,6 +23,7 @@ export * as DownloadPrivatePluginsRequest from "./lib/download-private-plugins-r
 export * as DownloadPrivatePluginsSuccess from "./lib/download-private-plugins-success";
 export * as DownloadPrivatePluginsFailure from "./lib/download-private-plugins-failure";
 export * as DownloadPrivatePluginsLog from "./lib/download-private-plugins-log";
+export * as PluginNotifyVersion from "./lib/plugin-notify-version";
 
 export enum KAFKA_TOPICS {
   /// build-manager
@@ -31,6 +32,7 @@ export enum KAFKA_TOPICS {
   CODE_GENERATION_SUCCESS_TOPIC = "build.internal.code-generation.success.1",
   CODE_GENERATION_FAILURE_TOPIC = "build.internal.code-generation.failure.1",
   CODE_GENERATION_NOTIFY_VERSION_TOPIC = "build.internal.code-generation.notify-version.1",
+  BUILD_PLUGIN_NOTIFY_VERSION_TOPIC = "build.internal.plugin.notify-version.1",
   DSG_LOG_TOPIC = "build.internal.dsg-log.1",
   /// git-pull-request
   CREATE_PULL_REQUEST_COMPLETED_TOPIC = "git.internal.pull-request.completed.1",

--- a/libs/schema-registry/src/lib/plugin-notify-version/index.ts
+++ b/libs/schema-registry/src/lib/plugin-notify-version/index.ts
@@ -1,0 +1,10 @@
+import { DecodedKafkaMessage } from "@amplication/util/kafka";
+import { Key } from "./key";
+import { Value } from "./value";
+
+interface KafkaEvent extends DecodedKafkaMessage {
+  key: Key;
+  value: Value;
+}
+
+export { Key, Value, KafkaEvent };

--- a/libs/schema-registry/src/lib/plugin-notify-version/key.ts
+++ b/libs/schema-registry/src/lib/plugin-notify-version/key.ts
@@ -1,0 +1,1 @@
+export class Key {}

--- a/libs/schema-registry/src/lib/plugin-notify-version/value.ts
+++ b/libs/schema-registry/src/lib/plugin-notify-version/value.ts
@@ -1,0 +1,15 @@
+import { IsString } from "class-validator";
+
+export class Value {
+  @IsString()
+  buildId!: string;
+
+  @IsString()
+  requestedFullPackageName!: string; // @amplication/db-postgres@latest
+
+  @IsString()
+  packageName!: string; // @amplication/db-postgres
+
+  @IsString()
+  packageVersion!: string; // 1.0.1
+}

--- a/packages/amplication-build-manager/src/build-runner/build-runner.controller.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.controller.ts
@@ -11,6 +11,7 @@ import {
   PackageManagerCreateFailure,
 } from "@amplication/schema-registry";
 import { plainToInstance } from "class-transformer";
+import { NotifyPluginVersionDto } from "./dto/NotifyPluginVersion";
 
 @Controller("build-runner")
 export class BuildRunnerController {
@@ -24,6 +25,13 @@ export class BuildRunnerController {
     @Payload() dto: CodeGenerationSuccessDto
   ): Promise<void> {
     await this.buildRunnerService.onCodeGenerationSuccess(dto);
+  }
+
+  @Post("notify-plugin-version")
+  async onNotifyPluginVersion(
+    @Payload() dto: NotifyPluginVersionDto
+  ): Promise<void> {
+    await this.buildRunnerService.emitBuildPluginNotifyVersion(dto);
   }
 
   @Post("code-generation-failure")

--- a/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
+++ b/packages/amplication-build-manager/src/build-runner/build-runner.service.ts
@@ -17,6 +17,7 @@ import {
   PackageManagerCreateFailure,
   PackageManagerCreateRequest,
   PackageManagerCreateSuccess,
+  PluginNotifyVersion,
 } from "@amplication/schema-registry";
 import { CodeGenerationRequest, EnumJobStatus } from "../types";
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
@@ -25,6 +26,7 @@ import { CodeGenerationFailureDto } from "./dto/CodeGenerationFailure";
 import { CodeGenerationSuccessDto } from "./dto/CodeGenerationSuccess";
 import { BuildLoggerService } from "../build-logger/build-logger.service";
 import { LogLevel } from "@amplication/util/logging";
+import { NotifyPluginVersionDto } from "./dto/NotifyPluginVersion";
 
 const OLD_DSG_IMAGE_NAME = "data-service-generator";
 
@@ -311,6 +313,20 @@ export class BuildRunnerService {
     await this.producerService.emitMessage(
       KAFKA_TOPICS.CODE_GENERATION_FAILURE_TOPIC,
       failureEvent
+    );
+  }
+
+  async emitBuildPluginNotifyVersion(args: NotifyPluginVersionDto) {
+    const event: PluginNotifyVersion.KafkaEvent = {
+      key: null,
+      value: args,
+    };
+
+    this.logger.debug("Emitting notify plugin version event", event);
+
+    await this.producerService.emitMessage(
+      KAFKA_TOPICS.BUILD_PLUGIN_NOTIFY_VERSION_TOPIC,
+      event
     );
   }
 

--- a/packages/amplication-build-manager/src/build-runner/dto/NotifyPluginVersion.ts
+++ b/packages/amplication-build-manager/src/build-runner/dto/NotifyPluginVersion.ts
@@ -1,0 +1,6 @@
+export class NotifyPluginVersionDto {
+  buildId!: string;
+  requestedFullPackageName!: string;
+  packageName!: string;
+  packageVersion!: string;
+}

--- a/packages/amplication-prisma-db/prisma/migrations/20241002062702_/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20241002062702_/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `pacakgeName` on the `BuildPlugin` table. All the data in the column will be lost.
+  - You are about to drop the column `pacakgeVersion` on the `BuildPlugin` table. All the data in the column will be lost.
+  - Added the required column `packageName` to the `BuildPlugin` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `packageVersion` to the `BuildPlugin` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "BuildPlugin" DROP COLUMN "pacakgeName",
+DROP COLUMN "pacakgeVersion",
+ADD COLUMN     "packageName" TEXT NOT NULL,
+ADD COLUMN     "packageVersion" TEXT NOT NULL;

--- a/packages/amplication-prisma-db/prisma/migrations/20241002063144_/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20241002063144_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[buildId,packageName]` on the table `BuildPlugin` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "BuildPlugin.buildId_packageName_unique" ON "BuildPlugin"("buildId", "packageName");

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -444,8 +444,10 @@ model BuildPlugin {
   buildId                  String
   build                    Build    @relation(fields: [buildId], references: [id], onDelete: Cascade)
   requestedFullPackageName String // @amplication/db-postgres@latest
-  pacakgeName              String // @amplication/db-postgres
-  pacakgeVersion           String // 1.0.1
+  packageName              String // @amplication/db-postgres
+  packageVersion           String // 1.0.1
+
+  @@unique([buildId, packageName], map: "BuildPlugin.buildId_packageName_unique")
 }
 
 model ResourceVersion {

--- a/packages/amplication-server/src/core/build/build.controller.ts
+++ b/packages/amplication-server/src/core/build/build.controller.ts
@@ -18,6 +18,7 @@ import {
   DownloadPrivatePluginsLog,
   DownloadPrivatePluginsSuccess,
   CodeGenerationNotifyVersion,
+  PluginNotifyVersion,
 } from "@amplication/schema-registry";
 
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
@@ -62,6 +63,23 @@ export class BuildController {
       this.logger.error("Failed to update code generator version ", error, {
         buildId: args.buildId,
         codeGeneratorVersion: args.codeGeneratorVersion,
+      });
+    }
+  }
+
+  @EventPattern(KAFKA_TOPICS.BUILD_PLUGIN_NOTIFY_VERSION_TOPIC)
+  async onPluginNotifyVersion(
+    @Payload() message: PluginNotifyVersion.Value
+  ): Promise<void> {
+    const args = plainToInstance(PluginNotifyVersion.Value, message);
+    try {
+      await this.buildService.notifyBuildPluginVersion(args);
+    } catch (error) {
+      this.logger.error("Failed to update plugin version ", error, {
+        buildId: args.buildId,
+        requestedFullPackageName: args.requestedFullPackageName,
+        packageName: args.packageName,
+        packageVersion: args.packageVersion,
       });
     }
   }

--- a/packages/amplication-server/src/core/build/dto/BuildPlugin.ts
+++ b/packages/amplication-server/src/core/build/dto/BuildPlugin.ts
@@ -1,0 +1,28 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { Build } from "./Build";
+
+@ObjectType({
+  isAbstract: true,
+})
+export class BuildPlugin {
+  @Field(() => String, { nullable: false })
+  id!: string;
+
+  @Field(() => Date, { nullable: false })
+  createdAt!: Date;
+
+  @Field(() => Build, { nullable: true })
+  build?: Build;
+
+  @Field(() => String, { nullable: false })
+  buildId!: string;
+
+  @Field(() => String, { nullable: false })
+  requestedFullPackageName!: string;
+
+  @Field(() => String, { nullable: false })
+  packageName!: string;
+
+  @Field(() => String, { nullable: false })
+  packageVersion!: string;
+}


### PR DESCRIPTION


Close: https://github.com/amplication/amplication/issues/9021

## PR Details

Add new model to save the plugin versions used in build 

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
