### PR TITLE
Fix/delete-user-entity

### DIFF
--- a/packages/amplication-client/src/Entity/EntityList.tsx
+++ b/packages/amplication-client/src/Entity/EntityList.tsx
@@ -68,7 +68,6 @@ const EntityList: React.FC<Props> = ({ match, innerRoutes }) => {
   const pageTitle = "Entities";
   const [searchPhrase, setSearchPhrase] = useState<string>("");
   const [newEntity, setNewEntity] = useState<boolean>(false);
-  const { pluginInstallations } = usePlugins(resource);
 
   const { baseUrl } = useResourceBaseUrl();
 
@@ -92,12 +91,6 @@ const EntityList: React.FC<Props> = ({ match, innerRoutes }) => {
     },
     [query]
   );
-
-  const isUserEntityMandatory =
-    pluginInstallations?.filter(
-      (x) =>
-        x?.configurations?.requireAuthenticationEntity === "true" && x.enabled
-    )?.length > 0;
 
   const handleNewEntityClick = useCallback(() => {
     setNewEntity(!newEntity);
@@ -267,7 +260,6 @@ const EntityList: React.FC<Props> = ({ match, innerRoutes }) => {
                     entity={entity}
                     resourceId={resource}
                     onError={setError}
-                    isUserEntityMandatory={isUserEntityMandatory}
                     relatedEntities={data.entities.filter(
                       (dataEntity) =>
                         dataEntity.fields.some(

--- a/packages/amplication-client/src/Entity/EntityListItem.tsx
+++ b/packages/amplication-client/src/Entity/EntityListItem.tsx
@@ -47,7 +47,6 @@ type Props = {
   onDelete?: () => void;
   onError: (error: Error) => void;
   relatedEntities: models.Entity[];
-  isUserEntityMandatory: boolean;
 };
 
 const CLASS_NAME = "entity-list-item";
@@ -58,7 +57,6 @@ export const EntityListItem = ({
   onDelete,
   onError,
   relatedEntities,
-  isUserEntityMandatory,
 }: Props) => {
   const { addEntity } = useContext(AppContext);
   const history = useHistory();
@@ -137,15 +135,17 @@ export const EntityListItem = ({
       variables: {
         entityId: entity.id,
       },
-    }).catch(onError);
-
-    if (authEntity === entity.name) {
-      const updateServiceSettings = {
-        ...serviceSettings?.serviceSettings,
-        authEntityName: null,
-      };
-      handleSubmit(updateServiceSettings);
-    }
+    })
+      .then(() => {
+        if (authEntity === entity.name) {
+          const updateServiceSettings = {
+            ...serviceSettings?.serviceSettings,
+            authEntityName: null,
+          };
+          handleSubmit(updateServiceSettings);
+        }
+      })
+      .catch(onError);
   }, [
     serviceSettings?.serviceSettings,
     deleteEntity,
@@ -163,8 +163,6 @@ export const EntityListItem = ({
   const isAuthEntity = serviceSettings?.serviceSettings?.authEntityName
     ? entity.name === serviceSettings?.serviceSettings?.authEntityName
     : entity.name === USER_ENTITY;
-
-  const isDeleteButtonDisable = isAuthEntity && isUserEntityMandatory;
 
   const deleteMessage = isAuthEntity
     ? "Deleting this entity may impact the authentication functionality of your service"
@@ -222,7 +220,6 @@ export const EntityListItem = ({
                 buttonStyle={EnumButtonStyle.Text}
                 icon="trash_2"
                 onClick={handleDelete}
-                disabled={isDeleteButtonDisable}
               />
             )
           }

--- a/packages/amplication-server/src/core/entity/entity.service.ts
+++ b/packages/amplication-server/src/core/entity/entity.service.ts
@@ -916,7 +916,7 @@ export class EntityService {
 
       if (serviceSettings.authEntityName === entity.name) {
         throw new AmplicationError(
-          `cannot delete auth entity : ${entity.name}.`
+          `The requested entity is required for authentication and cannot be deleted. You can delete the entity by unselecting the entity from the authentication settings.`
         );
       }
 


### PR DESCRIPTION


part of https://github.com/amplication/amplication/issues/9637

## PR Details

Remove the check on the client side before deleting user entity. only keep the server side validation.

This saves redundat logic based on the plugins and other configurations and saves some rounds trips to the server.

The user will get a more intuitive message when trying to delete and will know why it can't be deleted

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
