### PR TITLE
fix(server,gpt-gateway): inherit app config on the Kafka microservice

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,12 +1,17 @@
 {
   "root": true,
   "ignorePatterns": ["**/*"],
-  "plugins": ["perfectionist", "@nx"],
+  "plugins": ["perfectionist", "@nx", "nestjs-security"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
       "rules": {
         "no-console": "warn",
+        // One rule, not the recommended preset. connectMicroservice() without
+        // inheritAppConfig gives the transport none of the global pipes and
+        // guards registered on the HTTP app, so @EventPattern handlers run
+        // unvalidated while the HTTP routes beside them are fine.
+        "nestjs-security/no-hybrid-app-config-loss": "error",
         "@nx/enforce-module-boundaries": [
           "error",
           {

--- a/ee/packages/git-sync-manager/src/main.ts
+++ b/ee/packages/git-sync-manager/src/main.ts
@@ -13,7 +13,9 @@ import { Logger } from "@amplication/util/logging";
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
   app.useLogger(app.get(AmplicationLogger));
-  app.connectMicroservice<MicroserviceOptions>(createNestjsKafkaConfig());
+  app.connectMicroservice<MicroserviceOptions>(createNestjsKafkaConfig(), {
+    inheritAppConfig: true,
+  });
 
   await app.startAllMicroservices();
 

--- a/package.json
+++ b/package.json
@@ -289,6 +289,7 @@
     "eslint-import-resolver-lerna": "^2.0.0",
     "eslint-plugin-import": "2.29.0",
     "eslint-plugin-jsx-a11y": "6.7.1",
+    "eslint-plugin-nestjs-security": "^2.1.0",
     "eslint-plugin-perfectionist": "^2.5.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "7.32.2",

--- a/packages/amplication-build-manager/src/main.ts
+++ b/packages/amplication-build-manager/src/main.ts
@@ -16,7 +16,9 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
   app.useLogger(app.get(AmplicationLogger));
 
-  app.connectMicroservice<MicroserviceOptions>(createNestjsKafkaConfig());
+  app.connectMicroservice<MicroserviceOptions>(createNestjsKafkaConfig(), {
+    inheritAppConfig: true,
+  });
 
   await app.startAllMicroservices();
 

--- a/packages/amplication-server/src/main.ts
+++ b/packages/amplication-server/src/main.ts
@@ -38,7 +38,9 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
   app.useLogger(app.get(AmplicationLogger));
 
-  app.connectMicroservice<MicroserviceOptions>(createNestjsKafkaConfig());
+  app.connectMicroservice<MicroserviceOptions>(createNestjsKafkaConfig(), {
+    inheritAppConfig: true,
+  });
   app.use(graphqlUploadExpress({ maxFileSize: 1000000, maxFiles: 10 }));
 
   const document = SwaggerModule.createDocument(app, swaggerDocumentOptions);

--- a/packages/gpt-gateway/src/connectMicroservices.ts
+++ b/packages/gpt-gateway/src/connectMicroservices.ts
@@ -6,6 +6,7 @@ import { MicroserviceOptions } from "@nestjs/microservices";
 export async function connectMicroservices(app: INestApplication) {
   const configService = app.get(ConfigService);
   app.connectMicroservice<MicroserviceOptions>(
-    generateKafkaClientOptions(configService)
+    generateKafkaClientOptions(configService),
+    { inheritAppConfig: true }
   );
 }

--- a/packages/notification-service/src/main.ts
+++ b/packages/notification-service/src/main.ts
@@ -20,9 +20,12 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
   app.useLogger(app.get(AmplicationLogger));
 
-  app.connectMicroservice<MicroserviceOptions>({
-    strategy: new KafkaCustomTransport(createNestjsKafkaConfig().options),
-  });
+  app.connectMicroservice<MicroserviceOptions>(
+    {
+      strategy: new KafkaCustomTransport(createNestjsKafkaConfig().options),
+    },
+    { inheritAppConfig: true }
+  );
 
   await app.startAllMicroservices();
 


### PR DESCRIPTION
Two commits: the fix, and the one lint rule that reports it. The second is separable — drop it if you'd rather not take the dependency.

### 1. `fix(server,gpt-gateway): inherit app config on the Kafka microservice`

A hybrid app serves HTTP **and** a microservice transport from one process, and the two do not share configuration. Without `inheritAppConfig: true`, every global pipe, guard, interceptor and filter registered on the HTTP app is absent from the microservice's handlers.

Two services register a global `ValidationPipe` and then connect Kafka without it:

| service | global registered | `connectMicroservice` |
|---|---|---|
| `amplication-server` | `useGlobalPipes` (`main.ts:72`) | no hybrid options |
| `gpt-gateway` | `useGlobalPipes` (`main.ts:26`) | no hybrid options |

The effect: HTTP routes on those services validate their payloads, and the `@EventPattern` / `@MessagePattern` handlers reading from Kafka beside them do not. Nothing in the code says so — both halves look correct in isolation, which is why this survives review.

```diff
-  app.connectMicroservice<MicroserviceOptions>(createNestjsKafkaConfig());
+  app.connectMicroservice<MicroserviceOptions>(createNestjsKafkaConfig(), {
+    inheritAppConfig: true,
+  });
```

### 2. `chore(lint): enable nestjs-security/no-hybrid-app-config-loss`

An absent flag is not what review catches — it looked fine here for a while. This adds the single rule that reports it:

```jsonc
"plugins": ["perfectionist", "@nx", "nestjs-security"],
// …
"nestjs-security/no-hybrid-app-config-loss": "error",
```

**One rule, not the recommended preset.** No other rule from the plugin is enabled and nothing else in your ESLint config changes. It works with your ESLint 8.46 / `.eslintrc.json` setup (verified against that exact pair, not just flat config).

This commit also adds `inheritAppConfig: true` to the three remaining hybrid services — `git-sync-manager`, `notification-service`, `amplication-build-manager`. **To be precise about those three: they are not exposed today.** None of them registers a global pipe or guard anywhere in `src/`, so there is nothing for the transport to inherit and the flag is a no-op for them right now. They are included for two reasons: the rule can't be enforced at `error` with known violations left in the tree, and they become correct-by-construction the day any of them adds a global.

Verified against this repository:

- **before:** 5 findings — 2 real exposures, 3 no-ops
- **after:** 0 findings across every `connectMicroservice` call site

So enabling it does not turn your lint red today; it fails only if a hybrid service is added without the flag.

Disclosure: I maintain that plugin. Happy to drop commit 2 and land only the fix — the fix stands on its own.