### PR TITLE
feat: Set template version on service creation

### DIFF
--- a/ee/packages/git-sync-manager/src/models.ts
+++ b/ee/packages/git-sync-manager/src/models.ts
@@ -2933,6 +2933,7 @@ export type Resource = {
   projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
   serviceTemplate?: Maybe<Resource>;
+  serviceTemplateVersion?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
   version?: Maybe<ResourceVersion>;
 };

--- a/libs/util/code-gen-types/src/models.ts
+++ b/libs/util/code-gen-types/src/models.ts
@@ -2933,6 +2933,7 @@ export type Resource = {
   projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
   serviceTemplate?: Maybe<Resource>;
+  serviceTemplateVersion?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
   version?: Maybe<ResourceVersion>;
 };

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -2933,6 +2933,7 @@ export type Resource = {
   projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
   serviceTemplate?: Maybe<Resource>;
+  serviceTemplateVersion?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
   version?: Maybe<ResourceVersion>;
 };

--- a/packages/amplication-client/src/Project/ProjectPage.tsx
+++ b/packages/amplication-client/src/Project/ProjectPage.tsx
@@ -23,7 +23,7 @@ type Props = AppRouteProps & {
     project: string;
   }>;
 };
-const OVERVIEW = "Services";
+const OVERVIEW = "Catalog";
 
 const ProjectPage: React.FC<Props> = ({
   innerRoutes,

--- a/packages/amplication-client/src/Workspaces/ResourceListDataColumns.tsx
+++ b/packages/amplication-client/src/Workspaces/ResourceListDataColumns.tsx
@@ -1,4 +1,4 @@
-import { EnumTextStyle, Text } from "@amplication/ui/design-system";
+import { EnumTextStyle, Text, VersionTag } from "@amplication/ui/design-system";
 import { CodeGeneratorImage } from "../Components/CodeGeneratorImage";
 import ResourceCircleBadge from "../Components/ResourceCircleBadge";
 import { EnumResourceType, Resource } from "../models";
@@ -106,6 +106,24 @@ export const RESOURCE_LIST_COLUMNS: DataGridColumn<Resource>[] = [
       );
     },
     getValue: (row) => (row.serviceTemplate ? row.serviceTemplate.name : ""),
+    resizable: true,
+  },
+  {
+    key: "templateVersion",
+    name: "Template Version",
+    sortable: true,
+    width: 150,
+    renderCell: (props) => {
+      return (
+        <>
+          {props.row.serviceTemplateVersion && (
+            <VersionTag version={props.row.serviceTemplateVersion} />
+          )}
+        </>
+      );
+    },
+    getValue: (row) =>
+      row.serviceTemplateVersion ? row.serviceTemplateVersion : "",
     resizable: true,
   },
   {

--- a/packages/amplication-client/src/Workspaces/WorkspaceLayout.scss
+++ b/packages/amplication-client/src/Workspaces/WorkspaceLayout.scss
@@ -8,6 +8,12 @@
   color: var(--gray-base);
   flex: 1;
 
+  &--with-side-panel {
+    .amp-page-layout {
+      max-width: calc(100vw - var(--changes-menu-width) - 2px);
+    }
+  }
+
   &__page_content {
     display: flex;
     flex: 1;

--- a/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
+++ b/packages/amplication-client/src/Workspaces/WorkspaceLayout.tsx
@@ -33,6 +33,7 @@ import Assistant from "../Assistant/Assistant";
 import ResponsiveContainer from "../Components/ResponsiveContainer";
 import { AssistantContextProvider } from "../Assistant/context/AssistantContext";
 import { useProjectBaseUrl } from "../util/useProjectBaseUrl";
+import classNames from "classnames";
 
 const MobileMessage = lazy(() => import("../Layout/MobileMessage"));
 
@@ -174,6 +175,8 @@ const WorkspaceLayout: React.FC<Props> = ({
     }
   }, [currentWorkspace, trackEvent]);
 
+  const showSideBar = !!currentProject;
+
   return currentWorkspace ? (
     <AppContextProvider
       newVal={{
@@ -250,7 +253,11 @@ const WorkspaceLayout: React.FC<Props> = ({
                     <Assistant />
                   </div>
                 )}
-                <div className={moduleClass}>
+                <div
+                  className={classNames(moduleClass, {
+                    [`${moduleClass}--with-side-panel`]: showSideBar,
+                  })}
+                >
                   <WorkspaceHeader />
                   <CompleteInvitation />
                   <RedeemCoupon />
@@ -262,7 +269,7 @@ const WorkspaceLayout: React.FC<Props> = ({
                       {innerRoutes}
                     </ResponsiveContainer>
 
-                    {currentProject ? (
+                    {showSideBar ? (
                       <div className={`${moduleClass}__changes_menu`}>
                         <PendingChanges projectId={currentProject.id} />
                         {!isPlatformConsole && commitUtils.lastCommit && (

--- a/packages/amplication-client/src/Workspaces/queries/resourcesQueries.ts
+++ b/packages/amplication-client/src/Workspaces/queries/resourcesQueries.ts
@@ -38,6 +38,7 @@ export const GET_RESOURCES = gql`
         id
         name
       }
+      serviceTemplateVersion
       gitRepository {
         id
         name

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -2936,6 +2936,7 @@ export type Resource = {
   projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
   serviceTemplate?: Maybe<Resource>;
+  serviceTemplateVersion?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
   version?: Maybe<ResourceVersion>;
 };

--- a/packages/amplication-server/src/core/resource/resource.resolver.ts
+++ b/packages/amplication-server/src/core/resource/resource.resolver.ts
@@ -260,6 +260,33 @@ export class ResourceResolver {
     });
   }
 
+  @ResolveField(() => String, { nullable: true })
+  async serviceTemplateVersion(
+    @Parent() resource: Resource,
+    @UserEntity() user: User
+  ): Promise<string> {
+    if (!resource.id) {
+      return null;
+    }
+
+    if (resource.resourceType !== EnumResourceType.Service) {
+      return null;
+    }
+
+    const settings = await this.serviceSettingsService.getServiceSettingsBlock(
+      {
+        where: { id: resource.id },
+      },
+      user
+    );
+
+    if (!settings?.serviceTemplateVersion) {
+      return null;
+    }
+
+    return settings.serviceTemplateVersion.version;
+  }
+
   @ResolveField(() => ResourceVersion, { nullable: true })
   async version(
     @Parent() resource: Resource,

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -2038,6 +2038,7 @@ type Resource {
   projectId: String
   resourceType: EnumResourceType!
   serviceTemplate: Resource
+  serviceTemplateVersion: String
   updatedAt: DateTime!
   version: ResourceVersion
 }

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -2933,6 +2933,7 @@ export type Resource = {
   projectId?: Maybe<Scalars['String']['output']>;
   resourceType: EnumResourceType;
   serviceTemplate?: Maybe<Resource>;
+  serviceTemplateVersion?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
   version?: Maybe<ResourceVersion>;
 };


### PR DESCRIPTION


part of [#8942](https://github.com/amplication/amplication/issues/8942)

## PR Details

set the template version on service creation and show the template version on the catalog

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
