### PR TITLE
fix: add await to findUnique in service base template to resolve lint errors

### DIFF
--- a/packages/data-service-generator/src/server/resource/service/service.base.template.ts
+++ b/packages/data-service-generator/src/server/resource/service/service.base.template.ts
@@ -19,7 +19,7 @@ export class SERVICE_BASE {
   async FIND_ONE_ENTITY_FUNCTION(
     args: Prisma.FIND_ONE_ARGS
   ): Promise<PRISMA_ENTITY | null> {
-    return this.prisma.DELEGATE.findUnique(args);
+    return await this.prisma.DELEGATE.findUnique(args);
   }
   async CREATE_ENTITY_FUNCTION(
     args: Prisma.CREATE_ARGS

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-custom-path.spec.ts.snap
@@ -5653,7 +5653,7 @@ export class CustomerServiceBase {
   async customer(
     args: Prisma.CustomerFindUniqueArgs
   ): Promise<PrismaCustomer | null> {
-    return this.prisma.customer.findUnique(args);
+    return await this.prisma.customer.findUnique(args);
   }
   async createCustomer(
     args: Prisma.CustomerCreateArgs
@@ -6700,7 +6700,7 @@ export class EmptyServiceBase {
     return this.prisma.empty.findMany(args);
   }
   async empty(args: Prisma.EmptyFindUniqueArgs): Promise<PrismaEmpty | null> {
-    return this.prisma.empty.findUnique(args);
+    return await this.prisma.empty.findUnique(args);
   }
   async createEmpty(args: Prisma.EmptyCreateArgs): Promise<PrismaEmpty> {
     return this.prisma.empty.create(args);
@@ -8291,7 +8291,7 @@ export class OrderServiceBase {
     return this.prisma.order.findMany(args);
   }
   async order(args: Prisma.OrderFindUniqueArgs): Promise<PrismaOrder | null> {
-    return this.prisma.order.findUnique(args);
+    return await this.prisma.order.findUnique(args);
   }
   async createOrder(args: Prisma.OrderCreateArgs): Promise<PrismaOrder> {
     return this.prisma.order.create(args);
@@ -10049,7 +10049,7 @@ export class OrganizationServiceBase {
   async organization(
     args: Prisma.OrganizationFindUniqueArgs
   ): Promise<PrismaOrganization | null> {
-    return this.prisma.organization.findUnique(args);
+    return await this.prisma.organization.findUnique(args);
   }
   async createOrganization(
     args: Prisma.OrganizationCreateArgs
@@ -11538,7 +11538,7 @@ export class ProfileServiceBase {
   async profile(
     args: Prisma.ProfileFindUniqueArgs
   ): Promise<PrismaProfile | null> {
-    return this.prisma.profile.findUnique(args);
+    return await this.prisma.profile.findUnique(args);
   }
   async createProfile(args: Prisma.ProfileCreateArgs): Promise<PrismaProfile> {
     return this.prisma.profile.create(args);
@@ -14348,7 +14348,7 @@ export class UserServiceBase {
     return this.prisma.user.findMany(args);
   }
   async user(args: Prisma.UserFindUniqueArgs): Promise<PrismaUser | null> {
-    return this.prisma.user.findUnique(args);
+    return await this.prisma.user.findUnique(args);
   }
   async createUser(args: Prisma.UserCreateArgs): Promise<PrismaUser> {
     return this.prisma.user.create(args);

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-numeric-user-id.spec.ts.snap
@@ -5653,7 +5653,7 @@ export class CustomerServiceBase {
   async customer(
     args: Prisma.CustomerFindUniqueArgs
   ): Promise<PrismaCustomer | null> {
-    return this.prisma.customer.findUnique(args);
+    return await this.prisma.customer.findUnique(args);
   }
   async createCustomer(
     args: Prisma.CustomerCreateArgs
@@ -6700,7 +6700,7 @@ export class EmptyServiceBase {
     return this.prisma.empty.findMany(args);
   }
   async empty(args: Prisma.EmptyFindUniqueArgs): Promise<PrismaEmpty | null> {
-    return this.prisma.empty.findUnique(args);
+    return await this.prisma.empty.findUnique(args);
   }
   async createEmpty(args: Prisma.EmptyCreateArgs): Promise<PrismaEmpty> {
     return this.prisma.empty.create(args);
@@ -8291,7 +8291,7 @@ export class OrderServiceBase {
     return this.prisma.order.findMany(args);
   }
   async order(args: Prisma.OrderFindUniqueArgs): Promise<PrismaOrder | null> {
-    return this.prisma.order.findUnique(args);
+    return await this.prisma.order.findUnique(args);
   }
   async createOrder(args: Prisma.OrderCreateArgs): Promise<PrismaOrder> {
     return this.prisma.order.create(args);
@@ -10049,7 +10049,7 @@ export class OrganizationServiceBase {
   async organization(
     args: Prisma.OrganizationFindUniqueArgs
   ): Promise<PrismaOrganization | null> {
-    return this.prisma.organization.findUnique(args);
+    return await this.prisma.organization.findUnique(args);
   }
   async createOrganization(
     args: Prisma.OrganizationCreateArgs
@@ -11538,7 +11538,7 @@ export class ProfileServiceBase {
   async profile(
     args: Prisma.ProfileFindUniqueArgs
   ): Promise<PrismaProfile | null> {
-    return this.prisma.profile.findUnique(args);
+    return await this.prisma.profile.findUnique(args);
   }
   async createProfile(args: Prisma.ProfileCreateArgs): Promise<PrismaProfile> {
     return this.prisma.profile.create(args);
@@ -14352,7 +14352,7 @@ export class UserServiceBase {
     return this.prisma.user.findMany(args);
   }
   async user(args: Prisma.UserFindUniqueArgs): Promise<PrismaUser | null> {
-    return this.prisma.user.findUnique(args);
+    return await this.prisma.user.findUnique(args);
   }
   async createUser(args: Prisma.UserCreateArgs): Promise<PrismaUser> {
     return this.prisma.user.create(args);

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-auth-jwt.spec.ts.snap
@@ -6550,7 +6550,7 @@ export class CustomerServiceBase {
   async customer(
     args: Prisma.CustomerFindUniqueArgs
   ): Promise<PrismaCustomer | null> {
-    return this.prisma.customer.findUnique(args);
+    return await this.prisma.customer.findUnique(args);
   }
   async createCustomer(
     args: Prisma.CustomerCreateArgs
@@ -7697,7 +7697,7 @@ export class EmptyServiceBase {
     return this.prisma.empty.findMany(args);
   }
   async empty(args: Prisma.EmptyFindUniqueArgs): Promise<PrismaEmpty | null> {
-    return this.prisma.empty.findUnique(args);
+    return await this.prisma.empty.findUnique(args);
   }
   async createEmpty(args: Prisma.EmptyCreateArgs): Promise<PrismaEmpty> {
     return this.prisma.empty.create(args);
@@ -9892,7 +9892,7 @@ export class OrderServiceBase {
     return this.prisma.order.findMany(args);
   }
   async order(args: Prisma.OrderFindUniqueArgs): Promise<PrismaOrder | null> {
-    return this.prisma.order.findUnique(args);
+    return await this.prisma.order.findUnique(args);
   }
   async createOrder(args: Prisma.OrderCreateArgs): Promise<PrismaOrder> {
     return this.prisma.order.create(args);
@@ -11844,7 +11844,7 @@ export class OrganizationServiceBase {
   async organization(
     args: Prisma.OrganizationFindUniqueArgs
   ): Promise<PrismaOrganization | null> {
-    return this.prisma.organization.findUnique(args);
+    return await this.prisma.organization.findUnique(args);
   }
   async createOrganization(
     args: Prisma.OrganizationCreateArgs
@@ -13452,7 +13452,7 @@ export class ProfileServiceBase {
   async profile(
     args: Prisma.ProfileFindUniqueArgs
   ): Promise<PrismaProfile | null> {
-    return this.prisma.profile.findUnique(args);
+    return await this.prisma.profile.findUnique(args);
   }
   async createProfile(args: Prisma.ProfileCreateArgs): Promise<PrismaProfile> {
     return this.prisma.profile.create(args);
@@ -16517,7 +16517,7 @@ export class UserServiceBase {
     return this.prisma.user.findMany(args);
   }
   async user(args: Prisma.UserFindUniqueArgs): Promise<PrismaUser | null> {
-    return this.prisma.user.findUnique(args);
+    return await this.prisma.user.findUnique(args);
   }
   async createUser(args: Prisma.UserCreateArgs): Promise<PrismaUser> {
     return this.prisma.user.create({

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-disabled-module.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-disabled-module.spec.ts.snap
@@ -5653,7 +5653,7 @@ export class CustomerServiceBase {
   async customer(
     args: Prisma.CustomerFindUniqueArgs
   ): Promise<PrismaCustomer | null> {
-    return this.prisma.customer.findUnique(args);
+    return await this.prisma.customer.findUnique(args);
   }
   async createCustomer(
     args: Prisma.CustomerCreateArgs
@@ -6700,7 +6700,7 @@ export class EmptyServiceBase {
     return this.prisma.empty.findMany(args);
   }
   async empty(args: Prisma.EmptyFindUniqueArgs): Promise<PrismaEmpty | null> {
-    return this.prisma.empty.findUnique(args);
+    return await this.prisma.empty.findUnique(args);
   }
   async createEmpty(args: Prisma.EmptyCreateArgs): Promise<PrismaEmpty> {
     return this.prisma.empty.create(args);
@@ -8291,7 +8291,7 @@ export class OrderServiceBase {
     return this.prisma.order.findMany(args);
   }
   async order(args: Prisma.OrderFindUniqueArgs): Promise<PrismaOrder | null> {
-    return this.prisma.order.findUnique(args);
+    return await this.prisma.order.findUnique(args);
   }
   async createOrder(args: Prisma.OrderCreateArgs): Promise<PrismaOrder> {
     return this.prisma.order.create(args);
@@ -10049,7 +10049,7 @@ export class OrganizationServiceBase {
   async organization(
     args: Prisma.OrganizationFindUniqueArgs
   ): Promise<PrismaOrganization | null> {
-    return this.prisma.organization.findUnique(args);
+    return await this.prisma.organization.findUnique(args);
   }
   async createOrganization(
     args: Prisma.OrganizationCreateArgs
@@ -11538,7 +11538,7 @@ export class ProfileServiceBase {
   async profile(
     args: Prisma.ProfileFindUniqueArgs
   ): Promise<PrismaProfile | null> {
-    return this.prisma.profile.findUnique(args);
+    return await this.prisma.profile.findUnique(args);
   }
   async createProfile(args: Prisma.ProfileCreateArgs): Promise<PrismaProfile> {
     return this.prisma.profile.create(args);
@@ -14044,7 +14044,7 @@ export class UserServiceBase {
     return this.prisma.user.findMany(args);
   }
   async user(args: Prisma.UserFindUniqueArgs): Promise<PrismaUser | null> {
-    return this.prisma.user.findUnique(args);
+    return await this.prisma.user.findUnique(args);
   }
   async createUser(args: Prisma.UserCreateArgs): Promise<PrismaUser> {
     return this.prisma.user.create(args);

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-grpc.spec.ts.snap
@@ -5840,7 +5840,7 @@ export class CustomerServiceBase {
   async customer(
     args: Prisma.CustomerFindUniqueArgs
   ): Promise<PrismaCustomer | null> {
-    return this.prisma.customer.findUnique(args);
+    return await this.prisma.customer.findUnique(args);
   }
   async createCustomer(
     args: Prisma.CustomerCreateArgs
@@ -7061,7 +7061,7 @@ export class EmptyServiceBase {
     return this.prisma.empty.findMany(args);
   }
   async empty(args: Prisma.EmptyFindUniqueArgs): Promise<PrismaEmpty | null> {
-    return this.prisma.empty.findUnique(args);
+    return await this.prisma.empty.findUnique(args);
   }
   async createEmpty(args: Prisma.EmptyCreateArgs): Promise<PrismaEmpty> {
     return this.prisma.empty.create(args);
@@ -8779,7 +8779,7 @@ export class OrderServiceBase {
     return this.prisma.order.findMany(args);
   }
   async order(args: Prisma.OrderFindUniqueArgs): Promise<PrismaOrder | null> {
-    return this.prisma.order.findUnique(args);
+    return await this.prisma.order.findUnique(args);
   }
   async createOrder(args: Prisma.OrderCreateArgs): Promise<PrismaOrder> {
     return this.prisma.order.create(args);
@@ -10887,7 +10887,7 @@ export class OrganizationServiceBase {
   async organization(
     args: Prisma.OrganizationFindUniqueArgs
   ): Promise<PrismaOrganization | null> {
-    return this.prisma.organization.findUnique(args);
+    return await this.prisma.organization.findUnique(args);
   }
   async createOrganization(
     args: Prisma.OrganizationCreateArgs
@@ -12582,7 +12582,7 @@ export class ProfileServiceBase {
   async profile(
     args: Prisma.ProfileFindUniqueArgs
   ): Promise<PrismaProfile | null> {
-    return this.prisma.profile.findUnique(args);
+    return await this.prisma.profile.findUnique(args);
   }
   async createProfile(args: Prisma.ProfileCreateArgs): Promise<PrismaProfile> {
     return this.prisma.profile.create(args);
@@ -15694,7 +15694,7 @@ export class UserServiceBase {
     return this.prisma.user.findMany(args);
   }
   async user(args: Prisma.UserFindUniqueArgs): Promise<PrismaUser | null> {
-    return this.prisma.user.findUnique(args);
+    return await this.prisma.user.findUnique(args);
   }
   async createUser(args: Prisma.UserCreateArgs): Promise<PrismaUser> {
     return this.prisma.user.create(args);

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-with-kafka.spec.ts.snap
@@ -5740,7 +5740,7 @@ export class CustomerServiceBase {
   async customer(
     args: Prisma.CustomerFindUniqueArgs
   ): Promise<PrismaCustomer | null> {
-    return this.prisma.customer.findUnique(args);
+    return await this.prisma.customer.findUnique(args);
   }
   async createCustomer(
     args: Prisma.CustomerCreateArgs
@@ -6787,7 +6787,7 @@ export class EmptyServiceBase {
     return this.prisma.empty.findMany(args);
   }
   async empty(args: Prisma.EmptyFindUniqueArgs): Promise<PrismaEmpty | null> {
-    return this.prisma.empty.findUnique(args);
+    return await this.prisma.empty.findUnique(args);
   }
   async createEmpty(args: Prisma.EmptyCreateArgs): Promise<PrismaEmpty> {
     return this.prisma.empty.create(args);
@@ -8514,7 +8514,7 @@ export class OrderServiceBase {
     return this.prisma.order.findMany(args);
   }
   async order(args: Prisma.OrderFindUniqueArgs): Promise<PrismaOrder | null> {
-    return this.prisma.order.findUnique(args);
+    return await this.prisma.order.findUnique(args);
   }
   async createOrder(args: Prisma.OrderCreateArgs): Promise<PrismaOrder> {
     return this.prisma.order.create(args);
@@ -10272,7 +10272,7 @@ export class OrganizationServiceBase {
   async organization(
     args: Prisma.OrganizationFindUniqueArgs
   ): Promise<PrismaOrganization | null> {
-    return this.prisma.organization.findUnique(args);
+    return await this.prisma.organization.findUnique(args);
   }
   async createOrganization(
     args: Prisma.OrganizationCreateArgs
@@ -11761,7 +11761,7 @@ export class ProfileServiceBase {
   async profile(
     args: Prisma.ProfileFindUniqueArgs
   ): Promise<PrismaProfile | null> {
-    return this.prisma.profile.findUnique(args);
+    return await this.prisma.profile.findUnique(args);
   }
   async createProfile(args: Prisma.ProfileCreateArgs): Promise<PrismaProfile> {
     return this.prisma.profile.create(args);
@@ -14571,7 +14571,7 @@ export class UserServiceBase {
     return this.prisma.user.findMany(args);
   }
   async user(args: Prisma.UserFindUniqueArgs): Promise<PrismaUser | null> {
-    return this.prisma.user.findUnique(args);
+    return await this.prisma.user.findUnique(args);
   }
   async createUser(args: Prisma.UserCreateArgs): Promise<PrismaUser> {
     return this.prisma.user.create(args);

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-admin-ui.spec.ts.snap
@@ -2691,7 +2691,7 @@ export class CustomerServiceBase {
   async customer(
     args: Prisma.CustomerFindUniqueArgs
   ): Promise<PrismaCustomer | null> {
-    return this.prisma.customer.findUnique(args);
+    return await this.prisma.customer.findUnique(args);
   }
   async createCustomer(
     args: Prisma.CustomerCreateArgs
@@ -3738,7 +3738,7 @@ export class EmptyServiceBase {
     return this.prisma.empty.findMany(args);
   }
   async empty(args: Prisma.EmptyFindUniqueArgs): Promise<PrismaEmpty | null> {
-    return this.prisma.empty.findUnique(args);
+    return await this.prisma.empty.findUnique(args);
   }
   async createEmpty(args: Prisma.EmptyCreateArgs): Promise<PrismaEmpty> {
     return this.prisma.empty.create(args);
@@ -5329,7 +5329,7 @@ export class OrderServiceBase {
     return this.prisma.order.findMany(args);
   }
   async order(args: Prisma.OrderFindUniqueArgs): Promise<PrismaOrder | null> {
-    return this.prisma.order.findUnique(args);
+    return await this.prisma.order.findUnique(args);
   }
   async createOrder(args: Prisma.OrderCreateArgs): Promise<PrismaOrder> {
     return this.prisma.order.create(args);
@@ -7087,7 +7087,7 @@ export class OrganizationServiceBase {
   async organization(
     args: Prisma.OrganizationFindUniqueArgs
   ): Promise<PrismaOrganization | null> {
-    return this.prisma.organization.findUnique(args);
+    return await this.prisma.organization.findUnique(args);
   }
   async createOrganization(
     args: Prisma.OrganizationCreateArgs
@@ -8576,7 +8576,7 @@ export class ProfileServiceBase {
   async profile(
     args: Prisma.ProfileFindUniqueArgs
   ): Promise<PrismaProfile | null> {
-    return this.prisma.profile.findUnique(args);
+    return await this.prisma.profile.findUnique(args);
   }
   async createProfile(args: Prisma.ProfileCreateArgs): Promise<PrismaProfile> {
     return this.prisma.profile.create(args);
@@ -11386,7 +11386,7 @@ export class UserServiceBase {
     return this.prisma.user.findMany(args);
   }
   async user(args: Prisma.UserFindUniqueArgs): Promise<PrismaUser | null> {
-    return this.prisma.user.findUnique(args);
+    return await this.prisma.user.findUnique(args);
   }
   async createUser(args: Prisma.UserCreateArgs): Promise<PrismaUser> {
     return this.prisma.user.create(args);

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-default-actions.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-default-actions.spec.ts.snap
@@ -5653,7 +5653,7 @@ export class CustomerServiceBase {
   async customer(
     args: Prisma.CustomerFindUniqueArgs
   ): Promise<PrismaCustomer | null> {
-    return this.prisma.customer.findUnique(args);
+    return await this.prisma.customer.findUnique(args);
   }
   async createCustomer(
     args: Prisma.CustomerCreateArgs
@@ -6700,7 +6700,7 @@ export class EmptyServiceBase {
     return this.prisma.empty.findMany(args);
   }
   async empty(args: Prisma.EmptyFindUniqueArgs): Promise<PrismaEmpty | null> {
-    return this.prisma.empty.findUnique(args);
+    return await this.prisma.empty.findUnique(args);
   }
   async createEmpty(args: Prisma.EmptyCreateArgs): Promise<PrismaEmpty> {
     return this.prisma.empty.create(args);
@@ -8291,7 +8291,7 @@ export class OrderServiceBase {
     return this.prisma.order.findMany(args);
   }
   async order(args: Prisma.OrderFindUniqueArgs): Promise<PrismaOrder | null> {
-    return this.prisma.order.findUnique(args);
+    return await this.prisma.order.findUnique(args);
   }
   async createOrder(args: Prisma.OrderCreateArgs): Promise<PrismaOrder> {
     return this.prisma.order.create(args);
@@ -10049,7 +10049,7 @@ export class OrganizationServiceBase {
   async organization(
     args: Prisma.OrganizationFindUniqueArgs
   ): Promise<PrismaOrganization | null> {
-    return this.prisma.organization.findUnique(args);
+    return await this.prisma.organization.findUnique(args);
   }
   async createOrganization(
     args: Prisma.OrganizationCreateArgs
@@ -11538,7 +11538,7 @@ export class ProfileServiceBase {
   async profile(
     args: Prisma.ProfileFindUniqueArgs
   ): Promise<PrismaProfile | null> {
-    return this.prisma.profile.findUnique(args);
+    return await this.prisma.profile.findUnique(args);
   }
   async createProfile(args: Prisma.ProfileCreateArgs): Promise<PrismaProfile> {
     return this.prisma.profile.create(args);
@@ -14044,7 +14044,7 @@ export class UserServiceBase {
     return this.prisma.user.findMany(args);
   }
   async user(args: Prisma.UserFindUniqueArgs): Promise<PrismaUser | null> {
-    return this.prisma.user.findUnique(args);
+    return await this.prisma.user.findUnique(args);
   }
   async createUser(args: Prisma.UserCreateArgs): Promise<PrismaUser> {
     return this.prisma.user.create(args);

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-graphql.spec.ts.snap
@@ -5459,7 +5459,7 @@ export class CustomerServiceBase {
   async customer(
     args: Prisma.CustomerFindUniqueArgs
   ): Promise<PrismaCustomer | null> {
-    return this.prisma.customer.findUnique(args);
+    return await this.prisma.customer.findUnique(args);
   }
   async createCustomer(
     args: Prisma.CustomerCreateArgs
@@ -6426,7 +6426,7 @@ export class EmptyServiceBase {
     return this.prisma.empty.findMany(args);
   }
   async empty(args: Prisma.EmptyFindUniqueArgs): Promise<PrismaEmpty | null> {
-    return this.prisma.empty.findUnique(args);
+    return await this.prisma.empty.findUnique(args);
   }
   async createEmpty(args: Prisma.EmptyCreateArgs): Promise<PrismaEmpty> {
     return this.prisma.empty.create(args);
@@ -7876,7 +7876,7 @@ export class OrderServiceBase {
     return this.prisma.order.findMany(args);
   }
   async order(args: Prisma.OrderFindUniqueArgs): Promise<PrismaOrder | null> {
-    return this.prisma.order.findUnique(args);
+    return await this.prisma.order.findUnique(args);
   }
   async createOrder(args: Prisma.OrderCreateArgs): Promise<PrismaOrder> {
     return this.prisma.order.create(args);
@@ -9475,7 +9475,7 @@ export class OrganizationServiceBase {
   async organization(
     args: Prisma.OrganizationFindUniqueArgs
   ): Promise<PrismaOrganization | null> {
-    return this.prisma.organization.findUnique(args);
+    return await this.prisma.organization.findUnique(args);
   }
   async createOrganization(
     args: Prisma.OrganizationCreateArgs
@@ -10821,7 +10821,7 @@ export class ProfileServiceBase {
   async profile(
     args: Prisma.ProfileFindUniqueArgs
   ): Promise<PrismaProfile | null> {
-    return this.prisma.profile.findUnique(args);
+    return await this.prisma.profile.findUnique(args);
   }
   async createProfile(args: Prisma.ProfileCreateArgs): Promise<PrismaProfile> {
     return this.prisma.profile.create(args);
@@ -13401,7 +13401,7 @@ export class UserServiceBase {
     return this.prisma.user.findMany(args);
   }
   async user(args: Prisma.UserFindUniqueArgs): Promise<PrismaUser | null> {
-    return this.prisma.user.findUnique(args);
+    return await this.prisma.user.findUnique(args);
   }
   async createUser(args: Prisma.UserCreateArgs): Promise<PrismaUser> {
     return this.prisma.user.create(args);

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service-without-restApi.spec.ts.snap
@@ -5059,7 +5059,7 @@ export class CustomerServiceBase {
   async customer(
     args: Prisma.CustomerFindUniqueArgs
   ): Promise<PrismaCustomer | null> {
-    return this.prisma.customer.findUnique(args);
+    return await this.prisma.customer.findUnique(args);
   }
   async createCustomer(
     args: Prisma.CustomerCreateArgs
@@ -5770,7 +5770,7 @@ export class EmptyServiceBase {
     return this.prisma.empty.findMany(args);
   }
   async empty(args: Prisma.EmptyFindUniqueArgs): Promise<PrismaEmpty | null> {
-    return this.prisma.empty.findUnique(args);
+    return await this.prisma.empty.findUnique(args);
   }
   async createEmpty(args: Prisma.EmptyCreateArgs): Promise<PrismaEmpty> {
     return this.prisma.empty.create(args);
@@ -6962,7 +6962,7 @@ export class OrderServiceBase {
     return this.prisma.order.findMany(args);
   }
   async order(args: Prisma.OrderFindUniqueArgs): Promise<PrismaOrder | null> {
-    return this.prisma.order.findUnique(args);
+    return await this.prisma.order.findUnique(args);
   }
   async createOrder(args: Prisma.OrderCreateArgs): Promise<PrismaOrder> {
     return this.prisma.order.create(args);
@@ -8075,7 +8075,7 @@ export class OrganizationServiceBase {
   async organization(
     args: Prisma.OrganizationFindUniqueArgs
   ): Promise<PrismaOrganization | null> {
-    return this.prisma.organization.findUnique(args);
+    return await this.prisma.organization.findUnique(args);
   }
   async createOrganization(
     args: Prisma.OrganizationCreateArgs
@@ -9145,7 +9145,7 @@ export class ProfileServiceBase {
   async profile(
     args: Prisma.ProfileFindUniqueArgs
   ): Promise<PrismaProfile | null> {
-    return this.prisma.profile.findUnique(args);
+    return await this.prisma.profile.findUnique(args);
   }
   async createProfile(args: Prisma.ProfileCreateArgs): Promise<PrismaProfile> {
     return this.prisma.profile.create(args);
@@ -11251,7 +11251,7 @@ export class UserServiceBase {
     return this.prisma.user.findMany(args);
   }
   async user(args: Prisma.UserFindUniqueArgs): Promise<PrismaUser | null> {
-    return this.prisma.user.findUnique(args);
+    return await this.prisma.user.findUnique(args);
   }
   async createUser(args: Prisma.UserCreateArgs): Promise<PrismaUser> {
     return this.prisma.user.create(args);

--- a/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
+++ b/packages/data-service-generator/src/tests/__snapshots__/create-data-service.spec.ts.snap
@@ -5653,7 +5653,7 @@ export class CustomerServiceBase {
   async customer(
     args: Prisma.CustomerFindUniqueArgs
   ): Promise<PrismaCustomer | null> {
-    return this.prisma.customer.findUnique(args);
+    return await this.prisma.customer.findUnique(args);
   }
   async createCustomer(
     args: Prisma.CustomerCreateArgs
@@ -6700,7 +6700,7 @@ export class EmptyServiceBase {
     return this.prisma.empty.findMany(args);
   }
   async empty(args: Prisma.EmptyFindUniqueArgs): Promise<PrismaEmpty | null> {
-    return this.prisma.empty.findUnique(args);
+    return await this.prisma.empty.findUnique(args);
   }
   async createEmpty(args: Prisma.EmptyCreateArgs): Promise<PrismaEmpty> {
     return this.prisma.empty.create(args);
@@ -8291,7 +8291,7 @@ export class OrderServiceBase {
     return this.prisma.order.findMany(args);
   }
   async order(args: Prisma.OrderFindUniqueArgs): Promise<PrismaOrder | null> {
-    return this.prisma.order.findUnique(args);
+    return await this.prisma.order.findUnique(args);
   }
   async createOrder(args: Prisma.OrderCreateArgs): Promise<PrismaOrder> {
     return this.prisma.order.create(args);
@@ -10049,7 +10049,7 @@ export class OrganizationServiceBase {
   async organization(
     args: Prisma.OrganizationFindUniqueArgs
   ): Promise<PrismaOrganization | null> {
-    return this.prisma.organization.findUnique(args);
+    return await this.prisma.organization.findUnique(args);
   }
   async createOrganization(
     args: Prisma.OrganizationCreateArgs
@@ -11538,7 +11538,7 @@ export class ProfileServiceBase {
   async profile(
     args: Prisma.ProfileFindUniqueArgs
   ): Promise<PrismaProfile | null> {
-    return this.prisma.profile.findUnique(args);
+    return await this.prisma.profile.findUnique(args);
   }
   async createProfile(args: Prisma.ProfileCreateArgs): Promise<PrismaProfile> {
     return this.prisma.profile.create(args);
@@ -14348,7 +14348,7 @@ export class UserServiceBase {
     return this.prisma.user.findMany(args);
   }
   async user(args: Prisma.UserFindUniqueArgs): Promise<PrismaUser | null> {
-    return this.prisma.user.findUnique(args);
+    return await this.prisma.user.findUnique(args);
   }
   async createUser(args: Prisma.UserCreateArgs): Promise<PrismaUser> {
     return this.prisma.user.create(args);


### PR DESCRIPTION
## Summary

- The generated `findOne` method in `base.service.ts` returned `this.prisma.entity.findUnique(args)` directly, causing a TypeScript lint error because the unwrapped `Prisma__EntityClient` type isn't assignable to `Entity | null`.
- Adding `await` resolves the Promise before returning, yielding the correct plain entity type.

## Changes

- **`service.base.template.ts`**: Added `await` to the `findUnique` call in the `FIND_ONE_ENTITY_FUNCTION` method.
- **11 snapshot files**: Updated to reflect the `await` keyword in all generated base service `findOne` methods (6 entities x 11 test variants = 66 lines).

## How it was tested

- Verified the change matches the maintainer-recommended approach (see issue discussion: `await` not type-cast).
- Snapshot files updated to match the new template output. CI will run the full DSG test suite.

Fixes #7069