### PR TITLE
feat(server):cancel previous alerts when creating new alerts for the same objects

### DIFF
--- a/ee/packages/git-sync-manager/src/models.ts
+++ b/ee/packages/git-sync-manager/src/models.ts
@@ -959,6 +959,7 @@ export enum EnumModuleDtoType {
 }
 
 export enum EnumOutdatedVersionAlertStatus {
+  Canceled = 'Canceled',
   Ignored = 'Ignored',
   New = 'New',
   Resolved = 'Resolved'

--- a/libs/util/code-gen-types/src/models.ts
+++ b/libs/util/code-gen-types/src/models.ts
@@ -959,6 +959,7 @@ export enum EnumModuleDtoType {
 }
 
 export enum EnumOutdatedVersionAlertStatus {
+  Canceled = 'Canceled',
   Ignored = 'Ignored',
   New = 'New',
   Resolved = 'Resolved'

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -959,6 +959,7 @@ export enum EnumModuleDtoType {
 }
 
 export enum EnumOutdatedVersionAlertStatus {
+  Canceled = 'Canceled',
   Ignored = 'Ignored',
   New = 'New',
   Resolved = 'Resolved'

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -962,6 +962,7 @@ export enum EnumModuleDtoType {
 }
 
 export enum EnumOutdatedVersionAlertStatus {
+  Canceled = 'Canceled',
   Ignored = 'Ignored',
   New = 'New',
   Resolved = 'Resolved'

--- a/packages/amplication-prisma-db/prisma/migrations/20241005072219_migration/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20241005072219_migration/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "EnumOutdatedVersionAlertStatus" ADD VALUE 'Canceled';

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -502,6 +502,7 @@ enum EnumOutdatedVersionAlertStatus {
   New
   Resolved
   Ignored
+  Canceled
 }
 
 enum EnumOutdatedVersionAlertType {

--- a/packages/amplication-server/src/core/outdatedVersionAlert/dto/EnumOutdatedVersionAlertStatus.ts
+++ b/packages/amplication-server/src/core/outdatedVersionAlert/dto/EnumOutdatedVersionAlertStatus.ts
@@ -4,6 +4,7 @@ export enum EnumOutdatedVersionAlertStatus {
   New = "New",
   Resolved = "Resolved",
   Ignored = "Ignored",
+  Canceled = "Canceled",
 }
 
 registerEnumType(EnumOutdatedVersionAlertStatus, {

--- a/packages/amplication-server/src/core/outdatedVersionAlert/outdatedVersionAlert.service.ts
+++ b/packages/amplication-server/src/core/outdatedVersionAlert/outdatedVersionAlert.service.ts
@@ -26,6 +26,18 @@ export class OutdatedVersionAlertService {
   async create(
     args: CreateOutdatedVersionAlertArgs
   ): Promise<OutdatedVersionAlert> {
+    //update all previous alerts for the same resource and type that are still in status "new" to be canceled
+    await this.prisma.outdatedVersionAlert.updateMany({
+      where: {
+        resourceId: args.data.resource.connect.id,
+        type: args.data.type,
+        status: EnumOutdatedVersionAlertStatus.New,
+      },
+      data: {
+        status: EnumOutdatedVersionAlertStatus.Canceled,
+      },
+    });
+
     const outdatedVersionAlert = await this.prisma.outdatedVersionAlert.create({
       ...args,
       data: {

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -929,6 +929,7 @@ enum EnumModuleDtoType {
 }
 
 enum EnumOutdatedVersionAlertStatus {
+  Canceled
   Ignored
   New
   Resolved

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -959,6 +959,7 @@ export enum EnumModuleDtoType {
 }
 
 export enum EnumOutdatedVersionAlertStatus {
+  Canceled = 'Canceled',
   Ignored = 'Ignored',
   New = 'New',
   Resolved = 'Resolved'


### PR DESCRIPTION


Close: #9005

## PR Details

Change the status of previous unhandled alerts to canceled when creating new alerts for the same objects

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
