### PR TITLE
fix(server): do not load alerts for deleted services

### DIFF
--- a/packages/amplication-server/src/core/outdatedVersionAlert/outdatedVersionAlert.service.ts
+++ b/packages/amplication-server/src/core/outdatedVersionAlert/outdatedVersionAlert.service.ts
@@ -74,7 +74,16 @@ export class OutdatedVersionAlertService {
   async findMany(
     args: FindManyOutdatedVersionAlertArgs
   ): Promise<OutdatedVersionAlert[]> {
-    return this.prisma.outdatedVersionAlert.findMany(args);
+    return this.prisma.outdatedVersionAlert.findMany({
+      where: {
+        ...args.where,
+        resource: {
+          ...args.where?.resource,
+          deletedAt: null,
+          archived: { not: true },
+        },
+      },
+    });
   }
 
   async findOne(


### PR DESCRIPTION


Close: https://github.com/amplication/amplication/issues/9088

## PR Details

do not load alerts for deleted services

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
