### PR TITLE
fix(client):move new-resource form to the project context to access the permissions

### DIFF
--- a/packages/amplication-client/src/routes/appRoutes.tsx
+++ b/packages/amplication-client/src/routes/appRoutes.tsx
@@ -164,18 +164,6 @@ export const Routes: RouteDef[] = [
         ],
         routes: [
           {
-            path: "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})/new-resource",
-            Component: lazy(
-              () =>
-                import("../Resource/create-resource-page/CreateResourcePage")
-            ),
-            moduleName: "CreateResourcePage",
-            moduleClass: "create-resource-page",
-            exactPath: true,
-            routes: [],
-          },
-
-          {
             path: "/:workspace([A-Za-z0-9-]{20,})/platform/:project([A-Za-z0-9-]{20,})",
             Component: lazy(() => import("../Platform/ProjectPlatformPage")),
             moduleName: "ProjectPlatformPage",
@@ -441,6 +429,19 @@ export const Routes: RouteDef[] = [
               },
             ],
             routes: [
+              {
+                path: "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})/new-resource",
+                Component: lazy(
+                  () =>
+                    import(
+                      "../Resource/create-resource-page/CreateResourcePage"
+                    )
+                ),
+                moduleName: "CreateResourcePage",
+                moduleClass: "create-resource-page",
+                exactPath: true,
+                routes: [],
+              },
               {
                 path: "/:workspace([A-Za-z0-9-]{20,})/:project([A-Za-z0-9-]{20,})/welcome",
                 Component: lazy(


### PR DESCRIPTION

Close: https://github.com/amplication/amplication/issues/9619

## PR Details

Move the new-resource route to be a sub route of Project home to allow access to the resource context with the permissions object

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
