### PR TITLE
Fix/9058 unpublished templates

### DIFF
--- a/packages/amplication-client/src/ServiceTemplate/NewServiceFromTemplate.tsx
+++ b/packages/amplication-client/src/ServiceTemplate/NewServiceFromTemplate.tsx
@@ -63,14 +63,14 @@ const NewServiceFromTemplate = ({ serviceTemplateId, projectId }: Props) => {
     currentProject,
   } = useContext(AppContext);
 
-  const { serviceTemplates } = useServiceTemplate(currentProject);
+  const { publishedServiceTemplates } = useServiceTemplate(currentProject);
 
   const options = useMemo(() => {
-    return serviceTemplates.map((serviceTemplate) => ({
+    return publishedServiceTemplates.map((serviceTemplate) => ({
       value: serviceTemplate.id,
       label: serviceTemplate.name,
     }));
-  }, [serviceTemplates]);
+  }, [publishedServiceTemplates]);
 
   const handleSubmit = useCallback(
     (data: CreateType) => {

--- a/packages/amplication-client/src/ServiceTemplate/hooks/useServiceTemplate.ts
+++ b/packages/amplication-client/src/ServiceTemplate/hooks/useServiceTemplate.ts
@@ -31,6 +31,10 @@ const useServiceTemplate = (
 ) => {
   const [searchPhrase, setSearchPhrase] = useState<string>("");
 
+  const [publishedServiceTemplates, setPublishedServiceTemplates] = useState<
+    models.Resource[]
+  >([]);
+
   const {
     data: serviceTemplates,
     loading: loadingServiceTemplates,
@@ -45,6 +49,13 @@ const useServiceTemplate = (
           : undefined,
     },
     skip: !currentProject?.id,
+    onCompleted: (data) => {
+      const publishedServiceTemplates = data.serviceTemplates.filter(
+        (serviceTemplate) => serviceTemplate.version
+      );
+
+      setPublishedServiceTemplates(publishedServiceTemplates);
+    },
   });
 
   const [
@@ -136,6 +147,7 @@ const useServiceTemplate = (
     errorUpgradeServiceToLatestTemplateVersion,
     upgradeServiceToLatestTemplateVersionData:
       UpgradeServiceToLatestTemplateVersionData?.upgradeServiceToLatestTemplateVersion,
+    publishedServiceTemplates,
   };
 };
 

--- a/packages/amplication-server/src/core/resource/serviceTemplate.service.ts
+++ b/packages/amplication-server/src/core/resource/serviceTemplate.service.ts
@@ -114,6 +114,10 @@ export class ServiceTemplateService {
       template.id
     );
 
+    if (!templateVersion) {
+      throw new AmplicationError(`Template version not found`);
+    }
+
     const serviceSettings =
       await this.serviceSettingsService.getServiceSettingsValues(
         {


### PR DESCRIPTION
Close: #9058 

## PR Details

return only published templates from the useServiceTemplates hook. 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error


