### PR TITLE
feat(client):improve resource creation UX

### DIFF
--- a/libs/ui/design-system/src/lib/components/SelectField/SelectField.scss
+++ b/libs/ui/design-system/src/lib/components/SelectField/SelectField.scss
@@ -56,12 +56,12 @@
 
   &--has-error {
     .select-field__control {
-      border-color: var(--theme-red);
+      border-color: var(--color-negative);
 
       &:active,
       &:hover,
       &:focus {
-        border-color: var(--theme-red);
+        border-color: var(--color-negative);
       }
     }
   }

--- a/libs/ui/design-system/src/lib/components/SelectField/SelectField.tsx
+++ b/libs/ui/design-system/src/lib/components/SelectField/SelectField.tsx
@@ -113,7 +113,7 @@ export const SelectField = ({
   return (
     <div
       className={classNames("select-field", {
-        "select-field--has-error": meta.error,
+        "select-field--has-error": meta.error && meta.touched,
       })}
     >
       <label className={LABEL_CLASS}>

--- a/libs/ui/design-system/src/lib/components/Text/Text.tsx
+++ b/libs/ui/design-system/src/lib/components/Text/Text.tsx
@@ -22,10 +22,12 @@ export enum EnumTextColor {
   ThemeBlue = "theme-blue",
   ThemeGreen = "theme-green",
   ThemeRed = "theme-red",
+  ThemeLightRed = "theme-light-red",
   ThemeOrange = "theme-orange",
   Primary = "primary",
   ThemePink = "theme-pink",
   Secondary = "secondary",
+  error = "color-negative",
 }
 
 export enum EnumTextAlign {

--- a/libs/ui/design-system/src/lib/components/TextInput/TextInput.scss
+++ b/libs/ui/design-system/src/lib/components/TextInput/TextInput.scss
@@ -44,12 +44,12 @@
   &--has-error {
     input,
     textarea {
-      border-color: var(--theme-red);
+      border-color: var(--color-negative);
 
       &:active:not(:disabled),
       &:hover:not(:disabled),
       &:focus:not(:disabled) {
-        border-color: var(--theme-red);
+        border-color: var(--color-negative);
       }
     }
   }

--- a/libs/ui/design-system/src/lib/components/TextInput/TextInput.tsx
+++ b/libs/ui/design-system/src/lib/components/TextInput/TextInput.tsx
@@ -70,7 +70,7 @@ export function TextInput({
       {hasError && helpText && (
         <Text
           textStyle={EnumTextStyle.Description}
-          textColor={EnumTextColor.ThemeRed}
+          textColor={EnumTextColor.error}
         >
           {helpText}
         </Text>

--- a/libs/ui/design-system/src/lib/style/css-variables.scss
+++ b/libs/ui/design-system/src/lib/style/css-variables.scss
@@ -43,7 +43,7 @@
   --theme-orange: #f6aa50;
 
   --color-positive: #31c587;
-  --color-negative: var(--theme-red);
+  --color-negative: var(--theme-light-red);
   --theme-gradient: linear-gradient(45deg, #6c37ff 0%, #23c4da 100%);
 
   --tooltip-background: var(--gray-60);

--- a/packages/amplication-client/src/Blueprints/BlueprintSelectField.tsx
+++ b/packages/amplication-client/src/Blueprints/BlueprintSelectField.tsx
@@ -6,6 +6,7 @@ import { resourceThemeMap } from "../Resource/constants";
 
 type Props = Omit<SelectFieldProps, "options"> & {
   useKeyAsValue?: boolean;
+  onChange?: (value: string) => void;
 };
 
 const BlueprintSelectField = (props: Props) => {

--- a/packages/amplication-client/src/CustomProperties/CustomPropertiesFormFieldLink.tsx
+++ b/packages/amplication-client/src/CustomProperties/CustomPropertiesFormFieldLink.tsx
@@ -14,6 +14,13 @@ function CustomPropertiesFormFieldLink({
 }: Props) {
   return (
     <TextField
+      inputToolTip={
+        property.description
+          ? {
+              content: property.description,
+            }
+          : undefined
+      }
       disabled={disabled}
       label={property.name}
       name={`${fieldNamePrefix}properties.${property.key}`}

--- a/packages/amplication-client/src/CustomProperties/CustomPropertiesFormFieldMultiSelect.tsx
+++ b/packages/amplication-client/src/CustomProperties/CustomPropertiesFormFieldMultiSelect.tsx
@@ -20,6 +20,13 @@ function CustomPropertiesFormFieldMultiSelect({
 
   return (
     <SelectField
+      inputToolTip={
+        property.description
+          ? {
+              content: property.description,
+            }
+          : undefined
+      }
       disabled={disabled}
       isMulti
       label={property.name}

--- a/packages/amplication-client/src/CustomProperties/CustomPropertiesFormFieldSelect.tsx
+++ b/packages/amplication-client/src/CustomProperties/CustomPropertiesFormFieldSelect.tsx
@@ -20,6 +20,13 @@ function CustomPropertiesFormFieldSelect({
 
   return (
     <SelectField
+      inputToolTip={
+        property.description
+          ? {
+              content: property.description,
+            }
+          : undefined
+      }
       disabled={disabled}
       label={property.name}
       name={`${fieldNamePrefix}properties.${property.key}`}

--- a/packages/amplication-client/src/CustomProperties/CustomPropertiesFormFieldText.tsx
+++ b/packages/amplication-client/src/CustomProperties/CustomPropertiesFormFieldText.tsx
@@ -15,6 +15,13 @@ function CustomPropertiesFormFieldText({
   return (
     <TextField
       disabled={disabled}
+      inputToolTip={
+        property.description
+          ? {
+              content: property.description,
+            }
+          : undefined
+      }
       label={property.name}
       name={`${fieldNamePrefix}properties.${property.key}`}
     />

--- a/packages/amplication-client/src/Resource/create-resource-page/CreateResourceFormResourceSettings.tsx
+++ b/packages/amplication-client/src/Resource/create-resource-page/CreateResourceFormResourceSettings.tsx
@@ -43,7 +43,9 @@ export const CreateResourceFormResourceSettings = ({
   );
 
   return (
-    blueprint && (
+    blueprint &&
+    blueprint.properties &&
+    blueprint.properties.length > 0 && (
       <div>
         <FlexItem margin={EnumFlexItemMargin.Both}>
           <Text textStyle={EnumTextStyle.H4}>
@@ -51,12 +53,10 @@ export const CreateResourceFormResourceSettings = ({
           </Text>
         </FlexItem>
         <Panel panelStyle={EnumPanelStyle.Bordered}>
-          <FormColumns>
-            <ResourceSettingsFormFields
-              blueprintId={blueprintId}
-              fieldNamePrefix="settings."
-            />
-          </FormColumns>
+          <ResourceSettingsFormFields
+            blueprintId={blueprintId}
+            fieldNamePrefix="settings."
+          />
         </Panel>
       </div>
     )

--- a/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/RepositoryActions.scss
+++ b/packages/amplication-client/src/Resource/git/GitActions/RepositoryActions/RepositoryActions.scss
@@ -33,9 +33,9 @@
       @include flexFullRowWithSpacing;
       .amp-icon {
         margin-right: var(--default-spacing-small);
-        color: var(--theme-red);
+        color: var(--color-negative);
       }
-      color: var(--theme-red);
+      color: var(--color-negative);
     }
 
     &__name {

--- a/packages/amplication-client/src/style/mixin.scss
+++ b/packages/amplication-client/src/style/mixin.scss
@@ -73,7 +73,7 @@
 }
 
 @mixin errorMessage {
-  color: var(--theme-red);
+  color: var(--color-negative);
   font-size: 10px;
 }
 


### PR DESCRIPTION
Close: https://github.com/amplication/amplication/issues/9579

## PR Details

- Show the list of fields in a single column
- Show tooltip next to custom properties
- Show the blueprint description after selection
- Reset the initial value of the form after blueprint selection to allow correct behavior of validation 
- Hide the resource properties panel when there are no properties


<img width="1091" alt="image" src="https://github.com/user-attachments/assets/8c7f83d9-7670-42be-ae3d-afa3ec408553" />

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
