### PR TITLE
feat(client): Add project column to workspace tech debt view

### DIFF
--- a/packages/amplication-client/src/OutdatedVersionAlerts/OutdatedVersionAlertList.tsx
+++ b/packages/amplication-client/src/OutdatedVersionAlerts/OutdatedVersionAlertList.tsx
@@ -24,12 +24,19 @@ import useOutdatedVersionAlerts from "./hooks/useOutdatedVersionAlerts";
 import { COLUMNS } from "./OutdatedVersionAlertListDataColumns";
 import { AlertStatusFilter } from "./AlertStatusFilter";
 import { AlertTypeFilter } from "./AlertTypeFilter";
+import ProjectNameLink from "../Workspaces/ProjectNameLink";
+import { useLocation } from "react-router-dom";
 
 const CLASS_NAME = "resource-version-list";
 const PAGE_TITLE = "Tech Debt";
 
 function OutdatedVersionAlertList() {
   const { currentProject, currentResource } = useContext(AppContext);
+  const location = useLocation();
+
+  const isWorkspaceTechDebt = /^\/[A-Za-z0-9-]{20,}\/tech-debt/.test(
+    location.pathname
+  );
 
   const {
     outdatedVersionAlerts,
@@ -45,6 +52,23 @@ function OutdatedVersionAlertList() {
   } = useOutdatedVersionAlerts(currentProject?.id, currentResource?.id);
 
   const errorMessage = formatError(errorOutdatedVersionAlerts);
+
+  const columns = [
+    ...COLUMNS,
+    ...(isWorkspaceTechDebt
+      ? [
+          {
+            key: "project",
+            name: "Project",
+            sortable: true,
+            renderCell: (props) => {
+              return <ProjectNameLink project={props.row.resource?.project} />;
+            },
+            getValue: (row) => row.resource?.project?.name ?? "(unavailable)",
+          },
+        ]
+      : []),
+  ];
 
   const onSortColumnsChange = useCallback(
     (sortColumns: DataGridSortColumn[]) => {
@@ -123,7 +147,7 @@ function OutdatedVersionAlertList() {
       ) : (
         <div className={`${CLASS_NAME}__grid-container`}>
           <DataGrid
-            columns={COLUMNS}
+            columns={columns}
             clientSideSort={false}
             onSortColumnsChange={onSortColumnsChange}
             rows={outdatedVersionAlerts}

--- a/packages/amplication-client/src/OutdatedVersionAlerts/hooks/outdatedVersionAlertsQueries.ts
+++ b/packages/amplication-client/src/OutdatedVersionAlerts/hooks/outdatedVersionAlertsQueries.ts
@@ -10,6 +10,10 @@ export const OUTDATED_VERSION_ALERT_FIELDS_FRAGMENT = gql`
       name
       resourceType
       projectId
+      project {
+        id
+        name
+      }
     }
     resourceId
     blockId


### PR DESCRIPTION
Close: #9718 

## PR Details

- Enhance OutdatedVersionAlertList to display project name when viewing tech debt at workspace level
- Update GraphQL fragment to include project details
- Conditionally render project column based on current route

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
