### PR TITLE
docs: fix typos in CONTRIBUTING.md and README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We would ❤️ it if you contributed to the project and helped make Amplication
 
 ## Got a question?
 
-You can ask questions, consult with more experienced Amplication users, and discuss Amplication-related topics in the our [Discord channel](https://amplication.com/discord).
+You can ask questions, consult with more experienced Amplication users, and discuss Amplication-related topics in our [Discord channel](https://amplication.com/discord).
 
 ## Found a bug?
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Running Amplication
 Amplication is using a monorepo architecture - powered by <a href="https://nx.dev">Nx Workspaces</a> - where multiple applications and libraries exist in a single repository. To setup a local development environment the following steps can be followed:
 
 **BEFORE** you run the following steps make sure:
-1. You have typescript installed locally on you machine ```npm install -g typescript```
+1. You have typescript installed locally on your machine ```npm install -g typescript```
 2. You are using a supported node version (check `engines` `node` in the [package.json](./package.json))
 3. You are using a supported npm version (check `engines` `npm` in the [package.json](./package.json))
 4. You have `docker` installed and running on your machine


### PR DESCRIPTION
Fix minor typos in project documentation.

**CONTRIBUTING.md:**
- `in the our [Discord channel]` → `in our [Discord channel]` (extra article)

**README.md:**
- `on you machine` → `on your machine` (missing letter)

Closes #7372