### PR TITLE
fix(client): Clear email input after sending invite

### DIFF
--- a/packages/amplication-client/src/Workspaces/InviteMember.tsx
+++ b/packages/amplication-client/src/Workspaces/InviteMember.tsx
@@ -66,6 +66,7 @@ const InviteMember = () => {
     (data: Values) => {
       if (!isEmpty(data.email)) {
         inviteUser({ variables: { email: data.email } }).catch(console.error);
+        data.email = "";
       }
     },
     [inviteUser]


### PR DESCRIPTION
Signed-off-by: Itai Nathaniel <itainathaniel@gmail.com>

Close: #9664

## PR Details

It clears the email input after inviting the submitted email

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
