### PR TITLE
chore(ci): exclude generator-blueprints from Nx affected builds

### DIFF
--- a/.github/workflows/deployment.production.yml
+++ b/.github/workflows/deployment.production.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Evaluate affected projects
         id: configure-nx
         env:
-          NX_EXCLUDE: "--exclude=data-service-generator"
+          NX_EXCLUDE: "--exclude=data-service-generator,generator-blueprints"
         run: |
           echo affected-apps=$(npx nx print-affected --base=${{ steps.base.outputs.tag }} --type=app $NX_FORCE_ALL ${NX_EXCLUDE} | jq -c .projects) >> $GITHUB_OUTPUT
           echo affected-lib=$(npx nx print-affected --base=${{ steps.base.outputs.tag }} --type=lib $NX_FORCE_ALL $NX_EXCLUDE | jq -c .projects) >> $GITHUB_OUTPUT


### PR DESCRIPTION

Close: https://github.com/amplication/amplication/issues/9748

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

## PR Checklist

- [ ] Tests for the changes have been added
- [ ] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
